### PR TITLE
feat: Add Gemini 3.0 Flash Preview model to Google, OpenRouter, and Requesty adapters

### DIFF
--- a/src/services/llm/adapters/google/GoogleModels.ts
+++ b/src/services/llm/adapters/google/GoogleModels.ts
@@ -1,6 +1,6 @@
 /**
  * Google Model Specifications
- * Updated June 17, 2025 with latest Gemini releases
+ * Updated December 18, 2025 with Gemini 3 Flash release
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -15,6 +15,22 @@ export const GOOGLE_MODELS: ModelSpec[] = [
     maxTokens: 8192,
     inputCostPerMillion: 2.00,
     outputCostPerMillion: 12.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'google',
+    name: 'Gemini 3.0 Flash Preview',
+    apiName: 'gemini-3-flash-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.50,
+    outputCostPerMillion: 3.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -128,6 +128,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'Gemini 3.0 Flash Preview',
+    apiName: 'google/gemini-3-flash-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.50,
+    outputCostPerMillion: 3.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Gemini 2.5 Pro',
     apiName: 'google/gemini-2.5-pro',
     contextWindow: 1048576,

--- a/src/services/llm/adapters/requesty/RequestyModels.ts
+++ b/src/services/llm/adapters/requesty/RequestyModels.ts
@@ -126,6 +126,22 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   // Google models via Requesty
   {
     provider: 'requesty',
+    name: 'Gemini 3.0 Flash Preview',
+    apiName: 'google/gemini-3-flash-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.50,
+    outputCostPerMillion: 3.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'requesty',
     name: 'Gemini 2.5 Pro Experimental',
     apiName: 'google/gemini-2.5-pro',
     contextWindow: 1048576,


### PR DESCRIPTION
Add support for the newly released Gemini 3 Flash model with:
- 1M token context window
- 64K max output tokens
- $0.50/1M input, $3.00/1M output pricing
- Full capabilities: JSON, images, functions, streaming, and thinking mode