### PR TITLE
feat: add Claude Sonnet 4.6 and Gemini 3.1 Pro Preview

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "nexus",
     "name": "Nexus",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "minAppVersion": "0.15.0",
     "description": "Nexus MCP server integration for Obsidian",
     "author": "Synaptic Labs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nexus",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "description": "Model Context Protocol (MCP) integration for Obsidian",
     "main": "main.js",
     "scripts": {

--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -1,6 +1,6 @@
 /**
  * Anthropic Model Specifications
- * Updated February 5, 2026 with Claude Opus 4.6
+ * Updated February 19, 2026 with Claude Sonnet 4.6
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -112,6 +112,43 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
       supportsThinking: true
     }
   },
+  // Claude Sonnet 4.6
+  {
+    provider: 'anthropic',
+    name: 'Claude Sonnet 4.6',
+    apiName: 'claude-sonnet-4-6',
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Claude Sonnet 4.6 (1M context)
+  {
+    provider: 'anthropic',
+    name: 'Claude Sonnet 4.6 (1M)',
+    apiName: 'claude-sonnet-4-6',
+    contextWindow: 1000000,
+    maxTokens: 64000,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
+    betaHeaders: ['context-1m-2025-08-07'],
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
   {
     provider: 'anthropic',
     name: 'Claude 4.5 Sonnet',

--- a/src/services/llm/adapters/google/GoogleModels.ts
+++ b/src/services/llm/adapters/google/GoogleModels.ts
@@ -1,12 +1,30 @@
 /**
  * Google Model Specifications
- * Updated December 18, 2025 with Gemini 3 Flash release
+ * Updated February 19, 2026 with Gemini 3.1 Pro Preview
  */
 
 import { ModelSpec } from '../modelTypes';
 
 export const GOOGLE_MODELS: ModelSpec[] = [
-  // Gemini 3.0 models (latest)
+  // Gemini 3.1 models (latest)
+  {
+    provider: 'google',
+    name: 'Gemini 3.1 Pro Preview',
+    apiName: 'gemini-3.1-pro-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 2.00,
+    outputCostPerMillion: 12.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Gemini 3.0 models
   {
     provider: 'google',
     name: 'Gemini 3.0 Pro Preview',

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -1,7 +1,7 @@
 /**
  * OpenRouter Model Specifications
  * OpenRouter provides access to multiple providers through a unified API
- * Updated February 5, 2026 with Claude Opus 4.6
+ * Updated February 19, 2026 with Claude Sonnet 4.6 and Gemini 3.1 Pro Preview
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -112,6 +112,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   // Google models via OpenRouter
   {
     provider: 'openrouter',
+    name: 'Gemini 3.1 Pro Preview',
+    apiName: 'google/gemini-3.1-pro-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 2.00,
+    outputCostPerMillion: 12.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Gemini 3.0 Pro Preview',
     apiName: 'google/gemini-3-pro-preview',
     contextWindow: 1048576,
@@ -200,6 +216,38 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     maxTokens: 128000,
     inputCostPerMillion: 5.00,
     outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'Claude Sonnet 4.6',
+    apiName: 'anthropic/claude-sonnet-4.6',
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'Claude Sonnet 4.6 (1M)',
+    apiName: 'anthropic/claude-sonnet-4.6',
+    contextWindow: 1000000,
+    maxTokens: 64000,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,


### PR DESCRIPTION
## Summary
- Adds Claude Sonnet 4.6 (`claude-sonnet-4-6`): 200K ctx, 64K max output, $3/$15 per MTok — includes 1M context beta variant
- Adds Gemini 3.1 Pro Preview (`gemini-3.1-pro-preview`): 1M ctx, 65K max output, $2/$12 per MTok — released Feb 19, 2026
- All three adapter files updated: AnthropicModels, GoogleModels, OpenRouterModels

## Test plan
- [ ] Models appear in provider dropdowns in plugin settings
- [ ] API calls route correctly to new model IDs
- [ ] tsc --noEmit passes (verified during implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)