### PR TITLE
fix: resolve TypeScript build error in IPCTransportManager

### DIFF
--- a/src/server/transport/IPCTransportManager.ts
+++ b/src/server/transport/IPCTransportManager.ts
@@ -68,7 +68,7 @@ export class IPCTransportManager {
      * Falls back to the shared single-server path via StdioTransportManager
      * when no factory is available.
      */
-    private handleSocketConnection(socket: NodeJS.ReadWriteStream): void {
+    private handleSocketConnection(socket: Socket): void {
         if (this.serverFactory) {
             this.handleMultiClientConnection(socket);
         } else {
@@ -80,12 +80,12 @@ export class IPCTransportManager {
      * Per-connection server path: create a dedicated MCPSDKServer for this
      * socket so that multiple clients can coexist.
      */
-    private handleMultiClientConnection(socket: NodeJS.ReadWriteStream): void {
+    private handleMultiClientConnection(socket: Socket): void {
         try {
             const server = this.serverFactory!();
             const transport = new StdioServerTransport(socket, socket);
 
-            const netSocket = socket as Socket;
+            const netSocket = socket;
             let closed = false;
             const onSocketGone = () => {
                 if (closed) return;
@@ -110,19 +110,18 @@ export class IPCTransportManager {
                 });
         } catch (error) {
             logger.systemError(error as Error, 'IPC Socket Handling');
-            const netSocket = socket as Socket;
-            if (!netSocket.destroyed) netSocket.destroy();
+            if (!socket.destroyed) socket.destroy();
         }
     }
 
     /**
      * Legacy single-server path via StdioTransportManager (kept as fallback).
      */
-    private handleSingleClientConnection(socket: NodeJS.ReadWriteStream): void {
+    private handleSingleClientConnection(socket: Socket): void {
         try {
             const transport = this.stdioTransportManager.createSocketTransport(socket, socket);
 
-            const netSocket = socket as Socket;
+            const netSocket = socket;
             let closed = false;
             const onSocketGone = () => {
                 if (closed) return;
@@ -145,8 +144,7 @@ export class IPCTransportManager {
                 });
         } catch (error) {
             logger.systemError(error as Error, 'IPC Socket Handling');
-            const netSocket = socket as Socket;
-            if (!netSocket.destroyed) netSocket.destroy();
+            if (!socket.destroyed) socket.destroy();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes TS2345 build error where `NodeJS.ReadWriteStream` was not assignable to `Readable` in the `StdioServerTransport` constructor call.

**Root cause**: `handleSocketConnection` and its helpers typed the socket parameter as `NodeJS.ReadWriteStream`, but `StdioServerTransport` expects `Readable` (from `node:stream`). The `ReadWriteStream` interface lacks newer `Readable` properties (`readableAborted`, `readableDidRead`, etc.).

**Fix**: Changed socket parameter type from `NodeJS.ReadWriteStream` to `Socket` (from `net` module). `net.Socket` extends `stream.Duplex` which extends both `Readable` and `Writable`, satisfying the constructor signature. This is type-only — `net.createServer` already passes `Socket` at runtime. Removed 4 redundant `as Socket` casts.

- `npm run build` passes (tsc + esbuild)
- 619/619 tests pass
- No runtime behavior change

## Test plan

- [x] `npm run build` passes end-to-end (tsc type check + esbuild bundle)
- [x] `npm test` — 619 tests pass
- [ ] Manual: verify IPC transport connects in Obsidian with Claude Desktop