### PR TITLE
feat: lazy load tools - defer instantiation until first use

### DIFF
--- a/src/agents/LazyTool.ts
+++ b/src/agents/LazyTool.ts
@@ -1,0 +1,64 @@
+import { ITool } from './interfaces/ITool';
+import { JSONSchema } from '../types/schema/JSONSchemaTypes';
+
+/**
+ * Descriptor for lazy tool registration.
+ * Holds static metadata so tool instances are only created on first use.
+ */
+export interface LazyToolDescriptor {
+  slug: string;
+  name: string;
+  description: string;
+  version: string;
+  factory: () => ITool;
+}
+
+/**
+ * Proxy that implements ITool but defers real tool construction until first use.
+ *
+ * Metadata (slug, name, description, version) is available immediately without
+ * instantiating the underlying tool. Methods that require the real tool
+ * (getParameterSchema, getResultSchema, execute) trigger lazy construction
+ * on first call.
+ */
+export class LazyTool implements ITool {
+  readonly slug: string;
+  readonly name: string;
+  readonly description: string;
+  readonly version: string;
+
+  private _factory: (() => ITool) | null;
+  private _instance: ITool | null = null;
+
+  constructor(descriptor: LazyToolDescriptor) {
+    this.slug = descriptor.slug;
+    this.name = descriptor.name;
+    this.description = descriptor.description;
+    this.version = descriptor.version;
+    this._factory = descriptor.factory;
+  }
+
+  /**
+   * Get or create the real tool instance.
+   * Constructs on first call, caches for subsequent calls, releases factory closure.
+   */
+  private getInstance(): ITool {
+    if (!this._instance) {
+      this._instance = this._factory!();
+      this._factory = null; // Release closure for GC
+    }
+    return this._instance;
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getInstance().getParameterSchema();
+  }
+
+  getResultSchema(): JSONSchema {
+    return this.getInstance().getResultSchema();
+  }
+
+  async execute(params: unknown): Promise<unknown> {
+    return this.getInstance().execute(params);
+  }
+}

--- a/src/agents/baseAgent.ts
+++ b/src/agents/baseAgent.ts
@@ -1,6 +1,7 @@
 import { IAgent } from './interfaces/IAgent';
 import { ITool } from './interfaces/ITool';
 import { CommonResult } from '../types';
+import { LazyTool, LazyToolDescriptor } from './LazyTool';
 
 /**
  * Base class for all agents in the MCP plugin
@@ -68,6 +69,16 @@ export abstract class BaseAgent implements IAgent {
    */
   registerTool(tool: ITool): void {
     this.tools.set(tool.slug, tool);
+  }
+
+  /**
+   * Register a lazy-loaded tool with this agent.
+   * The tool instance is created on first use (getParameterSchema, execute, etc.)
+   * while metadata (slug, name, description, version) is available immediately.
+   * @param descriptor Tool metadata and factory function
+   */
+  registerLazyTool(descriptor: LazyToolDescriptor): void {
+    this.tools.set(descriptor.slug, new LazyTool(descriptor));
   }
 
   /**

--- a/src/agents/canvasManager/canvasManager.ts
+++ b/src/agents/canvasManager/canvasManager.ts
@@ -33,10 +33,30 @@ export class CanvasManagerAgent extends BaseAgent {
     this.app = app;
     this.plugin = plugin || null;
 
-    // Register 4 tools
-    this.registerTool(new ReadCanvasTool(app));
-    this.registerTool(new WriteCanvasTool(app));
-    this.registerTool(new UpdateCanvasTool(app));
-    this.registerTool(new ListCanvasTool(app));
+    // Register 4 tools - lazy loaded
+    this.registerLazyTool({
+      slug: 'read', name: 'Read Canvas',
+      description: 'Read the structure of a canvas file (nodes and edges)',
+      version: '1.0.0',
+      factory: () => new ReadCanvasTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'write', name: 'Write Canvas',
+      description: 'Create a NEW canvas file. Fails if canvas already exists - use canvasManager.update to modify existing canvases.',
+      version: '1.0.0',
+      factory: () => new WriteCanvasTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'update', name: 'Update Canvas',
+      description: 'Modify an EXISTING canvas file. Replaces nodes and/or edges arrays. Fails if canvas does not exist - use canvasManager.write to create new canvases.',
+      version: '1.0.0',
+      factory: () => new UpdateCanvasTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'list', name: 'List Canvases',
+      description: 'List canvas files in the vault with node/edge counts',
+      version: '1.0.0',
+      factory: () => new ListCanvasTool(app),
+    });
   }
 }

--- a/src/agents/contentManager/contentManager.ts
+++ b/src/agents/contentManager/contentManager.ts
@@ -60,10 +60,25 @@ export class ContentManagerAgent extends BaseAgent {
       this.workspaceService = plugin.services.workspaceService;
     }
 
-    // Register simplified tools (3 tools replacing 8)
-    this.registerTool(new ReadTool(app));
-    this.registerTool(new WriteTool(app));
-    this.registerTool(new UpdateTool(app));
+    // Register simplified tools (3 tools replacing 8) - lazy loaded
+    this.registerLazyTool({
+      slug: 'read', name: 'Read',
+      description: 'Read content from a file with line range',
+      version: '1.0.0',
+      factory: () => new ReadTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'write', name: 'Write',
+      description: 'Create a new file or overwrite existing file',
+      version: '1.0.0',
+      factory: () => new WriteTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'update', name: 'Update',
+      description: 'Insert, replace, or delete content at specific line positions. Returns linesDelta showing net line change - use this to adjust subsequent line numbers in multi-operation workflows.',
+      version: '1.0.0',
+      factory: () => new UpdateTool(app),
+    });
   }
   
   

--- a/src/agents/memoryManager/memoryManager.ts
+++ b/src/agents/memoryManager/memoryManager.ts
@@ -77,17 +77,57 @@ export class MemoryManagerAgent extends BaseAgent {
     this.memoryService = memoryService;
     this.workspaceService = workspaceService;
 
-    // Register state tools (3 tools: create, list, load)
-    this.registerTool(new CreateStateTool(this));
-    this.registerTool(new ListStatesTool(this));
-    this.registerTool(new LoadStateTool(this));
+    // Register state tools (3 tools: create, list, load) - lazy loaded
+    this.registerLazyTool({
+      slug: 'createState', name: 'Create State',
+      description: 'Create a state with restoration context for later resumption',
+      version: '2.0.0',
+      factory: () => new CreateStateTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'listStates', name: 'List States',
+      description: 'List states with optional filtering and sorting',
+      version: '2.0.0',
+      factory: () => new ListStatesTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'loadState', name: 'Load State',
+      description: 'Load a saved state and optionally create a continuation session with restored context',
+      version: '2.0.0',
+      factory: () => new LoadStateTool(this),
+    });
 
-    // Register workspace tools (5 tools: create, list, load, update, archive)
-    this.registerTool(new CreateWorkspaceTool(this));
-    this.registerTool(new ListWorkspacesTool(this));
-    this.registerTool(new LoadWorkspaceTool(this));
-    this.registerTool(new UpdateWorkspaceTool(this));
-    this.registerTool(new ArchiveWorkspaceTool(this));
+    // Register workspace tools (5 tools: create, list, load, update, archive) - lazy loaded
+    this.registerLazyTool({
+      slug: 'createWorkspace', name: 'Create Workspace',
+      description: 'Create a new workspace with structured context data',
+      version: '2.0.0',
+      factory: () => new CreateWorkspaceTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'listWorkspaces', name: 'List Workspaces',
+      description: 'List available workspaces with filters and sorting',
+      version: '1.0.0',
+      factory: () => new ListWorkspacesTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'loadWorkspace', name: 'Load Workspace',
+      description: 'Load a workspace by ID and restore context and state',
+      version: '2.0.0',
+      factory: () => new LoadWorkspaceTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'updateWorkspace', name: 'Update Workspace',
+      description: 'Update workspace properties. Pass only fields to change - others remain unchanged.',
+      version: '2.0.0',
+      factory: () => new UpdateWorkspaceTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'archiveWorkspace', name: 'Archive Workspace',
+      description: 'Archive a workspace (soft delete). Workspace will be hidden from lists but can be restored.',
+      version: '1.0.0',
+      factory: () => new ArchiveWorkspaceTool(this),
+    });
   }
 
   /**

--- a/src/agents/promptManager/promptManager.ts
+++ b/src/agents/promptManager/promptManager.ts
@@ -104,17 +104,47 @@ export class PromptManagerAgent extends BaseAgent {
     this.storageService = new CustomPromptStorageService(db || null, settings);
     this.vaultName = sanitizeVaultName(vault.getName());
 
-    // Register prompt management tools
-    this.registerTool(new ListPromptsTool(this.storageService));
-    this.registerTool(new GetPromptTool(this.storageService));
-    this.registerTool(new CreatePromptTool(this.storageService));
-    this.registerTool(new UpdatePromptTool(this.storageService));
-    this.registerTool(new ArchivePromptTool(this.storageService));
+    // Register prompt management tools - lazy loaded
+    this.registerLazyTool({
+      slug: 'listPrompts', name: 'List Prompts',
+      description: 'List all custom prompts',
+      version: '1.0.0',
+      factory: () => new ListPromptsTool(this.storageService),
+    });
+    this.registerLazyTool({
+      slug: 'getPrompt', name: 'Get Prompt',
+      description: 'Get a custom prompt for persona adoption - does NOT execute tasks automatically',
+      version: '1.0.0',
+      factory: () => new GetPromptTool(this.storageService),
+    });
+    this.registerLazyTool({
+      slug: 'createPrompt', name: 'Create Prompt',
+      description: 'Create a new custom prompt',
+      version: '1.0.0',
+      factory: () => new CreatePromptTool(this.storageService),
+    });
+    this.registerLazyTool({
+      slug: 'updatePrompt', name: 'Update Prompt',
+      description: 'Update an existing custom prompt',
+      version: '1.0.0',
+      factory: () => new UpdatePromptTool(this.storageService),
+    });
+    this.registerLazyTool({
+      slug: 'archivePrompt', name: 'Archive Prompt',
+      description: 'Archive a custom prompt by disabling it (preserves configuration for restoration)',
+      version: '1.0.0',
+      factory: () => new ArchivePromptTool(this.storageService),
+    });
 
-    // Register LLM tools with dependencies already available
-    this.registerTool(new ListModelsTool(this.providerManager));
+    // Register LLM tools - lazy loaded
+    this.registerLazyTool({
+      slug: 'listModels', name: 'List Available Models',
+      description: 'List available LLM models grouped by provider',
+      version: '2.0.0',
+      factory: () => new ListModelsTool(this.providerManager),
+    });
 
-    // Register unified prompt execution tool (handles single and batch)
+    // Register unified prompt execution tool (handles single and batch) - eager (complex dependencies)
     this.registerTool(new ExecutePromptsTool(
       undefined, // plugin - not needed in constructor injection pattern
       this.providerManager.getLLMService(), // Get LLM service from provider manager
@@ -129,10 +159,15 @@ export class PromptManagerAgent extends BaseAgent {
     const hasOpenRouterKey = llmProviders?.providers?.openrouter?.apiKey && llmProviders?.providers?.openrouter?.enabled;
 
     if (hasGoogleKey || hasOpenRouterKey) {
-      this.registerTool(new GenerateImageTool({
-        vault: this.vault,
-        llmSettings: llmProviders
-      }));
+      this.registerLazyTool({
+        slug: 'generateImage', name: 'Generate Image',
+        description: 'Generate images using Google Nano Banana models (direct or via OpenRouter). Supports reference images for style/composition guidance.',
+        version: '2.1.0',
+        factory: () => new GenerateImageTool({
+          vault: this.vault,
+          llmSettings: llmProviders
+        }),
+      });
     }
 
     // Register subagent tool (internal chat only - executor wired up separately)

--- a/src/agents/searchManager/searchManager.ts
+++ b/src/agents/searchManager/searchManager.ts
@@ -124,19 +124,28 @@ export class SearchManagerAgent extends BaseAgent {
     }
     this.registerTool(this.searchContentTool);
 
-    // Register focused search tools with enhanced validation and service integration
-    this.registerTool(new SearchDirectoryTool(
-      pluginOrFallback,
-      this.workspaceService || undefined
-    ));
+    // Register focused search tools - lazy loaded
+    this.registerLazyTool({
+      slug: 'searchDirectory', name: 'Search Directory',
+      description: 'FOCUSED directory search with REQUIRED paths parameter. Search for files and/or folders within specific directory paths using fuzzy matching and optional workspace context. Requires: query (search terms) and paths (directory paths to search - cannot be empty).',
+      version: '2.0.0',
+      factory: () => new SearchDirectoryTool(
+        pluginOrFallback,
+        this.workspaceService || undefined
+      ),
+    });
 
-
-    this.registerTool(new SearchMemoryTool(
-      pluginOrFallback,
-      this.memoryService || undefined,
-      this.workspaceService || undefined,
-      this.storageAdapter || undefined  // SQLite storage adapter for memory trace search
-    ));
+    this.registerLazyTool({
+      slug: 'searchMemory', name: 'Search Memory',
+      description: 'Search workspace memory for past conversations, tool execution history, and workspace state snapshots.\n\nTWO MODES:\n- Discovery (default): Search all memory across a workspace. Best for finding past discussions, tool usage, or workspace context.\n- Scoped (provide sessionId): Search within a specific session and get surrounding message context around each match. Best for recovering what happened in a particular session.\n\nTIPS:\n- Use natural language queries for conversations (e.g., "how did we implement auth?").\n- Use specific terms for tool history (e.g., agent or tool names).\n- Narrow results with memoryTypes if you know what you\'re looking for.\n- Use sessionId + windowSize to get full context around a match.\n\nREQUIRES: query. Optional: workspaceId (defaults to global workspace if omitted; available from your useTools context, or use MemoryManager listWorkspaces).',
+      version: '2.1.0',
+      factory: () => new SearchMemoryTool(
+        pluginOrFallback,
+        this.memoryService || undefined,
+        this.workspaceService || undefined,
+        this.storageAdapter || undefined
+      ),
+    });
   }
 
 

--- a/src/agents/storageManager/storageManager.ts
+++ b/src/agents/storageManager/storageManager.ts
@@ -33,13 +33,43 @@ export class StorageManagerAgent extends BaseAgent {
     this.app = app;
     this.vaultName = sanitizeVaultName(app.vault.getName());
 
-    // Register simplified CRUA tools
-    this.registerTool(new ListTool(app));
-    this.registerTool(new CreateFolderTool(app));
-    this.registerTool(new MoveTool(app));
-    this.registerTool(new CopyTool(app));
-    this.registerTool(new ArchiveTool(app));
-    this.registerTool(new OpenTool(app));
+    // Register simplified CRUA tools - lazy loaded
+    this.registerLazyTool({
+      slug: 'list', name: 'List',
+      description: 'List contents of a directory',
+      version: '1.0.0',
+      factory: () => new ListTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'createFolder', name: 'Create Folder',
+      description: 'Create a new folder in the vault',
+      version: '1.0.0',
+      factory: () => new CreateFolderTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'move', name: 'Move',
+      description: 'Move or rename a file or folder',
+      version: '1.0.0',
+      factory: () => new MoveTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'copy', name: 'Copy',
+      description: 'Duplicate a file',
+      version: '1.0.0',
+      factory: () => new CopyTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'archive', name: 'Archive',
+      description: 'Safely archive a file or folder (moves to .archive/ with timestamp)',
+      version: '1.0.0',
+      factory: () => new ArchiveTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'open', name: 'Open',
+      description: 'Open a file in the editor',
+      version: '1.0.0',
+      factory: () => new OpenTool(app),
+    });
   }
 
   /**


### PR DESCRIPTION
Tools are now wrapped in a LazyTool proxy that stores metadata (slug,
name, description, version) immediately but defers real tool construction
until first getParameterSchema(), getResultSchema(), or execute() call.
This reduces startup cost by avoiding eager instantiation of ~27 tools.

Tools kept eager: SubagentTool (needs post-construction wiring),
SearchContentTool (needs setEmbeddingService), ExecutePromptsTool
(complex dependencies used immediately).

https://claude.ai/code/session_01XghrzPjkhy7VUAjJD6crDF