### PR TITLE
fix: eliminate ghost workspaces from legacy JSONL migration

### DIFF
--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -199,6 +199,13 @@ export class SyncCoordinator {
 
     for (let i = 0; i < workspaceFiles.length; i++) {
       const file = workspaceFiles[i];
+
+      // Skip ws_undefined.jsonl — ghost workspace from legacy bugs
+      const filename = file.split('/').pop() || '';
+      if (filename === 'ws_undefined.jsonl') {
+        continue;
+      }
+
       try {
         const events = await this.jsonlWriter.getEventsNotFromDevice<WorkspaceEvent>(
           file, this.deviceId, lastSync
@@ -276,9 +283,27 @@ export class SyncCoordinator {
 
     for (let i = 0; i < workspaceFiles.length; i++) {
       const file = workspaceFiles[i];
+
+      // Skip ws_undefined.jsonl — ghost workspace from legacy bugs
+      const rebuildFilename = file.split('/').pop() || '';
+      if (rebuildFilename === 'ws_undefined.jsonl') {
+        continue;
+      }
+
       try {
         const events = await this.jsonlWriter.readEvents<WorkspaceEvent>(file);
         events.sort((a, b) => a.timestamp - b.timestamp);
+
+        // Skip orphaned JSONLs that have no workspace_created event (legacy pre-event-sourcing files)
+        const hasWorkspaceCreated = events.some(e => e.type === 'workspace_created');
+        if (!hasWorkspaceCreated && events.length > 0) {
+          const hasOrphanedEvents = events.some(e =>
+            e.type === 'trace_added' || e.type === 'session_created' || e.type === 'state_saved'
+          );
+          if (hasOrphanedEvents) {
+            continue;
+          }
+        }
 
         // Process in very small batches with delays to avoid OOM
         const result = await BatchOperations.executeBatch(

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -26,6 +26,14 @@ export class WorkspaceEventApplier {
   }
 
   /**
+   * Validate workspace ID to prevent ghost/orphan workspaces from being inserted.
+   * Rejects "undefined", "null", and empty/whitespace-only IDs.
+   */
+  private isValidWorkspaceId(id: string | undefined): boolean {
+    return !!id && id !== 'undefined' && id !== 'null' && id.trim().length > 0;
+  }
+
+  /**
    * Apply a workspace-related event to SQLite cache.
    */
   async apply(event: WorkspaceEvent): Promise<void> {
@@ -61,6 +69,9 @@ export class WorkspaceEventApplier {
     if (!event.data?.id || !event.data?.name) {
       return;
     }
+    if (!this.isValidWorkspaceId(event.data.id)) {
+      return;
+    }
 
     await this.sqliteCache.run(
       `INSERT OR REPLACE INTO workspaces
@@ -82,6 +93,10 @@ export class WorkspaceEventApplier {
   }
 
   private async applyWorkspaceUpdated(event: WorkspaceUpdatedEvent): Promise<void> {
+    if (!this.isValidWorkspaceId(event.workspaceId)) {
+      return;
+    }
+
     const updates: string[] = [];
     const values: any[] = [];
 
@@ -103,11 +118,17 @@ export class WorkspaceEventApplier {
   }
 
   private async applyWorkspaceDeleted(event: WorkspaceDeletedEvent): Promise<void> {
+    if (!this.isValidWorkspaceId(event.workspaceId)) {
+      return;
+    }
     await this.sqliteCache.run('DELETE FROM workspaces WHERE id = ?', [event.workspaceId]);
   }
 
   private async applySessionCreated(event: SessionCreatedEvent): Promise<void> {
     if (!event.data?.id || !event.workspaceId) {
+      return;
+    }
+    if (!this.isValidWorkspaceId(event.workspaceId)) {
       return;
     }
 
@@ -148,6 +169,9 @@ export class WorkspaceEventApplier {
     if (!event.data?.id || !event.sessionId || !event.workspaceId) {
       return;
     }
+    if (!this.isValidWorkspaceId(event.workspaceId)) {
+      return;
+    }
 
     await this.sqliteCache.run(
       `INSERT OR REPLACE INTO states
@@ -172,6 +196,9 @@ export class WorkspaceEventApplier {
 
   private async applyTraceAdded(event: TraceAddedEvent): Promise<void> {
     if (!event.data?.id || !event.sessionId || !event.workspaceId) {
+      return;
+    }
+    if (!this.isValidWorkspaceId(event.workspaceId)) {
       return;
     }
 

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -244,7 +244,10 @@ export class WorkspaceService {
         sortOrder: 'desc'
       });
 
-      return result.items.map(w => ({
+      return result.items
+        // Filter out ghost workspaces with invalid IDs or names from legacy migration
+        .filter(w => w.name && w.name !== 'undefined' && w.id && w.id !== 'undefined')
+        .map(w => ({
         id: w.id,
         name: w.name,
         description: w.description,

--- a/src/services/storage/FileSystemService.ts
+++ b/src/services/storage/FileSystemService.ts
@@ -127,7 +127,11 @@ export class FileSystemService {
     try {
       const files = await this.vaultOperations.listDirectory(this.workspacesPath);
       const workspaceIds = files.files
-        .filter(file => file.endsWith('.json') && !file.endsWith('index.json'))
+        .filter(file => {
+          // Exclude hidden files (e.g., .DS_Store) from workspace listing
+          const name = file.split('/').pop() || '';
+          return file.endsWith('.json') && !file.endsWith('index.json') && !name.startsWith('.');
+        })
         .map(file => {
           const filename = file.split('/').pop() || '';
           return filename.replace('.json', '');


### PR DESCRIPTION
## Problem
Vaults upgraded from pre-v4.x contain JSONL files without `workspace_created` events. During SQLite rebuild, these create orphan workspace records with IDs like "undefined" or empty strings. Ghost workspaces appear in the UI workspace list.

## Reproduction
1. Use a vault that was originally set up with an older Nexus version (pre-workspace events)
2. Delete `.nexus/cache.db` to force rebuild
3. Open workspace settings
4. Observe: ghost workspaces ("undefined", empty) appear in the list

## Fix
5-layer defense:
1. **WorkspaceEventApplier** — `isValidWorkspaceId()` rejects "undefined", "null", and empty IDs before any event is applied to SQLite
2. **SyncCoordinator** (rebuild) — skip orphaned JSONLs that contain only trace/session/state events but no `workspace_created` event
3. **SyncCoordinator** (incremental + rebuild) — skip `ws_undefined.jsonl` entirely
4. **WorkspaceService** — filter ghost workspaces with invalid names/IDs from `getAllWorkspaces()` results
5. **FileSystemService** — exclude hidden files (e.g., `.DS_Store`) from `listWorkspaceIds()`

## Files changed
- `src/database/sync/WorkspaceEventApplier.ts` (+27 lines)
- `src/database/sync/SyncCoordinator.ts` (+25 lines)
- `src/services/WorkspaceService.ts` (+3 lines)
- `src/services/storage/FileSystemService.ts` (+5 lines)

## Test plan
- [ ] Delete `.nexus/cache.db`, reopen vault → no ghost workspaces in list
- [ ] Vault with legacy JSONLs rebuilds cleanly
- [ ] Normal workspace CRUD still works
- [ ] `npm run build` passes clean