### PR TITLE
fix: move pipe setup inside socket connect handler

### DIFF
--- a/connector.ts
+++ b/connector.ts
@@ -131,41 +131,34 @@ function connectWithRetry() {
     try {
         const socket = createConnection(ipcPath);
 
-        // Pipe stdin/stdout to/from the socket
-        process.stdin.pipe(socket);
-        socket.pipe(process.stdout);
+        // Pipe stdin/stdout ONLY after connection is confirmed
+        socket.on('connect', () => {
+            hasConnected = true;
+            retryCount = 0;
+            process.stdin.pipe(socket);
+            socket.pipe(process.stdout);
+        });
 
         // Error handling - completely silent for expected connection errors
         socket.on('error', (err) => {
-            // Cast error to NodeJS.ErrnoException to access the code property
             const nodeErr = err as NodeJS.ErrnoException;
             const isWaitingError = nodeErr.code === 'ENOENT' || nodeErr.code === 'ECONNREFUSED';
 
-            // Be completely silent - any stderr output shows as notification in Claude Desktop
-            // Only truly unexpected errors should be logged (never ENOENT/ECONNREFUSED)
             if (!isWaitingError) {
-                // Even unexpected errors should be silent - user can't fix them anyway
-                // and it would clutter Claude Desktop with notifications
+                // Non-expected errors - still silent to avoid Claude Desktop notifications
             }
 
-            // Always retry with exponential backoff (capped at 30s)
             retryCount++;
             const retryDelay = calculateBackoff(retryCount);
             setTimeout(connectWithRetry, retryDelay);
         });
 
-        socket.on('connect', () => {
-            hasConnected = true;
-            // Silent on connection - no need to notify user
-            // Reset retry count on successful connection
-            retryCount = 0;
-        });
-
         socket.on('close', () => {
+            // Unpipe to prevent stdin consumption by dead socket
+            process.stdin.unpipe(socket);
             if (hasConnected) {
-                // Connection was lost - silently go back to waiting mode
-                retryCount = 0;  // Reset backoff
-                setTimeout(connectWithRetry, 1000);  // Start retry loop
+                retryCount = 0;
+                setTimeout(connectWithRetry, 1000);
             }
             // If we never connected, the error handler will schedule a retry
         });


### PR DESCRIPTION
## Problem

In `connector.ts`, the `process.stdin.pipe(socket)` and `socket.pipe(process.stdout)` calls are executed immediately after `net.connect()`, before the socket's `connect` event fires. If the connection is slow or fails, piping to a not-yet-connected socket can cause data loss or unhandled errors.

## Reproduction

1. Start the connector with a slow or congested local socket
2. Claude Desktop sends MCP messages immediately
3. Messages may be lost because `stdin` is piped to a socket that hasn't connected yet

## Fix

Move the `pipe()` calls inside the socket's `connect` event handler. This ensures stdin/stdout are only wired after the TCP connection is established.

## Files changed

- `connector.ts`