### PR TITLE
fix: WorkspacePromptResolver reads from SQLite storage service

### DIFF
--- a/src/agents/memoryManager/memoryManager.ts
+++ b/src/agents/memoryManager/memoryManager.ts
@@ -2,6 +2,7 @@ import { App } from 'obsidian';
 import { BaseAgent } from '../baseAgent';
 import { MemoryService } from "./services/MemoryService";
 import { WorkspaceService } from "../../services/WorkspaceService";
+import { CustomPromptStorageService } from "../promptManager/services/CustomPromptStorageService";
 import { sanitizeVaultName } from '../../utils/vaultUtils';
 import { getNexusPlugin } from '../../utils/pluginLocator';
 import { NexusPluginWithServices } from './tools/utils/pluginTypes';
@@ -38,6 +39,11 @@ export class MemoryManagerAgent extends BaseAgent {
   private readonly workspaceService: WorkspaceService;
 
   /**
+   * Custom prompt storage service for SQLite-backed prompt resolution
+   */
+  public readonly customPromptStorage?: CustomPromptStorageService;
+
+  /**
    * TaskService reference for loadWorkspace integration (optional, set during plugin init)
    */
   private taskService: { getWorkspaceSummary(workspaceId: string): Promise<any> } | null = null;
@@ -63,12 +69,14 @@ export class MemoryManagerAgent extends BaseAgent {
    * @param plugin Plugin instance for accessing shared services
    * @param memoryService Injected memory service
    * @param workspaceService Injected workspace service
+   * @param customPromptStorage Optional prompt storage service for SQLite-backed lookups
    */
   constructor(
     app: App,
     public plugin: any,
     memoryService: MemoryService,
-    workspaceService: WorkspaceService
+    workspaceService: WorkspaceService,
+    customPromptStorage?: CustomPromptStorageService
   ) {
     super(
       'memoryManager',
@@ -82,6 +90,7 @@ export class MemoryManagerAgent extends BaseAgent {
     // Store injected services
     this.memoryService = memoryService;
     this.workspaceService = workspaceService;
+    this.customPromptStorage = customPromptStorage;
 
     // Register state tools (3 tools: create, list, load) - lazy loaded
     this.registerLazyTool({

--- a/src/agents/memoryManager/services/WorkspacePromptResolver.ts
+++ b/src/agents/memoryManager/services/WorkspacePromptResolver.ts
@@ -7,7 +7,7 @@
  * compatibility for legacy workspace structures.
  *
  * Used by: LoadWorkspaceMode for resolving workspace prompts
- * Integrates with: Plugin settings (data.json customPrompts)
+ * Integrates with: CustomPromptStorageService (SQLite primary, data.json fallback)
  *
  * Responsibilities:
  * - Resolve workspace prompt from dedicatedAgent or legacy agents array
@@ -17,6 +17,7 @@
 
 import type { App } from 'obsidian';
 import { ProjectWorkspace, WorkspaceContext } from '../../../database/types/workspace/WorkspaceTypes';
+import { CustomPromptStorageService } from '../../promptManager/services/CustomPromptStorageService';
 
 /**
  * Prompt information returned from resolution operations
@@ -45,10 +46,12 @@ interface LegacyWorkspaceContext extends WorkspaceContext {
 export class WorkspacePromptResolver {
   private app: App;
   private plugin: any;
+  private customPromptStorage?: CustomPromptStorageService;
 
-  constructor(app: App, plugin: any) {
+  constructor(app: App, plugin: any, customPromptStorage?: CustomPromptStorageService) {
     this.app = app;
     this.plugin = plugin;
+    this.customPromptStorage = customPromptStorage;
   }
 
   /**
@@ -100,8 +103,7 @@ export class WorkspacePromptResolver {
 
   /**
    * Fetch prompt by name or ID (unified lookup)
-   * Tries ID first (more specific), then falls back to name
-   * Accesses prompts directly from plugin settings (data.json)
+   * Tries CustomPromptStorageService first (SQLite-backed), falls back to data.json
    * @param identifier The prompt name or ID
    * @param app The Obsidian app instance (unused, kept for compatibility)
    * @returns Prompt info or null if not found
@@ -111,25 +113,37 @@ export class WorkspacePromptResolver {
     app: App
   ): Promise<WorkspacePromptInfo | null> {
     try {
-      // Access customPrompts directly from plugin settings
+      // Primary: CustomPromptStorageService (SQLite -> internal fallback to data.json)
+      if (this.customPromptStorage) {
+        const prompt = this.customPromptStorage.getPromptByNameOrId(identifier);
+        if (prompt) {
+          return {
+            id: prompt.id,
+            name: prompt.name,
+            systemPrompt: prompt.prompt
+          };
+        }
+      }
+
+      // Fallback: direct data.json read (when service unavailable)
       const prompts = this.plugin?.settings?.settings?.customPrompts?.prompts || [];
 
       // Try ID lookup first (more specific)
-      let prompt = prompts.find((p: any) => p.id === identifier);
+      let fallbackPrompt = prompts.find((p: any) => p.id === identifier);
 
       // Fall back to name lookup
-      if (!prompt) {
-        prompt = prompts.find((p: any) => p.name === identifier);
+      if (!fallbackPrompt) {
+        fallbackPrompt = prompts.find((p: any) => p.name === identifier);
       }
 
-      if (!prompt) {
+      if (!fallbackPrompt) {
         return null;
       }
 
       return {
-        id: prompt.id,
-        name: prompt.name,
-        systemPrompt: prompt.prompt
+        id: fallbackPrompt.id,
+        name: fallbackPrompt.name,
+        systemPrompt: fallbackPrompt.prompt
       };
 
     } catch (error) {

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -63,7 +63,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
 
     // Initialize composed services
     this.dataFetcher = new WorkspaceDataFetcher();
-    this.promptResolver = new WorkspacePromptResolver(agent.app, agent.plugin);
+    this.promptResolver = new WorkspacePromptResolver(agent.app, agent.plugin, agent.customPromptStorage);
     this.contextBuilder = new WorkspaceContextBuilder();
     this.fileCollector = new WorkspaceFileCollector();
   }

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -275,7 +275,8 @@ export class AgentInitializationService {
       this.app,
       this.plugin,
       memoryService,
-      workspaceService
+      workspaceService,
+      this.customPromptStorage
     );
 
     this.agentManager.registerAgent(memoryManagerAgent);


### PR DESCRIPTION
## Problem

`WorkspacePromptResolver` reads custom prompts exclusively from `data.json` (plugin settings). When SQLite-backed `CustomPromptStorageService` is available and authoritative, prompts created/updated through the service layer are invisible to workspace loading. This causes workspaces to fail to resolve their dedicated agent prompt when the prompt was persisted via SQLite but not yet synced to `data.json`.

## Reproduction

1. Create a custom prompt via PromptManager (stored in SQLite via `CustomPromptStorageService`)
2. Assign the prompt as a workspace's dedicated agent
3. Load the workspace via `loadWorkspace` tool
4. Expected: workspace loads with the prompt's system prompt
5. Actual: prompt resolution returns null (only checked `data.json`)

## Fix

- `WorkspacePromptResolver`: accepts optional `CustomPromptStorageService` dependency. Primary lookup uses the service's `getPromptByNameOrId()` (which queries SQLite first, falls back internally). If the service is unavailable, falls back to direct `data.json` read.
- `MemoryManagerAgent`: accepts and exposes optional `customPromptStorage` parameter.
- `LoadWorkspaceTool`: passes `customPromptStorage` from agent to `WorkspacePromptResolver`.
- `AgentInitializationService`: passes `this.customPromptStorage` when constructing `MemoryManagerAgent`.

## Files changed

- `src/agents/memoryManager/memoryManager.ts`
- `src/agents/memoryManager/services/WorkspacePromptResolver.ts`
- `src/agents/memoryManager/tools/workspaces/loadWorkspace.ts`
- `src/services/agent/AgentInitializationService.ts`