### PR TITLE
fix: SettingsView reuses CustomPromptStorageService from ServiceManager

### DIFF
--- a/src/settings/SettingsView.ts
+++ b/src/settings/SettingsView.ts
@@ -366,8 +366,17 @@ export class SettingsView extends PluginSettingTab {
 
         // Initialize custom prompt storage if needed
         if (!this.customPromptStorage) {
-            // Pass null for db - SettingsView doesn't have access to database
-            this.customPromptStorage = new CustomPromptStorageService(null, this.settingsManager);
+            // Try ServiceManager first (has db, writes to SQLite + data.json)
+            if (this.serviceManager) {
+                const storageFromManager = this.serviceManager.getServiceIfReady<CustomPromptStorageService>('customPromptStorageService');
+                if (storageFromManager) {
+                    this.customPromptStorage = storageFromManager;
+                }
+            }
+            // Fallback: create without db (writes to data.json only)
+            if (!this.customPromptStorage) {
+                this.customPromptStorage = new CustomPromptStorageService(null, this.settingsManager);
+            }
         }
 
         return {


### PR DESCRIPTION
## Problem

`SettingsView` always creates a new `CustomPromptStorageService(null, settingsManager)` — passing `null` for the database. This means the settings UI reads/writes prompts exclusively through `data.json`, bypassing the SQLite-backed service that the rest of the application uses. Prompts edited in settings may not appear in workspace resolution (which reads SQLite), and vice versa.

## Reproduction

1. Open plugin settings, go to Prompts tab
2. Edit a custom prompt
3. Load a workspace that uses that prompt via MCP
4. The workspace may show stale prompt content (SQLite wasn't updated)

## Fix

Before creating a new `CustomPromptStorageService`, check if `ServiceManager` already has a fully initialized instance (with SQLite database). If available, reuse it. Only fall back to creating a db-less instance if the service isn't ready yet.

## Files changed

- `src/settings/SettingsView.ts`