### PR TITLE
feat: add merge mode to contentManager.setProperty for list fields

### DIFF
--- a/src/agents/contentManager/contentManager.ts
+++ b/src/agents/contentManager/contentManager.ts
@@ -3,7 +3,8 @@ import { BaseAgent } from '../baseAgent';
 import {
   ReadTool,
   WriteTool,
-  UpdateTool
+  UpdateTool,
+  SetPropertyTool
 } from './tools';
 import NexusPlugin from '../../main';
 import { WorkspaceService } from '../../services/WorkspaceService';
@@ -17,6 +18,7 @@ import { MemoryService } from '../memoryManager/services/MemoryService';
  * - read: Read content from files with explicit line ranges
  * - write: Create new files or overwrite existing files
  * - update: Insert, replace, delete, append, or prepend content
+ * - setProperty: Set frontmatter properties with optional merge mode
  */
 export class ContentManagerAgent extends BaseAgent {
   protected app: App;
@@ -78,6 +80,12 @@ export class ContentManagerAgent extends BaseAgent {
       description: 'Insert, replace, or delete content at specific line positions. Returns linesDelta showing net line change - use this to adjust subsequent line numbers in multi-operation workflows.',
       version: '1.0.0',
       factory: () => new UpdateTool(app),
+    });
+    this.registerLazyTool({
+      slug: 'setProperty', name: 'Set property',
+      description: 'Set a frontmatter property on a note. Supports "replace" (default) and "merge" (array union with dedup) modes.',
+      version: '1.0.0',
+      factory: () => new SetPropertyTool(app),
     });
   }
   

--- a/src/agents/contentManager/tools/index.ts
+++ b/src/agents/contentManager/tools/index.ts
@@ -1,4 +1,5 @@
-// ContentManager tools (3 tools)
+// ContentManager tools (4 tools)
 export { ReadTool } from './read';
 export { WriteTool } from './write';
 export { UpdateTool } from './update';
+export { SetPropertyTool } from './setProperty';

--- a/src/agents/contentManager/tools/setProperty.ts
+++ b/src/agents/contentManager/tools/setProperty.ts
@@ -1,0 +1,147 @@
+import { App, TFile } from 'obsidian';
+import { BaseTool } from '../../baseTool';
+import { SetPropertyParams, SetPropertyResult } from '../types';
+import { createErrorMessage } from '../../../utils/errorUtils';
+
+/**
+ * Location: src/agents/contentManager/tools/setProperty.ts
+ *
+ * Tool for setting frontmatter properties on notes.
+ * Supports two modes:
+ * - "replace" (default): overwrites the property value
+ * - "merge": performs array union with dedup for list fields;
+ *   equivalent to replace for scalars
+ *
+ * Uses Obsidian's fileManager.processFrontMatter() for atomic
+ * frontmatter manipulation.
+ *
+ * Relationships:
+ * - Part of ContentManager agent (CRUA + property operations)
+ * - Follows write tool response stripping principle (returns { success: true } only)
+ *
+ * Ref: #33
+ */
+export class SetPropertyTool extends BaseTool<SetPropertyParams, SetPropertyResult> {
+  private app: App;
+
+  constructor(app: App) {
+    super(
+      'setProperty',
+      'Set property',
+      'Set a frontmatter property on a note. Supports "replace" (default) and "merge" (array union with dedup) modes.',
+      '1.0.0'
+    );
+    this.app = app;
+  }
+
+  async execute(params: SetPropertyParams): Promise<SetPropertyResult> {
+    try {
+      const { path, property, value, mode = 'replace' } = params;
+
+      const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+      const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+
+      if (!file) {
+        return this.prepareResult(false, undefined,
+          `File not found: "${path}". Use searchContent to find files by name, or storageManager.list to explore folders.`
+        );
+      }
+
+      if (!(file instanceof TFile)) {
+        return this.prepareResult(false, undefined,
+          `Path is a folder, not a file: "${path}". Use storageManager.list to see its contents.`
+        );
+      }
+
+      let mergeError: string | null = null;
+
+      await this.app.fileManager.processFrontMatter(file, (frontmatter) => {
+        if (mode === 'merge') {
+          const existing = frontmatter[property];
+
+          if (existing === undefined || existing === null) {
+            frontmatter[property] = value;
+          } else if (Array.isArray(existing) && Array.isArray(value)) {
+            const merged = [...existing];
+            for (const item of value) {
+              if (!merged.includes(item)) {
+                merged.push(item);
+              }
+            }
+            frontmatter[property] = merged;
+          } else if (Array.isArray(existing) !== Array.isArray(value)) {
+            mergeError =
+              `Cannot merge: existing value is ${Array.isArray(existing) ? 'array' : 'scalar'} ` +
+              `but new value is ${Array.isArray(value) ? 'array' : 'scalar'}. ` +
+              `Use mode "replace" to overwrite, or ensure both values are the same type.`;
+            return;
+          } else {
+            // Scalar + Scalar: equivalent to replace
+            frontmatter[property] = value;
+          }
+        } else {
+          frontmatter[property] = value;
+        }
+      });
+
+      if (mergeError) {
+        return this.prepareResult(false, undefined, mergeError);
+      }
+
+      return { success: true };
+    } catch (error) {
+      return this.prepareResult(false, undefined, createErrorMessage('Error setting property: ', error));
+    }
+  }
+
+  getParameterSchema(): Record<string, unknown> {
+    const toolSchema = {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to the note file'
+        },
+        property: {
+          type: 'string',
+          description: 'Frontmatter property name (e.g. "tags", "aliases", "status")'
+        },
+        value: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'number' },
+            { type: 'boolean' },
+            { type: 'array', items: { type: 'string' } }
+          ],
+          description: 'Value to set. Can be a string, number, boolean, or array of strings.'
+        },
+        mode: {
+          type: 'string',
+          enum: ['replace', 'merge'],
+          default: 'replace',
+          description: "How to apply the value. 'replace' overwrites (default). 'merge' performs array union with dedup for list fields; equivalent to replace for scalars."
+        }
+      },
+      required: ['path', 'property', 'value']
+    };
+
+    return this.getMergedSchema(toolSchema);
+  }
+
+  getResultSchema(): Record<string, unknown> {
+    return {
+      type: 'object',
+      properties: {
+        success: {
+          type: 'boolean',
+          description: 'Whether the operation succeeded'
+        },
+        error: {
+          type: 'string',
+          description: 'Error message if failed (includes recovery guidance)'
+        }
+      },
+      required: ['success']
+    };
+  }
+}

--- a/src/agents/contentManager/types.ts
+++ b/src/agents/contentManager/types.ts
@@ -1,8 +1,29 @@
 import { CommonParameters, CommonResult } from '../../types';
 
 // ============================================================================
-// NEW SIMPLIFIED TOOLS (3 tools replacing 8)
+// NEW SIMPLIFIED TOOLS (3 tools replacing 8) + setProperty
 // ============================================================================
+
+/**
+ * Params for setting a frontmatter property on a note
+ */
+export interface SetPropertyParams extends CommonParameters {
+  /** Path to the note file */
+  path: string;
+  /** Frontmatter property name */
+  property: string;
+  /** Value to set (scalar or array) */
+  value: string | number | boolean | string[];
+  /** How to apply the value: 'replace' (default) or 'merge' (array union with dedup) */
+  mode?: 'replace' | 'merge';
+}
+
+/**
+ * Result of setting a frontmatter property
+ */
+export interface SetPropertyResult extends CommonResult {
+  // No data returned - LLM already knows the property and value it passed
+}
 
 /**
  * Params for reading content from a file


### PR DESCRIPTION
## Problem

ContentManager has no tool for manipulating frontmatter properties. The only way to update tags, aliases, or other YAML frontmatter fields is to edit the raw file content via `update` (line-based), which is fragile and requires knowing exact line numbers.

For list fields like `tags` and `aliases`, even if a `setProperty` tool existed, replacing the entire array to add a single item risks data loss from concurrent updates.

## Solution

Add a new `setProperty` tool to ContentManager with two modes:
- `"replace"` (default): sets the property value, replacing any existing value
- `"merge"`: for arrays, performs set union (append + dedup); for scalars, equivalent to replace

Uses Obsidian's `app.fileManager.processFrontMatter()` for atomic, platform-compatible frontmatter manipulation.

## Usage

```json
{"path": "note.md", "property": "tags", "value": ["new-tag"], "mode": "merge"}
```

## Behavior

| Scenario | Existing | New value | Mode | Result |
|----------|----------|-----------|------|--------|
| Append | `["a"]` | `["b"]` | merge | `["a", "b"]` |
| Dedup | `["a"]` | `["a", "b"]` | merge | `["a", "b"]` |
| New field | (none) | `["a"]` | merge | `["a"]` |
| Scalar | `"old"` | `"new"` | merge | `"new"` |
| Type mismatch | `"old"` | `["new"]` | merge | Error |
| Default | any | any | (absent) | replace |

## Files changed

- `src/agents/contentManager/tools/setProperty.ts` (new — 131 lines)
- `src/agents/contentManager/types.ts`
- `src/agents/contentManager/tools/index.ts`
- `src/agents/contentManager/contentManager.ts`

Ref: #33