### PR TITLE
feat: enrich write/update responses with verification data

### DIFF
--- a/src/agents/contentManager/tools/update.ts
+++ b/src/agents/contentManager/tools/update.ts
@@ -2,6 +2,7 @@ import { App, TFile } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { UpdateParams, UpdateResult } from '../types';
 import { ContentOperations } from '../utils/ContentOperations';
+import { WriteVerification } from '../types';
 import { createErrorMessage } from '../../../utils/errorUtils';
 import { addRecommendations, Recommendation } from '../../../utils/recommendationUtils';
 import { NudgeHelpers } from '../../../utils/nudgeHelpers';
@@ -47,6 +48,27 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
   }
 
   /**
+   * Compute verification fields for the content after an operation.
+   */
+  private async computeVerification(
+    finalContent: string,
+    affectedStart: number,
+    affectedEnd: number
+  ): Promise<WriteVerification> {
+    const totalLines = finalContent.split('\n').length;
+    const contentHash = await ContentOperations.computeContentHash(finalContent);
+    return {
+      totalLines,
+      linesAffected: {
+        start: affectedStart,
+        end: affectedEnd,
+        count: affectedEnd - affectedStart + 1
+      },
+      contentHash
+    };
+  }
+
+  /**
    * Execute the tool
    * @param params Tool parameters
    * @returns Promise that resolves with the update result
@@ -86,8 +108,14 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
 
         // Calculate linesDelta: number of lines added
         const linesAdded = content.split('\n').length;
+        const newTotalLines = newContent.split('\n').length;
+        const verification = await this.computeVerification(
+          newContent,
+          newTotalLines - linesAdded + 1,
+          newTotalLines
+        );
         // Append doesn't shift existing lines, so no hint needed
-        return { success: true, linesDelta: linesAdded };
+        return { success: true, linesDelta: linesAdded, ...verification };
       }
 
       // Validate line numbers
@@ -120,7 +148,12 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
 
         // Calculate linesDelta: number of lines inserted
         const delta = insertLines.length;
-        const result = { success: true, linesDelta: delta };
+        const verification = await this.computeVerification(
+          newContent,
+          startLine,
+          startLine + insertLines.length - 1
+        );
+        const result: UpdateResult = { success: true, linesDelta: delta, ...verification };
 
         // Add nudge if lines shifted
         const nudge = NudgeHelpers.checkLineShift(delta, startLine);
@@ -157,7 +190,12 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
 
         // Calculate linesDelta: negative (lines removed)
         const delta = -linesRemoved;
-        const result = { success: true, linesDelta: delta };
+        const verification = await this.computeVerification(
+          newContent,
+          startLine,
+          startLine  // After deletion, affected range collapses to the start point
+        );
+        const result: UpdateResult = { success: true, linesDelta: delta, ...verification };
 
         // Add nudge for line shift
         const nudge = NudgeHelpers.checkLineShift(delta, endLine);
@@ -175,7 +213,12 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
 
         // Calculate linesDelta: new lines minus removed lines
         const delta = replacementLines.length - linesRemoved;
-        const result = { success: true, linesDelta: delta };
+        const verification = await this.computeVerification(
+          newContent,
+          startLine,
+          startLine + replacementLines.length - 1
+        );
+        const result: UpdateResult = { success: true, linesDelta: delta, ...verification };
 
         // Add nudge if lines shifted
         const nudge = NudgeHelpers.checkLineShift(delta, endLine);
@@ -233,6 +276,23 @@ export class UpdateTool extends BaseTool<UpdateParams, UpdateResult> {
         linesDelta: {
           type: 'number',
           description: 'Net change in line count. Positive = lines added, negative = lines removed. Use this to adjust subsequent line numbers in multi-operation workflows.'
+        },
+        totalLines: {
+          type: 'number',
+          description: 'Total line count of the file after the update'
+        },
+        linesAffected: {
+          type: 'object',
+          properties: {
+            start: { type: 'number', description: 'First line affected (1-based)' },
+            end: { type: 'number', description: 'Last line affected (1-based)' },
+            count: { type: 'number', description: 'Number of lines affected' }
+          },
+          description: 'Range of lines affected by the operation'
+        },
+        contentHash: {
+          type: 'string',
+          description: 'SHA-256 hash of the full file content after updating (sha256:hex format). Use to verify content integrity without a follow-up read.'
         },
         recommendations: {
           type: 'array',

--- a/src/agents/contentManager/tools/write.ts
+++ b/src/agents/contentManager/tools/write.ts
@@ -86,8 +86,20 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
         await ContentOperations.createContent(this.app, path, content);
       }
 
-      // Success - LLM already knows the path and content it passed
-      return this.prepareResult(true);
+      // Compute verification data from the content we just wrote
+      const lines = content.split('\n');
+      const contentHash = await ContentOperations.computeContentHash(content);
+
+      return {
+        success: true,
+        totalLines: lines.length,
+        linesAffected: {
+          start: 1,
+          end: lines.length,
+          count: lines.length
+        },
+        contentHash
+      };
     } catch (error) {
       return this.prepareResult(false, undefined, createErrorMessage('Error writing file: ', error));
     }
@@ -132,6 +144,23 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
         success: {
           type: 'boolean',
           description: 'Whether the operation succeeded'
+        },
+        totalLines: {
+          type: 'number',
+          description: 'Total line count of the file after the write'
+        },
+        linesAffected: {
+          type: 'object',
+          properties: {
+            start: { type: 'number', description: 'First line affected (1-based)' },
+            end: { type: 'number', description: 'Last line affected (1-based)' },
+            count: { type: 'number', description: 'Number of lines affected' }
+          },
+          description: 'Range of lines affected (entire file for write operations)'
+        },
+        contentHash: {
+          type: 'string',
+          description: 'SHA-256 hash of the full file content after writing (sha256:hex format). Use to verify content integrity without a follow-up read.'
         },
         error: {
           type: 'string',

--- a/src/agents/contentManager/types.ts
+++ b/src/agents/contentManager/types.ts
@@ -72,10 +72,26 @@ export interface WriteParams extends CommonParameters {
 }
 
 /**
+ * Verification data returned after write/update operations.
+ * Eliminates the need for a follow-up read to confirm the operation landed correctly.
+ */
+export interface WriteVerification {
+  /** Total line count of the file after the operation */
+  totalLines?: number;
+  /** Range of lines affected by the operation */
+  linesAffected?: {
+    start: number;
+    end: number;
+    count: number;
+  };
+  /** SHA-256 hash of the full file content after the operation */
+  contentHash?: string;
+}
+
+/**
  * Result of writing content to a file
  */
-export interface WriteResult extends CommonResult {
-  // No data returned - LLM already knows the path and content it passed
+export interface WriteResult extends CommonResult, WriteVerification {
 }
 
 /**
@@ -106,7 +122,7 @@ export interface UpdateParams extends CommonParameters {
 /**
  * Result of updating content in a file
  */
-export interface UpdateResult extends CommonResult {
+export interface UpdateResult extends CommonResult, WriteVerification {
   /**
    * Net change in line count after the operation.
    * Positive = lines added, Negative = lines removed, Zero = no change.

--- a/src/agents/contentManager/utils/ContentOperations.ts
+++ b/src/agents/contentManager/utils/ContentOperations.ts
@@ -497,6 +497,20 @@ export class ContentOperations {
   }
 
   /**
+   * Compute SHA-256 hash of content using Web Crypto API (mobile-compatible).
+   * @param content The string to hash
+   * @returns Promise resolving to "sha256:<hex>" string
+   */
+  static async computeContentHash(content: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(content);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+    return `sha256:${hex}`;
+  }
+
+  /**
    * Escape special characters in a string for use in a regular expression
    * @param string String to escape
    * @returns Escaped string


### PR DESCRIPTION
## Problem

After every `write` or `update`, consumers must immediately `read` the file back to confirm the operation landed correctly. This doubles tool calls and adds latency to every write flow.

## Solution

Enrich the response object of `write` and `update` with verification data:
- `totalLines`: line count after operation
- `linesAffected`: `{start, end, count}` identifying which lines were modified
- `contentHash`: SHA-256 hash of file content after write (format: `sha256:<hex>`)

All fields are additive and optional — existing consumers are unaffected.

Uses Web Crypto API (`crypto.subtle.digest`) for hashing, consistent with the project's existing pattern (`CacheManager.ts`, `PKCEUtils.ts`). Mobile-compatible, no `node:crypto` dependency.

## Usage

After a successful update, the response includes:
```json
{
  "success": true,
  "totalLines": 42,
  "linesAffected": {"start": 5, "end": 8, "count": 4},
  "contentHash": "sha256:a1b2c3..."
}
```

Consumers can verify the operation without a follow-up read.

## Files changed

- `src/agents/contentManager/types.ts` (new `WriteVerification` interface)
- `src/agents/contentManager/tools/write.ts`
- `src/agents/contentManager/tools/update.ts`
- `src/agents/contentManager/services/ContentOperations.ts` (`computeContentHash` helper)

Ref: #33