### PR TITLE
Add GPT-5.4 model support

### DIFF
--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -189,6 +189,24 @@ export class ChatSettingsRenderer {
     return !!(codexConfig?.oauth?.connected && codexConfig?.apiKey);
   }
 
+  private buildModelOptionKey(provider: string, modelId: string): string {
+    return `${provider}::${modelId}`;
+  }
+
+  private async getDisplayModelsForProvider(providerId: string): Promise<Array<{ id: string; name: string; provider: string }>> {
+    let models = await this.providerManager.getModelsForProvider(providerId);
+
+    if (providerId === 'openai' && this.isCodexConnected()) {
+      const codexModels = await this.providerManager.getModelsForProvider('openai-codex');
+      models = [
+        ...models,
+        ...codexModels.map(model => ({ ...model, name: `${model.name} (ChatGPT)` }))
+      ];
+    }
+
+    return models;
+  }
+
   // ========== MODEL SECTION ==========
 
   private renderModelSection(parent: HTMLElement): void {
@@ -259,38 +277,27 @@ export class ChatSettingsRenderer {
 
           try {
             this.modelOptionMap.clear();
-            let models = await this.providerManager.getModelsForProvider(modelProviderId);
-
-            // Merge Codex models into OpenAI list when Codex OAuth is connected
-            if (modelProviderId === 'openai' && this.isCodexConnected()) {
-              const codexModels = await this.providerManager.getModelsForProvider('openai-codex');
-              const openaiModelIds = new Set(models.map(m => m.id));
-              for (const cm of codexModels) {
-                // Skip duplicates (same model ID available in both providers)
-                if (!openaiModelIds.has(cm.id)) {
-                  models = [...models, { ...cm, name: `${cm.name} (ChatGPT)` }];
-                }
-              }
-            }
-
+            const models = await this.getDisplayModelsForProvider(modelProviderId);
 
             if (models.length === 0) {
               dropdown.addOption('', 'No models available');
             } else {
               models.forEach(model => {
-                const optionKey = model.id;
+                const optionKey = this.buildModelOptionKey(model.provider, model.id);
                 this.modelOptionMap.set(optionKey, { provider: model.provider, modelId: model.id });
                 dropdown.addOption(optionKey, model.name);
               });
 
-              const exists = models.some(m => m.id === this.settings.model);
+              const selectedOptionKey = this.buildModelOptionKey(this.settings.provider, this.settings.model);
+              const exists = this.modelOptionMap.has(selectedOptionKey);
               if (exists) {
-                dropdown.setValue(this.settings.model);
+                dropdown.setValue(selectedOptionKey);
               } else if (models.length > 0) {
-                const firstEntry = this.modelOptionMap.get(models[0].id);
+                const firstOptionKey = this.buildModelOptionKey(models[0].provider, models[0].id);
+                const firstEntry = this.modelOptionMap.get(firstOptionKey);
                 this.settings.model = models[0].id;
                 if (firstEntry) this.settings.provider = firstEntry.provider;
-                dropdown.setValue(this.settings.model);
+                dropdown.setValue(firstOptionKey);
               }
             }
 
@@ -426,36 +433,29 @@ export class ChatSettingsRenderer {
 
         try {
           this.agentModelOptionMap.clear();
-          let models = await this.providerManager.getModelsForProvider(agentModelProviderId);
-
-          // Merge Codex models into OpenAI list when Codex OAuth is connected
-          if (agentModelProviderId === 'openai' && this.isCodexConnected()) {
-            const codexModels = await this.providerManager.getModelsForProvider('openai-codex');
-            const openaiModelIds = new Set(models.map(m => m.id));
-            for (const cm of codexModels) {
-              if (!openaiModelIds.has(cm.id)) {
-                models = [...models, { ...cm, name: `${cm.name} (ChatGPT)` }];
-              }
-            }
-          }
+          const models = await this.getDisplayModelsForProvider(agentModelProviderId);
 
           if (models.length === 0) {
             dropdown.addOption('', 'No models available');
           } else {
             models.forEach(model => {
-              const optionKey = model.id;
+              const optionKey = this.buildModelOptionKey(model.provider, model.id);
               this.agentModelOptionMap.set(optionKey, { provider: model.provider, modelId: model.id });
               dropdown.addOption(optionKey, model.name);
             });
 
-            const exists = models.some(m => m.id === this.settings.agentModel);
+            const selectedOptionKey = this.settings.agentProvider && this.settings.agentModel
+              ? this.buildModelOptionKey(this.settings.agentProvider, this.settings.agentModel)
+              : '';
+            const exists = selectedOptionKey ? this.agentModelOptionMap.has(selectedOptionKey) : false;
             if (exists) {
-              dropdown.setValue(this.settings.agentModel!);
+              dropdown.setValue(selectedOptionKey);
             } else if (models.length > 0) {
-              const firstEntry = this.agentModelOptionMap.get(models[0].id);
+              const firstOptionKey = this.buildModelOptionKey(models[0].provider, models[0].id);
+              const firstEntry = this.agentModelOptionMap.get(firstOptionKey);
               this.settings.agentModel = models[0].id;
               if (firstEntry) this.settings.agentProvider = firstEntry.provider;
-              dropdown.setValue(this.settings.agentModel);
+              dropdown.setValue(firstOptionKey);
             }
           }
 

--- a/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
@@ -88,7 +88,7 @@ export class OpenAICodexAdapter extends BaseAdapter {
    */
   constructor(tokens: CodexOAuthTokens, onTokenRefresh?: TokenPersistCallback) {
     // Pass accessToken as apiKey for BaseAdapter compatibility; baseUrl is the Codex endpoint
-    super(tokens.accessToken, 'gpt-5.3-codex', CODEX_API_ENDPOINT, false);
+    super(tokens.accessToken, 'gpt-5.4', CODEX_API_ENDPOINT, false);
     this.tokens = { ...tokens };
     this.onTokenRefresh = onTokenRefresh;
     this.initializeCache();
@@ -502,13 +502,14 @@ export class OpenAICodexAdapter extends BaseAdapter {
       supportsJSON: true,
       supportsImages: true,
       supportsFunctions: true,
-      supportsThinking: false,
-      maxContextWindow: 400000,
+      supportsThinking: true,
+      maxContextWindow: 1050000,
       supportedFeatures: [
         'streaming',
         'json_mode',
         'image_input',
         'tool_calling',
+        'thinking_models',
         'subscription_based',
         'oauth_required'
       ]

--- a/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
@@ -14,6 +14,22 @@ import { ModelSpec } from '../modelTypes';
 export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   {
     provider: 'openai-codex',
+    name: 'GPT-5.4',
+    apiName: 'gpt-5.4',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai-codex',
     name: 'GPT-5.3 Codex',
     apiName: 'gpt-5.3-codex',
     contextWindow: 400000,
@@ -110,4 +126,4 @@ export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   }
 ];
 
-export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.3-codex';
+export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.4';

--- a/src/services/llm/adapters/openai/DeepResearchHandler.ts
+++ b/src/services/llm/adapters/openai/DeepResearchHandler.ts
@@ -21,7 +21,9 @@ export class DeepResearchHandler {
   ) {}
 
   isDeepResearchModel(model: string): boolean {
-    return model.includes('deep-research') || model.includes('gpt-5.2-pro');
+    return model.includes('deep-research')
+      || model.includes('gpt-5.2-pro')
+      || model.includes('gpt-5.4-pro');
   }
 
   async generate(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
@@ -95,7 +97,11 @@ export class DeepResearchHandler {
 
   private async pollForCompletion(responseId: string, model: string, maxWaitTime = 300000): Promise<any> {
     const startTime = Date.now();
-    const pollInterval = (model.includes('o4-mini') || model.includes('gpt-5.2-pro')) ? 2000 : 5000;
+    const pollInterval = (
+      model.includes('o4-mini')
+      || model.includes('gpt-5.2-pro')
+      || model.includes('gpt-5.4-pro')
+    ) ? 2000 : 5000;
 
     while (Date.now() - startTime < maxWaitTime) {
       try {

--- a/src/services/llm/adapters/openai/OpenAIAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAIAdapter.ts
@@ -29,7 +29,7 @@ export class OpenAIAdapter extends BaseAdapter {
   private deepResearch: DeepResearchHandler;
 
   constructor(apiKey: string) {
-    super(apiKey, 'gpt-5');
+    super(apiKey, 'gpt-5.4');
     this.deepResearch = new DeepResearchHandler(this.apiKey, this.baseUrl);
     this.initializeCache();
   }
@@ -536,7 +536,7 @@ export class OpenAIAdapter extends BaseAdapter {
       supportsFunctions: true,
       supportsThinking: true,
       supportsImageGeneration: true,
-      maxContextWindow: 2000000, // GPT-5 context window
+      maxContextWindow: 1050000, // GPT-5.4/GPT-5.4 Pro context window
       supportedFeatures: [
         'streaming',
         'json_mode',

--- a/src/services/llm/adapters/openai/OpenAIModels.ts
+++ b/src/services/llm/adapters/openai/OpenAIModels.ts
@@ -1,6 +1,6 @@
 /**
  * OpenAI Model Specifications
- * Updated March 2026 - Added GPT-5.3 family
+ * Updated March 2026 - Added GPT-5.4 family
  *
  * Pricing Notes:
  * - GPT-5 family supports 90% caching discount (cached tokens: $0.125/M vs $1.25/M fresh)
@@ -13,7 +13,41 @@
 import { ModelSpec } from '../modelTypes';
 
 export const OPENAI_MODELS: ModelSpec[] = [
-  // GPT-5.3 family (latest models)
+  // GPT-5.4 family (latest models)
+  {
+    provider: 'openai',
+    name: 'GPT-5.4',
+    apiName: 'gpt-5.4',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 2.50,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai',
+    name: 'GPT-5.4 Pro',
+    apiName: 'gpt-5.4-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 30.00,
+    outputCostPerMillion: 180.00,
+    capabilities: {
+      supportsJSON: false,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // GPT-5.3 family
   {
     provider: 'openai',
     name: 'GPT-5.3 Chat',
@@ -151,4 +185,4 @@ export const OPENAI_MODELS: ModelSpec[] = [
   // These models use a different parameter structure and would need special handling
 ];
 
-export const OPENAI_DEFAULT_MODEL = 'gpt-5.1-2025-11-13';
+export const OPENAI_DEFAULT_MODEL = 'gpt-5.4';

--- a/tests/unit/OpenAICodexAdapter.test.ts
+++ b/tests/unit/OpenAICodexAdapter.test.ts
@@ -105,7 +105,7 @@ describe('OpenAICodexAdapter', () => {
 
     expect(request.headers.Authorization).toBe('Bearer test-access-token');
     expect(request.headers['ChatGPT-Account-Id']).toBe('acct-test-123');
-    expect(body.model).toBe('gpt-5.3-codex');
+    expect(body.model).toBe('gpt-5.4');
     expect(body.stream).toBe(true);
     expect(body.tool_choice).toBe('auto');
     expect(body.instructions).toContain('System message');
@@ -268,8 +268,10 @@ describe('OpenAICodexAdapter', () => {
     expect(capabilities.supportsStreaming).toBe(true);
     expect(capabilities.supportsFunctions).toBe(true);
     expect(capabilities.supportsImages).toBe(true);
-    expect(capabilities.maxContextWindow).toBe(400000);
+    expect(capabilities.supportsThinking).toBe(true);
+    expect(capabilities.maxContextWindow).toBe(1050000);
     expect(capabilities.supportedFeatures).toContain('tool_calling');
+    expect(capabilities.supportedFeatures).toContain('thinking_models');
     expect(capabilities.supportedFeatures).toContain('oauth_required');
   });
 


### PR DESCRIPTION
## Summary
- add GPT-5.4 and GPT-5.4 Pro to the standard OpenAI model registry and make GPT-5.4 the default OpenAI model
- add GPT-5.4 to the ChatGPT-authenticated model registry and make it the default ChatGPT-auth model
- route GPT-5.4 Pro through the existing background polling path and fix dropdown merging so OpenAI and ChatGPT variants with the same model ID both remain visible

## Testing
- npm run build