### PR TITLE
Fix workspace archive persistence

### DIFF
--- a/src/agents/memoryManager/tools/workspaces/archiveWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/archiveWorkspace.ts
@@ -80,7 +80,21 @@ export class ArchiveWorkspaceTool extends BaseTool<ArchiveWorkspaceParameters, A
             // Perform the update
             await workspaceService.updateWorkspace(existingWorkspace.id, workspaceCopy);
 
-            // Success - LLM already knows what it passed
+            const persistedWorkspace = await workspaceService.getWorkspaceByNameOrId(existingWorkspace.id);
+            const expectedArchivedState = !isRestore;
+
+            if (!persistedWorkspace) {
+                return this.prepareResult(false, undefined, `Workspace "${params.name}" could not be reloaded after ${isRestore ? 'restore' : 'archive'}.`);
+            }
+
+            if (persistedWorkspace.isArchived !== expectedArchivedState) {
+                return this.prepareResult(
+                    false,
+                    undefined,
+                    `Workspace "${params.name}" was not ${isRestore ? 'restored' : 'archived'} successfully. Persisted archive state did not change.`
+                );
+            }
+
             return this.prepareResult(true);
 
         } catch (error) {

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -72,6 +72,8 @@ export interface WorkspaceCreatedEvent extends BaseStorageEvent {
     created: number;
     /** Whether this workspace is active (defaults to true) */
     isActive?: boolean;
+    /** Whether this workspace is archived */
+    isArchived?: boolean;
     /** Optional dedicated agent ID */
     dedicatedAgentId?: string;
     /** JSON-serialized workspace context */
@@ -95,6 +97,7 @@ export interface WorkspaceUpdatedEvent extends BaseStorageEvent {
     rootFolder: string;
     lastAccessed: number;
     isActive: boolean;
+    isArchived: boolean;
     dedicatedAgentId: string;
     contextJson: string;
   }>;

--- a/src/database/migration/WorkspaceMigrator.ts
+++ b/src/database/migration/WorkspaceMigrator.ts
@@ -90,6 +90,7 @@ export class WorkspaceMigrator extends BaseMigrator<WorkspaceMigrationResult> {
         created: workspace.created,
         // Default to true if not specified (workspaces should be active by default)
         isActive: workspace.isActive !== undefined ? workspace.isActive : true,
+        isArchived: workspace.isArchived,
         contextJson: workspace.context ? JSON.stringify(workspace.context) : undefined,
       },
     } as Omit<WorkspaceCreatedEvent, 'id' | 'deviceId' | 'timestamp'>);

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -92,6 +92,8 @@ export class WorkspaceRepository
               description: data.description,
               rootFolder: data.rootFolder,
               created: data.created ?? now,
+              isActive: data.isActive,
+              isArchived: data.isArchived,
               dedicatedAgentId: data.dedicatedAgentId,
               contextJson
             }
@@ -100,8 +102,8 @@ export class WorkspaceRepository
 
         // 2. Update SQLite cache
         await this.sqliteCache.run(
-          `INSERT INTO workspaces (id, name, description, rootFolder, created, lastAccessed, isActive, dedicatedAgentId, contextJson)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO workspaces (id, name, description, rootFolder, created, lastAccessed, isActive, isArchived, dedicatedAgentId, contextJson)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
           [
             id,
             data.name,
@@ -111,6 +113,7 @@ export class WorkspaceRepository
             now,
             // Default to 1 (active) if not specified
             data.isActive !== undefined ? (data.isActive ? 1 : 0) : 1,
+            data.isArchived !== undefined ? (data.isArchived ? 1 : 0) : 0,
             data.dedicatedAgentId ?? null,
             contextJson ?? null  // SQLite needs null, not undefined
           ]
@@ -132,13 +135,14 @@ export class WorkspaceRepository
     try {
       await this.transaction(async () => {
         // 1. Write event to JSONL
-        const eventData: Partial<{ name: string; description: string; rootFolder: string; lastAccessed: number; isActive: boolean; dedicatedAgentId: string; contextJson: string }> = {
+        const eventData: Partial<{ name: string; description: string; rootFolder: string; lastAccessed: number; isActive: boolean; isArchived: boolean; dedicatedAgentId: string; contextJson: string }> = {
           lastAccessed: data.lastAccessed ?? Date.now()
         };
         if (data.name !== undefined) eventData.name = data.name;
         if (data.description !== undefined) eventData.description = data.description;
         if (data.rootFolder !== undefined) eventData.rootFolder = data.rootFolder;
         if (data.isActive !== undefined) eventData.isActive = data.isActive;
+        if (data.isArchived !== undefined) eventData.isArchived = data.isArchived;
         if (data.dedicatedAgentId !== undefined) eventData.dedicatedAgentId = data.dedicatedAgentId;
         if (data.context !== undefined) eventData.contextJson = JSON.stringify(data.context);
 
@@ -170,6 +174,10 @@ export class WorkspaceRepository
         if (data.isActive !== undefined) {
           setClauses.push('isActive = ?');
           params.push(data.isActive ? 1 : 0);
+        }
+        if (data.isArchived !== undefined) {
+          setClauses.push('isArchived = ?');
+          params.push(data.isArchived ? 1 : 0);
         }
         if (data.dedicatedAgentId !== undefined) {
           setClauses.push('dedicatedAgentId = ?');
@@ -236,6 +244,10 @@ export class WorkspaceRepository
         conditions.push('isActive = ?');
         params.push(criteria.isActive ? 1 : 0);
       }
+      if (criteria.isArchived !== undefined) {
+        conditions.push('isArchived = ?');
+        params.push(criteria.isArchived ? 1 : 0);
+      }
       if (conditions.length > 0) {
         sql += ` WHERE ${conditions.join(' AND ')}`;
       }
@@ -250,7 +262,7 @@ export class WorkspaceRepository
   // ============================================================================
 
   async getWorkspaces(options?: QueryOptions): Promise<PaginatedResult<WorkspaceMetadata>> {
-    const ALLOWED_SORT_COLUMNS = ['id', 'name', 'created', 'lastAccessed', 'isActive', 'rootFolder'] as const;
+    const ALLOWED_SORT_COLUMNS = ['id', 'name', 'created', 'lastAccessed', 'isActive', 'isArchived', 'rootFolder'] as const;
     const ALLOWED_SORT_ORDERS = ['asc', 'desc'] as const;
 
     const requestedSort = options?.sortBy ?? 'lastAccessed';
@@ -273,6 +285,10 @@ export class WorkspaceRepository
       if (options.filter.isActive !== undefined) {
         filters.push('isActive = ?');
         params.push(options.filter.isActive ? 1 : 0);
+      }
+      if (options.filter.isArchived !== undefined) {
+        filters.push('isArchived = ?');
+        params.push(options.filter.isArchived ? 1 : 0);
       }
       if (filters.length > 0) {
         whereClause = `WHERE ${filters.join(' AND ')}`;
@@ -355,6 +371,7 @@ export class WorkspaceRepository
       created: row.created,
       lastAccessed: row.lastAccessed,
       isActive: row.isActive === 1,
+      isArchived: row.isArchived === 1,
       dedicatedAgentId: row.dedicatedAgentId ?? undefined,
       context
     };

--- a/src/database/repositories/interfaces/IWorkspaceRepository.ts
+++ b/src/database/repositories/interfaces/IWorkspaceRepository.ts
@@ -27,6 +27,7 @@ export interface CreateWorkspaceData {
   rootFolder: string;
   created?: number;
   isActive?: boolean;
+  isArchived?: boolean;
   dedicatedAgentId?: string;
   /** Workspace context (purpose, workflows, keyFiles, etc.) */
   context?: WorkspaceContext;
@@ -41,6 +42,7 @@ export interface UpdateWorkspaceData {
   rootFolder?: string;
   lastAccessed?: number;
   isActive?: boolean;
+  isArchived?: boolean;
   dedicatedAgentId?: string;
   /** Workspace context (purpose, workflows, keyFiles, etc.) */
   context?: WorkspaceContext;

--- a/src/database/schema/SchemaMigrator.ts
+++ b/src/database/schema/SchemaMigrator.ts
@@ -73,7 +73,7 @@ export interface MigratableDatabase {
 // Alias for backward compatibility
 type Database = MigratableDatabase;
 
-export const CURRENT_SCHEMA_VERSION = 10;
+export const CURRENT_SCHEMA_VERSION = 11;
 
 export interface Migration {
   version: number;
@@ -380,6 +380,16 @@ export const MIGRATIONS: Migration[] = [
         }
       }
     }
+  },
+
+  // Version 10 -> 11: Add workspace archive flag
+  {
+    version: 11,
+    description: 'Add isArchived column to workspaces table for soft-delete persistence',
+    sql: [
+      'ALTER TABLE workspaces ADD COLUMN isArchived INTEGER DEFAULT 0',
+      'CREATE INDEX IF NOT EXISTS idx_workspaces_archived ON workspaces(isArchived)'
+    ]
   },
 ];
 

--- a/src/database/schema/schema.ts
+++ b/src/database/schema/schema.ts
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
   created INTEGER NOT NULL,
   lastAccessed INTEGER NOT NULL,
   isActive INTEGER DEFAULT 1,
+  isArchived INTEGER DEFAULT 0,
   contextJson TEXT,
   dedicatedAgentId TEXT,
   UNIQUE(name)
@@ -37,6 +38,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
 CREATE INDEX IF NOT EXISTS idx_workspaces_name ON workspaces(name);
 CREATE INDEX IF NOT EXISTS idx_workspaces_folder ON workspaces(rootFolder);
 CREATE INDEX IF NOT EXISTS idx_workspaces_active ON workspaces(isActive);
+CREATE INDEX IF NOT EXISTS idx_workspaces_archived ON workspaces(isArchived);
 CREATE INDEX IF NOT EXISTS idx_workspaces_accessed ON workspaces(lastAccessed);
 
 -- ==================== SESSIONS ====================

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -75,8 +75,8 @@ export class WorkspaceEventApplier {
 
     await this.sqliteCache.run(
       `INSERT OR REPLACE INTO workspaces
-       (id, name, description, rootFolder, created, lastAccessed, isActive, contextJson, dedicatedAgentId)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (id, name, description, rootFolder, created, lastAccessed, isActive, isArchived, contextJson, dedicatedAgentId)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         event.data.id,
         event.data.name,
@@ -86,6 +86,7 @@ export class WorkspaceEventApplier {
         event.data.created ?? Date.now(),
         // Default to 1 (active) if not specified
         event.data.isActive !== undefined ? (event.data.isActive ? 1 : 0) : 1,
+        event.data.isArchived !== undefined ? (event.data.isArchived ? 1 : 0) : 0,
         event.data.contextJson ?? null,
         event.data.dedicatedAgentId ?? null
       ]
@@ -105,6 +106,7 @@ export class WorkspaceEventApplier {
     if (event.data.rootFolder !== undefined) { updates.push('rootFolder = ?'); values.push(event.data.rootFolder); }
     if (event.data.lastAccessed !== undefined) { updates.push('lastAccessed = ?'); values.push(event.data.lastAccessed); }
     if (event.data.isActive !== undefined) { updates.push('isActive = ?'); values.push(event.data.isActive ? 1 : 0); }
+    if (event.data.isArchived !== undefined) { updates.push('isArchived = ?'); values.push(event.data.isArchived ? 1 : 0); }
     if (event.data.contextJson !== undefined) { updates.push('contextJson = ?'); values.push(event.data.contextJson); }
     if (event.data.dedicatedAgentId !== undefined) { updates.push('dedicatedAgentId = ?'); values.push(event.data.dedicatedAgentId); }
 

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -162,6 +162,7 @@ export class WorkspaceService {
           created: metadata.created,
           lastAccessed: metadata.lastAccessed,
           isActive: metadata.isActive,
+          isArchived: metadata.isArchived,
           dedicatedAgentId: metadata.dedicatedAgentId,
           context: metadata.context ? normalizeWorkspaceContext(metadata.context).context : metadata.context,
           sessions: {}
@@ -203,6 +204,7 @@ export class WorkspaceService {
             created: w.created,
             lastAccessed: w.lastAccessed,
             isActive: w.isActive,
+            isArchived: w.isArchived,
             dedicatedAgentId: w.dedicatedAgentId,
             context: w.context ? normalizeWorkspaceContext(w.context).context : w.context,
             sessions: {}
@@ -247,6 +249,7 @@ export class WorkspaceService {
         created: data.created || Date.now(),
         lastAccessed: data.lastAccessed || Date.now(),
         isActive: data.isActive ?? true,
+        isArchived: data.isArchived,
         dedicatedAgentId: data.dedicatedAgentId, // Pass through dedicatedAgentId
         context: hybridContext
       };
@@ -261,6 +264,7 @@ export class WorkspaceService {
         created: hybridData.created,
         lastAccessed: hybridData.lastAccessed,
         isActive: hybridData.isActive,
+        isArchived: hybridData.isArchived,
         context: data.context,
         sessions: {}
       };

--- a/src/services/helpers/WorkspaceTypeConverters.ts
+++ b/src/services/helpers/WorkspaceTypeConverters.ts
@@ -18,6 +18,7 @@ export function convertWorkspaceMetadata(hybrid: HybridTypes.WorkspaceMetadata):
     created: hybrid.created,
     lastAccessed: hybrid.lastAccessed,
     isActive: hybrid.isActive,
+    isArchived: hybrid.isArchived,
     sessionCount: 0, // Will be calculated if needed
     traceCount: 0    // Will be calculated if needed
   };

--- a/src/types/storage/StorageTypes.ts
+++ b/src/types/storage/StorageTypes.ts
@@ -222,6 +222,7 @@ export interface WorkspaceMetadata {
   created: number;
   lastAccessed: number;
   isActive?: boolean;
+  isArchived?: boolean;
   sessionCount: number;
   traceCount: number;
 }

--- a/tests/unit/WorkspaceArchive.test.ts
+++ b/tests/unit/WorkspaceArchive.test.ts
@@ -1,0 +1,159 @@
+import { App } from 'obsidian';
+import { ArchiveWorkspaceTool } from '../../src/agents/memoryManager/tools/workspaces/archiveWorkspace';
+import type { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import type { IStorageAdapter, QueryOptions } from '../../src/database/interfaces/IStorageAdapter';
+import { WorkspaceService } from '../../src/services/WorkspaceService';
+import type { PaginatedResult } from '../../src/types/pagination/PaginationTypes';
+import type { WorkspaceMetadata as HybridWorkspaceMetadata } from '../../src/types/storage/HybridStorageTypes';
+import type { IndividualWorkspace } from '../../src/types/storage/StorageTypes';
+
+function createPaginatedResult<T>(items: T[]): PaginatedResult<T> {
+  return {
+    items,
+    page: 0,
+    pageSize: items.length || 10,
+    totalItems: items.length,
+    totalPages: items.length === 0 ? 0 : 1,
+    hasNextPage: false,
+    hasPreviousPage: false
+  };
+}
+
+function createHybridWorkspace(overrides: Partial<HybridWorkspaceMetadata> = {}): HybridWorkspaceMetadata {
+  return {
+    id: 'ws-1',
+    name: 'Workspace',
+    rootFolder: '/',
+    created: 1,
+    lastAccessed: 1,
+    isActive: true,
+    ...overrides
+  };
+}
+
+function createIndividualWorkspace(overrides: Partial<IndividualWorkspace> = {}): IndividualWorkspace {
+  return {
+    id: 'ws-1',
+    name: 'Workspace',
+    rootFolder: '/',
+    created: 1,
+    lastAccessed: 1,
+    isActive: true,
+    sessions: {},
+    ...overrides
+  };
+}
+
+function createWorkspaceServiceWithAdapter(adapter: IStorageAdapter): WorkspaceService {
+  return new WorkspaceService(
+    {} as never,
+    {} as never,
+    {} as never,
+    adapter
+  );
+}
+
+describe('Workspace archive state', () => {
+  it('preserves isArchived on hybrid list and lookup paths', async () => {
+    const archivedWorkspace = createHybridWorkspace({
+      id: 'ws-archived',
+      name: 'Archived Workspace',
+      isArchived: true
+    });
+
+    const getWorkspace = jest.fn().mockImplementation(async (id: string) => {
+      return id === archivedWorkspace.id ? archivedWorkspace : null;
+    });
+
+    const getWorkspaces = jest.fn().mockImplementation(async (options?: QueryOptions) => {
+      if (options?.search === archivedWorkspace.name) {
+        return createPaginatedResult([archivedWorkspace]);
+      }
+
+      return createPaginatedResult([archivedWorkspace]);
+    });
+
+    const adapter = {
+      isReady: jest.fn().mockReturnValue(true),
+      getWorkspace,
+      getWorkspaces
+    } as unknown as IStorageAdapter;
+
+    const workspaceService = createWorkspaceServiceWithAdapter(adapter);
+
+    const listed = await workspaceService.getWorkspaces();
+    expect(listed).toHaveLength(1);
+    expect(listed[0].isArchived).toBe(true);
+
+    const loaded = await workspaceService.getWorkspaceByNameOrId('Archived Workspace');
+    expect(loaded?.id).toBe('ws-archived');
+    expect(loaded?.isArchived).toBe(true);
+    expect(getWorkspaces).toHaveBeenCalledWith(expect.objectContaining({ search: 'Archived Workspace' }));
+  });
+
+  it('returns failure when archive state does not persist after update', async () => {
+    const existingWorkspace = createIndividualWorkspace({ name: 'Workspace', isArchived: false });
+
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn()
+        .mockResolvedValueOnce(existingWorkspace)
+        .mockResolvedValueOnce({ ...existingWorkspace, lastAccessed: 2, isArchived: false }),
+      updateWorkspace: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const tool = new ArchiveWorkspaceTool({
+      getApp: () => new App()
+    } as MemoryManagerAgent);
+
+    (tool as unknown as {
+      serviceIntegration: {
+        getWorkspaceService: () => Promise<{ success: boolean; service: typeof workspaceService }>;
+      };
+    }).serviceIntegration = {
+      getWorkspaceService: jest.fn().mockResolvedValue({
+        success: true,
+        service: workspaceService
+      })
+    };
+
+    const result = await tool.execute({ name: 'Workspace' });
+
+    expect(workspaceService.updateWorkspace).toHaveBeenCalledWith(
+      'ws-1',
+      expect.objectContaining({ isArchived: true })
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Persisted archive state did not change');
+  });
+
+  it('returns success when archive state persists after update', async () => {
+    const existingWorkspace = createIndividualWorkspace({ name: 'Workspace', isArchived: false });
+
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn()
+        .mockResolvedValueOnce(existingWorkspace)
+        .mockResolvedValueOnce({ ...existingWorkspace, lastAccessed: 2, isArchived: true }),
+      updateWorkspace: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const tool = new ArchiveWorkspaceTool({
+      getApp: () => new App()
+    } as MemoryManagerAgent);
+
+    (tool as unknown as {
+      serviceIntegration: {
+        getWorkspaceService: () => Promise<{ success: boolean; service: typeof workspaceService }>;
+      };
+    }).serviceIntegration = {
+      getWorkspaceService: jest.fn().mockResolvedValue({
+        success: true,
+        service: workspaceService
+      })
+    };
+
+    const result = await tool.execute({ name: 'Workspace' });
+
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/tests/unit/WorkspaceRepository.test.ts
+++ b/tests/unit/WorkspaceRepository.test.ts
@@ -1,0 +1,109 @@
+import { WorkspaceRepository } from '../../src/database/repositories/WorkspaceRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+
+function createMockDeps(): RepositoryDependencies {
+  return {
+    sqliteCache: {
+      queryOne: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      run: jest.fn(),
+      transaction: jest.fn((fn: () => Promise<unknown>) => fn())
+    } as never,
+    jsonlWriter: {
+      appendEvent: jest.fn().mockResolvedValue({
+        id: 'evt-1',
+        type: 'workspace_updated',
+        timestamp: Date.now(),
+        deviceId: 'dev-1'
+      })
+    } as never,
+    queryCache: {
+      cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+      invalidateByType: jest.fn(),
+      invalidateById: jest.fn(),
+      invalidate: jest.fn()
+    } as never
+  };
+}
+
+describe('WorkspaceRepository', () => {
+  let repo: WorkspaceRepository;
+  let deps: RepositoryDependencies;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    repo = new WorkspaceRepository(deps);
+  });
+
+  it('persists isArchived on create', async () => {
+    await repo.create({
+      name: 'Archived Workspace',
+      rootFolder: '/',
+      isArchived: true
+    });
+
+    expect(deps.jsonlWriter.appendEvent).toHaveBeenCalledWith(
+      expect.stringContaining('workspaces/ws_'),
+      expect.objectContaining({
+        type: 'workspace_created',
+        data: expect.objectContaining({ isArchived: true })
+      })
+    );
+
+    expect(deps.sqliteCache.run).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO workspaces'),
+      expect.arrayContaining([1, 1])
+    );
+  });
+
+  it('persists isArchived on update', async () => {
+    await repo.update('ws-1', { isArchived: true, lastAccessed: 123 });
+
+    expect(deps.jsonlWriter.appendEvent).toHaveBeenCalledWith(
+      'workspaces/ws_ws-1.jsonl',
+      expect.objectContaining({
+        type: 'workspace_updated',
+        workspaceId: 'ws-1',
+        data: expect.objectContaining({
+          isArchived: true,
+          lastAccessed: 123
+        })
+      })
+    );
+
+    expect(deps.sqliteCache.run).toHaveBeenCalledWith(
+      expect.stringContaining('isArchived = ?'),
+      expect.arrayContaining([1, 123, 'ws-1'])
+    );
+  });
+
+  it('hydrates isArchived from SQLite rows', async () => {
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+      id: 'ws-1',
+      name: 'Workspace',
+      description: null,
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 2,
+      isActive: 1,
+      isArchived: 1,
+      dedicatedAgentId: null,
+      contextJson: null
+    });
+
+    const workspace = await repo.getById('ws-1');
+
+    expect(workspace?.isArchived).toBe(true);
+  });
+
+  it('supports filtering by isArchived', async () => {
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({ count: 0 });
+
+    await repo.getWorkspaces({ filter: { isArchived: true } });
+
+    expect(deps.sqliteCache.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('isArchived = ?'),
+      [1]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- persist workspace archive state through the hybrid repository, sync applier, and SQLite schema/migration paths
- keep WorkspaceService and archiveWorkspace aligned with the archived flag and fail loudly if persistence does not stick
- add regression tests for workspace archive persistence and archive tool verification

## Testing
- npm test -- tests/unit/WorkspaceArchive.test.ts tests/unit/WorkspaceRepository.test.ts
- npm run build (passed earlier in the original worktree; the clean worktree hits a local esbuild alias resolution issue because the plugin's node_modules alias is relative to the primary repo path)