### PR TITLE
Add Claude Code MCP integration

### DIFF
--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -157,22 +157,50 @@ export class ChatSettingsRenderer {
 
   private getEnabledProviders(): string[] {
     const llmSettings = this.config.llmProviderSettings;
-    return Object.keys(llmSettings.providers).filter(id => {
-      // Codex models are merged into the OpenAI provider display
-      if (id === 'openai-codex') return false;
+    const providers = new Set<string>();
+
+    for (const id of Object.keys(llmSettings.providers)) {
+      if (id === 'openai-codex') {
+        const config = llmSettings.providers[id];
+        if (config?.enabled && config?.oauth?.connected && config?.apiKey) {
+          providers.add('openai');
+        }
+        continue;
+      }
+
+      if (id === 'anthropic-claude-code') {
+        const config = llmSettings.providers[id];
+        if (config?.enabled && config?.oauth?.connected) {
+          providers.add('anthropic');
+        }
+        continue;
+      }
+
       const config = llmSettings.providers[id];
-      if (!config?.enabled) return false;
-      if (!isProviderCompatible(id)) return false;
-      // WebLLM doesn't need an API key
-      if (id === 'webllm') return true;
-      // Local providers store the server URL in apiKey
-      return !!config.apiKey;
-    });
+      if (!config?.enabled) continue;
+      if (!isProviderCompatible(id)) continue;
+
+      if (id === 'webllm') {
+        providers.add(id);
+        continue;
+      }
+
+      if (config.apiKey) {
+        providers.add(id);
+      }
+    }
+
+    return Array.from(providers);
   }
 
   private isCodexConnected(): boolean {
     const codexConfig = this.config.llmProviderSettings.providers['openai-codex'];
     return !!(codexConfig?.oauth?.connected && codexConfig?.apiKey);
+  }
+
+  private isClaudeCodeConnected(): boolean {
+    const claudeCodeConfig = this.config.llmProviderSettings.providers['anthropic-claude-code'];
+    return !!claudeCodeConfig?.oauth?.connected;
   }
 
   // ========== MODEL SECTION ==========
@@ -198,6 +226,7 @@ export class ChatSettingsRenderer {
       modelOptionMap: this.modelOptionMap,
       providerManager: this.providerManager,
       isCodexConnected: () => this.isCodexConnected(),
+      isClaudeCodeConnected: () => this.isClaudeCodeConnected(),
       getDefaultModelForProvider: (id) => this.getDefaultModelForProvider(id),
       notifyChange: () => this.notifyChange(),
       reRender: () => this.render(),
@@ -303,6 +332,7 @@ export class ChatSettingsRenderer {
       modelOptionMap: this.agentModelOptionMap,
       providerManager: this.providerManager,
       isCodexConnected: () => this.isCodexConnected(),
+      isClaudeCodeConnected: () => this.isClaudeCodeConnected(),
       getDefaultModelForProvider: (id) => this.getDefaultModelForProvider(id),
       notifyChange: () => this.notifyChange(),
       reRender: () => this.render(),

--- a/src/components/shared/ModelDropdownRenderer.ts
+++ b/src/components/shared/ModelDropdownRenderer.ts
@@ -18,6 +18,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   lmstudio: 'LM Studio',
   openai: 'OpenAI',
   anthropic: 'Anthropic',
+  'anthropic-claude-code': 'Claude Code',
   google: 'Google AI',
   mistral: 'Mistral AI',
   groq: 'Groq',
@@ -71,6 +72,9 @@ export interface ModelDropdownConfig {
 
   /** Whether Codex OAuth is connected (for merging Codex models into OpenAI) */
   isCodexConnected: () => boolean;
+
+  /** Whether Claude Code local auth is connected (for merging Claude Code models into Anthropic) */
+  isClaudeCodeConnected: () => boolean;
 
   /** Get default model for a provider (async) */
   getDefaultModelForProvider: (providerId: string) => Promise<string>;
@@ -139,7 +143,11 @@ function renderProviderDropdown(
 ): void {
   const providers = config.getProviders();
   const currentProvider = config.getCurrentProvider();
-  const displayProvider = currentProvider === 'openai-codex' ? 'openai' : currentProvider;
+  const displayProvider = currentProvider === 'openai-codex'
+    ? 'openai'
+    : currentProvider === 'anthropic-claude-code'
+      ? 'anthropic'
+      : currentProvider;
 
   new Setting(content)
     .setName('Provider')
@@ -190,7 +198,11 @@ function renderModelDropdown(
   config: ModelDropdownConfig
 ): void {
   const currentProvider = config.getCurrentProvider();
-  const modelProviderId = currentProvider === 'openai-codex' ? 'openai' : currentProvider;
+  const modelProviderId = currentProvider === 'openai-codex'
+    ? 'openai'
+    : currentProvider === 'anthropic-claude-code'
+      ? 'anthropic'
+      : currentProvider;
 
   // Ollama special case: show text input instead of dropdown
   if (config.showOllamaTextInput && modelProviderId === 'ollama') {
@@ -221,6 +233,14 @@ function renderModelDropdown(
           models = [
             ...models,
             ...codexModels.map(model => ({ ...model, name: `${model.name} (ChatGPT)` }))
+          ];
+        }
+
+        if (modelProviderId === 'anthropic' && config.isClaudeCodeConnected()) {
+          const claudeCodeModels = await config.providerManager.getModelsForProvider('anthropic-claude-code');
+          models = [
+            ...models,
+            ...claudeCodeModels.map(model => ({ ...model, name: `${model.name} (Claude Code)` }))
           ];
         }
 

--- a/src/core/commands/MaintenanceCommandManager.ts
+++ b/src/core/commands/MaintenanceCommandManager.ts
@@ -3,7 +3,7 @@
  * Handles maintenance and troubleshooting commands
  */
 
-import { Notice } from 'obsidian';
+import { Notice, Platform } from 'obsidian';
 import { CommandContext } from './CommandDefinitions';
 import type NexusPlugin from '../../main';
 
@@ -29,6 +29,7 @@ export class MaintenanceCommandManager {
    */
   registerMaintenanceCommands(): void {
     this.registerDiagnosticsCommand();
+    this.registerClaudeHeadlessExperimentCommand();
   }
 
   /**
@@ -46,6 +47,26 @@ export class MaintenanceCommandManager {
       name: 'Run Service Diagnostics',
       callback: async () => {
         await this.runServiceDiagnostics();
+      }
+    });
+  }
+
+  /**
+   * Register an experimental command that launches the user's local Claude CLI
+   * in print mode against this vault's Nexus MCP connector.
+   */
+  private registerClaudeHeadlessExperimentCommand(): void {
+    this.context.plugin.addCommand({
+      id: 'experimental-run-claude-headless-session',
+      name: 'Experimental: Run Claude Headless Session',
+      callback: async () => {
+        if (!Platform.isDesktop) {
+          new Notice('This experiment is only available on desktop.');
+          return;
+        }
+
+        const { ClaudeHeadlessModal } = await import('../../ui/experimental/ClaudeHeadlessModal');
+        new ClaudeHeadlessModal(this.context.plugin.app, this.context.plugin).open();
       }
     });
   }

--- a/src/services/StaticModelsService.ts
+++ b/src/services/StaticModelsService.ts
@@ -13,6 +13,7 @@ import { OPENROUTER_MODELS } from './llm/adapters/openrouter/OpenRouterModels';
 import { REQUESTY_MODELS } from './llm/adapters/requesty/RequestyModels';
 import { PERPLEXITY_MODELS } from './llm/adapters/perplexity/PerplexityModels';
 import { OPENAI_CODEX_MODELS } from './llm/adapters/openai-codex/OpenAICodexModels';
+import { ANTHROPIC_CLAUDE_CODE_MODELS } from './llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels';
 
 export interface ModelWithProvider {
   provider: string;
@@ -65,7 +66,8 @@ export class StaticModelsService {
       { provider: 'openrouter', models: OPENROUTER_MODELS },
       { provider: 'requesty', models: REQUESTY_MODELS },
       { provider: 'perplexity', models: PERPLEXITY_MODELS },
-      { provider: 'openai-codex', models: OPENAI_CODEX_MODELS }
+      { provider: 'openai-codex', models: OPENAI_CODEX_MODELS },
+      { provider: 'anthropic-claude-code', models: ANTHROPIC_CLAUDE_CODE_MODELS }
     ];
 
     providerModels.forEach(({ provider, models }) => {
@@ -115,6 +117,9 @@ export class StaticModelsService {
       case 'openai-codex':
         providerModels = OPENAI_CODEX_MODELS;
         break;
+      case 'anthropic-claude-code':
+        providerModels = ANTHROPIC_CLAUDE_CODE_MODELS;
+        break;
       default:
         return [];
     }
@@ -154,7 +159,7 @@ export class StaticModelsService {
    * Get provider information
    */
   getAvailableProviders(): string[] {
-    return ['openai', 'anthropic', 'google', 'mistral', 'groq', 'openrouter', 'requesty', 'perplexity', 'openai-codex'];
+    return ['openai', 'anthropic', 'anthropic-claude-code', 'google', 'mistral', 'groq', 'openrouter', 'requesty', 'perplexity', 'openai-codex'];
   }
 
   /**

--- a/src/services/external/ClaudeCodeAuthService.ts
+++ b/src/services/external/ClaudeCodeAuthService.ts
@@ -1,0 +1,168 @@
+import { App, FileSystemAdapter, Platform } from 'obsidian';
+import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
+
+export interface ClaudeCodeAuthStatus {
+    available: boolean;
+    loggedIn: boolean;
+    authMethod: string;
+    claudePath: string | null;
+    error?: string;
+}
+
+interface ClaudeAuthStatusJson {
+    loggedIn?: boolean;
+    authMethod?: string;
+}
+
+export class ClaudeCodeAuthService {
+    constructor(private app: App) {}
+
+    async getStatus(): Promise<ClaudeCodeAuthStatus> {
+        const claudePath = resolveDesktopBinaryPath('claude');
+        if (!claudePath) {
+            return {
+                available: false,
+                loggedIn: false,
+                authMethod: 'none',
+                claudePath: null,
+                error: 'Claude Code was not found on PATH.'
+            };
+        }
+
+        const result = await this.runProcess(claudePath, ['auth', 'status'], this.getVaultBasePath() ?? undefined);
+        const raw = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n').trim();
+
+        try {
+            const parsed = JSON.parse(result.stdout) as ClaudeAuthStatusJson;
+            return {
+                available: true,
+                loggedIn: !!parsed.loggedIn,
+                authMethod: parsed.authMethod || 'unknown',
+                claudePath
+            };
+        } catch {
+            return {
+                available: true,
+                loggedIn: false,
+                authMethod: 'unknown',
+                claudePath,
+                error: raw || 'Unable to read Claude auth status.'
+            };
+        }
+    }
+
+    async connectSubscriptionLogin(): Promise<{ success: boolean; apiKey?: string; metadata?: Record<string, string>; error?: string }> {
+        if (!Platform.isDesktop) {
+            return { success: false, error: 'Claude Code auth is only available on desktop.' };
+        }
+
+        const initialStatus = await this.getStatus();
+        if (!initialStatus.available || !initialStatus.claudePath) {
+            return { success: false, error: initialStatus.error || 'Claude Code was not found on PATH.' };
+        }
+
+        if (initialStatus.loggedIn) {
+            return {
+                success: true,
+                apiKey: 'claude-code-local-auth',
+                metadata: {
+                    authMethod: initialStatus.authMethod,
+                    claudePath: initialStatus.claudePath
+                }
+            };
+        }
+
+        const childProcess = require('child_process') as typeof import('child_process');
+        const child = childProcess.spawn(
+            initialStatus.claudePath,
+            ['auth', 'login', '--claudeai'],
+            {
+                cwd: this.getVaultBasePath() ?? undefined,
+                env: { ...process.env },
+                stdio: 'ignore'
+            }
+        );
+
+        const startedAt = Date.now();
+        const timeoutMs = 180_000;
+        while (Date.now() - startedAt < timeoutMs) {
+            await this.sleep(1500);
+
+            const status = await this.getStatus();
+            if (status.loggedIn) {
+                return {
+                    success: true,
+                    apiKey: 'claude-code-local-auth',
+                    metadata: {
+                        authMethod: status.authMethod,
+                        claudePath: status.claudePath || initialStatus.claudePath
+                    }
+                };
+            }
+
+            if (child.exitCode !== null && child.exitCode !== 0) {
+                return {
+                    success: false,
+                    error: 'Claude login exited before authentication completed.'
+                };
+            }
+        }
+
+        return {
+            success: false,
+            error: 'Claude login did not complete in time. If needed, run `claude auth login --claudeai` in your terminal and try again.'
+        };
+    }
+
+    private async runProcess(
+        command: string,
+        args: string[],
+        cwd?: string
+    ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+        const childProcess = require('child_process') as typeof import('child_process');
+
+        return await new Promise((resolve) => {
+            const child = childProcess.spawn(command, args, {
+                cwd,
+                env: { ...process.env },
+                stdio: ['ignore', 'pipe', 'pipe']
+            });
+
+            let stdout = '';
+            let stderr = '';
+
+            child.stdout.on('data', (chunk: Buffer | string) => {
+                stdout += chunk.toString();
+            });
+
+            child.stderr.on('data', (chunk: Buffer | string) => {
+                stderr += chunk.toString();
+            });
+
+            child.on('error', (error: Error) => {
+                resolve({
+                    stdout,
+                    stderr: stderr ? `${stderr}\n${error.message}` : error.message,
+                    exitCode: null
+                });
+            });
+
+            child.on('close', (exitCode: number | null) => {
+                resolve({ stdout, stderr, exitCode });
+            });
+        });
+    }
+
+    private getVaultBasePath(): string | null {
+        const adapter = this.app.vault.adapter;
+        if (adapter instanceof FileSystemAdapter) {
+            return adapter.getBasePath();
+        }
+
+        return null;
+    }
+
+    private async sleep(ms: number): Promise<void> {
+        await new Promise((resolve) => window.setTimeout(resolve, ms));
+    }
+}

--- a/src/services/external/ClaudeHeadlessService.ts
+++ b/src/services/external/ClaudeHeadlessService.ts
@@ -1,0 +1,287 @@
+import { App, FileSystemAdapter, Plugin, Platform } from 'obsidian';
+import { getPrimaryServerKey } from '../../constants/branding';
+import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
+
+export interface ClaudeHeadlessPreflightResult {
+    claudePath: string | null;
+    nodePath: string | null;
+    connectorPath: string | null;
+    vaultPath: string | null;
+    isAuthenticated: boolean;
+    authStatusText: string;
+}
+
+export interface ClaudeHeadlessRunOptions {
+    prompt: string;
+    model?: string;
+    maxTurns?: number;
+    bypassPermissions?: boolean;
+}
+
+export interface ClaudeHeadlessRunResult {
+    success: boolean;
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+    durationMs: number;
+    commandLine: string;
+    preflight: ClaudeHeadlessPreflightResult;
+}
+
+interface ProcessResult {
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+}
+
+export class ClaudeHeadlessService {
+    constructor(
+        private app: App,
+        private plugin: Plugin
+    ) {}
+
+    async getPreflight(): Promise<ClaudeHeadlessPreflightResult> {
+        const claudePath = resolveDesktopBinaryPath('claude');
+        const nodePath = resolveDesktopBinaryPath('node');
+        const connectorPath = this.getConnectorPath();
+        const vaultPath = this.getVaultBasePath();
+
+        if (!claudePath) {
+            return {
+                claudePath: null,
+                nodePath,
+                connectorPath,
+                vaultPath,
+                isAuthenticated: false,
+                authStatusText: 'Claude Code was not found on PATH.'
+            };
+        }
+
+        const authResult = await this.runProcess(claudePath, ['auth', 'status', '--text'], vaultPath ?? undefined, this.buildClaudeEnv());
+        const authStatusText = [authResult.stdout.trim(), authResult.stderr.trim()]
+            .filter(Boolean)
+            .join('\n')
+            .trim();
+
+        return {
+            claudePath,
+            nodePath,
+            connectorPath,
+            vaultPath,
+            isAuthenticated: authResult.exitCode === 0,
+            authStatusText: authStatusText || 'Claude auth status is unavailable.'
+        };
+    }
+
+    async run(options: ClaudeHeadlessRunOptions): Promise<ClaudeHeadlessRunResult> {
+        const startedAt = Date.now();
+        const preflight = await this.getPreflight();
+        const prompt = options.prompt.trim();
+
+        if (!Platform.isDesktop) {
+            return this.buildFailureResult('Claude headless mode is only available on desktop.', preflight, startedAt);
+        }
+
+        if (!prompt) {
+            return this.buildFailureResult('Prompt is required.', preflight, startedAt);
+        }
+
+        if (!preflight.claudePath) {
+            return this.buildFailureResult('Claude Code was not found on PATH.', preflight, startedAt);
+        }
+
+        if (!preflight.nodePath) {
+            return this.buildFailureResult('Node.js was not found on PATH.', preflight, startedAt);
+        }
+
+        if (!preflight.connectorPath) {
+            return this.buildFailureResult('connector.js could not be resolved for this vault.', preflight, startedAt);
+        }
+
+        if (!preflight.vaultPath) {
+            return this.buildFailureResult('Vault base path is unavailable. This experiment requires the desktop filesystem adapter.', preflight, startedAt);
+        }
+
+        const fsPromises = require('fs/promises') as typeof import('fs/promises');
+        const pathMod = require('path') as typeof import('path');
+        const osMod = require('os') as typeof import('os');
+
+        const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-claude-headless-'));
+        const mcpConfigPath = pathMod.join(tempDir, 'mcp.json');
+
+        try {
+            await fsPromises.writeFile(
+                mcpConfigPath,
+                JSON.stringify(this.buildMcpConfig(preflight.nodePath, preflight.connectorPath), null, 2),
+                'utf8'
+            );
+
+            const args = [
+                '-p',
+                '--strict-mcp-config',
+                '--mcp-config',
+                mcpConfigPath,
+                '--tools',
+                '',
+                '--disable-slash-commands',
+                '--output-format',
+                'text',
+                '--max-turns',
+                String(Math.max(1, options.maxTurns ?? 8))
+            ];
+
+            if (options.bypassPermissions !== false) {
+                args.push('--dangerously-skip-permissions');
+            }
+
+            const model = options.model?.trim();
+            if (model) {
+                args.push('--model', model);
+            }
+
+            args.push(prompt);
+
+            const processResult = await this.runProcess(
+                preflight.claudePath,
+                args,
+                preflight.vaultPath,
+                this.buildClaudeEnv()
+            );
+
+            return {
+                success: processResult.exitCode === 0,
+                stdout: processResult.stdout,
+                stderr: processResult.stderr,
+                exitCode: processResult.exitCode,
+                durationMs: Date.now() - startedAt,
+                commandLine: this.formatCommand(preflight.claudePath, args),
+                preflight
+            };
+        } catch (error) {
+            return this.buildFailureResult((error as Error).message, preflight, startedAt);
+        } finally {
+            try {
+                await fsPromises.rm(tempDir, { recursive: true, force: true });
+            } catch {
+                // Best-effort cleanup only.
+            }
+        }
+    }
+
+    private buildMcpConfig(nodePath: string, connectorPath: string): Record<string, unknown> {
+        const serverKey = getPrimaryServerKey(this.app.vault.getName());
+        return {
+            mcpServers: {
+                [serverKey]: {
+                    type: 'stdio',
+                    command: nodePath,
+                    args: [connectorPath]
+                }
+            }
+        };
+    }
+
+    private buildFailureResult(message: string, preflight: ClaudeHeadlessPreflightResult, startedAt: number): ClaudeHeadlessRunResult {
+        return {
+            success: false,
+            stdout: '',
+            stderr: message,
+            exitCode: null,
+            durationMs: Date.now() - startedAt,
+            commandLine: '',
+            preflight
+        };
+    }
+
+    private buildClaudeEnv(): NodeJS.ProcessEnv {
+        const env = { ...process.env };
+
+        // Favor the user's local Claude subscription login instead of any API key
+        // accidentally inherited from the Obsidian/Electron environment.
+        delete env.ANTHROPIC_API_KEY;
+        delete env.ANTHROPIC_AUTH_TOKEN;
+
+        return env;
+    }
+
+    private async runProcess(
+        command: string,
+        args: string[],
+        cwd?: string,
+        env?: NodeJS.ProcessEnv
+    ): Promise<ProcessResult> {
+        const childProcess = require('child_process') as typeof import('child_process');
+
+        return await new Promise<ProcessResult>((resolve) => {
+            const child = childProcess.spawn(command, args, {
+                cwd,
+                env,
+                stdio: ['ignore', 'pipe', 'pipe']
+            });
+
+            let stdout = '';
+            let stderr = '';
+
+            child.stdout.on('data', (chunk: Buffer | string) => {
+                stdout += chunk.toString();
+            });
+
+            child.stderr.on('data', (chunk: Buffer | string) => {
+                stderr += chunk.toString();
+            });
+
+            child.on('error', (error: Error) => {
+                resolve({
+                    stdout,
+                    stderr: stderr ? `${stderr}\n${error.message}` : error.message,
+                    exitCode: null
+                });
+            });
+
+            child.on('close', (exitCode: number | null) => {
+                resolve({
+                    stdout,
+                    stderr,
+                    exitCode
+                });
+            });
+        });
+    }
+
+    private getConnectorPath(): string | null {
+        const vaultBasePath = this.getVaultBasePath();
+        if (!vaultBasePath) {
+            return null;
+        }
+
+        const pathMod = require('path') as typeof import('path');
+        const manifestDir = this.plugin.manifest.dir;
+        const pluginFolderName = manifestDir ? manifestDir.split('/').pop() || manifestDir : '';
+
+        if (!pluginFolderName) {
+            return null;
+        }
+
+        return pathMod.join(vaultBasePath, '.obsidian', 'plugins', pluginFolderName, 'connector.js');
+    }
+
+    private getVaultBasePath(): string | null {
+        const adapter = this.app.vault.adapter;
+        if (adapter instanceof FileSystemAdapter) {
+            return adapter.getBasePath();
+        }
+
+        return null;
+    }
+
+    private formatCommand(command: string, args: string[]): string {
+        const parts = [command, ...args].map((part) => {
+            if (/[\s"]/u.test(part)) {
+                return `"${part.replace(/"/g, '\\"')}"`;
+            }
+            return part;
+        });
+
+        return parts.join(' ');
+    }
+}

--- a/src/services/llm/adapters/ModelRegistry.ts
+++ b/src/services/llm/adapters/ModelRegistry.ts
@@ -16,6 +16,7 @@ import { OPENROUTER_MODELS, OPENROUTER_DEFAULT_MODEL } from './openrouter/OpenRo
 import { REQUESTY_MODELS, REQUESTY_DEFAULT_MODEL } from './requesty/RequestyModels';
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL } from './groq/GroqModels';
 import { OPENAI_CODEX_MODELS, OPENAI_CODEX_DEFAULT_MODEL } from './openai-codex/OpenAICodexModels';
+import { ANTHROPIC_CLAUDE_CODE_MODELS, ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL } from './anthropic-claude-code/AnthropicClaudeCodeModels';
 import type { LLMProviderSettings } from '../../../types';
 
 // Re-export ModelSpec for convenience
@@ -29,6 +30,7 @@ export type { ModelSpec };
 export const AI_MODELS: Record<string, ModelSpec[]> = {
   openai: OPENAI_MODELS,
   'openai-codex': OPENAI_CODEX_MODELS,
+  'anthropic-claude-code': ANTHROPIC_CLAUDE_CODE_MODELS,
   google: GOOGLE_MODELS,
   anthropic: ANTHROPIC_MODELS,
   mistral: MISTRAL_MODELS,
@@ -211,6 +213,7 @@ export class ModelRegistry {
 export const DEFAULT_MODELS: Record<string, string> = {
   openai: OPENAI_DEFAULT_MODEL,
   'openai-codex': OPENAI_CODEX_DEFAULT_MODEL,
+  'anthropic-claude-code': ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL,
   google: GOOGLE_DEFAULT_MODEL,
   anthropic: ANTHROPIC_DEFAULT_MODEL,
   mistral: MISTRAL_DEFAULT_MODEL,

--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
@@ -1,0 +1,531 @@
+import { FileSystemAdapter, Vault } from 'obsidian';
+import { BaseAdapter } from '../BaseAdapter';
+import { resolveDesktopBinaryPath } from '../../../../utils/binaryDiscovery';
+import {
+  GenerateOptions,
+  StreamChunk,
+  LLMResponse,
+  ModelInfo,
+  ProviderCapabilities,
+  ModelPricing,
+  LLMProviderError
+} from '../types';
+import { ModelRegistry } from '../ModelRegistry';
+import { getAllPluginIds, getPrimaryServerKey } from '../../../../constants/branding';
+
+type ClaudeCodeToolCall = NonNullable<StreamChunk['toolCalls']>[number];
+
+export class AnthropicClaudeCodeAdapter extends BaseAdapter {
+  readonly name = 'anthropic-claude-code';
+  readonly baseUrl = 'claude-code://local';
+
+  constructor(private vault: Vault) {
+    super('claude-code-local-auth', 'claude-sonnet-4-6', 'claude-code://local', false);
+    this.initializeCache();
+  }
+
+  async generateUncached(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
+    const model = options?.model || this.currentModel;
+    let fullText = '';
+    let finalToolCalls: StreamChunk['toolCalls'];
+
+    for await (const chunk of this.generateStreamAsync(prompt, options)) {
+      if (chunk.content) {
+        fullText += chunk.content;
+      }
+
+      if (chunk.toolCalls && chunk.toolCalls.length > 0) {
+        finalToolCalls = chunk.toolCalls;
+      }
+    }
+
+    return this.buildLLMResponse(
+      fullText,
+      model,
+      { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+      { localCli: true, providerExecutedTools: true },
+      finalToolCalls && finalToolCalls.length > 0 ? 'tool_calls' : 'stop',
+      finalToolCalls
+    );
+  }
+
+  async* generateStreamAsync(prompt: string, options?: GenerateOptions): AsyncGenerator<StreamChunk, void, unknown> {
+    const runtime = await this.getRuntime();
+    if (!runtime.claudePath) {
+      throw new LLMProviderError('Claude Code was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
+    }
+    if (!runtime.connectorPath) {
+      throw new LLMProviderError('Nexus connector.js was not found for this vault.', this.name, 'CONFIGURATION_ERROR');
+    }
+    if (!runtime.vaultPath) {
+      throw new LLMProviderError('Vault filesystem path is unavailable.', this.name, 'CONFIGURATION_ERROR');
+    }
+
+    const authStatus = await this.readAuthStatus(runtime.claudePath, runtime.vaultPath);
+    if (!authStatus.loggedIn) {
+      throw new LLMProviderError(
+        'Claude Code is not logged in. Connect it from the Anthropic provider card first.',
+        this.name,
+        'AUTHENTICATION_ERROR'
+      );
+    }
+
+    const fsPromises = require('fs/promises') as typeof import('fs/promises');
+    const osMod = require('os') as typeof import('os');
+    const pathMod = require('path') as typeof import('path');
+    const childProcess = require('child_process') as typeof import('child_process');
+    const readline = require('readline') as typeof import('readline');
+
+    const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-claude-code-adapter-'));
+    const mcpConfigPath = pathMod.join(tempDir, 'mcp.json');
+    const toolCalls = new Map<string, ClaudeCodeToolCall>();
+    let accumulatedText = '';
+    let stderr = '';
+
+    try {
+      await fsPromises.writeFile(
+        mcpConfigPath,
+        JSON.stringify({
+          mcpServers: {
+            [getPrimaryServerKey(this.vault.getName())]: {
+              type: 'stdio',
+              command: runtime.nodePath,
+              args: [runtime.connectorPath]
+            }
+          }
+        }, null, 2),
+        'utf8'
+      );
+
+      const args = [
+        '-p',
+        '--verbose',
+        '--strict-mcp-config',
+        '--mcp-config',
+        mcpConfigPath,
+        '--tools',
+        '',
+        '--disable-slash-commands',
+        '--no-session-persistence',
+        '--dangerously-skip-permissions',
+        '--output-format',
+        'stream-json',
+        '--max-turns',
+        String(Math.max(1, options?.maxTokens ? Math.min(12, Math.ceil(options.maxTokens / 8000)) : 8))
+      ];
+
+      if (options?.systemPrompt?.trim()) {
+        args.push('--append-system-prompt', options.systemPrompt.trim());
+      }
+
+      if (options?.enableThinking && options?.thinkingEffort) {
+        args.push('--effort', options.thinkingEffort);
+      }
+
+      const model = options?.model || this.currentModel;
+      if (model) {
+        args.push('--model', model);
+      }
+
+      args.push(prompt);
+
+      const env = { ...process.env };
+      delete env.ANTHROPIC_API_KEY;
+      delete env.ANTHROPIC_AUTH_TOKEN;
+
+      const child = childProcess.spawn(runtime.claudePath, args, {
+        cwd: runtime.vaultPath,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      const closePromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+        child.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
+          resolve({ exitCode, signal });
+        });
+      });
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+
+      const stdoutReader = readline.createInterface({ input: child.stdout });
+
+      for await (const line of stdoutReader) {
+        const parsed = this.parseStreamJsonLine(line);
+        if (!parsed) {
+          continue;
+        }
+
+        if (parsed.type === 'assistant') {
+          const contentBlocks = this.extractContentBlocks(this.extractMessagePayload(parsed));
+          const reasoningDelta = this.collectReasoningText(contentBlocks);
+          if (reasoningDelta) {
+            yield {
+              content: '',
+              complete: false,
+              reasoning: reasoningDelta,
+              reasoningComplete: true
+            };
+          }
+
+          const toolUses = this.collectToolUses(contentBlocks);
+          for (const toolUse of toolUses) {
+            toolCalls.set(toolUse.id, toolUse);
+          }
+
+          const textDelta = this.collectAssistantText(contentBlocks);
+          if (textDelta) {
+            accumulatedText += textDelta;
+            yield {
+              content: textDelta,
+              complete: false
+            };
+          }
+        } else if (parsed.type === 'user') {
+          const contentBlocks = this.extractContentBlocks(this.extractMessagePayload(parsed));
+          this.applyToolResults(contentBlocks, toolCalls);
+        } else if (parsed.type === 'result') {
+          const resultText = typeof parsed.result === 'string' ? parsed.result : '';
+          if (!accumulatedText && resultText) {
+            accumulatedText = resultText;
+            yield {
+              content: resultText,
+              complete: false
+            };
+          }
+        }
+      }
+
+      const closeResult = await closePromise;
+
+      if (closeResult.exitCode !== 0) {
+        throw new LLMProviderError(
+          stderr.trim() || `Claude Code exited with status ${closeResult.exitCode ?? 'unknown'}`,
+          this.name,
+          'PROVIDER_ERROR'
+        );
+      }
+
+      const finalizedToolCalls = Array.from(toolCalls.values()).map((toolCall) => ({
+        ...toolCall,
+        providerExecuted: true,
+        success: toolCall.success !== false
+      }));
+
+      yield {
+        content: '',
+        complete: true,
+        toolCalls: finalizedToolCalls.length > 0 ? finalizedToolCalls : undefined,
+        metadata: {
+          authMethod: authStatus.authMethod,
+          localCli: true,
+          providerExecutedTools: true
+        }
+      };
+    } finally {
+      try {
+        await fsPromises.rm(tempDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup only.
+      }
+    }
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    const models = ModelRegistry.getProviderModels('anthropic-claude-code');
+    return models.map(model => ModelRegistry.toModelInfo(model));
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      supportsStreaming: true,
+      streamingMode: 'buffered',
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsThinking: true,
+      maxContextWindow: 200000,
+      supportedFeatures: ['claude-code', 'mcp', 'subscription-auth']
+    };
+  }
+
+  async getModelPricing(modelId: string): Promise<ModelPricing | null> {
+    const model = ModelRegistry.findModel('anthropic-claude-code', modelId);
+    if (!model) {
+      return null;
+    }
+
+    return {
+      rateInputPerMillion: model.inputCostPerMillion,
+      rateOutputPerMillion: model.outputCostPerMillion,
+      currency: 'USD'
+    };
+  }
+
+  private async getRuntime(): Promise<{
+    claudePath: string | null;
+    nodePath: string | null;
+    connectorPath: string | null;
+    vaultPath: string | null;
+  }> {
+    const claudePath = resolveDesktopBinaryPath('claude');
+    const nodePath = resolveDesktopBinaryPath('node');
+    const vaultPath = this.getVaultBasePath();
+
+    if (!nodePath) {
+      throw new LLMProviderError('Node.js was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
+    }
+
+    return {
+      claudePath,
+      nodePath,
+      connectorPath: this.getConnectorPath(vaultPath),
+      vaultPath
+    };
+  }
+
+  private parseStreamJsonLine(line: string): Record<string, unknown> | null {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(trimmed) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  private extractMessagePayload(parsed: Record<string, unknown>): Record<string, unknown> | null {
+    const message = parsed.message;
+    if (message && typeof message === 'object' && !Array.isArray(message)) {
+      return message as Record<string, unknown>;
+    }
+
+    return parsed;
+  }
+
+  private extractContentBlocks(messagePayload: Record<string, unknown> | null): Record<string, unknown>[] {
+    if (!messagePayload) {
+      return [];
+    }
+
+    const content = messagePayload.content;
+    if (!Array.isArray(content)) {
+      return [];
+    }
+
+    return content.filter((block): block is Record<string, unknown> => typeof block === 'object' && block !== null && !Array.isArray(block));
+  }
+
+  private collectAssistantText(contentBlocks: Record<string, unknown>[]): string {
+    return contentBlocks
+      .filter((block) => block.type === 'text')
+      .map((block) => typeof block.text === 'string' ? block.text : '')
+      .join('');
+  }
+
+  private collectReasoningText(contentBlocks: Record<string, unknown>[]): string {
+    return contentBlocks
+      .filter((block) => block.type === 'thinking' || block.type === 'reasoning')
+      .map((block) => {
+        if (typeof block.thinking === 'string') {
+          return block.thinking;
+        }
+        if (typeof block.text === 'string') {
+          return block.text;
+        }
+        if (typeof block.summary === 'string') {
+          return block.summary;
+        }
+        return '';
+      })
+      .join('');
+  }
+
+  private collectToolUses(contentBlocks: Record<string, unknown>[]): ClaudeCodeToolCall[] {
+    return contentBlocks
+      .filter((block) => block.type === 'tool_use')
+      .map((block, index) => {
+        const toolName = typeof block.name === 'string' ? block.name : 'unknown_tool';
+        const toolInput = this.normalizeToolInput(block.input);
+        const toolId = typeof block.id === 'string'
+          ? block.id
+          : `claude_tool_${index}_${Date.now()}`;
+
+        return {
+          id: toolId,
+          type: 'function',
+          name: toolName,
+          function: {
+            name: toolName,
+            arguments: JSON.stringify(toolInput)
+          },
+          parameters: toolInput,
+          providerExecuted: true
+        };
+      });
+  }
+
+  private applyToolResults(
+    contentBlocks: Record<string, unknown>[],
+    toolCalls: Map<string, ClaudeCodeToolCall>
+  ): void {
+    for (const block of contentBlocks) {
+      if (block.type !== 'tool_result') {
+        continue;
+      }
+
+      const toolUseId = typeof block.tool_use_id === 'string'
+        ? block.tool_use_id
+        : typeof block.toolUseId === 'string'
+          ? block.toolUseId
+          : typeof block.id === 'string'
+            ? block.id
+            : null;
+
+      if (!toolUseId) {
+        continue;
+      }
+
+      const existing = toolCalls.get(toolUseId);
+      if (!existing) {
+        continue;
+      }
+
+      const normalizedResult = this.normalizeToolResultContent(block.content);
+      const isError = block.is_error === true || block.isError === true;
+
+      existing.result = normalizedResult;
+      existing.success = !isError;
+      existing.error = isError
+        ? typeof normalizedResult === 'string'
+          ? normalizedResult
+          : JSON.stringify(normalizedResult, null, 2)
+        : undefined;
+    }
+  }
+
+  private normalizeToolInput(input: unknown): Record<string, unknown> {
+    if (input && typeof input === 'object' && !Array.isArray(input)) {
+      return input as Record<string, unknown>;
+    }
+
+    return {};
+  }
+
+  private normalizeToolResultContent(content: unknown): unknown {
+    if (typeof content === 'string') {
+      return content;
+    }
+
+    if (!Array.isArray(content)) {
+      return content;
+    }
+
+    const normalized = content.map((block) => {
+      if (!block || typeof block !== 'object') {
+        return block;
+      }
+
+      const typedBlock = block as Record<string, unknown>;
+      if (typedBlock.type === 'text' && typeof typedBlock.text === 'string') {
+        return typedBlock.text;
+      }
+
+      return typedBlock;
+    });
+
+    if (normalized.every((item) => typeof item === 'string')) {
+      return normalized.join('\n');
+    }
+
+    return normalized;
+  }
+
+  private getVaultBasePath(): string | null {
+    const adapter = this.vault.adapter;
+    if (adapter instanceof FileSystemAdapter) {
+      return adapter.getBasePath();
+    }
+    return null;
+  }
+
+  private getConnectorPath(vaultPath: string | null): string | null {
+    if (!vaultPath) {
+      return null;
+    }
+
+    const pathMod = require('path') as typeof import('path');
+    const nodeFs = require('fs') as typeof import('fs');
+
+    for (const pluginId of getAllPluginIds()) {
+      const candidate = pathMod.join(vaultPath, '.obsidian', 'plugins', pluginId, 'connector.js');
+      if (nodeFs.existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
+
+  private async readAuthStatus(claudePath: string, cwd: string): Promise<{ loggedIn: boolean; authMethod: string }> {
+    const result = await this.runProcess(claudePath, ['auth', 'status'], cwd);
+    try {
+      const parsed = JSON.parse(result.stdout) as { loggedIn?: boolean; authMethod?: string };
+      return {
+        loggedIn: !!parsed.loggedIn,
+        authMethod: parsed.authMethod || 'unknown'
+      };
+    } catch {
+      return {
+        loggedIn: false,
+        authMethod: 'unknown'
+      };
+    }
+  }
+
+  private async runProcess(
+    command: string,
+    args: string[],
+    cwd?: string
+  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
+    const childProcess = require('child_process') as typeof import('child_process');
+
+    return await new Promise((resolve) => {
+      const env = { ...process.env };
+      delete env.ANTHROPIC_API_KEY;
+      delete env.ANTHROPIC_AUTH_TOKEN;
+
+      const child = childProcess.spawn(command, args, {
+        cwd,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk: Buffer | string) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr.on('data', (chunk: Buffer | string) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('error', (error: Error) => {
+        resolve({
+          stdout,
+          stderr: stderr ? `${stderr}\n${error.message}` : error.message,
+          exitCode: null
+        });
+      });
+
+      child.on('close', (exitCode: number | null) => {
+        resolve({ stdout, stderr, exitCode });
+      });
+    });
+  }
+}

--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
@@ -1,0 +1,54 @@
+import { ModelSpec } from '../modelTypes';
+
+export const ANTHROPIC_CLAUDE_CODE_MODELS: ModelSpec[] = [
+  {
+    provider: 'anthropic-claude-code',
+    name: 'Claude 4.5 Haiku',
+    apiName: 'claude-haiku-4-5-20251001',
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
+    name: 'Claude Sonnet 4.6',
+    apiName: 'claude-sonnet-4-6',
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
+    name: 'Claude Opus 4.6',
+    apiName: 'claude-opus-4-6',
+    contextWindow: 200000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  }
+];
+
+export const ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-4-6';

--- a/src/services/llm/adapters/types.ts
+++ b/src/services/llm/adapters/types.ts
@@ -6,7 +6,7 @@
 /**
  * Supported LLM providers
  */
-export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'google' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
+export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'anthropic-claude-code' | 'google' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
 
 export interface GenerateOptions {
   model?: string;
@@ -137,10 +137,18 @@ export type ToolCallFormat = 'bracket' | 'xml' | 'native';
 export interface ToolCall {
   id: string;
   type: 'function';
+  name?: string;
+  displayName?: string;
+  technicalName?: string;
   function: {
     name: string;
     arguments: string;
   };
+  parameters?: Record<string, unknown>;
+  result?: unknown;
+  success?: boolean;
+  error?: string;
+  providerExecuted?: boolean;
   // OpenRouter: reasoning_details for Gemini models (must be preserved in continuations)
   reasoning_details?: any[];
   // Google Gemini: thought_signature for thinking models

--- a/src/services/llm/core/AdapterRegistry.ts
+++ b/src/services/llm/core/AdapterRegistry.ts
@@ -227,6 +227,7 @@ export class AdapterRegistry implements IAdapterRegistry {
     // ═══════════════════════════════════════════════════════════════════════════
     if (!onMobile) {
       await this.initializeCodexAdapter(providers['openai-codex']);
+      await this.initializeClaudeCodeAdapter(providers['anthropic-claude-code']);
 
       // Ollama - apiKey is actually the server URL
       if (providers.ollama?.enabled && providers.ollama.apiKey) {
@@ -326,6 +327,27 @@ export class AdapterRegistry implements IAdapterRegistry {
     } catch (error) {
       console.error('AdapterRegistry: Failed to initialize OpenAI Codex adapter:', error);
       this.logError('openai-codex', error);
+    }
+  }
+
+  /**
+   * Initialize the Claude Code adapter from local CLI auth state.
+   */
+  private async initializeClaudeCodeAdapter(config: LLMProviderConfig | undefined): Promise<void> {
+    if (!config?.enabled) return;
+
+    const oauth = config.oauth;
+    if (!oauth?.connected || !this.vault) {
+      return;
+    }
+
+    try {
+      const { AnthropicClaudeCodeAdapter } = await import('../adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter');
+      const adapter = new AnthropicClaudeCodeAdapter(this.vault);
+      this.adapters.set('anthropic-claude-code', adapter);
+    } catch (error) {
+      console.error('AdapterRegistry: Failed to initialize Claude Code adapter:', error);
+      this.logError('anthropic-claude-code', error);
     }
   }
 

--- a/src/services/llm/core/StreamingOrchestrator.ts
+++ b/src/services/llm/core/StreamingOrchestrator.ts
@@ -277,6 +277,24 @@ export class StreamingOrchestrator {
         return;
       }
 
+      const providerExecutedTools = detectedToolCalls.every((toolCall) =>
+        toolCall.providerExecuted ||
+        toolCall.result !== undefined ||
+        toolCall.success !== undefined ||
+        toolCall.error !== undefined
+      );
+
+      if (providerExecutedTools) {
+        yield {
+          chunk: '',
+          complete: true,
+          content: fullContent,
+          toolCalls: detectedToolCalls,
+          usage: finalUsage
+        };
+        return;
+      }
+
       // Tool calls detected - delegate to ToolContinuationService
       yield* this.toolContinuation.executeToolsAndContinue(
         activeAdapter,

--- a/src/services/llm/providers/ProviderManager.ts
+++ b/src/services/llm/providers/ProviderManager.ts
@@ -241,6 +241,11 @@ export class LLMProviderManager {
         description: 'Claude models with strong reasoning and safety features'
       },
       {
+        id: 'anthropic-claude-code',
+        name: 'Claude Code',
+        description: 'Claude models via your local Claude Code subscription login — desktop only'
+      },
+      {
         id: 'google',
         name: 'Google',
         description: 'Gemini models with multimodal capabilities and thinking mode'
@@ -303,6 +308,8 @@ export class LLMProviderManager {
       } else if (provider.id === 'openai-codex') {
         // Codex uses OAuth — check for connected OAuth state with access token
         hasApiKey = !!(config?.oauth?.connected && config?.apiKey);
+      } else if (provider.id === 'anthropic-claude-code') {
+        hasApiKey = !!config?.oauth?.connected;
       } else if (provider.id === 'ollama' || provider.id === 'lmstudio') {
         hasApiKey = !!(config?.apiKey && config.apiKey.trim());
       } else {

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -22,6 +22,7 @@ import { LLMSettingsNotifier } from '../../services/llm/LLMSettingsNotifier';
 import { isDesktop, supportsLocalLLM, MOBILE_COMPATIBLE_PROVIDERS, isProviderComingSoon } from '../../utils/platform';
 import type { OAuthModalConfig, SecondaryOAuthProviderConfig } from '../../components/llm-provider/types';
 import { OAuthService } from '../../services/oauth/OAuthService';
+import { ClaudeCodeAuthService } from '../../services/external/ClaudeCodeAuthService';
 
 /**
  * Provider display configuration
@@ -91,6 +92,12 @@ export class ProvidersTab {
             name: 'Anthropic',
             keyFormat: 'sk-ant-...',
             signupUrl: 'https://console.anthropic.com/login',
+            category: 'cloud'
+        },
+        'anthropic-claude-code': {
+            name: 'Claude Code',
+            keyFormat: 'Local Claude Code login required',
+            signupUrl: 'https://claude.ai/download',
             category: 'cloud'
         },
         google: {
@@ -234,6 +241,15 @@ export class ProvidersTab {
                 error: error instanceof Error ? error.message : 'OAuth flow failed',
             };
         }
+    }
+
+    /**
+     * Start a local Claude Code subscription login flow.
+     * Reuses the OAuth-style banner UI even though auth is handled by the local CLI.
+     */
+    private async startClaudeCodeConnectFlow(): Promise<{ success: boolean; apiKey?: string; metadata?: Record<string, string>; error?: string }> {
+        const authService = new ClaudeCodeAuthService(this.services.app);
+        return await authService.connectSubscriptionLogin();
     }
 
     /**
@@ -401,6 +417,7 @@ export class ProvidersTab {
         if (!config.enabled) return false;
         // WebLLM doesn't need an API key
         if (providerId === 'webllm') return true;
+        if (providerId === 'anthropic-claude-code') return !!config.oauth?.connected;
         // Other providers need an API key
         return !!config.apiKey;
     }
@@ -436,6 +453,27 @@ export class ProvidersTab {
                     },
                 };
             }
+        } else if (providerId === 'anthropic') {
+            const claudeCodeDisplay = this.providerConfigs['anthropic-claude-code'];
+            const claudeCodeConfig = settings.providers['anthropic-claude-code'] || {
+                apiKey: '',
+                enabled: false,
+            };
+
+            secondaryOAuthProvider = {
+                providerId: 'anthropic-claude-code',
+                providerLabel: 'Claude Code',
+                description: 'Connect your local Claude Code subscription login and use Claude models through the desktop CLI.',
+                config: { ...claudeCodeConfig },
+                oauthConfig: {
+                    providerLabel: 'Claude Code',
+                    startFlow: () => this.startClaudeCodeConnectFlow(),
+                },
+                onConfigChange: async (updatedClaudeCodeConfig: LLMProviderConfig) => {
+                    settings.providers['anthropic-claude-code'] = updatedClaudeCodeConfig;
+                    await this.saveSettings();
+                },
+            };
         }
 
         const modalConfig: LLMProviderModalConfig = {

--- a/src/types/chat/ChatTypes.ts
+++ b/src/types/chat/ChatTypes.ts
@@ -73,6 +73,7 @@ export interface ToolCall {
   error?: string;
   parameters?: Record<string, unknown>;
   executionTime?: number;
+  providerExecuted?: boolean;
   /** Format the model used: 'bracket' = [TOOL_CALLS], 'xml' = <tool_call>, 'native' = OpenAI tool_calls */
   sourceFormat?: ToolCallFormat;
 }

--- a/src/types/llm/ProviderTypes.ts
+++ b/src/types/llm/ProviderTypes.ts
@@ -97,6 +97,10 @@ export const DEFAULT_LLM_PROVIDER_SETTINGS: LLMProviderSettings = {
       apiKey: '',
       enabled: false
     },
+    'anthropic-claude-code': {
+      apiKey: '',
+      enabled: false
+    },
     google: {
       apiKey: '',
       enabled: false

--- a/src/ui/chat/coordinators/ToolEventCoordinator.ts
+++ b/src/ui/chat/coordinators/ToolEventCoordinator.ts
@@ -64,6 +64,22 @@ export class ToolEventCoordinator {
         };
 
         messageBubble.handleToolEvent('detected', toolData);
+
+        if (
+          toolCall.providerExecuted &&
+          (
+            toolCall.result !== undefined ||
+            toolCall.success !== undefined ||
+            toolCall.error !== undefined
+          )
+        ) {
+          messageBubble.handleToolEvent('completed', {
+            toolId: toolCall.id,
+            result: toolCall.result,
+            success: toolCall.success !== false,
+            error: toolCall.error
+          });
+        }
       }
     }
   }

--- a/src/ui/chat/utils/ProviderUtils.ts
+++ b/src/ui/chat/utils/ProviderUtils.ts
@@ -10,6 +10,7 @@ export class ProviderUtils {
     const displayNames: Record<string, string> = {
       'openai': 'OpenAI',
       'anthropic': 'Anthropic',
+      'anthropic-claude-code': 'Anthropic (Claude Code)',
       'mistral': 'Mistral AI',
       'ollama': 'Ollama',
       'lmstudio': 'LM Studio',
@@ -73,6 +74,7 @@ export class ProviderUtils {
     const colors: Record<string, string> = {
       'openai': '#10a37f',
       'anthropic': '#d97757',
+      'anthropic-claude-code': '#d97757',
       'mistral': '#ff6b35',
       'ollama': '#000000',
       'lmstudio': '#4A90E2',
@@ -92,6 +94,7 @@ export class ProviderUtils {
     const icons: Record<string, string> = {
       'openai': '🤖',
       'anthropic': '🧠',
+      'anthropic-claude-code': '🧠',
       'mistral': '🌪️',
       'ollama': '🦙',
       'lmstudio': '🖥️',
@@ -124,6 +127,7 @@ export class ProviderUtils {
     const abbreviations: Record<string, string> = {
       'openai': 'OAI',
       'anthropic': 'ANT',
+      'anthropic-claude-code': 'ACC',
       'mistral': 'MST',
       'ollama': 'OLL',
       'lmstudio': 'LMS',
@@ -143,6 +147,7 @@ export class ProviderUtils {
     const streamingProviders = [
       'openai',
       'anthropic',
+      'anthropic-claude-code',
       'mistral',
       'ollama',
       'lmstudio',    // ✅ LM Studio streaming via OpenAI-compatible API
@@ -168,6 +173,7 @@ export class ProviderUtils {
       'mistral',     // ✅ Native Mistral function calling
       'requesty',    // ✅ OpenAI-compatible function calling
       'anthropic',   // ✅ Native Claude tool calling
+      'anthropic-claude-code',
       'google'       // ✅ Native Google Gemini function calling (functionDeclarations)
     ];
     // Note: Perplexity does NOT support function calling (web search focused)
@@ -221,7 +227,7 @@ export class ProviderUtils {
     return {
       streaming: this.supportsStreaming(providerId),
       functionCalling: this.supportsFunctionCalling(providerId),
-      imageInput: ['openai', 'anthropic', 'google'].includes(providerId),
+      imageInput: ['openai', 'anthropic', 'anthropic-claude-code', 'google'].includes(providerId),
       jsonMode: ['openai', 'mistral'].includes(providerId)
     };
   }

--- a/src/ui/experimental/ClaudeHeadlessModal.ts
+++ b/src/ui/experimental/ClaudeHeadlessModal.ts
@@ -1,0 +1,248 @@
+import {
+    App,
+    ButtonComponent,
+    Component,
+    Modal,
+    Notice,
+    Setting,
+    TextAreaComponent,
+    TextComponent,
+    ToggleComponent
+} from 'obsidian';
+import type { Plugin } from 'obsidian';
+import {
+    ClaudeHeadlessService,
+    type ClaudeHeadlessPreflightResult,
+    type ClaudeHeadlessRunResult
+} from '../../services/external/ClaudeHeadlessService';
+
+export class ClaudeHeadlessModal extends Modal {
+    private readonly service: ClaudeHeadlessService;
+    private promptValue = '';
+    private modelValue = 'sonnet';
+    private maxTurnsValue = '8';
+    private bypassPermissions = true;
+    private isRunning = false;
+
+    private promptInput: TextAreaComponent | null = null;
+    private statusEl: HTMLDivElement | null = null;
+    private outputEl: HTMLPreElement | null = null;
+    private runButton: ButtonComponent | null = null;
+    private copyButton: ButtonComponent | null = null;
+
+    constructor(app: App, plugin: Plugin) {
+        super(app);
+        this.service = new ClaudeHeadlessService(app, plugin);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('nexus-claude-headless-modal');
+
+        contentEl.createEl('h2', { text: 'Experimental Claude headless session' });
+        contentEl.createEl('p', {
+            text: 'This launches your local Claude Code CLI in print mode, restricts built-in tools, and exposes only the Nexus MCP server for this vault.',
+            cls: 'setting-item-description'
+        });
+
+        this.statusEl = contentEl.createDiv('nexus-claude-headless-status');
+        this.setStatus('Checking Claude installation and auth status…', 'muted');
+
+        const promptSetting = new Setting(contentEl)
+            .setName('Prompt')
+            .setDesc('Cmd/Ctrl+Enter runs the session.');
+        this.promptInput = new TextAreaComponent(promptSetting.controlEl);
+        this.promptInput.setPlaceholder('Ask Claude to inspect, edit, or organize your vault through Nexus MCP tools.');
+        this.promptInput.setValue(this.promptValue);
+        this.promptInput.inputEl.rows = 8;
+        this.promptInput.inputEl.addClass('nexus-claude-headless-prompt');
+        this.registerModalDomEvent(this.promptInput.inputEl, 'keydown', (event: KeyboardEvent) => {
+            if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+                event.preventDefault();
+                void this.runClaudeSession();
+            }
+        });
+
+        new Setting(contentEl)
+            .setName('Model')
+            .setDesc('Claude model alias or full name passed to the local CLI.')
+            .addText((text: TextComponent) => {
+                text
+                    .setPlaceholder('sonnet')
+                    .setValue(this.modelValue)
+                    .onChange((value) => {
+                        this.modelValue = value;
+                    });
+            });
+
+        new Setting(contentEl)
+            .setName('Max turns')
+            .setDesc('Agentic turn cap for print mode.')
+            .addText((text: TextComponent) => {
+                text
+                    .setPlaceholder('8')
+                    .setValue(this.maxTurnsValue)
+                    .onChange((value) => {
+                        this.maxTurnsValue = value;
+                    });
+            });
+
+        new Setting(contentEl)
+            .setName('Bypass permissions')
+            .setDesc('Recommended for print mode so Nexus MCP tool calls do not stop on permission prompts.')
+            .addToggle((toggle: ToggleComponent) => {
+                toggle
+                    .setValue(this.bypassPermissions)
+                    .onChange((value) => {
+                        this.bypassPermissions = value;
+                    });
+            });
+
+        contentEl.createEl('h3', { text: 'Output' });
+        this.outputEl = contentEl.createEl('pre', { cls: 'nexus-claude-headless-output' });
+        this.outputEl.setText('No run yet.');
+
+        const buttonRow = contentEl.createDiv('nexus-claude-headless-buttons');
+
+        this.copyButton = new ButtonComponent(buttonRow)
+            .setButtonText('Copy output')
+            .setDisabled(true);
+        this.registerModalDomEvent(this.copyButton.buttonEl, 'click', () => {
+            const output = this.outputEl?.textContent?.trim();
+            if (!output) {
+                return;
+            }
+            void navigator.clipboard.writeText(output);
+            new Notice('Claude output copied to clipboard.');
+        });
+
+        new ButtonComponent(buttonRow)
+            .setButtonText('Close')
+            .onClick(() => {
+                this.close();
+            });
+
+        this.runButton = new ButtonComponent(buttonRow)
+            .setButtonText('Run Claude')
+            .setCta()
+            .onClick(() => {
+                void this.runClaudeSession();
+            });
+
+        void this.loadPreflightStatus();
+
+        window.setTimeout(() => {
+            this.promptInput?.inputEl.focus();
+        }, 0);
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+
+    private registerModalDomEvent<K extends keyof HTMLElementEventMap>(
+        element: HTMLElement,
+        type: K,
+        handler: (event: HTMLElementEventMap[K]) => void
+    ): void {
+        (this as unknown as Component).registerDomEvent(element, type, handler as EventListener);
+    }
+
+    private async loadPreflightStatus(): Promise<void> {
+        const preflight = await this.service.getPreflight();
+        this.setStatus(this.formatPreflight(preflight), preflight.isAuthenticated ? 'success' : 'warning');
+    }
+
+    private async runClaudeSession(): Promise<void> {
+        if (this.isRunning) {
+            return;
+        }
+
+        const prompt = this.promptInput?.getValue().trim() ?? '';
+        if (!prompt) {
+            new Notice('Enter a prompt first.');
+            this.promptInput?.inputEl.focus();
+            return;
+        }
+
+        this.isRunning = true;
+        this.setButtonsDisabled(true);
+        this.setStatus('Running Claude headless session…', 'muted');
+        if (this.outputEl) {
+            this.outputEl.setText('Running…');
+        }
+
+        const maxTurns = Number.parseInt(this.maxTurnsValue, 10);
+        const result = await this.service.run({
+            prompt,
+            model: this.modelValue,
+            maxTurns: Number.isFinite(maxTurns) ? maxTurns : 8,
+            bypassPermissions: this.bypassPermissions
+        });
+
+        this.renderResult(result);
+        this.setButtonsDisabled(false);
+        this.isRunning = false;
+    }
+
+    private renderResult(result: ClaudeHeadlessRunResult): void {
+        const outputParts = [
+            result.stdout.trim(),
+            result.stderr.trim() ? `STDERR:\n${result.stderr.trim()}` : '',
+            result.commandLine ? `Command:\n${result.commandLine}` : ''
+        ].filter(Boolean);
+
+        if (this.outputEl) {
+            this.outputEl.setText(outputParts.join('\n\n') || 'Claude returned no output.');
+        }
+
+        this.copyButton?.setDisabled(outputParts.length === 0);
+
+        const durationSeconds = (result.durationMs / 1000).toFixed(1);
+        if (result.success) {
+            this.setStatus(`Completed in ${durationSeconds}s.`, 'success');
+            new Notice('Claude headless session completed.');
+            return;
+        }
+
+        const authHint = result.preflight.isAuthenticated
+            ? ''
+            : ' Claude is not logged in locally. Run `claude auth login` in your terminal, then try again.';
+        this.setStatus(`Run failed after ${durationSeconds}s.${authHint}`, 'error');
+        new Notice('Claude headless session failed. Review the output in the modal.');
+    }
+
+    private setButtonsDisabled(isDisabled: boolean): void {
+        this.runButton?.setDisabled(isDisabled);
+        if (isDisabled) {
+            this.copyButton?.setDisabled(true);
+        }
+    }
+
+    private setStatus(message: string, tone: 'muted' | 'success' | 'warning' | 'error'): void {
+        if (!this.statusEl) {
+            return;
+        }
+
+        this.statusEl.setText(message);
+        this.statusEl.removeClass(
+            'nexus-claude-headless-status-muted',
+            'nexus-claude-headless-status-success',
+            'nexus-claude-headless-status-warning',
+            'nexus-claude-headless-status-error'
+        );
+        this.statusEl.addClass(`nexus-claude-headless-status-${tone}`);
+    }
+
+    private formatPreflight(preflight: ClaudeHeadlessPreflightResult): string {
+        const details = [
+            `Claude: ${preflight.claudePath ?? 'not found'}`,
+            `Node: ${preflight.nodePath ?? 'not found'}`,
+            `Connector: ${preflight.connectorPath ?? 'not found'}`,
+            `Auth: ${preflight.authStatusText}`
+        ];
+
+        return details.join('\n');
+    }
+}

--- a/src/utils/binaryDiscovery.ts
+++ b/src/utils/binaryDiscovery.ts
@@ -1,0 +1,110 @@
+import { Platform } from 'obsidian';
+
+const COMMON_UNIX_BIN_DIRS = [
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    '/opt/local/bin',
+    '/usr/bin',
+    '/bin',
+    '/usr/sbin',
+    '/sbin'
+];
+
+const COMMON_WINDOWS_BIN_DIRS = [
+    'C:\\Program Files\\nodejs',
+    'C:\\Program Files\\Claude',
+    'C:\\Program Files\\Anthropic\\Claude'
+];
+
+export function resolveDesktopBinaryPath(binaryName: string): string | null {
+    if (!Platform.isDesktop) {
+        return null;
+    }
+
+    const fromPath = resolveFromCurrentPath(binaryName);
+    if (fromPath) {
+        return fromPath;
+    }
+
+    const fromCommonLocations = resolveFromCommonLocations(binaryName);
+    if (fromCommonLocations) {
+        return fromCommonLocations;
+    }
+
+    return resolveFromLoginShell(binaryName);
+}
+
+function resolveFromCurrentPath(binaryName: string): string | null {
+    try {
+        const childProcess = require('child_process') as typeof import('child_process');
+        const nodeFs = require('fs') as typeof import('fs');
+        const command = Platform.isWin ? `where ${binaryName}` : `which ${binaryName}`;
+        const result = childProcess.execSync(command, {
+            encoding: 'utf8',
+            timeout: 5000,
+            env: { ...process.env }
+        }).trim();
+
+        const firstLine = result.split(/\r?\n/u)[0]?.trim();
+        if (firstLine && nodeFs.existsSync(firstLine)) {
+            return firstLine;
+        }
+    } catch {
+        // Fall through to deterministic location checks.
+    }
+
+    return null;
+}
+
+function resolveFromCommonLocations(binaryName: string): string | null {
+    try {
+        const nodeFs = require('fs') as typeof import('fs');
+        const pathMod = require('path') as typeof import('path');
+        const binDirs = Platform.isWin ? COMMON_WINDOWS_BIN_DIRS : COMMON_UNIX_BIN_DIRS;
+        const candidateNames = Platform.isWin ? [binaryName, `${binaryName}.exe`, `${binaryName}.cmd`] : [binaryName];
+
+        for (const dir of binDirs) {
+            for (const candidateName of candidateNames) {
+                const candidate = pathMod.join(dir, candidateName);
+                if (nodeFs.existsSync(candidate)) {
+                    return candidate;
+                }
+            }
+        }
+    } catch {
+        // Fall through to shell lookup.
+    }
+
+    return null;
+}
+
+function resolveFromLoginShell(binaryName: string): string | null {
+    if (Platform.isWin) {
+        return null;
+    }
+
+    try {
+        const childProcess = require('child_process') as typeof import('child_process');
+        const nodeFs = require('fs') as typeof import('fs');
+        const shell = process.env.SHELL || '/bin/zsh';
+        const escapedBinaryName = binaryName.replace(/'/g, `'\\''`);
+        const result = childProcess.execFileSync(
+            shell,
+            ['-lc', `command -v '${escapedBinaryName}'`],
+            {
+                encoding: 'utf8',
+                timeout: 5000,
+                env: { ...process.env }
+            }
+        ).trim();
+
+        const firstLine = result.split(/\r?\n/u)[0]?.trim();
+        if (firstLine && nodeFs.existsSync(firstLine)) {
+            return firstLine;
+        }
+    } catch {
+        // No login-shell resolution available.
+    }
+
+    return null;
+}

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-03-22T11:05:08.612Z
+ * Generated: 2026-03-23T12:26:09.592Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -155,6 +155,7 @@ export const getMobileUnavailableFeatures = (): string[] => {
         'Local LLM providers (Ollama, LM Studio)',
         'WebLLM/Nexus local models',
         'ChatGPT Codex OAuth provider',
+        'Claude Code subscription provider',
     ];
 };
 
@@ -178,6 +179,7 @@ export const MOBILE_COMPATIBLE_PROVIDERS = [
  */
 export const DESKTOP_ONLY_PROVIDERS = [
     'openai-codex',  // OAuth callback server remains desktop only
+    'anthropic-claude-code', // Local Claude Code runtime + desktop auth
     'ollama',       // Local server - desktop only
     'lmstudio',     // Local server - desktop only
     'webllm',       // WebGPU - disabled due to bugs

--- a/styles.css
+++ b/styles.css
@@ -228,6 +228,68 @@
     color: var(--text-on-accent);
 }
 
+/* =========================== */
+/* CLAUDE HEADLESS EXPERIMENT  */
+/* =========================== */
+
+.nexus-claude-headless-modal textarea.nexus-claude-headless-prompt {
+    width: 100%;
+    min-height: 10rem;
+    resize: vertical;
+}
+
+.nexus-claude-headless-status {
+    margin-bottom: var(--space-m);
+    padding: var(--space-s) var(--space-m);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    white-space: pre-wrap;
+    font-size: 0.9rem;
+}
+
+.nexus-claude-headless-status-muted {
+    color: var(--text-muted);
+    background: var(--background-secondary);
+}
+
+.nexus-claude-headless-status-success {
+    color: var(--text-normal);
+    background: var(--background-secondary);
+}
+
+.nexus-claude-headless-status-warning {
+    color: var(--text-normal);
+    background: var(--background-secondary);
+}
+
+.nexus-claude-headless-status-error {
+    color: var(--text-normal);
+    background: color-mix(in srgb, var(--background-modifier-error) 20%, var(--background-primary));
+    border-color: var(--background-modifier-error);
+}
+
+.nexus-claude-headless-output {
+    max-height: 18rem;
+    overflow: auto;
+    margin: 0 0 var(--space-m);
+    padding: var(--space-m);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-m);
+    background: var(--background-secondary);
+    color: var(--text-normal);
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-family: var(--font-monospace);
+    font-size: 0.85rem;
+}
+
+.nexus-claude-headless-buttons {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-s);
+    flex-wrap: wrap;
+}
+
 /* Inline rename input */
 .conversation-rename-input {
     width: 100%;


### PR DESCRIPTION
## Summary
- add Claude Code auth and Anthropic-provider UI integration, including Claude Code model labeling
- add a headless Claude Code runner and adapter that uses the local Claude CLI with MCP-only configuration
- surface Claude Code stream-json tool calls and reasoning traces in the existing chat accordions, and add desktop binary discovery for macOS GUI launches

## Testing
- npm run build