### PR TITLE
feat: add Gemini CLI and GitHub Copilot providers with DRY CLI infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,5 @@
 # Claude Code Context Document
-Last Updated: 2026-03-13
+Last Updated: 2026-03-24
 
 ## Project Overview
 - **Name**: Claudesidian MCP
@@ -488,9 +488,10 @@ agents/
 ## Current Context
 
 ### Active Branch
-`main` (current) — active worktrees:
+`feat/provider-integrations` (current worktree: `.worktrees/feat/provider-integrations`) — active worktrees:
 - `.worktrees/feat/elevenlabs-dynamic-models` (branch: `feat/elevenlabs-dynamic-models`)
 - `.worktrees/feat/large-file-refactoring` (branch: `feat/large-file-refactoring`)
+- `.worktrees/feat/provider-integrations` (branch: `feat/provider-integrations`) ← active
 
 ### Open PRs
 | # | Title | Status |
@@ -498,6 +499,13 @@ agents/
 | **#24** | Socket lifecycle fix (DylanLacey) | Transport fix in main (v4.3.2); mux awaiting contributor socket path fix |
 
 ### Current Work
+**New LLM Provider Integrations** (Mar 24) — Peer-reviewed, fixes needed before testing:
+- **Claude Code** ✅ committed (PR #58) — solid, minor DRY opportunities
+- **Codex** ✅ committed — solid
+- **Gemini CLI** ⚠️ uncommitted — `runProcess()` duplication, streaming declaration misleading (`supportsStreaming: true` but batch-only), sandbox disabled
+- **GitHub Copilot** ❌ uncommitted — non-functional: token never passed to adapter, OAuth device flow broken (discards device_code response), missing from ~10 integration points (`SupportedProvider` type, `DEFAULT_LLM_PROVIDER_SETTINGS`, `StaticModelsService`, `ProviderUtils` maps, etc.), `initializeCache()` never called
+- **Shared DRY debt**: `runProcess()` duplicated 3× (Claude Code adapter, Gemini CLI adapter, GeminiCliAuthService); vault/connector path resolution duplicated in Claude Code adapter and `geminiCli.ts`
+
 **Large File Refactoring + DRY Consolidation** — Branch `feat/large-file-refactoring`, PR pending. Plan: `docs/plans/large-file-refactoring-plan.md`. Waves 0-3 complete:
 - DualBackendExecutor helper (eliminates dual-backend if/else across 3 services)
 - ModelDropdownRenderer shared component (ChatSettingsRenderer 798→552 lines)
@@ -560,11 +568,11 @@ A branch IS a conversation with parent metadata:
 | registerDomEvent | ~27 raw addEventListener (modals + view components) | ~27 to fix |
 | console.log cleanup | 398 → 37 (WebLLM: 25, others: 12) | 37 to fix |
 | Inline styles | 85 → 10 (all dynamic/justified — progress bars, positioning) | 0 blocking |
-| Type safety (`as any`) | Regressed from 0 → 16 | 16 to fix |
+| Type safety (`as any`) | Regressed from 0 → 16; GithubCopilotAdapter adds 7 more | ~23 to fix |
 | `@ts-ignore` | Regressed from 1 → 5 | 5 to fix |
 | SQL injection | sortBy column interpolation in 2 repositories | 2 to fix |
 | Timer leak | ContentCache.ts unmanaged setInterval | 1 to fix |
-| Node.js imports | 4 ungated imports (path, fs, child_process) — mobile crash risk | 4 to fix |
+| Node.js imports | 4 pre-existing + new CLI utils (desktopProcess, geminiCli, binaryDiscovery) — mobile crash risk; CLI features are desktop-only, need Platform guards | ~7 to fix |
 | Accessibility | ~5 icon buttons missing aria-label | ~5 to fix |
 
 ## Development Notes
@@ -677,7 +685,7 @@ Key files: `src/ui/chat/components/suggesters/`, `MessageEnhancer.ts`, `SystemPr
 <!-- SESSION_START -->
 ## Current Session
 <!-- Auto-managed by session_init hook. Overwritten each session. -->
-- Resume: `claude --resume 5313cad9-b60d-4476-b092-5231b694bc90`
-- Team: `pact-5313cad9`
-- Started: 2026-03-23 11:49:31 UTC
+- Resume: `claude --resume 871c2f0a-4323-4b1c-94da-7ae242b1024c`
+- Team: `pact-871c2f0a`
+- Started: 2026-03-24 11:54:27 UTC
 <!-- SESSION_END -->

--- a/src/components/llm-provider/providers/GenericProviderModal.ts
+++ b/src/components/llm-provider/providers/GenericProviderModal.ts
@@ -16,7 +16,7 @@ import {
 } from '../types';
 import { LLMValidationService } from '../../../services/llm/validation/ValidationService';
 import { ModelWithProvider } from '../../../services/StaticModelsService';
-import { renderOAuthBanner, updateConnectButtonState } from '../../shared/OAuthBannerComponent';
+import { renderOAuthBanner, updateConnectButtonState, renderCliStatusBanner, updateCheckStatusButtonState } from '../../shared/OAuthBannerComponent';
 import { OAuthFlowManager } from '../../../services/oauth/OAuthFlowManager';
 
 export class GenericProviderModal implements IProviderModal {
@@ -33,6 +33,7 @@ export class GenericProviderModal implements IProviderModal {
   // Secondary OAuth UI elements
   private secondaryBannerContainer: HTMLElement | null = null;
   private secondaryConnectButton: HTMLButtonElement | null = null;
+  private secondaryCheckStatusButton: HTMLButtonElement | null = null;
 
   // State
   private apiKey: string = '';
@@ -102,8 +103,8 @@ export class GenericProviderModal implements IProviderModal {
       });
     }
 
-    // Set up secondary OAuth flow manager
-    if (config.secondaryOAuthProvider) {
+    // Set up secondary OAuth flow manager (skip for statusOnly — handled via direct startFlow)
+    if (config.secondaryOAuthProvider && !config.secondaryOAuthProvider.statusOnly) {
       const secondary = config.secondaryOAuthProvider;
       this.secondaryFlowManager = new OAuthFlowManager({
         oauthConfig: secondary.oauthConfig,
@@ -222,13 +223,13 @@ export class GenericProviderModal implements IProviderModal {
       cls: 'setting-item-description',
     });
 
-    // Banner container for connected/disconnected state
+    // Banner container for connected/disconnected or status indicator
     this.secondaryBannerContainer = section.createDiv('oauth-banner-container');
     this.refreshSecondaryBanner();
   }
 
   /**
-   * Refresh the secondary OAuth banner
+   * Refresh the secondary OAuth/CLI status banner
    */
   private refreshSecondaryBanner(): void {
     if (!this.secondaryBannerContainer) return;
@@ -236,13 +237,66 @@ export class GenericProviderModal implements IProviderModal {
     const secondary = this.config.secondaryOAuthProvider;
     if (!secondary) return;
 
-    const result = renderOAuthBanner(this.secondaryBannerContainer, {
-      providerLabel: secondary.oauthConfig.providerLabel,
-      isConnected: !!secondary.config.oauth?.connected,
-      onConnect: () => this.secondaryFlowManager?.connect(),
-      onDisconnect: () => this.secondaryFlowManager?.disconnect(),
-    });
-    this.secondaryConnectButton = result.connectButton;
+    if (secondary.statusOnly) {
+      // CLI status indicator: shows authenticated/not-authenticated + "Check status" button
+      const result = renderCliStatusBanner(this.secondaryBannerContainer, {
+        providerLabel: secondary.oauthConfig.providerLabel,
+        isAuthenticated: !!secondary.config.oauth?.connected,
+        notAuthenticatedHint: secondary.statusHint,
+        onCheckStatus: () => this.checkSecondaryCliStatus(),
+      });
+      this.secondaryCheckStatusButton = result.checkStatusButton;
+    } else {
+      // Standard OAuth connect/disconnect banner
+      const result = renderOAuthBanner(this.secondaryBannerContainer, {
+        providerLabel: secondary.oauthConfig.providerLabel,
+        isConnected: !!secondary.config.oauth?.connected,
+        onConnect: () => this.secondaryFlowManager?.connect(),
+        onDisconnect: () => this.secondaryFlowManager?.disconnect(),
+      });
+      this.secondaryConnectButton = result.connectButton;
+    }
+  }
+
+  /**
+   * Run a CLI status check for a statusOnly secondary provider.
+   * Calls startFlow (which is check-only), updates config on success,
+   * and refreshes the status banner.
+   */
+  private async checkSecondaryCliStatus(): Promise<void> {
+    const secondary = this.config.secondaryOAuthProvider;
+    if (!secondary) return;
+
+    updateCheckStatusButtonState(this.secondaryCheckStatusButton, true);
+
+    try {
+      const result = await secondary.oauthConfig.startFlow({});
+
+      if (result.success && result.apiKey) {
+        secondary.config.apiKey = result.apiKey;
+        secondary.config.oauth = {
+          connected: true,
+          providerId: secondary.providerId,
+          connectedAt: Date.now(),
+          metadata: result.metadata,
+        };
+        secondary.config.enabled = true;
+        secondary.onConfigChange(secondary.config);
+        new Notice(`${secondary.oauthConfig.providerLabel} authenticated`);
+      } else {
+        secondary.config.apiKey = '';
+        secondary.config.oauth = undefined;
+        secondary.config.enabled = false;
+        secondary.onConfigChange(secondary.config);
+        new Notice(result.error || `${secondary.oauthConfig.providerLabel} not authenticated`);
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      new Notice(`Status check failed: ${errorMessage}`);
+    } finally {
+      updateCheckStatusButtonState(this.secondaryCheckStatusButton, false);
+      this.refreshSecondaryBanner();
+    }
   }
 
   /**
@@ -462,5 +516,6 @@ export class GenericProviderModal implements IProviderModal {
     this.connectButton = null;
     this.secondaryBannerContainer = null;
     this.secondaryConnectButton = null;
+    this.secondaryCheckStatusButton = null;
   }
 }

--- a/src/components/llm-provider/types.ts
+++ b/src/components/llm-provider/types.ts
@@ -83,6 +83,10 @@ export interface SecondaryOAuthProviderConfig {
   oauthConfig: OAuthModalConfig;
   /** Callback when secondary provider configuration changes */
   onConfigChange: (config: LLMProviderConfig) => void;
+  /** If true, render a CLI status indicator instead of OAuth connect/disconnect banner */
+  statusOnly?: boolean;
+  /** Hint text shown when not authenticated (e.g., "run `gemini auth` in your terminal") */
+  statusHint?: string;
 }
 
 /**

--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -176,6 +176,22 @@ export class ChatSettingsRenderer {
         continue;
       }
 
+      if (id === 'google-gemini-cli') {
+        const config = llmSettings.providers[id];
+        if (config?.enabled && config?.oauth?.connected) {
+          providers.add('google');
+        }
+        continue;
+      }
+
+      if (id === 'github-copilot') {
+        const config = llmSettings.providers[id];
+        if (config?.enabled && config?.oauth?.connected && config?.apiKey) {
+          providers.add('github-copilot');
+        }
+        continue;
+      }
+
       const config = llmSettings.providers[id];
       if (!config?.enabled) continue;
       if (!isProviderCompatible(id)) continue;
@@ -203,6 +219,11 @@ export class ChatSettingsRenderer {
     return !!claudeCodeConfig?.oauth?.connected;
   }
 
+  private isGeminiCliConnected(): boolean {
+    const geminiCliConfig = this.config.llmProviderSettings.providers['google-gemini-cli'];
+    return !!geminiCliConfig?.oauth?.connected;
+  }
+
   // ========== MODEL SECTION ==========
 
   private renderModelSection(parent: HTMLElement): void {
@@ -227,6 +248,7 @@ export class ChatSettingsRenderer {
       providerManager: this.providerManager,
       isCodexConnected: () => this.isCodexConnected(),
       isClaudeCodeConnected: () => this.isClaudeCodeConnected(),
+      isGeminiCliConnected: () => this.isGeminiCliConnected(),
       getDefaultModelForProvider: (id) => this.getDefaultModelForProvider(id),
       notifyChange: () => this.notifyChange(),
       reRender: () => this.render(),
@@ -333,6 +355,7 @@ export class ChatSettingsRenderer {
       providerManager: this.providerManager,
       isCodexConnected: () => this.isCodexConnected(),
       isClaudeCodeConnected: () => this.isClaudeCodeConnected(),
+      isGeminiCliConnected: () => this.isGeminiCliConnected(),
       getDefaultModelForProvider: (id) => this.getDefaultModelForProvider(id),
       notifyChange: () => this.notifyChange(),
       reRender: () => this.render(),

--- a/src/components/shared/ModelDropdownRenderer.ts
+++ b/src/components/shared/ModelDropdownRenderer.ts
@@ -20,12 +20,14 @@ const PROVIDER_NAMES: Record<string, string> = {
   anthropic: 'Anthropic',
   'anthropic-claude-code': 'Claude Code',
   google: 'Google AI',
+  'google-gemini-cli': 'Gemini CLI',
   mistral: 'Mistral AI',
   groq: 'Groq',
   openrouter: 'OpenRouter',
   requesty: 'Requesty',
   perplexity: 'Perplexity',
-  'openai-codex': 'ChatGPT'
+  'openai-codex': 'ChatGPT',
+  'github-copilot': 'GitHub Copilot'
 };
 
 export { PROVIDER_NAMES };
@@ -75,6 +77,9 @@ export interface ModelDropdownConfig {
 
   /** Whether Claude Code local auth is connected (for merging Claude Code models into Anthropic) */
   isClaudeCodeConnected: () => boolean;
+
+  /** Whether Gemini CLI local auth is connected (for merging Gemini CLI models into Google) */
+  isGeminiCliConnected: () => boolean;
 
   /** Get default model for a provider (async) */
   getDefaultModelForProvider: (providerId: string) => Promise<string>;
@@ -147,6 +152,8 @@ function renderProviderDropdown(
     ? 'openai'
     : currentProvider === 'anthropic-claude-code'
       ? 'anthropic'
+      : currentProvider === 'google-gemini-cli'
+        ? 'google'
       : currentProvider;
 
   new Setting(content)
@@ -202,6 +209,8 @@ function renderModelDropdown(
     ? 'openai'
     : currentProvider === 'anthropic-claude-code'
       ? 'anthropic'
+      : currentProvider === 'google-gemini-cli'
+        ? 'google'
       : currentProvider;
 
   // Ollama special case: show text input instead of dropdown
@@ -241,6 +250,14 @@ function renderModelDropdown(
           models = [
             ...models,
             ...claudeCodeModels.map(model => ({ ...model, name: `${model.name} (Claude Code)` }))
+          ];
+        }
+
+        if (modelProviderId === 'google' && config.isGeminiCliConnected()) {
+          const geminiCliModels = await config.providerManager.getModelsForProvider('google-gemini-cli');
+          models = [
+            ...models,
+            ...geminiCliModels.map(model => ({ ...model, name: `${model.name} (Gemini CLI)` }))
           ];
         }
 

--- a/src/components/shared/OAuthBannerComponent.ts
+++ b/src/components/shared/OAuthBannerComponent.ts
@@ -76,6 +76,91 @@ export function renderOAuthBanner(
 }
 
 /**
+ * Configuration for rendering a CLI status banner
+ */
+export interface CliStatusBannerConfig {
+  /** The provider label to display (e.g., "Gemini CLI") */
+  providerLabel: string;
+  /** Whether the provider is currently authenticated */
+  isAuthenticated: boolean;
+  /** Error/instruction text when not authenticated (e.g., "run `gemini auth` in your terminal") */
+  notAuthenticatedHint?: string;
+  /** Called when the "Check status" button is clicked */
+  onCheckStatus: () => void;
+}
+
+/**
+ * Result of rendering a CLI status banner
+ */
+export interface CliStatusBannerRenderResult {
+  /** The "Check status" button element */
+  checkStatusButton: HTMLButtonElement;
+}
+
+/**
+ * Render a CLI status banner into the given container.
+ * Shows authentication status with a "Check status" button instead of
+ * OAuth connect/disconnect controls.
+ *
+ * @param container - The container element to render into (will be emptied first)
+ * @param config - Banner configuration
+ * @returns References to rendered elements
+ */
+export function renderCliStatusBanner(
+  container: HTMLElement,
+  config: CliStatusBannerConfig,
+): CliStatusBannerRenderResult {
+  container.empty();
+
+  const banner = container.createDiv('cli-status-banner');
+
+  const statusRow = banner.createDiv('cli-status-row');
+
+  const statusText = statusRow.createSpan('cli-status-text');
+  if (config.isAuthenticated) {
+    statusText.addClass('cli-status-authenticated');
+    statusText.textContent = `${config.providerLabel} authenticated`;
+  } else {
+    statusText.addClass('cli-status-not-authenticated');
+    statusText.textContent = config.notAuthenticatedHint
+      ? `Not authenticated \u2014 ${config.notAuthenticatedHint}`
+      : `${config.providerLabel} not authenticated`;
+  }
+
+  const checkStatusButton = statusRow.createEl('button', {
+    text: 'Check status',
+    cls: 'cli-status-check-btn',
+  });
+  checkStatusButton.setAttribute('aria-label', `Check ${config.providerLabel} authentication status`);
+  checkStatusButton.onclick = () => config.onCheckStatus();
+
+  return { checkStatusButton };
+}
+
+/**
+ * Update a "Check status" button's visual state while a status check is running.
+ *
+ * @param button - The check status button to update
+ * @param checking - Whether a check is in progress
+ */
+export function updateCheckStatusButtonState(
+  button: HTMLButtonElement | null,
+  checking: boolean,
+): void {
+  if (!button) return;
+
+  if (checking) {
+    button.textContent = 'Checking...';
+    button.disabled = true;
+    button.addClass('cli-status-checking');
+  } else {
+    button.textContent = 'Check status';
+    button.disabled = false;
+    button.removeClass('cli-status-checking');
+  }
+}
+
+/**
  * Update a connect button's visual state during an OAuth flow.
  *
  * @param button - The connect button to update (may be null if connected)

--- a/src/main.ts
+++ b/src/main.ts
@@ -98,10 +98,12 @@ export default class NexusPlugin extends Plugin {
                     const { OAuthService } = await import('./services/oauth/OAuthService');
                     const { OpenRouterOAuthProvider } = await import('./services/oauth/providers/OpenRouterOAuthProvider');
                     const { OpenAICodexOAuthProvider } = await import('./services/oauth/providers/OpenAICodexOAuthProvider');
+            const { GithubCopilotOAuthProvider } = await import('./services/oauth/providers/GithubCopilotOAuthProvider');
 
                     const oauthService = OAuthService.getInstance();
                     oauthService.registerProvider(new OpenRouterOAuthProvider());
                     oauthService.registerProvider(new OpenAICodexOAuthProvider());
+            oauthService.registerProvider(new GithubCopilotOAuthProvider());
                 } catch (error) {
                     console.error(`[${BRAND_NAME}] Failed to initialize OAuth providers:`, error);
                     // Continue without OAuth — manual API key entry still works

--- a/src/services/StaticModelsService.ts
+++ b/src/services/StaticModelsService.ts
@@ -14,6 +14,8 @@ import { REQUESTY_MODELS } from './llm/adapters/requesty/RequestyModels';
 import { PERPLEXITY_MODELS } from './llm/adapters/perplexity/PerplexityModels';
 import { OPENAI_CODEX_MODELS } from './llm/adapters/openai-codex/OpenAICodexModels';
 import { ANTHROPIC_CLAUDE_CODE_MODELS } from './llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels';
+import { GOOGLE_GEMINI_CLI_MODELS } from './llm/adapters/google-gemini-cli/GoogleGeminiCliModels';
+import { GITHUB_COPILOT_MODELS } from './llm/adapters/github-copilot/GithubCopilotModels';
 
 export interface ModelWithProvider {
   provider: string;
@@ -61,13 +63,15 @@ export class StaticModelsService {
       { provider: 'openai', models: OPENAI_MODELS },
       { provider: 'anthropic', models: ANTHROPIC_MODELS },
       { provider: 'google', models: GOOGLE_MODELS },
+      { provider: 'google-gemini-cli', models: GOOGLE_GEMINI_CLI_MODELS },
       { provider: 'mistral', models: MISTRAL_MODELS },
       { provider: 'groq', models: GROQ_MODELS },
       { provider: 'openrouter', models: OPENROUTER_MODELS },
       { provider: 'requesty', models: REQUESTY_MODELS },
       { provider: 'perplexity', models: PERPLEXITY_MODELS },
       { provider: 'openai-codex', models: OPENAI_CODEX_MODELS },
-      { provider: 'anthropic-claude-code', models: ANTHROPIC_CLAUDE_CODE_MODELS }
+      { provider: 'anthropic-claude-code', models: ANTHROPIC_CLAUDE_CODE_MODELS },
+      { provider: 'github-copilot', models: GITHUB_COPILOT_MODELS }
     ];
 
     providerModels.forEach(({ provider, models }) => {
@@ -99,6 +103,9 @@ export class StaticModelsService {
       case 'google':
         providerModels = GOOGLE_MODELS;
         break;
+      case 'google-gemini-cli':
+        providerModels = GOOGLE_GEMINI_CLI_MODELS;
+        break;
       case 'mistral':
         providerModels = MISTRAL_MODELS;
         break;
@@ -119,6 +126,9 @@ export class StaticModelsService {
         break;
       case 'anthropic-claude-code':
         providerModels = ANTHROPIC_CLAUDE_CODE_MODELS;
+        break;
+      case 'github-copilot':
+        providerModels = GITHUB_COPILOT_MODELS;
         break;
       default:
         return [];
@@ -159,7 +169,7 @@ export class StaticModelsService {
    * Get provider information
    */
   getAvailableProviders(): string[] {
-    return ['openai', 'anthropic', 'anthropic-claude-code', 'google', 'mistral', 'groq', 'openrouter', 'requesty', 'perplexity', 'openai-codex'];
+    return ['openai', 'anthropic', 'anthropic-claude-code', 'google', 'google-gemini-cli', 'github-copilot', 'mistral', 'groq', 'openrouter', 'requesty', 'perplexity', 'openai-codex'];
   }
 
   /**

--- a/src/services/external/GeminiCliAuthService.ts
+++ b/src/services/external/GeminiCliAuthService.ts
@@ -1,0 +1,131 @@
+/**
+ * src/services/external/GeminiCliAuthService.ts
+ *
+ * Auth status checker for the Gemini CLI provider. The plugin does not
+ * initiate authentication — users must install and authenticate the
+ * Gemini CLI externally before using it. This service only checks
+ * whether the CLI is present and authenticated.
+ */
+import { App, Platform } from 'obsidian';
+import { runCliProcess, CliProcessResult } from '../../utils/cliProcessRunner';
+import {
+    buildGeminiCliEnv,
+    buildGeminiCliSystemSettings,
+    resolveGeminiCliRuntime
+} from '../../utils/geminiCli';
+
+export interface GeminiCliAuthStatus {
+    available: boolean;
+    loggedIn: boolean;
+    authMethod: string;
+    geminiPath: string | null;
+    error?: string;
+}
+
+export class GeminiCliAuthService {
+    constructor(private app: App) {}
+
+    /**
+     * Check whether the Gemini CLI is installed and authenticated.
+     */
+    async getStatus(): Promise<GeminiCliAuthStatus> {
+        if (!Platform.isDesktop) {
+            return {
+                available: false,
+                loggedIn: false,
+                authMethod: 'none',
+                geminiPath: null,
+                error: 'Gemini CLI is only available on desktop.'
+            };
+        }
+
+        const runtime = resolveGeminiCliRuntime(this.app.vault);
+        if (!runtime.geminiPath) {
+            return {
+                available: false,
+                loggedIn: false,
+                authMethod: 'none',
+                geminiPath: null,
+                error: 'Gemini CLI was not found on PATH. Install it from https://github.com/google-gemini/gemini-cli'
+            };
+        }
+
+        const probe = await this.runAuthProbe();
+        return {
+            available: true,
+            loggedIn: probe.exitCode === 0,
+            authMethod: probe.exitCode === 0 ? 'google-cli-login' : 'unknown',
+            geminiPath: runtime.geminiPath,
+            error: probe.exitCode === 0
+                ? undefined
+                : 'Gemini CLI is not authenticated. Run `gemini` in your terminal and choose "Login with Google" to authenticate.'
+        };
+    }
+
+    /**
+     * Check if the CLI is authenticated. If yes, return the sentinel key.
+     * If not, return a clear error directing the user to authenticate externally.
+     *
+     * This is used as the "connect" flow — it's check-only, no terminal launch.
+     */
+    async checkAuth(): Promise<{ success: boolean; apiKey?: string; metadata?: Record<string, string>; error?: string }> {
+        const status = await this.getStatus();
+
+        if (!status.available) {
+            return { success: false, error: status.error };
+        }
+
+        if (!status.loggedIn) {
+            return { success: false, error: status.error };
+        }
+
+        return {
+            success: true,
+            apiKey: 'gemini-cli-local-auth',
+            metadata: {
+                authMethod: status.authMethod,
+                geminiPath: status.geminiPath || ''
+            }
+        };
+    }
+
+    private async runAuthProbe(): Promise<CliProcessResult> {
+        const runtime = resolveGeminiCliRuntime(this.app.vault);
+        if (!runtime.geminiPath || !runtime.vaultPath) {
+            return { stdout: '', stderr: 'Gemini CLI runtime is unavailable.', exitCode: null };
+        }
+
+        const fsPromises = require('fs/promises') as typeof import('fs/promises');
+        const osMod = require('os') as typeof import('os');
+        const pathMod = require('path') as typeof import('path');
+        const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-gemini-auth-'));
+        const settingsPath = pathMod.join(tempDir, 'system-settings.json');
+
+        try {
+            await fsPromises.writeFile(
+                settingsPath,
+                JSON.stringify(buildGeminiCliSystemSettings(runtime), null, 2),
+                'utf8'
+            );
+
+            const handle = runCliProcess(
+                runtime.geminiPath,
+                [
+                    '--prompt',
+                    'Reply with exactly OK.',
+                    '--model',
+                    'gemini-2.5-flash',
+                    '--output-format',
+                    'json'
+                ],
+                {
+                    cwd: runtime.vaultPath,
+                    env: buildGeminiCliEnv(settingsPath)
+                }
+            );
+            return await handle.result;
+        } finally {
+            await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+        }
+    }
+}

--- a/src/services/llm/adapters/ModelRegistry.ts
+++ b/src/services/llm/adapters/ModelRegistry.ts
@@ -17,6 +17,8 @@ import { REQUESTY_MODELS, REQUESTY_DEFAULT_MODEL } from './requesty/RequestyMode
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL } from './groq/GroqModels';
 import { OPENAI_CODEX_MODELS, OPENAI_CODEX_DEFAULT_MODEL } from './openai-codex/OpenAICodexModels';
 import { ANTHROPIC_CLAUDE_CODE_MODELS, ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL } from './anthropic-claude-code/AnthropicClaudeCodeModels';
+import { GOOGLE_GEMINI_CLI_MODELS, GOOGLE_GEMINI_CLI_DEFAULT_MODEL } from './google-gemini-cli/GoogleGeminiCliModels';
+import { GITHUB_COPILOT_MODELS, GITHUB_COPILOT_DEFAULT_MODEL } from './github-copilot/GithubCopilotModels';
 import type { LLMProviderSettings } from '../../../types';
 
 // Re-export ModelSpec for convenience
@@ -31,12 +33,14 @@ export const AI_MODELS: Record<string, ModelSpec[]> = {
   openai: OPENAI_MODELS,
   'openai-codex': OPENAI_CODEX_MODELS,
   'anthropic-claude-code': ANTHROPIC_CLAUDE_CODE_MODELS,
+  'google-gemini-cli': GOOGLE_GEMINI_CLI_MODELS,
   google: GOOGLE_MODELS,
   anthropic: ANTHROPIC_MODELS,
   mistral: MISTRAL_MODELS,
   openrouter: OPENROUTER_MODELS,
   requesty: REQUESTY_MODELS,
-  groq: GROQ_MODELS
+  groq: GROQ_MODELS,
+  'github-copilot': GITHUB_COPILOT_MODELS
 };
 
 /**
@@ -214,10 +218,12 @@ export const DEFAULT_MODELS: Record<string, string> = {
   openai: OPENAI_DEFAULT_MODEL,
   'openai-codex': OPENAI_CODEX_DEFAULT_MODEL,
   'anthropic-claude-code': ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL,
+  'google-gemini-cli': GOOGLE_GEMINI_CLI_DEFAULT_MODEL,
   google: GOOGLE_DEFAULT_MODEL,
   anthropic: ANTHROPIC_DEFAULT_MODEL,
   mistral: MISTRAL_DEFAULT_MODEL,
   openrouter: OPENROUTER_DEFAULT_MODEL,
   requesty: REQUESTY_DEFAULT_MODEL,
-  groq: GROQ_DEFAULT_MODEL
+  groq: GROQ_DEFAULT_MODEL,
+  'github-copilot': GITHUB_COPILOT_DEFAULT_MODEL
 };

--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
@@ -1,6 +1,10 @@
-import { FileSystemAdapter, Vault } from 'obsidian';
+import { Vault } from 'obsidian';
+import type { ChildProcess } from 'child_process';
 import { BaseAdapter } from '../BaseAdapter';
 import { resolveDesktopBinaryPath } from '../../../../utils/binaryDiscovery';
+import { getVaultBasePath, getConnectorPath } from '../../../../utils/cliPathUtils';
+import { runCliProcess } from '../../../../utils/cliProcessRunner';
+import { spawnDesktopProcess } from '../../../../utils/desktopProcess';
 import {
   GenerateOptions,
   StreamChunk,
@@ -11,13 +15,14 @@ import {
   LLMProviderError
 } from '../types';
 import { ModelRegistry } from '../ModelRegistry';
-import { getAllPluginIds, getPrimaryServerKey } from '../../../../constants/branding';
+import { getPrimaryServerKey } from '../../../../constants/branding';
 
 type ClaudeCodeToolCall = NonNullable<StreamChunk['toolCalls']>[number];
 
 export class AnthropicClaudeCodeAdapter extends BaseAdapter {
   readonly name = 'anthropic-claude-code';
   readonly baseUrl = 'claude-code://local';
+  private activeProcess: ChildProcess | null = null;
 
   constructor(private vault: Vault) {
     super('claude-code-local-auth', 'claude-sonnet-4-6', 'claude-code://local', false);
@@ -109,9 +114,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
         '--no-session-persistence',
         '--dangerously-skip-permissions',
         '--output-format',
-        'stream-json',
-        '--max-turns',
-        String(Math.max(1, options?.maxTokens ? Math.min(12, Math.ceil(options.maxTokens / 8000)) : 8))
+        'stream-json'
       ];
 
       if (options?.systemPrompt?.trim()) {
@@ -133,11 +136,17 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
       delete env.ANTHROPIC_API_KEY;
       delete env.ANTHROPIC_AUTH_TOKEN;
 
-      const child = childProcess.spawn(runtime.claudePath, args, {
+      const child = spawnDesktopProcess(childProcess, runtime.claudePath, args, {
         cwd: runtime.vaultPath,
         env,
         stdio: ['ignore', 'pipe', 'pipe']
       });
+      this.activeProcess = child;
+
+      if (!child.stdout || !child.stderr) {
+        throw new LLMProviderError('Failed to capture Claude Code process output.', this.name, 'CONFIGURATION_ERROR');
+      }
+
       const closePromise = new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
         child.on('close', (exitCode: number | null, signal: NodeJS.Signals | null) => {
           resolve({ exitCode, signal });
@@ -223,6 +232,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
         }
       };
     } finally {
+      this.activeProcess = null;
       try {
         await fsPromises.rm(tempDir, { recursive: true, force: true });
       } catch {
@@ -270,7 +280,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
   }> {
     const claudePath = resolveDesktopBinaryPath('claude');
     const nodePath = resolveDesktopBinaryPath('node');
-    const vaultPath = this.getVaultBasePath();
+    const vaultPath = getVaultBasePath(this.vault);
 
     if (!nodePath) {
       throw new LLMProviderError('Node.js was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
@@ -279,7 +289,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
     return {
       claudePath,
       nodePath,
-      connectorPath: this.getConnectorPath(vaultPath),
+      connectorPath: getConnectorPath(vaultPath),
       vaultPath
     };
   }
@@ -444,34 +454,21 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
     return normalized;
   }
 
-  private getVaultBasePath(): string | null {
-    const adapter = this.vault.adapter;
-    if (adapter instanceof FileSystemAdapter) {
-      return adapter.getBasePath();
+
+  abort(): void {
+    if (this.activeProcess) {
+      this.activeProcess.kill();
+      this.activeProcess = null;
     }
-    return null;
-  }
-
-  private getConnectorPath(vaultPath: string | null): string | null {
-    if (!vaultPath) {
-      return null;
-    }
-
-    const pathMod = require('path') as typeof import('path');
-    const nodeFs = require('fs') as typeof import('fs');
-
-    for (const pluginId of getAllPluginIds()) {
-      const candidate = pathMod.join(vaultPath, '.obsidian', 'plugins', pluginId, 'connector.js');
-      if (nodeFs.existsSync(candidate)) {
-        return candidate;
-      }
-    }
-
-    return null;
   }
 
   private async readAuthStatus(claudePath: string, cwd: string): Promise<{ loggedIn: boolean; authMethod: string }> {
-    const result = await this.runProcess(claudePath, ['auth', 'status'], cwd);
+    const env = { ...process.env };
+    delete env.ANTHROPIC_API_KEY;
+    delete env.ANTHROPIC_AUTH_TOKEN;
+
+    const handle = runCliProcess(claudePath, ['auth', 'status'], { cwd, env });
+    const result = await handle.result;
     try {
       const parsed = JSON.parse(result.stdout) as { loggedIn?: boolean; authMethod?: string };
       return {
@@ -484,48 +481,5 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
         authMethod: 'unknown'
       };
     }
-  }
-
-  private async runProcess(
-    command: string,
-    args: string[],
-    cwd?: string
-  ): Promise<{ stdout: string; stderr: string; exitCode: number | null }> {
-    const childProcess = require('child_process') as typeof import('child_process');
-
-    return await new Promise((resolve) => {
-      const env = { ...process.env };
-      delete env.ANTHROPIC_API_KEY;
-      delete env.ANTHROPIC_AUTH_TOKEN;
-
-      const child = childProcess.spawn(command, args, {
-        cwd,
-        env,
-        stdio: ['ignore', 'pipe', 'pipe']
-      });
-
-      let stdout = '';
-      let stderr = '';
-
-      child.stdout.on('data', (chunk: Buffer | string) => {
-        stdout += chunk.toString();
-      });
-
-      child.stderr.on('data', (chunk: Buffer | string) => {
-        stderr += chunk.toString();
-      });
-
-      child.on('error', (error: Error) => {
-        resolve({
-          stdout,
-          stderr: stderr ? `${stderr}\n${error.message}` : error.message,
-          exitCode: null
-        });
-      });
-
-      child.on('close', (exitCode: number | null) => {
-        resolve({ stdout, stderr, exitCode });
-      });
-    });
   }
 }

--- a/src/services/llm/adapters/github-copilot/GithubCopilotAdapter.ts
+++ b/src/services/llm/adapters/github-copilot/GithubCopilotAdapter.ts
@@ -1,0 +1,175 @@
+import { BaseAdapter } from '../BaseAdapter';
+import { GenerateOptions, StreamChunk, LLMResponse, ModelInfo, ProviderCapabilities, ModelPricing } from '../types';
+import { GITHUB_COPILOT_MODELS, GITHUB_COPILOT_DEFAULT_MODEL } from './GithubCopilotModels';
+import { ProviderHttpClient } from '../shared/ProviderHttpClient';
+import { BufferedSSEStreamProcessor } from '../../streaming/BufferedSSEStreamProcessor';
+import { LLMProviderConfig } from '../../../../types';
+
+const COPILOT_API_ENDPOINT = 'https://api.githubcopilot.com/chat/completions';
+const COPILOT_MODELS_ENDPOINT = 'https://api.githubcopilot.com/models';
+
+export class GithubCopilotAdapter extends BaseAdapter {
+  readonly name = 'github-copilot';
+  readonly baseUrl = COPILOT_API_ENDPOINT;
+
+  constructor(apiKey?: string, defaultModel?: string) {
+    super(apiKey || '', defaultModel || GITHUB_COPILOT_DEFAULT_MODEL);
+    this.initializeCache();
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      supportsStreaming: true,
+      streamingMode: 'streaming',
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsThinking: true,
+      maxContextWindow: 200000,
+      supportedFeatures: ['chat']
+    };
+  }
+
+  async getModelPricing(modelId: string): Promise<ModelPricing | null> {
+    return null;
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    const toModelInfo = (model: any): ModelInfo => ({
+      id: model.apiName || model.id,
+      name: model.name || model.id,
+      contextWindow: model.contextWindow || 200000,
+      maxOutputTokens: model.maxTokens || 64000,
+      supportsJSON: model.capabilities ? model.capabilities.supportsJSON : true,
+      supportsImages: model.capabilities ? model.capabilities.supportsImages : true,
+      supportsFunctions: model.capabilities ? model.capabilities.supportsFunctions : true,
+      supportsStreaming: model.capabilities ? model.capabilities.supportsStreaming : true,
+      supportsThinking: model.capabilities ? model.capabilities.supportsThinking : false,
+      pricing: { inputPerMillion: 0, outputPerMillion: 0, currency: 'USD', lastUpdated: '' }
+    });
+
+    if (this.apiKey) {
+      try {
+        const syncedModels = await this.syncModels(this.apiKey);
+        if (syncedModels && syncedModels.length > 0) {
+          const merged = GITHUB_COPILOT_MODELS.map(base => {
+            const found = syncedModels.find((m: any) => m.id === base.apiName);
+            return found ? { ...base, ...found } : base;
+          });
+          return merged.map(toModelInfo);
+        }
+      } catch (err) {}
+    }
+    return GITHUB_COPILOT_MODELS.map(toModelInfo);
+  }
+
+  async syncModels(token: string): Promise<any[]> {
+    const sessionToken = await this.getSessionToken(token);
+    const headers = this.getAuthHeaders(sessionToken);
+
+    const response = await ProviderHttpClient.request({
+      url: COPILOT_MODELS_ENDPOINT,
+      provider: this.name,
+      operation: 'syncModels',
+      method: 'GET',
+      headers
+    });
+    return (response.json as any).data || [];
+  }
+
+  private async getSessionToken(ghuToken: string): Promise<string> {
+    const headers = {
+      'Authorization': `token ${ghuToken}`,
+      'Accept': 'application/json',
+      'Editor-Version': 'vscode/1.90.0',
+      'Editor-Plugin-Version': 'copilot-chat/0.17.1',
+      'User-Agent': 'GitHubCopilotChat/0.17.1'
+    };
+
+    const response = await ProviderHttpClient.request({
+      url: 'https://api.github.com/copilot_internal/v2/token',
+      provider: this.name,
+      operation: 'getSessionToken',
+      method: 'GET',
+      headers
+    });
+    
+    const json = response.json as any;
+    if (!json.token) throw new Error('Failed to fetch Copilot session token');
+    return json.token;
+  }
+
+  private getAuthHeaders(sessionToken: string): Record<string, string> {
+    return {
+      'Authorization': `Bearer ${sessionToken}`,
+      'Editor-Version': 'vscode/1.90.0',
+      'Editor-Plugin-Version': 'copilot-chat/0.17.1',
+      'User-Agent': 'GitHubCopilotChat/0.17.1',
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
+    };
+  }
+
+  async generateUncached(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
+    if (!this.apiKey) throw new Error('GitHub Copilot requires authentication.');
+
+    const sessionToken = await this.getSessionToken(this.apiKey);
+    const headers = this.getAuthHeaders(sessionToken);
+    
+    // Fallback standard options to prevent type errors on options?.messages
+    const messages = options && 'messages' in options ? (options as any).messages : [{ role: 'user', content: prompt }];
+
+    const payload = {
+      model: options?.model || this.currentModel,
+      messages: messages,
+      temperature: options?.temperature ?? 0.5,
+      stream: false
+    };
+
+    const response = await ProviderHttpClient.request({
+      url: this.baseUrl,
+      provider: this.name,
+      operation: 'generateMessage',
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    });
+    
+    const data = response.json as any;
+    return {
+      text: data.choices?.[0]?.message?.content || '',
+      model: data.model,
+      usage: data.usage
+    };
+  }
+
+  async *generateStreamAsync(prompt: string, options?: GenerateOptions): AsyncGenerator<StreamChunk, void, unknown> {
+    if (!this.apiKey) throw new Error('GitHub Copilot requires authentication.');
+
+    const sessionToken = await this.getSessionToken(this.apiKey);
+    const headers = this.getAuthHeaders(sessionToken);
+
+    const messages = options && 'messages' in options ? (options as any).messages : [{ role: 'user', content: prompt }];
+
+    const payload = {
+      model: options?.model || this.currentModel,
+      messages: messages,
+      temperature: options?.temperature ?? 0.5,
+      stream: true
+    };
+
+    const stream = await this.requestStream({
+      url: this.baseUrl,
+      operation: 'generateStreamAsync',
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload)
+    });
+
+    yield* this.processNodeStream(stream, {
+      extractContent: (parsed) => parsed.choices?.[0]?.delta?.content || null,
+      extractToolCalls: () => null,
+      extractFinishReason: (parsed) => parsed.choices?.[0]?.finish_reason || null
+    });
+  }
+}

--- a/src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
+++ b/src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
@@ -1,0 +1,75 @@
+import { ModelSpec } from '../modelTypes';
+
+/**
+ * Base GitHub Copilot Models.
+ * At runtime, the adapter will query the /models endpoint to get the real available slugs 
+ * and merge them into or overwrite these, ensuring we have exactly the slugs Copilot expects.
+ */
+export const GITHUB_COPILOT_MODELS: ModelSpec[] = [
+  {
+    provider: 'github-copilot',
+    name: 'Claude Sonnet 4.6 (Copilot)',
+    apiName: 'claude-sonnet-4-6', // Base fallback
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'github-copilot',
+    name: 'Claude Opus 4.6 (Copilot)',
+    apiName: 'claude-opus-4-6',
+    contextWindow: 200000,
+    maxTokens: 64000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'github-copilot',
+    name: 'GPT-5.4 (Copilot)',
+    apiName: 'gpt-5.4',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'github-copilot',
+    name: 'Gemini 3.1 Pro (Preview Copilot)',
+    apiName: 'gemini-3.1-pro-preview',
+    contextWindow: 1050000,
+    maxTokens: 65000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  }
+];
+
+export const GITHUB_COPILOT_DEFAULT_MODEL = 'claude-sonnet-4-6';

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -1,0 +1,264 @@
+/**
+ * src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+ *
+ * LLM adapter for Google Gemini CLI. Runs the CLI as a child process in
+ * non-streaming (JSON output) mode and parses the result.
+ */
+import { Vault } from 'obsidian';
+import type { ChildProcess } from 'child_process';
+import { BaseAdapter } from '../BaseAdapter';
+import {
+  GenerateOptions,
+  StreamChunk,
+  LLMResponse,
+  ModelInfo,
+  ProviderCapabilities,
+  ModelPricing,
+  LLMProviderError,
+  TokenUsage
+} from '../types';
+import { ModelRegistry } from '../ModelRegistry';
+import { runCliProcess } from '../../../../utils/cliProcessRunner';
+import {
+  buildGeminiCliEnv,
+  buildGeminiCliSystemSettings,
+  resolveGeminiCliRuntime
+} from '../../../../utils/geminiCli';
+
+interface GeminiCliJsonResponse {
+  response?: string;
+  text?: string;
+  content?: string;
+  output?: string;
+  result?: {
+    text?: string;
+  };
+  stats?: {
+    models?: Array<Record<string, unknown>>;
+    tools?: unknown;
+  };
+  error?: string | { message?: string };
+}
+
+export class GoogleGeminiCliAdapter extends BaseAdapter {
+  readonly name = 'google-gemini-cli';
+  readonly baseUrl = 'gemini-cli://local';
+  private activeProcess: ChildProcess | null = null;
+
+  constructor(private vault: Vault) {
+    super('gemini-cli-local-auth', 'gemini-2.5-pro', 'gemini-cli://local', false);
+    this.initializeCache();
+  }
+
+  async generateUncached(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
+    const runtime = resolveGeminiCliRuntime(this.vault);
+    if (!runtime.geminiPath) {
+      throw new LLMProviderError('Gemini CLI was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
+    }
+    if (!runtime.nodePath) {
+      throw new LLMProviderError('Node.js was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
+    }
+    if (!runtime.connectorPath) {
+      throw new LLMProviderError('Nexus connector.js was not found for this vault.', this.name, 'CONFIGURATION_ERROR');
+    }
+    if (!runtime.vaultPath) {
+      throw new LLMProviderError('Vault filesystem path is unavailable.', this.name, 'CONFIGURATION_ERROR');
+    }
+
+    const fsPromises = require('fs/promises') as typeof import('fs/promises');
+    const osMod = require('os') as typeof import('os');
+    const pathMod = require('path') as typeof import('path');
+
+    const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-gemini-cli-'));
+    const settingsPath = pathMod.join(tempDir, 'system-settings.json');
+
+    try {
+      await fsPromises.writeFile(
+        settingsPath,
+        JSON.stringify(buildGeminiCliSystemSettings(runtime), null, 2),
+        'utf8'
+      );
+
+      const combinedPrompt = this.buildPrompt(prompt, options?.systemPrompt);
+      const args = [
+        '--prompt',
+        combinedPrompt,
+        '--model',
+        options?.model || this.currentModel,
+        '--output-format',
+        'json'
+      ];
+
+      const handle = runCliProcess(runtime.geminiPath, args, {
+        cwd: runtime.vaultPath,
+        env: buildGeminiCliEnv(settingsPath)
+      });
+      this.activeProcess = handle.child;
+      const result = await handle.result;
+      this.activeProcess = null;
+
+      if (result.exitCode !== 0) {
+        throw new LLMProviderError(
+          result.stderr.trim() || result.stdout.trim() || `Gemini CLI exited with status ${result.exitCode ?? 'unknown'}`,
+          this.name,
+          result.exitCode === null ? 'CONFIGURATION_ERROR' : 'PROVIDER_ERROR'
+        );
+      }
+
+      const parsed = this.parseOutput(result.stdout);
+      if (!parsed) {
+        throw new LLMProviderError(
+          'Gemini CLI returned an unreadable JSON response.',
+          this.name,
+          'PROVIDER_ERROR'
+        );
+      }
+
+      const errorMessage = typeof parsed.error === 'string'
+        ? parsed.error
+        : parsed.error?.message;
+      if (errorMessage) {
+        throw new LLMProviderError(errorMessage, this.name, 'PROVIDER_ERROR');
+      }
+
+      const text = this.extractText(parsed);
+      const usage = this.extractUsageFromStats(parsed);
+
+      return this.buildLLMResponse(
+        text,
+        options?.model || this.currentModel,
+        usage || { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        {
+          localCli: true,
+          outputFormat: 'json',
+          toolSummary: parsed.stats?.tools
+        },
+        'stop'
+      );
+    } finally {
+      this.activeProcess = null;
+      await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+
+  async* generateStreamAsync(prompt: string, options?: GenerateOptions): AsyncGenerator<StreamChunk, void, unknown> {
+    const response = await this.generateUncached(prompt, options);
+    yield {
+      content: response.text,
+      complete: true,
+      usage: response.usage
+    };
+  }
+
+  async listModels(): Promise<ModelInfo[]> {
+    return ModelRegistry.getProviderModels('google-gemini-cli').map(model => ModelRegistry.toModelInfo(model));
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      supportsStreaming: false,
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsThinking: true,
+      maxContextWindow: 1048576,
+      supportedFeatures: ['gemini-cli', 'mcp', 'google-login']
+    };
+  }
+
+  async getModelPricing(modelId: string): Promise<ModelPricing | null> {
+    const model = ModelRegistry.findModel('google-gemini-cli', modelId);
+    if (!model) {
+      return null;
+    }
+
+    return {
+      rateInputPerMillion: model.inputCostPerMillion,
+      rateOutputPerMillion: model.outputCostPerMillion,
+      currency: 'USD'
+    };
+  }
+
+  abort(): void {
+    if (this.activeProcess) {
+      this.activeProcess.kill();
+      this.activeProcess = null;
+    }
+  }
+
+  private buildPrompt(prompt: string, systemPrompt?: string): string {
+    if (!systemPrompt?.trim()) {
+      return prompt;
+    }
+
+    return `System instructions:\n${systemPrompt.trim()}\n\nUser request:\n${prompt}`;
+  }
+
+  private parseOutput(stdout: string): GeminiCliJsonResponse | null {
+    const trimmed = stdout.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(trimmed) as GeminiCliJsonResponse;
+    } catch {
+      const lastJsonLine = trimmed
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .reverse()
+        .find((line) => line.startsWith('{') && line.endsWith('}'));
+
+      if (!lastJsonLine) {
+        return null;
+      }
+
+      try {
+        return JSON.parse(lastJsonLine) as GeminiCliJsonResponse;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  private extractText(parsed: GeminiCliJsonResponse): string {
+    if (typeof parsed.response === 'string') return parsed.response;
+    if (typeof parsed.text === 'string') return parsed.text;
+    if (typeof parsed.content === 'string') return parsed.content;
+    if (typeof parsed.output === 'string') return parsed.output;
+    if (typeof parsed.result?.text === 'string') return parsed.result.text;
+    return '';
+  }
+
+  private extractUsageFromStats(parsed: GeminiCliJsonResponse): TokenUsage | undefined {
+    const modelStats = Array.isArray(parsed.stats?.models) ? parsed.stats?.models[0] : undefined;
+    if (!modelStats || typeof modelStats !== 'object') {
+      return undefined;
+    }
+
+    const promptTokens = this.readNumber(modelStats, ['promptTokens', 'inputTokens']);
+    const completionTokens = this.readNumber(modelStats, ['candidatesTokens', 'outputTokens', 'completionTokens']);
+    const totalTokens = this.readNumber(modelStats, ['totalTokens']);
+
+    if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) {
+      return undefined;
+    }
+
+    return {
+      promptTokens: promptTokens || 0,
+      completionTokens: completionTokens || 0,
+      totalTokens: totalTokens || ((promptTokens || 0) + (completionTokens || 0))
+    };
+  }
+
+  private readNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+}

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
@@ -1,0 +1,38 @@
+import { ModelSpec } from '../modelTypes';
+
+export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
+  {
+    provider: 'google-gemini-cli',
+    name: 'Gemini 2.5 Pro',
+    apiName: 'gemini-2.5-pro',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'google-gemini-cli',
+    name: 'Gemini 2.5 Flash',
+    apiName: 'gemini-2.5-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  }
+];
+
+export const GOOGLE_GEMINI_CLI_DEFAULT_MODEL = 'gemini-2.5-pro';

--- a/src/services/llm/adapters/types.ts
+++ b/src/services/llm/adapters/types.ts
@@ -6,7 +6,7 @@
 /**
  * Supported LLM providers
  */
-export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'anthropic-claude-code' | 'google' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
+export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'anthropic-claude-code' | 'google' | 'google-gemini-cli' | 'github-copilot' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
 
 export interface GenerateOptions {
   model?: string;

--- a/src/services/llm/core/AdapterRegistry.ts
+++ b/src/services/llm/core/AdapterRegistry.ts
@@ -228,6 +228,8 @@ export class AdapterRegistry implements IAdapterRegistry {
     if (!onMobile) {
       await this.initializeCodexAdapter(providers['openai-codex']);
       await this.initializeClaudeCodeAdapter(providers['anthropic-claude-code']);
+      await this.initializeGeminiCliAdapter(providers['google-gemini-cli']);
+      await this.initializeGithubCopilotAdapter(providers['github-copilot']);
 
       // Ollama - apiKey is actually the server URL
       if (providers.ollama?.enabled && providers.ollama.apiKey) {
@@ -348,6 +350,48 @@ export class AdapterRegistry implements IAdapterRegistry {
     } catch (error) {
       console.error('AdapterRegistry: Failed to initialize Claude Code adapter:', error);
       this.logError('anthropic-claude-code', error);
+    }
+  }
+
+  /**
+   * Initialize the Gemini CLI adapter from local CLI auth state.
+   */
+  private async initializeGeminiCliAdapter(config: LLMProviderConfig | undefined): Promise<void> {
+    if (!config?.enabled) return;
+
+    const oauth = config.oauth;
+    if (!oauth?.connected || !this.vault) {
+      return;
+    }
+
+    try {
+      const { GoogleGeminiCliAdapter } = await import('../adapters/google-gemini-cli/GoogleGeminiCliAdapter');
+      const adapter = new GoogleGeminiCliAdapter(this.vault);
+      this.adapters.set('google-gemini-cli', adapter);
+    } catch (error) {
+      console.error('AdapterRegistry: Failed to initialize Gemini CLI adapter:', error);
+      this.logError('google-gemini-cli', error);
+    }
+  }
+
+  /**
+   * Initialize the GitHub Copilot adapter.
+   */
+  private async initializeGithubCopilotAdapter(config: LLMProviderConfig | undefined): Promise<void> {
+    if (!config?.enabled) return;
+
+    const oauth = config.oauth;
+    if (!oauth?.connected || !config.apiKey) {
+      return; // Not connected via OAuth or no token — skip initialization
+    }
+
+    try {
+      const { GithubCopilotAdapter } = await import('../adapters/github-copilot/GithubCopilotAdapter');
+      const adapter = new GithubCopilotAdapter(config.apiKey);
+      this.adapters.set('github-copilot', adapter);
+    } catch (error) {
+      console.error('AdapterRegistry: Failed to initialize GitHub Copilot adapter:', error);
+      this.logError('github-copilot', error);
     }
   }
 

--- a/src/services/llm/providers/ProviderManager.ts
+++ b/src/services/llm/providers/ProviderManager.ts
@@ -251,6 +251,11 @@ export class LLMProviderManager {
         description: 'Gemini models with multimodal capabilities and thinking mode'
       },
       {
+        id: 'google-gemini-cli',
+        name: 'Gemini CLI',
+        description: 'Gemini models via your local Gemini CLI Google login — desktop only'
+      },
+      {
         id: 'mistral',
         name: 'Mistral',
         description: 'European models with strong coding and multilingual support'
@@ -279,6 +284,11 @@ export class LLMProviderManager {
         id: 'openai-codex',
         name: 'ChatGPT (Codex)',
         description: 'GPT models via ChatGPT subscription — free inference, requires OAuth sign-in'
+      },
+      {
+        id: 'github-copilot',
+        name: 'GitHub Copilot',
+        description: 'AI models via GitHub Copilot subscription — free inference, requires OAuth device flow'
       },
       {
         id: 'webllm',
@@ -310,6 +320,10 @@ export class LLMProviderManager {
         hasApiKey = !!(config?.oauth?.connected && config?.apiKey);
       } else if (provider.id === 'anthropic-claude-code') {
         hasApiKey = !!config?.oauth?.connected;
+      } else if (provider.id === 'google-gemini-cli') {
+        hasApiKey = !!config?.oauth?.connected;
+      } else if (provider.id === 'github-copilot') {
+        hasApiKey = !!(config?.oauth?.connected && config?.apiKey);
       } else if (provider.id === 'ollama' || provider.id === 'lmstudio') {
         hasApiKey = !!(config?.apiKey && config.apiKey.trim());
       } else {

--- a/src/services/oauth/index.ts
+++ b/src/services/oauth/index.ts
@@ -32,3 +32,4 @@ export { OAuthService } from './OAuthService';
 
 export { OpenRouterOAuthProvider } from './providers/OpenRouterOAuthProvider';
 export { OpenAICodexOAuthProvider } from './providers/OpenAICodexOAuthProvider';
+export { GithubCopilotOAuthProvider } from './providers/GithubCopilotOAuthProvider';

--- a/src/services/oauth/providers/GithubCopilotOAuthProvider.ts
+++ b/src/services/oauth/providers/GithubCopilotOAuthProvider.ts
@@ -1,0 +1,200 @@
+/**
+ * GithubCopilotOAuthProvider.ts
+ * Location: src/services/oauth/providers/GithubCopilotOAuthProvider.ts
+ *
+ * OAuth provider for GitHub Copilot using the GitHub Device Flow (RFC 8628).
+ * Unlike standard PKCE OAuth providers, Copilot uses device authorization:
+ *   1. POST to /login/device/code → get device_code + user_code + verification_uri
+ *   2. User opens verification_uri and enters user_code
+ *   3. Poll /login/oauth/access_token with device_code until token granted
+ *
+ * The access token (ghu_*) is then used to obtain ephemeral Copilot session
+ * tokens from api.github.com/copilot_internal/v2/token.
+ *
+ * Used by: ProvidersTab (startGithubCopilotDeviceFlow), AdapterRegistry
+ */
+
+import { Notice } from 'obsidian';
+import { IOAuthProvider, OAuthProviderConfig, OAuthResult } from '../IOAuthProvider';
+import { ProviderHttpClient } from '../../llm/adapters/shared/ProviderHttpClient';
+
+/** GitHub's OAuth app client ID for Copilot Chat (VS Code extension) */
+const COPILOT_CLIENT_ID = '01ab8ac9400c4e429b23';
+
+/** Device authorization endpoint */
+const DEVICE_CODE_URL = 'https://github.com/login/device/code';
+
+/** Token exchange/polling endpoint */
+const TOKEN_URL = 'https://github.com/login/oauth/access_token';
+
+/** Where the user enters their code */
+const VERIFICATION_URL = 'https://github.com/login/device';
+
+/** Default polling interval in ms (GitHub recommends at least 5s) */
+const POLL_INTERVAL_MS = 5000;
+
+/** Maximum time to wait for user to complete device flow (5 minutes) */
+const MAX_POLL_DURATION_MS = 300000;
+
+/**
+ * Response from GitHub's device code endpoint
+ */
+interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+/**
+ * Response from GitHub's token polling endpoint
+ */
+interface TokenPollResponse {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+  interval?: number;
+}
+
+export class GithubCopilotOAuthProvider implements IOAuthProvider {
+  config: OAuthProviderConfig = {
+    providerId: 'github-copilot',
+    displayName: 'GitHub Copilot',
+    authUrl: DEVICE_CODE_URL,
+    tokenUrl: TOKEN_URL,
+    preferredPort: 0,
+    callbackPath: '',
+    scopes: ['read:user'],
+    tokenType: 'permanent-key',
+    clientId: COPILOT_CLIENT_ID,
+    experimental: true,
+    experimentalWarning: 'This connects via an undocumented GitHub Copilot proxy. Requires an active GitHub Copilot subscription.'
+  };
+
+  /**
+   * Not used for device flow — the device flow does not open a browser auth URL.
+   * Returns an empty string; the actual verification URL is opened by startDeviceFlow().
+   */
+  buildAuthUrl(_callbackUrl: string, _codeChallenge: string, _state: string): string {
+    return '';
+  }
+
+  /**
+   * Exchange a device_code for an access token by polling GitHub's token endpoint.
+   * Called after the user has entered their user_code at the verification URL.
+   *
+   * @param code - The device_code from the device flow initiation
+   */
+  async exchangeCode(code: string, _codeVerifier: string, _callbackUrl: string): Promise<OAuthResult> {
+    const startTime = Date.now();
+    let pollInterval = POLL_INTERVAL_MS;
+
+    while (Date.now() - startTime < MAX_POLL_DURATION_MS) {
+      const response = await ProviderHttpClient.request({
+        url: TOKEN_URL,
+        provider: 'github-copilot',
+        operation: 'pollDeviceToken',
+        method: 'POST',
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          client_id: COPILOT_CLIENT_ID,
+          device_code: code,
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code'
+        })
+      });
+
+      const res = response.json as TokenPollResponse | null;
+      if (!res) {
+        throw new Error('Empty response from GitHub token endpoint');
+      }
+
+      if (res.access_token) {
+        return { apiKey: res.access_token };
+      }
+
+      if (res.error === 'authorization_pending') {
+        // User hasn't completed flow yet — wait and retry
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+        continue;
+      }
+
+      if (res.error === 'slow_down') {
+        // GitHub is asking us to increase the polling interval
+        pollInterval = (res.interval ?? 10) * 1000;
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+        continue;
+      }
+
+      if (res.error === 'expired_token') {
+        throw new Error('Device code expired. Please try connecting again.');
+      }
+
+      if (res.error === 'access_denied') {
+        throw new Error('Authorization was denied. Please try again.');
+      }
+
+      // Unknown error
+      throw new Error(res.error_description || res.error || 'Device flow token exchange failed');
+    }
+
+    throw new Error('Device login timed out. Please try connecting again.');
+  }
+
+  /**
+   * Start the full GitHub device authorization flow.
+   *
+   * This method is called directly by ProvidersTab (bypassing OAuthService.startFlow(),
+   * which assumes a redirect-based PKCE flow). It:
+   *   1. Requests a device_code + user_code from GitHub
+   *   2. Opens the verification URL in the user's browser
+   *   3. Shows the user_code via Obsidian Notice so the user can enter it
+   *   4. Polls for the access token
+   *
+   * @returns OAuthResult with the GitHub OAuth token (ghu_*)
+   */
+  async startDeviceFlow(): Promise<OAuthResult> {
+    // Step 1: Request device code
+    const deviceResponse = await ProviderHttpClient.request({
+      url: DEVICE_CODE_URL,
+      provider: 'github-copilot',
+      operation: 'requestDeviceCode',
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        client_id: COPILOT_CLIENT_ID,
+        scope: this.config.scopes.join(' ')
+      })
+    });
+
+    const deviceData = deviceResponse.json as DeviceCodeResponse | null;
+    if (!deviceData?.device_code || !deviceData?.user_code) {
+      throw new Error('Failed to initialize GitHub device flow — no device code returned');
+    }
+
+    // Step 2: Open verification URL in browser
+    try {
+      const { shell } = require('electron');
+      shell.openExternal(deviceData.verification_uri || VERIFICATION_URL);
+    } catch {
+      window.open(deviceData.verification_uri || VERIFICATION_URL, '_blank');
+    }
+
+    // Step 3: Show user_code via Notice (persistent — 30 second duration)
+    new Notice(
+      `GitHub Copilot: Enter code ${deviceData.user_code} in your browser to complete sign-in.`,
+      30000
+    );
+
+    // Step 4: Poll for token using exchangeCode
+    return this.exchangeCode(deviceData.device_code, '', '');
+  }
+}

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -23,6 +23,7 @@ import { isDesktop, supportsLocalLLM, MOBILE_COMPATIBLE_PROVIDERS, isProviderCom
 import type { OAuthModalConfig, SecondaryOAuthProviderConfig } from '../../components/llm-provider/types';
 import { OAuthService } from '../../services/oauth/OAuthService';
 import { ClaudeCodeAuthService } from '../../services/external/ClaudeCodeAuthService';
+import { GeminiCliAuthService } from '../../services/external/GeminiCliAuthService';
 
 /**
  * Provider display configuration
@@ -106,6 +107,12 @@ export class ProvidersTab {
             signupUrl: 'https://aistudio.google.com/app/apikey',
             category: 'cloud'
         },
+        'google-gemini-cli': {
+            name: 'Gemini CLI',
+            keyFormat: 'Local Gemini CLI Google login required',
+            signupUrl: 'https://github.com/google-gemini/gemini-cli',
+            category: 'cloud'
+        },
         mistral: {
             name: 'Mistral AI',
             keyFormat: 'msak_...',
@@ -140,6 +147,12 @@ export class ProvidersTab {
             name: 'ChatGPT (Codex)',
             keyFormat: 'OAuth sign-in required',
             signupUrl: 'https://chatgpt.com',
+            category: 'cloud'
+        },
+        'github-copilot': {
+            name: 'GitHub Copilot',
+            keyFormat: 'Device flow sign-in required',
+            signupUrl: 'https://github.com/features/copilot',
             category: 'cloud'
         }
     };
@@ -212,6 +225,19 @@ export class ProvidersTab {
                 },
             };
         }
+
+        // GitHub Copilot (experimental) — uses device flow, bypasses OAuthService.startFlow()
+        if (oauthService.hasProvider('github-copilot')) {
+            this.providerConfigs['github-copilot'] = {
+                ...this.providerConfigs['github-copilot'],
+                oauthConfig: {
+                    providerLabel: 'GitHub Copilot',
+                    experimental: true,
+                    experimentalWarning: 'This connects via an undocumented GitHub Copilot proxy. Requires an active GitHub Copilot subscription.',
+                    startFlow: () => this.startGithubCopilotDeviceFlow(),
+                },
+            };
+        }
     }
 
     /**
@@ -250,6 +276,36 @@ export class ProvidersTab {
     private async startClaudeCodeConnectFlow(): Promise<{ success: boolean; apiKey?: string; metadata?: Record<string, string>; error?: string }> {
         const authService = new ClaudeCodeAuthService(this.services.app);
         return await authService.connectSubscriptionLogin();
+    }
+
+    /**
+     * Check Gemini CLI auth status. The plugin does not initiate auth —
+     * users must authenticate externally via `gemini` in their terminal.
+     */
+    private async startGeminiCliConnectFlow(): Promise<{ success: boolean; apiKey?: string; metadata?: Record<string, string>; error?: string }> {
+        const authService = new GeminiCliAuthService(this.services.app);
+        return await authService.checkAuth();
+    }
+
+    /**
+     * Start a GitHub Copilot device authorization flow.
+     * Bypasses OAuthService.startFlow() since device flow has no redirect callback.
+     */
+    private async startGithubCopilotDeviceFlow(): Promise<{ success: boolean; apiKey?: string; error?: string }> {
+        try {
+            const { GithubCopilotOAuthProvider } = await import('../../services/oauth/providers/GithubCopilotOAuthProvider');
+            const provider = new GithubCopilotOAuthProvider();
+            const result = await provider.startDeviceFlow();
+            return {
+                success: true,
+                apiKey: result.apiKey,
+            };
+        } catch (error) {
+            return {
+                success: false,
+                error: error instanceof Error ? error.message : 'GitHub Copilot device flow failed',
+            };
+        }
     }
 
     /**
@@ -418,6 +474,8 @@ export class ProvidersTab {
         // WebLLM doesn't need an API key
         if (providerId === 'webllm') return true;
         if (providerId === 'anthropic-claude-code') return !!config.oauth?.connected;
+        if (providerId === 'google-gemini-cli') return !!config.oauth?.connected;
+        if (providerId === 'github-copilot') return !!(config.oauth?.connected && config.apiKey);
         // Other providers need an API key
         return !!config.apiKey;
     }
@@ -463,7 +521,7 @@ export class ProvidersTab {
             secondaryOAuthProvider = {
                 providerId: 'anthropic-claude-code',
                 providerLabel: 'Claude Code',
-                description: 'Connect your local Claude Code subscription login and use Claude models through the desktop CLI.',
+                description: 'Use Claude models through the desktop CLI. Authenticate by running `claude auth login` in your terminal first.',
                 config: { ...claudeCodeConfig },
                 oauthConfig: {
                     providerLabel: 'Claude Code',
@@ -473,6 +531,30 @@ export class ProvidersTab {
                     settings.providers['anthropic-claude-code'] = updatedClaudeCodeConfig;
                     await this.saveSettings();
                 },
+                statusOnly: true,
+                statusHint: 'run `claude auth login` in your terminal',
+            };
+        } else if (providerId === 'google') {
+            const geminiCliConfig = settings.providers['google-gemini-cli'] || {
+                apiKey: '',
+                enabled: false,
+            };
+
+            secondaryOAuthProvider = {
+                providerId: 'google-gemini-cli',
+                providerLabel: 'Gemini CLI',
+                description: 'Use Gemini models through the desktop CLI. Authenticate by running `gemini` in your terminal first.',
+                config: { ...geminiCliConfig },
+                oauthConfig: {
+                    providerLabel: 'Gemini CLI',
+                    startFlow: () => this.startGeminiCliConnectFlow(),
+                },
+                onConfigChange: async (updatedGeminiCliConfig: LLMProviderConfig) => {
+                    settings.providers['google-gemini-cli'] = updatedGeminiCliConfig;
+                    await this.saveSettings();
+                },
+                statusOnly: true,
+                statusHint: 'run `gemini auth` in your terminal',
             };
         }
 

--- a/src/types/llm/ProviderTypes.ts
+++ b/src/types/llm/ProviderTypes.ts
@@ -101,6 +101,10 @@ export const DEFAULT_LLM_PROVIDER_SETTINGS: LLMProviderSettings = {
       apiKey: '',
       enabled: false
     },
+    'google-gemini-cli': {
+      apiKey: '',
+      enabled: false
+    },
     google: {
       apiKey: '',
       enabled: false
@@ -128,6 +132,10 @@ export const DEFAULT_LLM_PROVIDER_SETTINGS: LLMProviderSettings = {
       enabled: false
     },
     'openai-codex': {
+      apiKey: '',
+      enabled: false
+    },
+    'github-copilot': {
       apiKey: '',
       enabled: false
     },

--- a/src/ui/chat/utils/ProviderUtils.ts
+++ b/src/ui/chat/utils/ProviderUtils.ts
@@ -11,12 +11,14 @@ export class ProviderUtils {
       'openai': 'OpenAI',
       'anthropic': 'Anthropic',
       'anthropic-claude-code': 'Anthropic (Claude Code)',
+      'google-gemini-cli': 'Google (Gemini CLI)',
       'mistral': 'Mistral AI',
       'ollama': 'Ollama',
       'lmstudio': 'LM Studio',
       'webllm': 'Nexus (Local)',
       'openrouter': 'OpenRouter',
       'google': 'Google',
+      'github-copilot': 'GitHub Copilot',
       'cohere': 'Cohere',
       'huggingface': 'Hugging Face',
       'groq': 'Groq',
@@ -75,12 +77,14 @@ export class ProviderUtils {
       'openai': '#10a37f',
       'anthropic': '#d97757',
       'anthropic-claude-code': '#d97757',
+      'google-gemini-cli': '#4285f4',
       'mistral': '#ff6b35',
       'ollama': '#000000',
       'lmstudio': '#4A90E2',
       'webllm': '#00d4aa',  // WebGPU green
       'openrouter': '#8b5cf6',
       'google': '#4285f4',
+      'github-copilot': '#1f6feb',
       'cohere': '#39c6b9',
       'huggingface': '#ff9a00'
     };
@@ -95,12 +99,14 @@ export class ProviderUtils {
       'openai': '🤖',
       'anthropic': '🧠',
       'anthropic-claude-code': '🧠',
+      'google-gemini-cli': '🔍',
       'mistral': '🌪️',
       'ollama': '🦙',
       'lmstudio': '🖥️',
       'webllm': '🌐',
       'openrouter': '🔀',
       'google': '🔍',
+      'github-copilot': '✈️',
       'cohere': '🧬',
       'huggingface': '🤗'
     };
@@ -128,12 +134,14 @@ export class ProviderUtils {
       'openai': 'OAI',
       'anthropic': 'ANT',
       'anthropic-claude-code': 'ACC',
+      'google-gemini-cli': 'GCL',
       'mistral': 'MST',
       'ollama': 'OLL',
       'lmstudio': 'LMS',
       'webllm': 'WEB',
       'openrouter': 'OR',
       'google': 'GGL',
+      'github-copilot': 'GHC',
       'cohere': 'COH',
       'huggingface': 'HF'
     };
@@ -148,13 +156,15 @@ export class ProviderUtils {
       'openai',
       'anthropic',
       'anthropic-claude-code',
+      'google-gemini-cli',
       'mistral',
       'ollama',
       'lmstudio',    // ✅ LM Studio streaming via OpenAI-compatible API
       'webllm',      // ✅ WebLLM streaming via MLC.ai WebGPU
       'openrouter',
       'google',      // ✅ Google Gemini streaming via generateContentStream
-      'groq'         // ✅ Groq streaming support
+      'groq',        // ✅ Groq streaming support
+      'github-copilot' // ✅ GitHub Copilot streaming via OpenAI-compatible SSE
     ];
     return streamingProviders.includes(providerId);
   }
@@ -174,7 +184,9 @@ export class ProviderUtils {
       'requesty',    // ✅ OpenAI-compatible function calling
       'anthropic',   // ✅ Native Claude tool calling
       'anthropic-claude-code',
-      'google'       // ✅ Native Google Gemini function calling (functionDeclarations)
+      'google-gemini-cli',
+      'google',      // ✅ Native Google Gemini function calling (functionDeclarations)
+      'github-copilot' // ✅ OpenAI-compatible function calling via Copilot proxy
     ];
     // Note: Perplexity does NOT support function calling (web search focused)
     return functionCallingProviders.includes(providerId);
@@ -227,7 +239,7 @@ export class ProviderUtils {
     return {
       streaming: this.supportsStreaming(providerId),
       functionCalling: this.supportsFunctionCalling(providerId),
-      imageInput: ['openai', 'anthropic', 'anthropic-claude-code', 'google'].includes(providerId),
+      imageInput: ['openai', 'anthropic', 'anthropic-claude-code', 'google', 'google-gemini-cli', 'github-copilot'].includes(providerId),
       jsonMode: ['openai', 'mistral'].includes(providerId)
     };
   }

--- a/src/utils/binaryDiscovery.ts
+++ b/src/utils/binaryDiscovery.ts
@@ -35,6 +35,10 @@ export function resolveDesktopBinaryPath(binaryName: string): string | null {
 }
 
 function resolveFromCurrentPath(binaryName: string): string | null {
+    if (!Platform.isDesktop) {
+        return null;
+    }
+
     try {
         const childProcess = require('child_process') as typeof import('child_process');
         const nodeFs = require('fs') as typeof import('fs');
@@ -45,7 +49,7 @@ function resolveFromCurrentPath(binaryName: string): string | null {
             env: { ...process.env }
         }).trim();
 
-        const firstLine = result.split(/\r?\n/u)[0]?.trim();
+        const firstLine = result.split(/\r?\n/)[0]?.trim();
         if (firstLine && nodeFs.existsSync(firstLine)) {
             return firstLine;
         }
@@ -57,6 +61,10 @@ function resolveFromCurrentPath(binaryName: string): string | null {
 }
 
 function resolveFromCommonLocations(binaryName: string): string | null {
+    if (!Platform.isDesktop) {
+        return null;
+    }
+
     try {
         const nodeFs = require('fs') as typeof import('fs');
         const pathMod = require('path') as typeof import('path');
@@ -79,7 +87,7 @@ function resolveFromCommonLocations(binaryName: string): string | null {
 }
 
 function resolveFromLoginShell(binaryName: string): string | null {
-    if (Platform.isWin) {
+    if (!Platform.isDesktop || Platform.isWin) {
         return null;
     }
 
@@ -98,7 +106,7 @@ function resolveFromLoginShell(binaryName: string): string | null {
             }
         ).trim();
 
-        const firstLine = result.split(/\r?\n/u)[0]?.trim();
+        const firstLine = result.split(/\r?\n/)[0]?.trim();
         if (firstLine && nodeFs.existsSync(firstLine)) {
             return firstLine;
         }

--- a/src/utils/cliPathUtils.ts
+++ b/src/utils/cliPathUtils.ts
@@ -1,0 +1,41 @@
+/**
+ * src/utils/cliPathUtils.ts
+ *
+ * Shared vault base path and connector.js resolution helpers.
+ * Used by CLI adapter runtimes (Claude Code, Gemini CLI) and auth services.
+ */
+import { FileSystemAdapter, Vault } from 'obsidian';
+import { getAllPluginIds } from '../constants/branding';
+
+/**
+ * Returns the filesystem base path for the vault, or null on mobile.
+ */
+export function getVaultBasePath(vault: Vault): string | null {
+  const adapter = vault.adapter;
+  if (adapter instanceof FileSystemAdapter) {
+    return adapter.getBasePath();
+  }
+  return null;
+}
+
+/**
+ * Finds the connector.js file for this plugin across all known plugin IDs.
+ * Returns the absolute path, or null if not found.
+ */
+export function getConnectorPath(vaultPath: string | null): string | null {
+  if (!vaultPath) {
+    return null;
+  }
+
+  const pathMod = require('path') as typeof import('path');
+  const nodeFs = require('fs') as typeof import('fs');
+
+  for (const pluginId of getAllPluginIds()) {
+    const candidate = pathMod.join(vaultPath, '.obsidian', 'plugins', pluginId, 'connector.js');
+    if (nodeFs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}

--- a/src/utils/cliProcessRunner.ts
+++ b/src/utils/cliProcessRunner.ts
@@ -1,0 +1,82 @@
+/**
+ * src/utils/cliProcessRunner.ts
+ *
+ * Shared CLI process runner for spawn-collect-resolve pattern.
+ * Used by AnthropicClaudeCodeAdapter, GoogleGeminiCliAdapter, and GeminiCliAuthService.
+ */
+import type { ChildProcess, SpawnOptions } from 'child_process';
+import { spawnDesktopProcess } from './desktopProcess';
+
+export interface CliProcessResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export interface CliProcessHandle {
+  child: ChildProcess;
+  result: Promise<CliProcessResult>;
+}
+
+/**
+ * Spawns a CLI process and collects stdout/stderr until it exits.
+ *
+ * Returns both the child process reference (for abort wiring) and a
+ * promise that resolves with the collected output and exit code.
+ *
+ * Uses `spawnDesktopProcess` for cross-platform Windows .cmd/.bat handling.
+ */
+export function runCliProcess(
+  command: string,
+  args: string[],
+  options?: {
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+  }
+): CliProcessHandle {
+  const childProcess = require('child_process') as typeof import('child_process');
+
+  const spawnOptions: SpawnOptions = {
+    cwd: options?.cwd,
+    env: options?.env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  };
+
+  const child = spawnDesktopProcess(childProcess, command, args, spawnOptions);
+
+  const result = new Promise<CliProcessResult>((resolve) => {
+    if (!child.stdout || !child.stderr) {
+      resolve({
+        stdout: '',
+        stderr: 'Failed to capture CLI process output.',
+        exitCode: null
+      });
+      return;
+    }
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error: Error) => {
+      resolve({
+        stdout,
+        stderr: stderr ? `${stderr}\n${error.message}` : error.message,
+        exitCode: null
+      });
+    });
+
+    child.on('close', (exitCode: number | null) => {
+      resolve({ stdout, stderr, exitCode });
+    });
+  });
+
+  return { child, result };
+}

--- a/src/utils/desktopProcess.ts
+++ b/src/utils/desktopProcess.ts
@@ -1,0 +1,26 @@
+import { Platform } from 'obsidian';
+
+type ChildProcessModule = typeof import('child_process');
+type SpawnOptions = import('child_process').SpawnOptions;
+
+function isWindowsCommandWrapper(command: string): boolean {
+    if (!Platform.isWin) {
+        return false;
+    }
+
+    const lower = command.toLowerCase();
+    return lower.endsWith('.cmd') || lower.endsWith('.bat');
+}
+
+export function spawnDesktopProcess(
+    childProcess: ChildProcessModule,
+    command: string,
+    args: string[],
+    options: SpawnOptions
+) {
+    return childProcess.spawn(command, args, {
+        ...options,
+        shell: options.shell ?? isWindowsCommandWrapper(command),
+        windowsHide: true
+    });
+}

--- a/src/utils/geminiCli.ts
+++ b/src/utils/geminiCli.ts
@@ -1,0 +1,100 @@
+import { Vault } from 'obsidian';
+import { getPrimaryServerKey } from '../constants/branding';
+import { resolveDesktopBinaryPath } from './binaryDiscovery';
+import { getVaultBasePath, getConnectorPath } from './cliPathUtils';
+
+export interface GeminiCliRuntime {
+    geminiPath: string | null;
+    nodePath: string | null;
+    connectorPath: string | null;
+    vaultPath: string | null;
+    serverKey: string;
+}
+
+const BUILT_IN_TOOL_EXCLUSIONS = [
+    'edit',
+    'list_directory',
+    'read_file',
+    'read_many_files',
+    'run_shell_command',
+    'save_memory',
+    'web_fetch',
+    'write_file',
+    'google_web_search'
+];
+
+export function resolveGeminiCliRuntime(vault: Vault): GeminiCliRuntime {
+    const geminiPath = resolveDesktopBinaryPath('gemini');
+    const nodePath = resolveDesktopBinaryPath('node');
+    const vaultPath = getVaultBasePath(vault);
+
+    return {
+        geminiPath,
+        nodePath,
+        connectorPath: getConnectorPath(vaultPath),
+        vaultPath,
+        serverKey: getPrimaryServerKey(vault.getName())
+    };
+}
+
+export function buildGeminiCliEnv(systemSettingsPath?: string): NodeJS.ProcessEnv {
+    const env = { ...process.env };
+
+    delete env.GEMINI_API_KEY;
+    delete env.GOOGLE_API_KEY;
+    delete env.GOOGLE_GENAI_USE_VERTEXAI;
+    delete env.GOOGLE_CLOUD_PROJECT;
+    delete env.GOOGLE_APPLICATION_CREDENTIALS;
+
+    if (systemSettingsPath) {
+        env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = systemSettingsPath;
+    } else {
+        delete env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
+    }
+
+    return env;
+}
+
+export function buildGeminiCliSystemSettings(runtime: GeminiCliRuntime): Record<string, unknown> {
+    return {
+        general: {
+            disableAutoUpdate: true,
+            disableUpdateNag: true
+        },
+        privacy: {
+            usageStatisticsEnabled: false
+        },
+        security: {
+            folderTrust: {
+                enabled: false
+            }
+        },
+        ui: {
+            hideBanner: true,
+            hideFooter: true,
+            hideTips: true
+        },
+        output: {
+            format: 'json'
+        },
+        tools: {
+            sandbox: false,
+            core: [],
+            exclude: BUILT_IN_TOOL_EXCLUSIONS
+        },
+        mcp: {
+            allowed: [runtime.serverKey]
+        },
+        mcpServers: runtime.nodePath && runtime.connectorPath ? {
+            [runtime.serverKey]: {
+                command: runtime.nodePath,
+                args: [runtime.connectorPath],
+                cwd: runtime.vaultPath || undefined,
+                timeout: 600000,
+                trust: true,
+                includeTools: ['getTools', 'useTools']
+            }
+        } : {}
+    };
+}
+

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -156,6 +156,7 @@ export const getMobileUnavailableFeatures = (): string[] => {
         'WebLLM/Nexus local models',
         'ChatGPT Codex OAuth provider',
         'Claude Code subscription provider',
+        'Gemini CLI Google-login provider',
     ];
 };
 
@@ -180,6 +181,8 @@ export const MOBILE_COMPATIBLE_PROVIDERS = [
 export const DESKTOP_ONLY_PROVIDERS = [
     'openai-codex',  // OAuth callback server remains desktop only
     'anthropic-claude-code', // Local Claude Code runtime + desktop auth
+    'google-gemini-cli', // Local Gemini CLI runtime + desktop auth
+    'github-copilot', // OAuth device flow requires desktop
     'ollama',       // Local server - desktop only
     'lmstudio',     // Local server - desktop only
     'webllm',       // WebGPU - disabled due to bugs

--- a/styles.css
+++ b/styles.css
@@ -7105,6 +7105,44 @@ body.is-mobile .chat-loading-overlay {
     cursor: wait;
 }
 
+/* CLI status banner (for statusOnly secondary providers like Gemini CLI, Claude Code) */
+.cli-status-banner {
+    margin-bottom: var(--space-sm, 8px);
+}
+
+.cli-status-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-xs, 4px) var(--space-sm, 8px);
+    border-radius: var(--radius-s);
+    background-color: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+}
+
+.cli-status-text {
+    font-size: var(--font-ui-small);
+}
+
+.cli-status-authenticated {
+    color: var(--text-success, var(--interactive-accent));
+}
+
+.cli-status-not-authenticated {
+    color: var(--text-muted);
+}
+
+.cli-status-check-btn {
+    font-size: var(--font-ui-smaller);
+    padding: var(--space-xs, 4px) var(--space-sm, 8px);
+    cursor: pointer;
+}
+
+.cli-status-checking {
+    opacity: 0.6;
+    cursor: wait;
+}
+
 /* Consent modal */
 .oauth-consent-modal,
 .oauth-preauth-modal {


### PR DESCRIPTION
## Summary

- **Gemini CLI provider**: Local CLI-based LLM via `google-gemini-cli` adapter. Auth is check-only — user must run `gemini auth` externally; settings shows live status indicator. Batch mode only (`supportsStreaming: false`). Abort wired to `child.kill()`.
- **GitHub Copilot provider**: OAuth device flow (RFC 8628), session token caching with TTL, 401 → "token expired, reconnect in Settings" error, registered in all integration points, BaseAdapter pattern compliant, dynamic model listing preserved.
- **CLI infrastructure DRY**: Extracted shared `cliProcessRunner.ts` (was duplicated 3×) and `cliPathUtils.ts` (was duplicated 2×). Both Claude Code and Gemini CLI adapters now use shared utilities.
- **Claude Code improvements**: Abort wired to `child.kill()`, removed `maxTurns` limit (`maxTokens/8000` heuristic), switched subprocess spawning to `spawnDesktopProcess` for Windows compat.
- **Cleanup**: Deleted `externalTerminal.ts` (dead code), added `Platform.isDesktop` guards to `binaryDiscovery.ts`.

## Architecture note

Claude Code subagent ↔ Claudesidian subagent integration is a separate design question — see issue #60.

## Test plan

- [ ] Gemini CLI: install `gemini` CLI and run `gemini auth`, then verify provider appears in dropdown and chat works
- [ ] Gemini CLI: verify settings shows "authenticated" status after auth, "not authenticated" before
- [ ] Gemini CLI: verify abort button kills the subprocess
- [ ] GitHub Copilot: complete device flow OAuth in settings, verify model dropdown populates dynamically
- [ ] GitHub Copilot: verify session token is reused across requests (only 1 HTTP call per turn after first)
- [ ] GitHub Copilot: simulate expired token, verify actionable error message
- [ ] Claude Code: verify abort button stops the running process
- [ ] All providers: verify no regressions on existing providers (Anthropic, OpenAI, Gemini HTTP, Codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)