### PR TITLE
fix: prepend node binary directory to PATH for Gemini CLI subprocess

### DIFF
--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -91,7 +91,7 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
 
       const handle = runCliProcess(runtime.geminiPath, args, {
         cwd: runtime.vaultPath,
-        env: buildGeminiCliEnv(settingsPath)
+        env: buildGeminiCliEnv(settingsPath, runtime.nodePath)
       });
       this.activeProcess = handle.child;
       const result = await handle.result;

--- a/src/utils/geminiCli.ts
+++ b/src/utils/geminiCli.ts
@@ -37,7 +37,7 @@ export function resolveGeminiCliRuntime(vault: Vault): GeminiCliRuntime {
     };
 }
 
-export function buildGeminiCliEnv(systemSettingsPath?: string): NodeJS.ProcessEnv {
+export function buildGeminiCliEnv(systemSettingsPath?: string, nodePath?: string | null): NodeJS.ProcessEnv {
     const env = { ...process.env };
 
     delete env.GEMINI_API_KEY;
@@ -50,6 +50,16 @@ export function buildGeminiCliEnv(systemSettingsPath?: string): NodeJS.ProcessEn
         env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = systemSettingsPath;
     } else {
         delete env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
+    }
+
+    // Prepend the node binary's directory to PATH so that subprocess spawns
+    // (e.g. `node connector.js`) succeed when Obsidian runs with a restricted
+    // PATH that omits nvm/homebrew/system node locations.
+    if (nodePath) {
+        const pathMod = require('path') as typeof import('path');
+        const nodeDir = pathMod.dirname(nodePath);
+        const separator = process.platform === 'win32' ? ';' : ':';
+        env.PATH = nodeDir + separator + (env.PATH || '');
     }
 
     return env;


### PR DESCRIPTION
Gemini CLI was failing with `env: node: No such file or directory` because Obsidian runs with a restricted PATH that doesn't include the node binary directory (e.g. nvm paths). Fix prepends the resolved node binary's directory to PATH before spawning the Gemini CLI process.