### PR TITLE
fix: write system prompt to temp file to avoid Windows argv limit

### DIFF
--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
@@ -84,6 +84,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
 
     const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-claude-code-adapter-'));
     const mcpConfigPath = pathMod.join(tempDir, 'mcp.json');
+    const systemPromptPath = pathMod.join(tempDir, 'system-prompt.txt');
     const trimmedSystemPrompt = options?.systemPrompt?.trim();
     const toolCalls = new Map<string, ClaudeCodeToolCall>();
     let accumulatedText = '';
@@ -120,7 +121,8 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
       ];
 
       if (trimmedSystemPrompt) {
-        args.push('--append-system-prompt', trimmedSystemPrompt);
+        await fsPromises.writeFile(systemPromptPath, trimmedSystemPrompt, 'utf8');
+        args.push('--append-system-prompt-file', systemPromptPath);
       }
 
       if (options?.enableThinking && options?.thinkingEffort) {
@@ -502,7 +504,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
     const estimatedArgvChars = this.estimateArgvChars(command, args);
     if (estimatedArgvChars > MAX_SAFE_WINDOWS_ARGV_CHARS) {
       throw new LLMProviderError(
-        'Claude Code could not start because the appended system prompt is too large for Windows command-line limits. Reduce attached context files or shorten the system prompt and try again.',
+        'Claude Code could not start because the local CLI command was too long for Windows command-line limits. Reduce attached context files and try again.',
         this.name,
         'REQUEST_TOO_LARGE'
       );

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-03-25T19:54:19.060Z
+ * Generated: 2026-03-26T10:18:12.827Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/unit/AnthropicClaudeCodeAdapter.test.ts
+++ b/tests/unit/AnthropicClaudeCodeAdapter.test.ts
@@ -59,10 +59,11 @@ describe('AnthropicClaudeCodeAdapter', () => {
     } as any);
   });
 
-  it('keeps the appended system prompt on argv and sends the user prompt through stdin', async () => {
+  it('writes the system prompt to a temp file and sends the user prompt through stdin', async () => {
     const child = createMockChildProcess();
     const stdinChunks: string[] = [];
     let capturedArgs: string[] = [];
+    let systemPromptContents = '';
 
     child.stdin.on('data', (chunk: Buffer | string) => {
       stdinChunks.push(chunk.toString());
@@ -70,8 +71,13 @@ describe('AnthropicClaudeCodeAdapter', () => {
 
     spawnDesktopProcess.mockImplementation((_childProcess, _command, args) => {
       capturedArgs = args;
+      const systemPromptIndex = args.indexOf('--append-system-prompt-file');
+      const systemPromptPath = systemPromptIndex >= 0 ? args[systemPromptIndex + 1] : '';
 
-      process.nextTick(() => {
+      process.nextTick(async () => {
+        systemPromptContents = systemPromptPath
+          ? await fsPromises.readFile(systemPromptPath, 'utf8')
+          : '';
         child.stdout.write(JSON.stringify({
           type: 'assistant',
           message: {
@@ -93,11 +99,11 @@ describe('AnthropicClaudeCodeAdapter', () => {
       chunks.push(chunk);
     }
 
-    expect(capturedArgs).toContain('--append-system-prompt');
-    expect(capturedArgs).toContain('Use the workspace notes');
-    expect(capturedArgs).not.toContain('--system-prompt-file');
-    expect(capturedArgs).not.toContain('--append-system-prompt-file');
+    expect(capturedArgs).toContain('--append-system-prompt-file');
+    expect(capturedArgs).not.toContain('--append-system-prompt');
+    expect(capturedArgs).not.toContain('Use the workspace notes');
     expect(capturedArgs).not.toContain('Explain the bug');
+    expect(systemPromptContents).toBe('Use the workspace notes');
     expect(stdinChunks.join('')).toBe('Explain the bug');
     expect(chunks.some((chunk) => chunk.content === 'Hello from Claude Code')).toBe(true);
   });
@@ -105,10 +111,13 @@ describe('AnthropicClaudeCodeAdapter', () => {
   it('cleans up temp files after a successful run', async () => {
     const child = createMockChildProcess();
     let mcpConfigPath = '';
+    let systemPromptPath = '';
 
     spawnDesktopProcess.mockImplementation((_childProcess, _command, args) => {
       const configIndex = args.indexOf('--mcp-config');
       mcpConfigPath = configIndex >= 0 ? args[configIndex + 1] : '';
+      const systemPromptIndex = args.indexOf('--append-system-prompt-file');
+      systemPromptPath = systemPromptIndex >= 0 ? args[systemPromptIndex + 1] : '';
 
       process.nextTick(() => {
         child.stdout.end();
@@ -126,15 +135,46 @@ describe('AnthropicClaudeCodeAdapter', () => {
     }
 
     await expect(fsPromises.access(mcpConfigPath)).rejects.toThrow();
+    await expect(fsPromises.access(systemPromptPath)).rejects.toThrow();
   });
 
-  it('blocks oversized appended system prompts on Windows before spawn', async () => {
+  it('allows large system prompts on Windows because they are written to a temp file', async () => {
     Platform.isWin = true;
     const oversizedSystemPrompt = 'A'.repeat(40_000);
+    const child = createMockChildProcess();
+    let capturedSystemPrompt = '';
+
+    spawnDesktopProcess.mockImplementation((_childProcess, _command, args) => {
+      const systemPromptIndex = args.indexOf('--append-system-prompt-file');
+      const systemPromptPath = systemPromptIndex >= 0 ? args[systemPromptIndex + 1] : '';
+
+      process.nextTick(async () => {
+        capturedSystemPrompt = await fsPromises.readFile(systemPromptPath, 'utf8');
+        child.stdout.end();
+        child.stderr.end();
+        child.emit('close', 0, null);
+      });
+
+      return child;
+    });
+
+    for await (const _chunk of adapter.generateStreamAsync('Explain the bug', {
+      systemPrompt: oversizedSystemPrompt
+    })) {
+      // drain
+    }
+
+    expect(spawnDesktopProcess).toHaveBeenCalledTimes(1);
+    expect(capturedSystemPrompt).toBe(oversizedSystemPrompt);
+  });
+
+  it('still blocks oversized remaining argv on Windows before spawn', async () => {
+    Platform.isWin = true;
+    const oversizedModel = 'A'.repeat(40_000);
 
     await expect(async () => {
       for await (const _chunk of adapter.generateStreamAsync('Explain the bug', {
-        systemPrompt: oversizedSystemPrompt
+        model: oversizedModel
       })) {
         // drain
       }


### PR DESCRIPTION
## Summary

- **System prompt via temp file**: Replaces `--append-system-prompt <text>` (inline argv) with `--append-system-prompt-file <path>` — writes the system prompt to a temp file alongside the existing MCP config, so large system prompts no longer contribute to the Windows `CreateProcess` 32,767-char argv limit
- **Clearer error message**: Updated the `REQUEST_TOO_LARGE` error to accurately reflect that it's the total CLI command length (not just the system prompt) that exceeded the limit
- **Tests updated**: All 4 adapter tests pass; test now verifies file contents rather than argv contents

## Motivation

Follow-up to PR #65 (v5.5.0). The initial fix moved the user prompt body to stdin, but the system prompt was still passed inline on the command line. On Windows with large workspaces, a long system prompt could still push argv over the limit.

## Test plan
- [ ] `npm run test -- --testPathPattern=AnthropicClaudeCodeAdapter` — all 4 tests pass
- [ ] `npm run build` — clean build
- [ ] Manual: send a message with a large workspace/system prompt on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)