### PR TITLE
fix: restore task/project data from JSONL and resolve workspace names to UUIDs

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -29,18 +29,49 @@ import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/
 import { PaginatedResult } from '../../../types/pagination/PaginationTypes';
 import { TaskBoardEvents } from '../../../services/task/TaskBoardEvents';
 
+/**
+ * Function type for resolving a workspace identifier (UUID or name) to a UUID.
+ * Returns the resolved UUID if found, or null if no match.
+ */
+export type WorkspaceResolver = (workspaceId: string) => Promise<string | null>;
+
 export class TaskService {
+  private resolveWorkspace: WorkspaceResolver | null;
+
   constructor(
     private projectRepo: IProjectRepository,
     private taskRepo: ITaskRepository,
-    private dagService: IDAGService
-  ) {}
+    private dagService: IDAGService,
+    resolveWorkspace?: WorkspaceResolver
+  ) {
+    this.resolveWorkspace = resolveWorkspace ?? null;
+  }
+
+  /**
+   * Resolve a raw workspace identifier (UUID or name) to a workspace UUID.
+   * If no resolver is configured, returns the raw ID unchanged.
+   * Throws if the workspace cannot be found.
+   */
+  private async resolveWorkspaceId(rawId: string): Promise<string> {
+    if (!this.resolveWorkspace) return rawId;
+
+    const resolvedId = await this.resolveWorkspace(rawId);
+    if (!resolvedId) {
+      throw new Error(
+        `Workspace "${rawId}" not found. Call loadWorkspace or createWorkspace first to get a valid workspaceId.`
+      );
+    }
+    return resolvedId;
+  }
 
   // ────────────────────────────────────────────────────────────────
   // Projects
   // ────────────────────────────────────────────────────────────────
 
   async createProject(workspaceId: string, data: CreateProjectData): Promise<string> {
+    // Resolve workspace name → UUID transparently
+    workspaceId = await this.resolveWorkspaceId(workspaceId);
+
     // Check for duplicate name in workspace
     const existing = await this.projectRepo.getByName(workspaceId, data.name);
     if (existing) {
@@ -66,6 +97,7 @@ export class TaskService {
   }
 
   async listProjects(workspaceId: string, options?: ProjectListOptions): Promise<PaginatedResult<ProjectMetadata>> {
+    workspaceId = await this.resolveWorkspaceId(workspaceId);
     return this.projectRepo.getByWorkspace(workspaceId, {
       page: options?.page,
       pageSize: options?.pageSize,
@@ -221,6 +253,7 @@ export class TaskService {
   }
 
   async listWorkspaceTasks(workspaceId: string, options?: TaskListOptions): Promise<PaginatedResult<TaskMetadata>> {
+    workspaceId = await this.resolveWorkspaceId(workspaceId);
     return this.taskRepo.getByWorkspace(workspaceId, {
       page: options?.page,
       pageSize: options?.pageSize,
@@ -460,6 +493,7 @@ export class TaskService {
   // ────────────────────────────────────────────────────────────────
 
   async getWorkspaceSummary(workspaceId: string): Promise<WorkspaceTaskSummary> {
+    workspaceId = await this.resolveWorkspaceId(workspaceId);
     const projects = await this.projectRepo.getByWorkspace(workspaceId, { pageSize: 1000 });
     const allTasks = await this.taskRepo.getByWorkspace(workspaceId, { pageSize: 10000 });
 

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -42,8 +42,10 @@ import {
 } from '../../types/storage/HybridStorageTypes';
 import { RepositoryDependencies } from '../repositories/base/BaseRepository';
 import { LegacyMigrator } from '../migration/LegacyMigrator';
-import { WorkspaceEvent } from '../interfaces/StorageEvents';
+import { WorkspaceEvent, TaskEvent } from '../interfaces/StorageEvents';
 import { WorkspaceEventApplier } from '../sync/WorkspaceEventApplier';
+import { TaskEventApplier } from '../sync/TaskEventApplier';
+import { resolveWorkspaceId } from '../sync/resolveWorkspaceId';
 
 // Import all repositories
 import { WorkspaceRepository } from '../repositories/WorkspaceRepository';
@@ -218,6 +220,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
       // 2. Ensure JSONL directories exist
       await this.jsonlWriter.ensureDirectory('workspaces');
       await this.jsonlWriter.ensureDirectory('conversations');
+      await this.jsonlWriter.ensureDirectory('tasks');
 
       const migrator = new LegacyMigrator(this.app);
       const migrationNeeded = await migrator.isMigrationNeeded();
@@ -259,6 +262,13 @@ export class HybridStorageAdapter implements IStorageAdapter {
           await this.reconcileMissingWorkspaces();
         } catch (reconcileError) {
           console.error('[HybridStorageAdapter] Workspace reconciliation failed:', reconcileError);
+        }
+
+        // 6. Reconcile JSONL tasks missing from SQLite
+        try {
+          await this.reconcileMissingTasks();
+        } catch (reconcileError) {
+          console.error('[HybridStorageAdapter] Task reconciliation failed:', reconcileError);
         }
       }
 
@@ -318,6 +328,56 @@ export class HybridStorageAdapter implements IStorageAdapter {
         reconciled++;
       } catch (e) {
         console.error(`[HybridStorageAdapter] Failed to reconcile workspace ${id}:`, e);
+      }
+    }
+
+    if (reconciled > 0) {
+      await this.sqliteCache.save();
+    }
+  }
+
+  /**
+   * Reconcile JSONL task files that are missing from SQLite.
+   * Handles the case where incremental sync skips same-device events,
+   * leaving tasks in JSONL but absent from the SQLite cache.
+   */
+  private async reconcileMissingTasks(): Promise<void> {
+    const taskFiles = await this.jsonlWriter.listFiles('tasks');
+    if (taskFiles.length === 0) return;
+
+    const taskApplier = new TaskEventApplier(this.sqliteCache);
+    let reconciled = 0;
+
+    for (const file of taskFiles) {
+      // Extract workspaceId from filename (pattern: tasks/tasks_{workspaceId}.jsonl)
+      const match = file.match(/tasks\/tasks_(.+)\.jsonl$/);
+      if (!match) continue;
+
+      const fileWorkspaceId = match[1];
+
+      // Resolve workspace ID (handles name → UUID transparently)
+      const resolved = await resolveWorkspaceId(fileWorkspaceId, this.sqliteCache);
+      const effectiveId = resolved.id ?? fileWorkspaceId;
+
+      // Check if any projects already exist for this workspace in SQLite
+      const existingProjects = await this.sqliteCache.query<{ id: string }>(
+        'SELECT id FROM projects WHERE workspaceId = ? LIMIT 1',
+        [effectiveId]
+      );
+
+      if (existingProjects.length > 0) continue;
+
+      // No projects found for this workspace — replay all events from JSONL
+      try {
+        const events = await this.jsonlWriter.readEvents<TaskEvent>(file);
+        events.sort((a, b) => a.timestamp - b.timestamp);
+
+        for (const event of events) {
+          await taskApplier.apply(event);
+        }
+        reconciled++;
+      } catch (e) {
+        console.error(`[HybridStorageAdapter] Failed to reconcile tasks from ${file}:`, e);
       }
     }
 

--- a/src/database/storage/SQLiteCacheManager.ts
+++ b/src/database/storage/SQLiteCacheManager.ts
@@ -639,6 +639,10 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
   async clearAllData(): Promise<void> {
     await this.transaction(async () => {
       this.db.exec(`
+        DELETE FROM task_note_links;
+        DELETE FROM task_dependencies;
+        DELETE FROM tasks;
+        DELETE FROM projects;
         DELETE FROM messages;
         DELETE FROM conversations;
         DELETE FROM memory_traces;

--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -6,6 +6,7 @@
  * Thin orchestrator that delegates event application to:
  * - WorkspaceEventApplier: workspace, session, state, trace events
  * - ConversationEventApplier: conversation, message events
+ * - TaskEventApplier: project, task, dependency, note-link events
  *
  * Design Principles:
  * - Single Responsibility: Orchestration only
@@ -18,9 +19,11 @@ import {
   StorageEvent,
   WorkspaceEvent,
   ConversationEvent,
+  TaskEvent,
 } from '../interfaces/StorageEvents';
 import { WorkspaceEventApplier } from './WorkspaceEventApplier';
 import { ConversationEventApplier } from './ConversationEventApplier';
+import { TaskEventApplier } from './TaskEventApplier';
 
 /**
  * Validate workspace ID to prevent ghost/orphan workspaces.
@@ -36,7 +39,7 @@ function isValidWorkspaceId(id: string): boolean {
 
 export interface IJSONLWriter {
   getDeviceId(): string;
-  listFiles(category: 'workspaces' | 'conversations'): Promise<string[]>;
+  listFiles(category: 'workspaces' | 'conversations' | 'tasks'): Promise<string[]>;
   readEvents<T extends StorageEvent>(file: string): Promise<T[]>;
   getEventsNotFromDevice<T extends StorageEvent>(
     file: string,
@@ -51,6 +54,8 @@ export interface ISQLiteCacheManager {
   isEventApplied(eventId: string): Promise<boolean>;
   markEventApplied(eventId: string): Promise<void>;
   run(sql: string, params?: any[]): Promise<any>;
+  query<T>(sql: string, params?: any[]): Promise<T[]>;
+  queryOne<T>(sql: string, params?: any[]): Promise<T | null>;
   clearAllData(): Promise<void>;
   rebuildFTSIndexes(): Promise<void>;
   save(): Promise<void>;
@@ -88,6 +93,7 @@ export class SyncCoordinator {
   private deviceId: string;
   private workspaceApplier: WorkspaceEventApplier;
   private conversationApplier: ConversationEventApplier;
+  private taskApplier: TaskEventApplier;
 
   constructor(jsonlWriter: IJSONLWriter, sqliteCache: ISQLiteCacheManager) {
     this.jsonlWriter = jsonlWriter;
@@ -95,6 +101,7 @@ export class SyncCoordinator {
     this.deviceId = jsonlWriter.getDeviceId();
     this.workspaceApplier = new WorkspaceEventApplier(sqliteCache);
     this.conversationApplier = new ConversationEventApplier(sqliteCache);
+    this.taskApplier = new TaskEventApplier(sqliteCache);
   }
 
   /**
@@ -126,6 +133,12 @@ export class SyncCoordinator {
       eventsApplied += conversationResult.applied;
       eventsSkipped += conversationResult.skipped;
       filesProcessed.push(...conversationResult.files);
+
+      // Process task files
+      const taskResult = await this.processTaskFiles(lastSync, options, errors);
+      eventsApplied += taskResult.applied;
+      eventsSkipped += taskResult.skipped;
+      filesProcessed.push(...taskResult.files);
 
       // Update sync state and save
       await this.sqliteCache.updateSyncState(this.deviceId, Date.now(), {});
@@ -166,6 +179,11 @@ export class SyncCoordinator {
       const conversationResult = await this.rebuildConversations(options, errors, batchSize);
       eventsApplied += conversationResult.applied;
       filesProcessed.push(...conversationResult.files);
+
+      // Rebuild tasks (must come after workspaces for normalizeWorkspaceId to work)
+      const taskResult = await this.rebuildTasks(options, errors, batchSize);
+      eventsApplied += taskResult.applied;
+      filesProcessed.push(...taskResult.files);
 
       // Rebuild FTS and save
       options.onProgress?.('Rebuilding search indexes', 0, 1);
@@ -369,6 +387,89 @@ export class SyncCoordinator {
 
         files.push(file);
         options.onProgress?.('Processing conversations', i + 1, conversationFiles.length);
+
+        // Save after each file to prevent memory accumulation (OOM prevention)
+        await this.sqliteCache.save();
+      } catch (e) {
+        errors.push(`Failed to process ${file}: ${e}`);
+      }
+    }
+
+    return { applied, files };
+  }
+
+  private async processTaskFiles(
+    lastSync: number,
+    options: SyncOptions,
+    errors: string[]
+  ): Promise<{ applied: number; skipped: number; files: string[] }> {
+    let applied = 0;
+    let skipped = 0;
+    const files: string[] = [];
+
+    const taskFiles = await this.jsonlWriter.listFiles('tasks');
+    options.onProgress?.('Processing tasks', 0, taskFiles.length);
+
+    for (let i = 0; i < taskFiles.length; i++) {
+      const file = taskFiles[i];
+      try {
+        const events = await this.jsonlWriter.getEventsNotFromDevice<TaskEvent>(
+          file, this.deviceId, lastSync
+        );
+
+        for (const event of events) {
+          if (await this.sqliteCache.isEventApplied(event.id)) {
+            skipped++;
+            continue;
+          }
+          await this.taskApplier.apply(event);
+          await this.sqliteCache.markEventApplied(event.id);
+          applied++;
+        }
+
+        files.push(file);
+        options.onProgress?.('Processing tasks', i + 1, taskFiles.length);
+      } catch (e) {
+        errors.push(`Failed to process ${file}: ${e}`);
+      }
+    }
+
+    return { applied, skipped, files };
+  }
+
+  private async rebuildTasks(
+    options: SyncOptions,
+    errors: string[],
+    batchSize: number
+  ): Promise<{ applied: number; files: string[] }> {
+    let applied = 0;
+    const files: string[] = [];
+
+    const taskFiles = await this.jsonlWriter.listFiles('tasks');
+    options.onProgress?.('Processing tasks', 0, taskFiles.length);
+
+    for (let i = 0; i < taskFiles.length; i++) {
+      const file = taskFiles[i];
+      try {
+        const events = await this.jsonlWriter.readEvents<TaskEvent>(file);
+        events.sort((a, b) => a.timestamp - b.timestamp);
+
+        const result = await BatchOperations.executeBatch(
+          events,
+          async (event) => {
+            await this.taskApplier.apply(event);
+            await this.sqliteCache.markEventApplied(event.id);
+          },
+          { batchSize: Math.min(batchSize, 10), delayBetweenBatches: 10 }
+        );
+
+        applied += result.totalProcessed;
+        if (result.errors.length > 0) {
+          errors.push(...result.errors.map(e => `${file}: ${e.error.message}`));
+        }
+
+        files.push(file);
+        options.onProgress?.('Processing tasks', i + 1, taskFiles.length);
 
         // Save after each file to prevent memory accumulation (OOM prevention)
         await this.sqliteCache.save();

--- a/src/database/sync/TaskEventApplier.ts
+++ b/src/database/sync/TaskEventApplier.ts
@@ -1,0 +1,248 @@
+/**
+ * Location: src/database/sync/TaskEventApplier.ts
+ *
+ * Applies task-management events to SQLite cache.
+ * Handles: project, task, dependency, and note-link events.
+ *
+ * Mirrors the pattern established by WorkspaceEventApplier.
+ * Includes workspace ID normalization to fix orphaned data
+ * where workspaceId is a name string instead of a UUID.
+ */
+
+import {
+  TaskEvent,
+  ProjectCreatedEvent,
+  ProjectUpdatedEvent,
+  ProjectDeletedEvent,
+  TaskCreatedEvent,
+  TaskUpdatedEvent,
+  TaskDeletedEvent,
+  TaskDependencyAddedEvent,
+  TaskDependencyRemovedEvent,
+  TaskNoteLinkedEvent,
+  TaskNoteUnlinkedEvent,
+} from '../interfaces/StorageEvents';
+import { ISQLiteCacheManager } from './SyncCoordinator';
+import { resolveWorkspaceId } from './resolveWorkspaceId';
+
+/**
+ * Normalize a workspaceId that may be a name string instead of a UUID.
+ * Uses the shared resolveWorkspaceId helper. Falls back to the original
+ * value if no match is found (data will be orphaned but won't crash).
+ */
+async function normalizeWorkspaceId(
+  workspaceId: string,
+  sqliteCache: ISQLiteCacheManager
+): Promise<string> {
+  if (!workspaceId) return workspaceId;
+
+  const result = await resolveWorkspaceId(workspaceId, sqliteCache);
+
+  if (result.warning) {
+    console.error(`[TaskEventApplier] ${result.warning}`);
+  }
+
+  return result.id ?? workspaceId;
+}
+
+export class TaskEventApplier {
+  private sqliteCache: ISQLiteCacheManager;
+
+  constructor(sqliteCache: ISQLiteCacheManager) {
+    this.sqliteCache = sqliteCache;
+  }
+
+  /**
+   * Apply a task-related event to SQLite cache.
+   */
+  async apply(event: TaskEvent): Promise<void> {
+    switch (event.type) {
+      case 'project_created':
+        await this.applyProjectCreated(event);
+        break;
+      case 'project_updated':
+        await this.applyProjectUpdated(event);
+        break;
+      case 'project_deleted':
+        await this.applyProjectDeleted(event);
+        break;
+      case 'task_created':
+        await this.applyTaskCreated(event);
+        break;
+      case 'task_updated':
+        await this.applyTaskUpdated(event);
+        break;
+      case 'task_deleted':
+        await this.applyTaskDeleted(event);
+        break;
+      case 'task_dependency_added':
+        await this.applyDependencyAdded(event);
+        break;
+      case 'task_dependency_removed':
+        await this.applyDependencyRemoved(event);
+        break;
+      case 'task_note_linked':
+        await this.applyNoteLinked(event);
+        break;
+      case 'task_note_unlinked':
+        await this.applyNoteUnlinked(event);
+        break;
+    }
+  }
+
+  private async applyProjectCreated(event: ProjectCreatedEvent): Promise<void> {
+    if (!event.data?.id || !event.data?.name) return;
+
+    const workspaceId = await normalizeWorkspaceId(
+      event.data.workspaceId,
+      this.sqliteCache
+    );
+
+    await this.sqliteCache.run(
+      `INSERT OR REPLACE INTO projects
+       (id, workspaceId, name, description, status, created, updated, metadataJson)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        event.data.id,
+        workspaceId,
+        event.data.name,
+        event.data.description ?? null,
+        event.data.status ?? 'active',
+        event.data.created ?? Date.now(),
+        event.data.updated ?? Date.now(),
+        event.data.metadataJson ?? null,
+      ]
+    );
+  }
+
+  private async applyProjectUpdated(event: ProjectUpdatedEvent): Promise<void> {
+    if (!event.projectId) return;
+
+    const updates: string[] = [];
+    const values: any[] = [];
+
+    if (event.data.name !== undefined) { updates.push('name = ?'); values.push(event.data.name); }
+    if (event.data.description !== undefined) { updates.push('description = ?'); values.push(event.data.description); }
+    if (event.data.status !== undefined) { updates.push('status = ?'); values.push(event.data.status); }
+    if (event.data.updated !== undefined) { updates.push('updated = ?'); values.push(event.data.updated); }
+    if (event.data.metadataJson !== undefined) { updates.push('metadataJson = ?'); values.push(event.data.metadataJson); }
+
+    if (updates.length > 0) {
+      values.push(event.projectId);
+      await this.sqliteCache.run(
+        `UPDATE projects SET ${updates.join(', ')} WHERE id = ?`,
+        values
+      );
+    }
+  }
+
+  private async applyProjectDeleted(event: ProjectDeletedEvent): Promise<void> {
+    if (!event.projectId) return;
+    // CASCADE will handle tasks, dependencies, and note links
+    await this.sqliteCache.run('DELETE FROM projects WHERE id = ?', [event.projectId]);
+  }
+
+  private async applyTaskCreated(event: TaskCreatedEvent): Promise<void> {
+    if (!event.data?.id || !event.data?.projectId) return;
+
+    const workspaceId = await normalizeWorkspaceId(
+      event.data.workspaceId,
+      this.sqliteCache
+    );
+
+    await this.sqliteCache.run(
+      `INSERT OR REPLACE INTO tasks
+       (id, projectId, workspaceId, parentTaskId, title, description, status, priority,
+        created, updated, completedAt, dueDate, assignee, tagsJson, metadataJson)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        event.data.id,
+        event.data.projectId,
+        workspaceId,
+        event.data.parentTaskId ?? null,
+        event.data.title,
+        event.data.description ?? null,
+        event.data.status ?? 'todo',
+        event.data.priority ?? 'medium',
+        event.data.created ?? Date.now(),
+        event.data.updated ?? Date.now(),
+        event.data.completedAt ?? null,
+        event.data.dueDate ?? null,
+        event.data.assignee ?? null,
+        event.data.tagsJson ?? null,
+        event.data.metadataJson ?? null,
+      ]
+    );
+  }
+
+  private async applyTaskUpdated(event: TaskUpdatedEvent): Promise<void> {
+    if (!event.taskId) return;
+
+    const updates: string[] = [];
+    const values: any[] = [];
+
+    if (event.data.projectId !== undefined) { updates.push('projectId = ?'); values.push(event.data.projectId); }
+    if (event.data.parentTaskId !== undefined) { updates.push('parentTaskId = ?'); values.push(event.data.parentTaskId); }
+    if (event.data.title !== undefined) { updates.push('title = ?'); values.push(event.data.title); }
+    if (event.data.description !== undefined) { updates.push('description = ?'); values.push(event.data.description); }
+    if (event.data.status !== undefined) { updates.push('status = ?'); values.push(event.data.status); }
+    if (event.data.priority !== undefined) { updates.push('priority = ?'); values.push(event.data.priority); }
+    if (event.data.updated !== undefined) { updates.push('updated = ?'); values.push(event.data.updated); }
+    if (event.data.completedAt !== undefined) { updates.push('completedAt = ?'); values.push(event.data.completedAt); }
+    if (event.data.dueDate !== undefined) { updates.push('dueDate = ?'); values.push(event.data.dueDate); }
+    if (event.data.assignee !== undefined) { updates.push('assignee = ?'); values.push(event.data.assignee); }
+    if (event.data.tagsJson !== undefined) { updates.push('tagsJson = ?'); values.push(event.data.tagsJson); }
+    if (event.data.metadataJson !== undefined) { updates.push('metadataJson = ?'); values.push(event.data.metadataJson); }
+
+    if (updates.length > 0) {
+      values.push(event.taskId);
+      await this.sqliteCache.run(
+        `UPDATE tasks SET ${updates.join(', ')} WHERE id = ?`,
+        values
+      );
+    }
+  }
+
+  private async applyTaskDeleted(event: TaskDeletedEvent): Promise<void> {
+    if (!event.taskId) return;
+    await this.sqliteCache.run('DELETE FROM tasks WHERE id = ?', [event.taskId]);
+  }
+
+  private async applyDependencyAdded(event: TaskDependencyAddedEvent): Promise<void> {
+    if (!event.taskId || !event.dependsOnTaskId) return;
+
+    await this.sqliteCache.run(
+      `INSERT OR IGNORE INTO task_dependencies (taskId, dependsOnTaskId, created)
+       VALUES (?, ?, ?)`,
+      [event.taskId, event.dependsOnTaskId, event.timestamp ?? Date.now()]
+    );
+  }
+
+  private async applyDependencyRemoved(event: TaskDependencyRemovedEvent): Promise<void> {
+    if (!event.taskId || !event.dependsOnTaskId) return;
+
+    await this.sqliteCache.run(
+      'DELETE FROM task_dependencies WHERE taskId = ? AND dependsOnTaskId = ?',
+      [event.taskId, event.dependsOnTaskId]
+    );
+  }
+
+  private async applyNoteLinked(event: TaskNoteLinkedEvent): Promise<void> {
+    if (!event.taskId || !event.notePath) return;
+
+    await this.sqliteCache.run(
+      `INSERT OR IGNORE INTO task_note_links (taskId, notePath, linkType, created)
+       VALUES (?, ?, ?, ?)`,
+      [event.taskId, event.notePath, event.linkType ?? 'reference', event.timestamp ?? Date.now()]
+    );
+  }
+
+  private async applyNoteUnlinked(event: TaskNoteUnlinkedEvent): Promise<void> {
+    if (!event.taskId || !event.notePath) return;
+
+    await this.sqliteCache.run(
+      'DELETE FROM task_note_links WHERE taskId = ? AND notePath = ?',
+      [event.taskId, event.notePath]
+    );
+  }
+}

--- a/src/database/sync/index.ts
+++ b/src/database/sync/index.ts
@@ -12,6 +12,9 @@
  */
 
 export { SyncCoordinator } from './SyncCoordinator';
+export { TaskEventApplier } from './TaskEventApplier';
+export { resolveWorkspaceId } from './resolveWorkspaceId';
+export type { ResolveResult } from './resolveWorkspaceId';
 export type {
   SyncResult,
   SyncOptions,

--- a/src/database/sync/resolveWorkspaceId.ts
+++ b/src/database/sync/resolveWorkspaceId.ts
@@ -1,0 +1,79 @@
+/**
+ * Location: src/database/sync/resolveWorkspaceId.ts
+ *
+ * Shared workspace ID resolution utility. Transparently resolves workspace
+ * names to UUIDs so users and agents never need to know or pass raw UUIDs.
+ *
+ * Resolution order:
+ * 1. Exact UUID match in workspaces table
+ * 2. Name match (non-archived) — single match returns UUID transparently
+ * 3. Multiple name matches — returns null with warning listing all UUIDs
+ * 4. No match — returns null (caller decides: error or fallback)
+ *
+ * Used by:
+ * - TaskEventApplier (rebuild path — normalizes orphaned workspaceIds)
+ * - TaskService via AgentInitializationService (runtime validation)
+ * - HybridStorageAdapter.reconcileMissingTasks (startup repair)
+ */
+
+import { ISQLiteCacheManager } from './SyncCoordinator';
+
+export interface ResolveResult {
+  /** The resolved workspace UUID, or null if not found or ambiguous */
+  id: string | null;
+  /** Whether the input was resolved from a name (not a direct UUID match) */
+  resolvedFromName: boolean;
+  /** Warning/error message if ambiguous or not found */
+  warning?: string;
+  /** All matching UUIDs when ambiguous (caller can surface these to the user) */
+  matchingIds?: string[];
+}
+
+/**
+ * Resolve a raw workspace identifier (UUID or name) to a workspace UUID.
+ *
+ * @param rawId - UUID or workspace name string
+ * @param sqliteCache - Database access for workspace lookups
+ * @returns ResolveResult with the resolved UUID or null
+ */
+export async function resolveWorkspaceId(
+  rawId: string,
+  sqliteCache: ISQLiteCacheManager
+): Promise<ResolveResult> {
+  if (!rawId) {
+    return { id: null, resolvedFromName: false };
+  }
+
+  // 1. Try exact UUID match
+  const byId = await sqliteCache.queryOne<{ id: string }>(
+    'SELECT id FROM workspaces WHERE id = ?',
+    [rawId]
+  );
+  if (byId) {
+    return { id: rawId, resolvedFromName: false };
+  }
+
+  // 2. Try name match (prefer non-archived workspaces)
+  const byName = await sqliteCache.query<{ id: string; lastAccessed: number }>(
+    'SELECT id, lastAccessed FROM workspaces WHERE name = ? AND isArchived = 0',
+    [rawId]
+  );
+
+  if (byName.length === 1) {
+    // Single match — use it transparently
+    return { id: byName[0].id, resolvedFromName: true };
+  }
+
+  if (byName.length > 1) {
+    // Multiple matches — return null with nudge listing all UUIDs
+    const ids = byName.map(w => w.id);
+    return {
+      id: null,
+      resolvedFromName: false,
+      warning: `Multiple workspaces named "${rawId}" found. Please retry with the specific workspace UUID: [${ids.join(', ')}]`,
+      matchingIds: ids,
+    };
+  }
+  // 3. No match at all
+  return { id: null, resolvedFromName: false };
+}

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -307,7 +307,23 @@ export class AgentInitializationService {
     }
 
     const dagService = new DAGService();
-    const taskService = new TaskService(adapter.projects, adapter.tasks, dagService);
+
+    // Workspace resolver: checks by ID first, then by name, returns resolved UUID or null
+    const { resolveWorkspaceId } = await import('../../database/sync/resolveWorkspaceId');
+    const sqliteCache = adapter.cache;
+    const validateWorkspace = async (workspaceId: string): Promise<string | null> => {
+      const result = await resolveWorkspaceId(workspaceId, sqliteCache);
+      if (result.warning) {
+        console.error(`[TaskService] ${result.warning}`);
+      }
+      // Ambiguous name — fail with nudge listing all matching UUIDs
+      if (result.matchingIds && result.matchingIds.length > 1) {
+        throw new Error(result.warning);
+      }
+      return result.id;
+    };
+
+    const taskService = new TaskService(adapter.projects, adapter.tasks, dagService, validateWorkspace);
     const taskManagerAgent = new TaskManagerAgent(this.app, this.plugin, taskService);
 
     this.agentManager.registerAgent(taskManagerAgent);


### PR DESCRIPTION
## Summary

- **Task board data loss on rebuild**: `fullRebuild()` previously skipped task/project JSONL files — deleting `cache.db` permanently lost task data from SQLite even though JSONL files were intact. New `rebuildTasks()` + `TaskEventApplier` replays all `tasks_*.jsonl` files into SQLite on rebuild and incremental sync.
- **Orphaned workspaceIds**: Tasks created with name-based workspace IDs (e.g. `"Website Redesign"`, `"default"`) were invisible to the Task Board. `resolveWorkspaceId` now transparently maps names → UUIDs at both write time (TaskService) and rebuild time (TaskEventApplier).
- **Ambiguous name guard**: If two workspaces share a name, tool calls fail with a nudge listing all matching UUIDs so the agent can retry with the specific one — no silent fallback.
- **`clearAllData()` fixed**: Now clears task tables in FK-safe order so `fullRebuild` always starts from a clean slate.
- **`reconcileMissingTasks()`**: Runs at startup alongside the existing workspace reconciler to repair any task JSONL files not yet reflected in SQLite.

## Files changed

| File | Change |
|------|--------|
| `src/database/sync/TaskEventApplier.ts` | **NEW** — handles all 10 task event types |
| `src/database/sync/resolveWorkspaceId.ts` | **NEW** — shared workspace name→UUID resolver |
| `src/database/sync/SyncCoordinator.ts` | `rebuildTasks()` + `processTaskFiles()` |
| `src/database/storage/SQLiteCacheManager.ts` | `clearAllData()` now clears task tables |
| `src/database/adapters/HybridStorageAdapter.ts` | `reconcileMissingTasks()` at startup |
| `src/agents/taskManager/services/TaskService.ts` | Workspace name→UUID resolution on write |
| `src/services/agent/AgentInitializationService.ts` | DI wiring for `resolveWorkspaceId` |
| `src/database/sync/index.ts` | New exports |

## Test plan

- [ ] Delete `cache.db`, restart plugin — verify existing task JSONL data repopulates in Task Board
- [ ] Create a project using workspace name (e.g. `"Blog Testing Workspace"`) — verify it resolves to UUID and creates successfully
- [ ] Create a project using workspace UUID directly — verify unchanged behaviour
- [ ] Attempt create with ambiguous name (two workspaces same name) — verify tool returns error with UUID list
- [ ] Attempt create with unknown workspace name — verify error message prompts to create/load workspace first
- [ ] Verify Synaptic Labs vault: "Website Redesign Sprint" project appears in Task Board after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)