### PR TITLE
fix: restore column scroll in task board

### DIFF
--- a/src/ui/tasks/TaskBoardView.ts
+++ b/src/ui/tasks/TaskBoardView.ts
@@ -275,7 +275,7 @@ export class TaskBoardView extends ItemView {
     const shell = container.createDiv('nexus-task-board-shell');
     this.renderHeader(shell);
     this.renderToolbar(shell);
-    this.columnsContainer = shell.createDiv();
+    this.columnsContainer = shell.createDiv('nexus-task-board-columns-wrapper');
     this.renderColumns();
   }
 

--- a/styles.css
+++ b/styles.css
@@ -7296,6 +7296,14 @@ body.is-mobile .chat-loading-overlay {
     overflow: hidden;
 }
 
+.nexus-task-board-columns-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+}
+
 .nexus-task-board-header,
 .nexus-task-board-toolbar,
 .nexus-task-board-column {


### PR DESCRIPTION
## Summary

- Gives `columnsContainer` the class `nexus-task-board-columns-wrapper` (was a bare `div` with no class)
- Adds CSS for the wrapper: `flex: 1 1 auto; min-height: 0; overflow: hidden`

## Root Cause

The classless wrapper div broke the flex height chain, so `.nexus-task-board-column-body`'s `overflow-y: auto` never activated — columns grew to their full content height with no scroll.

## Test plan

- [ ] Open task board with enough tasks to overflow a column
- [ ] Verify each column body scrolls independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)