### PR TITLE
feat: add task note links to board cards and edit modal

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -488,6 +488,10 @@ export class TaskService {
     await this.taskRepo.removeNoteLink(taskId, notePath);
   }
 
+  async getNoteLinks(taskId: string): Promise<NoteLink[]> {
+    return this.taskRepo.getNoteLinks(taskId);
+  }
+
   async getTasksForNote(notePath: string): Promise<TaskMetadata[]> {
     return this.taskRepo.getByLinkedNote(notePath);
   }

--- a/src/agents/taskManager/taskManager.ts
+++ b/src/agents/taskManager/taskManager.ts
@@ -100,7 +100,7 @@ export class TaskManagerAgent extends BaseAgent {
     });
     this.registerLazyTool({
       slug: 'updateTask', name: 'Update Task',
-      description: 'Update task fields (title, description, status, priority, dueDate, assignee, tags) and manage DAG dependencies (addDependencies/removeDependencies). Dependency additions are validated for cycles. Requires a taskId (from createTask or listTasks).',
+      description: 'Update task fields (title, description, status, priority, dueDate, assignee, tags), manage DAG dependencies (addDependencies/removeDependencies), and manage note links (addNoteLinks/removeNoteLinks). Dependency additions are validated for cycles. Requires a taskId (from createTask or listTasks).',
       version: '1.0.0',
       factory: () => new UpdateTaskTool(this.taskService),
     });

--- a/src/agents/taskManager/tools/tasks/updateTask.ts
+++ b/src/agents/taskManager/tools/tasks/updateTask.ts
@@ -17,7 +17,7 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
     super(
       'updateTask',
       'Update Task',
-      'Update task fields (title, description, status, priority, dueDate, assignee, tags) and manage DAG dependencies (addDependencies/removeDependencies). Dependency additions are validated for cycles. Requires a taskId (from createTask or listTasks).',
+      'Update task fields (title, description, status, priority, dueDate, assignee, tags), manage DAG dependencies (addDependencies/removeDependencies), and manage note links (addNoteLinks/removeNoteLinks). Dependency additions are validated for cycles. Requires a taskId (from createTask or listTasks).',
       '1.0.0'
     );
   }
@@ -60,6 +60,20 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
         }
       }
 
+      // Add note links
+      if (params.addNoteLinks && params.addNoteLinks.length > 0) {
+        for (const link of params.addNoteLinks) {
+          await this.taskService.linkNote(params.taskId, link.notePath, link.linkType ?? 'reference');
+        }
+      }
+
+      // Remove note links
+      if (params.removeNoteLinks && params.removeNoteLinks.length > 0) {
+        for (const notePath of params.removeNoteLinks) {
+          await this.taskService.unlinkNote(params.taskId, notePath);
+        }
+      }
+
       return { success: true };
     } catch (error) {
       return { success: false, error: createErrorMessage('Failed to update task: ', error) };
@@ -80,6 +94,19 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
         tags: { type: 'array', items: { type: 'string' }, description: 'Replace entire tags array with these values' },
         addDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs to add as DAG dependencies — this task cannot start until these are done. Cycles are rejected with an error.' },
         removeDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs to remove from this task\'s dependencies' },
+        addNoteLinks: {
+          type: 'array',
+          description: 'Vault notes to link to this task',
+          items: {
+            type: 'object',
+            properties: {
+              notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
+              linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'Type of link (default: reference)' }
+            },
+            required: ['notePath']
+          }
+        },
+        removeNoteLinks: { type: 'array', items: { type: 'string' }, description: 'Vault note paths to unlink from this task' },
         metadata: { type: 'object', description: 'Custom metadata to merge (keys are merged, not replaced)', additionalProperties: true }
       },
       required: ['taskId']

--- a/src/agents/taskManager/types.ts
+++ b/src/agents/taskManager/types.ts
@@ -209,6 +209,8 @@ export interface UpdateTaskParameters extends CommonParameters {
   tags?: string[];
   addDependencies?: string[];
   removeDependencies?: string[];
+  addNoteLinks?: Array<{ notePath: string; linkType?: LinkType }>;
+  removeNoteLinks?: string[];
   metadata?: Record<string, unknown>;
 }
 

--- a/src/ui/tasks/TaskBoardEditModal.ts
+++ b/src/ui/tasks/TaskBoardEditModal.ts
@@ -1,5 +1,6 @@
 import { ButtonComponent, DropdownComponent, Modal, Notice, TextAreaComponent, TextComponent } from 'obsidian';
 import type { App } from 'obsidian';
+import type { NoteLink } from '../../database/repositories/interfaces/ITaskRepository';
 
 export interface TaskBoardProjectOption {
   id: string;
@@ -24,6 +25,7 @@ export interface TaskBoardEditableTask {
   assignee: string;
   tags: string;
   parentTaskId: string;
+  noteLinks: NoteLink[];
 }
 
 interface TaskBoardEditModalOptions {
@@ -129,6 +131,9 @@ export class TaskBoardEditModal extends Modal {
     tagsInput.setValue(this.draft.tags);
     tagsInput.onChange((value) => { this.draft.tags = value; });
 
+    // Linked notes
+    this.renderLinkedNotesSection(details);
+
     // Actions
     const actions = contentEl.createDiv('nexus-form-actions');
 
@@ -218,6 +223,68 @@ export class TaskBoardEditModal extends Modal {
     input.addEventListener('input', () => {
       onChange(input.value);
     });
+  }
+
+  private renderLinkedNotesSection(container: HTMLElement): void {
+    const subsection = container.createDiv('nexus-form-field');
+    subsection.createEl('label', { text: 'Linked notes', cls: 'nexus-form-label' });
+
+    const listContainer = subsection.createDiv('nexus-item-list');
+
+    const updateList = () => {
+      listContainer.empty();
+
+      if (this.draft.noteLinks.length === 0) {
+        listContainer.createEl('span', { text: 'None', cls: 'nexus-form-hint' });
+      } else {
+        this.draft.noteLinks.forEach((link, index) => {
+          const item = listContainer.createDiv('nexus-item-row');
+
+          const input = new TextComponent(item);
+          input.setPlaceholder('path/to/note.md');
+          input.setValue(link.notePath);
+          input.onChange((value) => {
+            this.draft.noteLinks[index] = { ...this.draft.noteLinks[index], notePath: value };
+          });
+
+          const actions = item.createDiv('nexus-item-actions');
+
+          const typeDropdown = new DropdownComponent(actions);
+          typeDropdown.addOption('reference', 'Reference');
+          typeDropdown.addOption('input', 'Input');
+          typeDropdown.addOption('output', 'Output');
+          typeDropdown.setValue(link.linkType || 'reference');
+          typeDropdown.onChange((value) => {
+            this.draft.noteLinks[index] = {
+              ...this.draft.noteLinks[index],
+              linkType: value as NoteLink['linkType']
+            };
+          });
+
+          new ButtonComponent(actions)
+            .setButtonText('×')
+            .setWarning()
+            .onClick(() => {
+              this.draft.noteLinks.splice(index, 1);
+              updateList();
+            });
+        });
+      }
+    };
+
+    updateList();
+
+    new ButtonComponent(subsection)
+      .setButtonText('+ Add note link')
+      .onClick(() => {
+        this.draft.noteLinks.push({
+          taskId: this.draft.id,
+          notePath: '',
+          linkType: 'reference',
+          created: Date.now()
+        });
+        updateList();
+      });
   }
 
   private async handleSave(): Promise<void> {

--- a/src/ui/tasks/TaskBoardView.ts
+++ b/src/ui/tasks/TaskBoardView.ts
@@ -12,7 +12,7 @@ import type { AgentManager } from '../../services/AgentManager';
 import type { WorkspaceMetadata } from '../../types/storage/StorageTypes';
 import type { TaskService } from '../../agents/taskManager/services/TaskService';
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
-import type { TaskMetadata, TaskStatus } from '../../database/repositories/interfaces/ITaskRepository';
+import type { TaskMetadata, TaskStatus, NoteLink, LinkType } from '../../database/repositories/interfaces/ITaskRepository';
 import { TaskBoardEditModal, type TaskBoardEditableTask, type TaskBoardParentTaskOption, type TaskBoardProjectOption } from './TaskBoardEditModal';
 import { TASK_BOARD_VIEW_TYPE, type TaskBoardViewState } from './taskBoardNavigation';
 import { TaskBoardEvents, type TaskBoardDataChangedEvent } from '../../services/task/TaskBoardEvents';
@@ -24,6 +24,7 @@ interface TaskManagerAgentLike {
 interface TaskBoardTask extends TaskMetadata {
   projectName: string;
   workspaceName: string;
+  noteLinks: NoteLink[];
 }
 
 const STATUS_COLUMNS: Array<{ id: TaskStatus; label: string }> = [
@@ -237,15 +238,28 @@ export class TaskBoardView extends ItemView {
     this.projects = workspaceData.flatMap(entry => entry.projects);
     const projectMap = new Map(this.projects.map(project => [project.id, project]));
 
-    this.tasks = workspaceData.flatMap(entry =>
+    const allTasks = workspaceData.flatMap(entry =>
       entry.tasks
         .filter(task => projectMap.has(task.projectId))
         .map(task => ({
           ...task,
           projectName: projectMap.get(task.projectId)?.name || 'Unknown project',
-          workspaceName: entry.workspace.name
+          workspaceName: entry.workspace.name,
+          noteLinks: [] as NoteLink[]
         }))
     );
+
+    // Load note links for all tasks
+    const noteLinksResults = await Promise.all(
+      allTasks.map(task =>
+        this.taskService!.getNoteLinks(task.id).catch(() => [] as NoteLink[])
+      )
+    );
+    allTasks.forEach((task, index) => {
+      task.noteLinks = noteLinksResults[index];
+    });
+
+    this.tasks = allTasks;
 
     this.ensureValidFilters();
   }
@@ -570,6 +584,27 @@ export class TaskBoardView extends ItemView {
       cls: 'nexus-task-board-card-meta',
       text: `${task.workspaceName} · ${task.projectName}`
     });
+
+    if (task.noteLinks.length > 0) {
+      const linksRow = card.createDiv('nexus-task-board-card-links');
+      task.noteLinks.forEach(link => {
+        const fileName = link.notePath.split('/').pop()?.replace(/\.md$/, '') || link.notePath;
+        const linkEl = linksRow.createEl('a', {
+          cls: 'nexus-task-board-card-link',
+          text: fileName,
+          attr: { 'aria-label': link.notePath }
+        });
+        this.registerDomEvent(linkEl, 'click', (event) => {
+          event.stopPropagation();
+          const file = this.app.vault.getFileByPath(link.notePath);
+          if (file) {
+            void this.app.workspace.getLeaf(false).openFile(file);
+          } else {
+            new Notice(`File not found: ${link.notePath}`);
+          }
+        });
+      });
+    }
   }
 
   private getFilteredProjectsForToolbar(): ProjectMetadata[] {
@@ -753,7 +788,8 @@ export class TaskBoardView extends ItemView {
       dueDate: this.toDateInputValue(task.dueDate),
       assignee: task.assignee || '',
       tags: task.tags?.join(', ') || '',
-      parentTaskId: task.parentTaskId || ''
+      parentTaskId: task.parentTaskId || '',
+      noteLinks: [...task.noteLinks]
     };
 
     const projects = this.projects
@@ -815,6 +851,25 @@ export class TaskBoardView extends ItemView {
         projectId: projectChanged ? updatedTask.projectId : undefined,
         parentTaskId: parentChanged ? (updatedTask.parentTaskId || null) : undefined
       });
+    }
+
+    // Sync note links: compare original vs updated
+    const originalPaths = new Set(originalTask.noteLinks.map(link => link.notePath));
+    const updatedLinks = updatedTask.noteLinks.filter(link => link.notePath.trim());
+    const updatedPaths = new Map<string, LinkType>(updatedLinks.map(link => [link.notePath.trim(), link.linkType || 'reference']));
+
+    // Remove links that were deleted
+    for (const path of originalPaths) {
+      if (!updatedPaths.has(path)) {
+        await this.taskService.unlinkNote(originalTask.id, path);
+      }
+    }
+
+    // Add new links (or re-link with potentially different type)
+    for (const [path, linkType] of updatedPaths) {
+      if (!originalPaths.has(path)) {
+        await this.taskService.linkNote(originalTask.id, path, linkType);
+      }
     }
 
     await this.loadBoardData();

--- a/styles.css
+++ b/styles.css
@@ -7499,6 +7499,46 @@ body.is-mobile .chat-loading-overlay {
     margin-top: var(--space-xs);
 }
 
+.nexus-task-board-card-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    margin-top: var(--space-xs);
+}
+
+.nexus-task-board-card-link {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px var(--space-xs);
+    font-size: var(--font-smaller);
+    color: var(--text-accent);
+    background: var(--background-secondary);
+    border-radius: var(--radius-s);
+    cursor: pointer;
+    text-decoration: none;
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.nexus-task-board-card-link::before {
+    content: '[[';
+    color: var(--text-faint);
+    margin-right: 1px;
+}
+
+.nexus-task-board-card-link::after {
+    content: ']]';
+    color: var(--text-faint);
+    margin-left: 1px;
+}
+
+.nexus-task-board-card-link:hover {
+    color: var(--interactive-accent-hover);
+    background: var(--background-modifier-hover);
+}
+
 .nexus-task-board-icon-button {
     width: 28px;
     height: 28px;
@@ -7609,6 +7649,11 @@ body.is-mobile .chat-loading-overlay {
 
 .nexus-task-edit-modal .nexus-detail-title {
     margin-top: 0;
+}
+
+.nexus-task-edit-modal .nexus-item-actions select {
+    font-size: var(--font-smaller);
+    padding: var(--space-xs);
 }
 
 body.is-mobile .nexus-task-board-shell {


### PR DESCRIPTION
- Show wiki-style [[note]] links on task board cards that open the file on click
- Add linked notes section to TaskBoardEditModal with add/remove and link type selector
- Load note links for all tasks in board data via TaskService.getNoteLinks()
- Sync note link changes (add/remove) when saving task edits
- Add addNoteLinks/removeNoteLinks params to updateTask tool schema for LLM use
- Add getNoteLinks method to TaskService facade
- Add CSS styles for card note link pills with [[ ]] decoration

https://claude.ai/code/session_01SqqF9howxAALzPcu4XYZPL