### PR TITLE
Add desktop Web Viewer tools app

### DIFF
--- a/src/agents/apps/BaseAppAgent.ts
+++ b/src/agents/apps/BaseAppAgent.ts
@@ -9,7 +9,7 @@
 import { BaseAgent } from '../baseAgent';
 import { AppManifest, AppCredentialField, ElevenLabsModel } from '../../types/apps/AppTypes';
 import { CommonResult } from '../../types';
-import { Vault } from 'obsidian';
+import { App, Vault } from 'obsidian';
 
 /**
  * Result type for fetchTTSModels. Defined here so subclasses and consumers
@@ -25,6 +25,7 @@ export abstract class BaseAppAgent extends BaseAgent {
   readonly manifest: AppManifest;
   protected credentials: Record<string, string> = {};
   protected appSettings: Record<string, string> = {};
+  private _app: App | null = null;
   private _vault: Vault | null = null;
 
   constructor(manifest: AppManifest) {
@@ -91,6 +92,23 @@ export abstract class BaseAppAgent extends BaseAgent {
   getMissingCredentials(): AppCredentialField[] {
     return this.manifest.credentials
       .filter(c => c.required && !this.credentials[c.key]?.trim());
+  }
+
+  /**
+   * Inject the Obsidian App instance. Called by AppManager after construction.
+   * Tools that need workspace or command access can use getApp().
+   */
+  setApp(app: App): void {
+    this._app = app;
+    this._vault = app.vault;
+  }
+
+  /**
+   * Get the App instance for workspace and command operations.
+   * Returns null if the app has not been injected yet.
+   */
+  getApp(): App | null {
+    return this._app;
   }
 
   /**

--- a/src/agents/apps/index.ts
+++ b/src/agents/apps/index.ts
@@ -2,3 +2,4 @@
  * App agents barrel export
  */
 export { BaseAppAgent } from './BaseAppAgent';
+export { WebToolsAgent } from './webTools/WebToolsAgent';

--- a/src/agents/apps/webTools/WebToolsAgent.ts
+++ b/src/agents/apps/webTools/WebToolsAgent.ts
@@ -1,0 +1,37 @@
+import { AppManifest } from '../../../types/apps/AppTypes';
+import { BaseAppAgent } from '../BaseAppAgent';
+import { CaptureToMarkdownTool } from './tools/captureToMarkdown';
+import { CapturePagePdfTool } from './tools/capturePagePdf';
+import { CapturePagePngTool } from './tools/capturePagePng';
+import { ExtractLinksTool } from './tools/extractLinks';
+import { OpenWebpageTool } from './tools/openWebpage';
+
+const WEB_TOOLS_MANIFEST: AppManifest = {
+  id: 'web-tools',
+  agentName: 'webTools',
+  name: 'Web Tools',
+  description: 'Desktop Web Viewer tools for opening webpages and saving them into the vault as Markdown',
+  version: '1.0.0',
+  author: 'Nexus',
+  docsUrl: 'https://help.obsidian.md/plugins/web-viewer',
+  credentials: [],
+  tools: [
+    { slug: 'openWebpage', description: 'Open a webpage in Obsidian Web Viewer' },
+    { slug: 'captureToMarkdown', description: 'Save a Web Viewer page into the vault as Markdown' },
+    { slug: 'capturePagePng', description: 'Capture a Web Viewer page as a PNG image' },
+    { slug: 'capturePagePdf', description: 'Print a Web Viewer page to PDF' },
+    { slug: 'extractLinks', description: 'Extract links from a Web Viewer page' },
+  ],
+};
+
+export class WebToolsAgent extends BaseAppAgent {
+  constructor() {
+    super(WEB_TOOLS_MANIFEST);
+
+    this.registerTool(new OpenWebpageTool(this));
+    this.registerTool(new CaptureToMarkdownTool(this));
+    this.registerTool(new CapturePagePngTool(this));
+    this.registerTool(new CapturePagePdfTool(this));
+    this.registerTool(new ExtractLinksTool(this));
+  }
+}

--- a/src/agents/apps/webTools/tools/capturePagePdf.ts
+++ b/src/agents/apps/webTools/tools/capturePagePdf.ts
@@ -1,0 +1,130 @@
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import { isDesktop, isElectron } from '../../../../utils/platform';
+import {
+  ensureParentFolderExists,
+  getWebViewerContents,
+  getWebViewerLeaf,
+  getWebViewerState,
+  openWebViewerUrl,
+  resolveUniqueFilePath,
+  toArrayBuffer,
+  waitForWebViewerReady,
+  WebViewerOpenMode,
+} from '../utils/webViewer';
+
+interface CapturePagePdfParams extends CommonParameters {
+  url?: string;
+  mode?: WebViewerOpenMode;
+  outputPath: string;
+  timeoutMs?: number;
+  settleMs?: number;
+}
+
+export class CapturePagePdfTool extends BaseTool<CapturePagePdfParams, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'capturePagePdf',
+      'Capture Page PDF',
+      'Print the current Web Viewer page to PDF and save it to the vault. Desktop only.',
+      '1.0.0'
+    );
+    this.agent = agent;
+  }
+
+  async execute(params: CapturePagePdfParams): Promise<CommonResult> {
+    if (!isDesktop() || !isElectron()) {
+      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
+    }
+
+    const app = this.agent.getApp();
+    if (!app) {
+      return this.prepareResult(false, undefined, 'Obsidian app is not available.');
+    }
+
+    const timeoutMs = params.timeoutMs ?? 20000;
+    const settleMs = params.settleMs ?? 1200;
+
+    try {
+      const leaf = params.url
+        ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
+        : getWebViewerLeaf(app);
+
+      if (!leaf) {
+        return this.prepareResult(false, undefined, 'No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.');
+      }
+
+      await app.workspace.revealLeaf(leaf);
+      await app.workspace.setActiveLeaf(leaf, { focus: true });
+      const contents = await waitForWebViewerReady(leaf, timeoutMs, settleMs)
+        ?? getWebViewerContents(leaf);
+      if (!contents?.printToPDF) {
+        return this.prepareResult(false, undefined, 'Web Viewer printToPDF() is unavailable in this Obsidian build.');
+      }
+
+      const pdfData = toArrayBuffer(await contents.printToPDF({
+        printBackground: true,
+        landscape: false,
+        pageSize: 'Letter',
+        margins: {
+          top: 0.4,
+          bottom: 0.4,
+          left: 0.4,
+          right: 0.4,
+        },
+      }));
+      const state = getWebViewerState(leaf);
+      const outputPath = resolveUniqueFilePath(app.vault, params.outputPath, 'pdf');
+
+      await ensureParentFolderExists(app.vault, outputPath);
+      await app.vault.createBinary(outputPath, pdfData);
+
+      return this.prepareResult(true, {
+        path: outputPath,
+        sourceUrl: state?.url ?? params.url ?? null,
+        title: state?.title ?? 'web-capture',
+        format: 'pdf',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.prepareResult(false, undefined, `Failed to capture PDF: ${message}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional URL to open in Web Viewer before capturing.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab when url is provided.',
+          default: 'tab',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Destination PDF path in the vault. Required so the caller explicitly chooses where the document is saved.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum time to wait for page load.',
+          default: 20000,
+        },
+        settleMs: {
+          type: 'number',
+          description: 'Extra delay after page load before printing.',
+          default: 1200,
+        },
+      },
+      required: ['outputPath'],
+    });
+  }
+}

--- a/src/agents/apps/webTools/tools/capturePagePng.ts
+++ b/src/agents/apps/webTools/tools/capturePagePng.ts
@@ -1,0 +1,121 @@
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import { isDesktop, isElectron } from '../../../../utils/platform';
+import {
+  ensureParentFolderExists,
+  getWebViewerContents,
+  getWebViewerLeaf,
+  getWebViewerState,
+  openWebViewerUrl,
+  resolveUniqueFilePath,
+  toArrayBuffer,
+  waitForWebViewerReady,
+  WebViewerOpenMode,
+} from '../utils/webViewer';
+
+interface CapturePagePngParams extends CommonParameters {
+  url?: string;
+  mode?: WebViewerOpenMode;
+  outputPath: string;
+  timeoutMs?: number;
+  settleMs?: number;
+}
+
+export class CapturePagePngTool extends BaseTool<CapturePagePngParams, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'capturePagePng',
+      'Capture Page PNG',
+      'Capture the current Web Viewer page as a PNG image and save it to the vault. Desktop only.',
+      '1.0.0'
+    );
+    this.agent = agent;
+  }
+
+  async execute(params: CapturePagePngParams): Promise<CommonResult> {
+    if (!isDesktop() || !isElectron()) {
+      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
+    }
+
+    const app = this.agent.getApp();
+    if (!app) {
+      return this.prepareResult(false, undefined, 'Obsidian app is not available.');
+    }
+
+    const timeoutMs = params.timeoutMs ?? 20000;
+    const settleMs = params.settleMs ?? 1200;
+
+    try {
+      const leaf = params.url
+        ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
+        : getWebViewerLeaf(app);
+
+      if (!leaf) {
+        return this.prepareResult(false, undefined, 'No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.');
+      }
+
+      await app.workspace.revealLeaf(leaf);
+      await app.workspace.setActiveLeaf(leaf, { focus: true });
+      const contents = await waitForWebViewerReady(leaf, timeoutMs, settleMs)
+        ?? getWebViewerContents(leaf);
+      if (!contents?.capturePage) {
+        return this.prepareResult(false, undefined, 'Web Viewer capturePage() is unavailable in this Obsidian build.');
+      }
+
+      const image = await contents.capturePage();
+      const pngData = toArrayBuffer(image.toPNG());
+      const state = getWebViewerState(leaf);
+      const outputPath = resolveUniqueFilePath(app.vault, params.outputPath, 'png');
+
+      await ensureParentFolderExists(app.vault, outputPath);
+      await app.vault.createBinary(outputPath, pngData);
+
+      return this.prepareResult(true, {
+        path: outputPath,
+        sourceUrl: state?.url ?? params.url ?? null,
+        title: state?.title ?? 'web-capture',
+        format: 'png',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.prepareResult(false, undefined, `Failed to capture PNG: ${message}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional URL to open in Web Viewer before capturing.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab when url is provided.',
+          default: 'tab',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Destination PNG path in the vault. Required so the caller explicitly chooses where the image is saved.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum time to wait for page load.',
+          default: 20000,
+        },
+        settleMs: {
+          type: 'number',
+          description: 'Extra delay after page load before capturing.',
+          default: 1200,
+        },
+      },
+      required: ['outputPath'],
+    });
+  }
+}

--- a/src/agents/apps/webTools/tools/captureToMarkdown.ts
+++ b/src/agents/apps/webTools/tools/captureToMarkdown.ts
@@ -1,0 +1,176 @@
+import { TFile } from 'obsidian';
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import { isDesktop, isElectron } from '../../../../utils/platform';
+import {
+  ensureParentFolderExists,
+  findCreatedMarkdownFile,
+  getWebViewerLeaf,
+  getWebViewerState,
+  hasWebViewerSaveCommand,
+  openWebViewerUrl,
+  resolveUniqueMarkdownPath,
+  waitForWebViewerReady,
+  WEB_VIEWER_SAVE_COMMAND_ID,
+  WebViewerOpenMode,
+} from '../utils/webViewer';
+
+interface CaptureToMarkdownParams extends CommonParameters {
+  url?: string;
+  mode?: WebViewerOpenMode;
+  outputPath: string;
+  timeoutMs?: number;
+  settleMs?: number;
+}
+
+export class CaptureToMarkdownTool extends BaseTool<CaptureToMarkdownParams, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'captureToMarkdown',
+      'Capture To Markdown',
+      'Save the active Web Viewer page to the vault as Markdown using Obsidian Web Viewer. Desktop only.',
+      '1.0.0'
+    );
+    this.agent = agent;
+  }
+
+  async execute(params: CaptureToMarkdownParams): Promise<CommonResult> {
+    if (!isDesktop() || !isElectron()) {
+      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
+    }
+
+    const app = this.agent.getApp();
+    if (!app) {
+      return this.prepareResult(false, undefined, 'Obsidian app is not available.');
+    }
+
+    if (!hasWebViewerSaveCommand(app)) {
+      return this.prepareResult(
+        false,
+        undefined,
+        'Web Viewer Save to vault command is unavailable. Enable the core Web Viewer plugin in Obsidian.'
+      );
+    }
+
+    const timeoutMs = params.timeoutMs ?? 20000;
+    const settleMs = params.settleMs ?? 1200;
+
+    try {
+      const leaf = params.url
+        ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
+        : getWebViewerLeaf(app);
+
+      if (!leaf) {
+        return this.prepareResult(
+          false,
+          undefined,
+          'No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.'
+        );
+      }
+
+      await app.workspace.revealLeaf(leaf);
+      await app.workspace.setActiveLeaf(leaf, { focus: true });
+      await waitForWebViewerReady(leaf, timeoutMs, settleMs);
+
+      const beforePaths = new Set(app.vault.getMarkdownFiles().map((file) => file.path));
+      const startTimeMs = Date.now();
+
+      await app.commands.executeCommandById(WEB_VIEWER_SAVE_COMMAND_ID);
+
+      let createdFile = await this.waitForCreatedFile(beforePaths, startTimeMs, timeoutMs);
+      if (!createdFile) {
+        return this.prepareResult(
+          false,
+          undefined,
+          'Web Viewer did not create a Markdown note. The page may not be readable yet or extraction may have failed.'
+        );
+      }
+
+      let movedFromPath: string | undefined;
+      const targetPath = resolveUniqueMarkdownPath(app.vault, params.outputPath);
+      if (createdFile.path !== targetPath) {
+        await ensureParentFolderExists(app.vault, targetPath);
+        movedFromPath = createdFile.path;
+        await app.vault.rename(createdFile, targetPath);
+        const movedFile = app.vault.getAbstractFileByPath(targetPath);
+        if (movedFile instanceof TFile) {
+          createdFile = movedFile;
+        }
+      }
+
+      const state = getWebViewerState(leaf);
+
+      return this.prepareResult(true, {
+        path: createdFile.path,
+        sourceUrl: state?.url ?? params.url ?? null,
+        title: state?.title ?? createdFile.basename,
+        usedBuiltInSaveCommand: true,
+        movedFromPath,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.prepareResult(false, undefined, `Failed to capture webpage: ${message}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional URL to open in Web Viewer before capturing. If omitted, captures the active Web Viewer tab.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab when url is provided.',
+          default: 'tab',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Destination note path in the vault. Required so the caller explicitly chooses where the Markdown capture is saved.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum time to wait for page load and note creation.',
+          default: 20000,
+        },
+        settleMs: {
+          type: 'number',
+          description: 'Extra delay after page load before invoking Save to vault.',
+          default: 1200,
+        },
+      },
+      required: ['outputPath'],
+    });
+  }
+
+  private async waitForCreatedFile(
+    beforePaths: Set<string>,
+    startTimeMs: number,
+    timeoutMs: number
+  ): Promise<TFile | null> {
+    const app = this.agent.getApp();
+    if (!app) {
+      return null;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const file = findCreatedMarkdownFile(app.vault, beforePaths, startTimeMs);
+      if (file) {
+        return file;
+      }
+
+      await new Promise<void>((resolve) => window.setTimeout(resolve, 200));
+    }
+
+    return null;
+  }
+}

--- a/src/agents/apps/webTools/tools/extractLinks.ts
+++ b/src/agents/apps/webTools/tools/extractLinks.ts
@@ -1,0 +1,135 @@
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import { isDesktop, isElectron } from '../../../../utils/platform';
+import {
+  getWebViewerContents,
+  getWebViewerLeaf,
+  getWebViewerState,
+  openWebViewerUrl,
+  waitForWebViewerReady,
+  WebViewerOpenMode,
+} from '../utils/webViewer';
+
+interface ExtractLinksParams extends CommonParameters {
+  url?: string;
+  mode?: WebViewerOpenMode;
+  maxLinks?: number;
+  timeoutMs?: number;
+  settleMs?: number;
+}
+
+interface ExtractedLink {
+  href: string;
+  text: string;
+}
+
+export class ExtractLinksTool extends BaseTool<ExtractLinksParams, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'extractLinks',
+      'Extract Links',
+      'Extract links from the current Web Viewer page. Desktop only.',
+      '1.0.0'
+    );
+    this.agent = agent;
+  }
+
+  async execute(params: ExtractLinksParams): Promise<CommonResult> {
+    if (!isDesktop() || !isElectron()) {
+      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
+    }
+
+    const app = this.agent.getApp();
+    if (!app) {
+      return this.prepareResult(false, undefined, 'Obsidian app is not available.');
+    }
+
+    const timeoutMs = params.timeoutMs ?? 20000;
+    const settleMs = params.settleMs ?? 1200;
+    const maxLinks = params.maxLinks ?? 200;
+
+    try {
+      const leaf = params.url
+        ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
+        : getWebViewerLeaf(app);
+
+      if (!leaf) {
+        return this.prepareResult(false, undefined, 'No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.');
+      }
+
+      await app.workspace.revealLeaf(leaf);
+      await app.workspace.setActiveLeaf(leaf, { focus: true });
+      const contents = await waitForWebViewerReady(leaf, timeoutMs, settleMs)
+        ?? getWebViewerContents(leaf);
+      if (!contents?.executeJavaScript) {
+        return this.prepareResult(false, undefined, 'Web Viewer executeJavaScript() is unavailable in this Obsidian build.');
+      }
+
+      const links = await contents.executeJavaScript<ExtractedLink[]>(
+        `(function() {
+          const seen = new Set();
+          return Array.from(document.links)
+            .map((link) => ({
+              href: link.href || '',
+              text: (link.innerText || link.textContent || '').trim()
+            }))
+            .filter((link) => {
+              if (!link.href || seen.has(link.href)) return false;
+              seen.add(link.href);
+              return true;
+            })
+            .slice(0, ${Math.max(1, maxLinks)});
+        })()`
+      );
+
+      const state = getWebViewerState(leaf);
+
+      return this.prepareResult(true, {
+        sourceUrl: state?.url ?? params.url ?? null,
+        title: state?.title ?? null,
+        count: links.length,
+        links,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.prepareResult(false, undefined, `Failed to extract links: ${message}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'Optional URL to open in Web Viewer before extracting links.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab when url is provided.',
+          default: 'tab',
+        },
+        maxLinks: {
+          type: 'number',
+          description: 'Maximum number of links to return.',
+          default: 200,
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum time to wait for page load.',
+          default: 20000,
+        },
+        settleMs: {
+          type: 'number',
+          description: 'Extra delay after page load before extracting links.',
+          default: 1200,
+        },
+      },
+    });
+  }
+}

--- a/src/agents/apps/webTools/tools/openWebpage.ts
+++ b/src/agents/apps/webTools/tools/openWebpage.ts
@@ -1,0 +1,99 @@
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import {
+  getWebViewerState,
+  openWebViewerUrl,
+  waitForWebViewerReady,
+  WebViewerOpenMode,
+} from '../utils/webViewer';
+import { isDesktop, isElectron } from '../../../../utils/platform';
+
+interface OpenWebpageParams extends CommonParameters {
+  url: string;
+  mode?: WebViewerOpenMode;
+  focus?: boolean;
+  timeoutMs?: number;
+  settleMs?: number;
+}
+
+export class OpenWebpageTool extends BaseTool<OpenWebpageParams, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'openWebpage',
+      'Open Webpage',
+      'Open a webpage in Obsidian Web Viewer. Desktop only.',
+      '1.0.0'
+    );
+    this.agent = agent;
+  }
+
+  async execute(params: OpenWebpageParams): Promise<CommonResult> {
+    if (!isDesktop() || !isElectron()) {
+      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
+    }
+
+    const app = this.agent.getApp();
+    if (!app) {
+      return this.prepareResult(false, undefined, 'Obsidian app is not available.');
+    }
+
+    const mode = params.mode ?? 'tab';
+    const focus = params.focus !== false;
+    const timeoutMs = params.timeoutMs ?? 15000;
+    const settleMs = params.settleMs ?? 800;
+
+    try {
+      const leaf = await openWebViewerUrl(app, params.url, mode, focus);
+      await waitForWebViewerReady(leaf, timeoutMs, settleMs);
+      const state = getWebViewerState(leaf);
+
+      return this.prepareResult(true, {
+        url: state?.url ?? params.url,
+        title: state?.title ?? params.url,
+        mode,
+        focused: focus,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return this.prepareResult(false, undefined, `Failed to open webpage: ${message}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The webpage URL to open in Obsidian Web Viewer.',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab.',
+          default: 'tab',
+        },
+        focus: {
+          type: 'boolean',
+          description: 'Whether to focus the Web Viewer tab after opening it.',
+          default: true,
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Maximum time to wait for the page to load.',
+          default: 15000,
+        },
+        settleMs: {
+          type: 'number',
+          description: 'Extra delay after load before returning, to allow client-side rendering to settle.',
+          default: 800,
+        },
+      },
+      required: ['url'],
+    });
+  }
+}

--- a/src/agents/apps/webTools/utils/webViewer.ts
+++ b/src/agents/apps/webTools/utils/webViewer.ts
@@ -1,0 +1,221 @@
+import { App, normalizePath, TFile, TFolder, Vault, View, WorkspaceLeaf } from 'obsidian';
+import { sanitizeName } from '../../../../utils/pathUtils';
+
+export type WebViewerOpenMode = 'tab' | 'split' | 'window' | 'current';
+
+interface WebViewerState extends Record<string, unknown> {
+  url?: string;
+  title?: string;
+  navigate?: boolean;
+  mode?: string;
+}
+
+interface WebViewerWebContents {
+  isLoading?(): boolean;
+  capturePage?(): Promise<NativeImageLike>;
+  printToPDF?(options?: Record<string, unknown>): Promise<ArrayBuffer | SharedArrayBuffer | Uint8Array>;
+  executeJavaScript?<T>(code: string): Promise<T>;
+}
+
+interface NativeImageLike {
+  toPNG(): Uint8Array | ArrayBuffer;
+}
+
+interface WebViewerLikeView extends View {
+  getState(): WebViewerState;
+  webview?: WebViewerWebContents;
+}
+
+export const WEB_VIEWER_VIEW_TYPE = 'webviewer';
+export const WEB_VIEWER_SAVE_COMMAND_ID = 'webviewer:save-to-vault';
+
+export function getLeafForMode(app: App, mode: WebViewerOpenMode): WorkspaceLeaf {
+  switch (mode) {
+    case 'tab':
+      return app.workspace.getLeaf('tab');
+    case 'split':
+      return app.workspace.getLeaf('split');
+    case 'window':
+      return app.workspace.getLeaf('window');
+    case 'current':
+    default:
+      return app.workspace.getLeaf(false);
+  }
+}
+
+export function getWebViewerLeaf(app: App): WorkspaceLeaf | null {
+  const activeLeaf = app.workspace.activeLeaf;
+  if (activeLeaf?.view.getViewType() === WEB_VIEWER_VIEW_TYPE) {
+    return activeLeaf;
+  }
+
+  return app.workspace.getLeavesOfType(WEB_VIEWER_VIEW_TYPE)[0] ?? null;
+}
+
+export async function openWebViewerUrl(
+  app: App,
+  url: string,
+  mode: WebViewerOpenMode,
+  focus: boolean
+): Promise<WorkspaceLeaf> {
+  const leaf = getLeafForMode(app, mode);
+
+  await leaf.setViewState({
+    type: WEB_VIEWER_VIEW_TYPE,
+    active: focus,
+    state: {
+      url,
+      title: url,
+      navigate: true,
+    },
+  });
+
+  await app.workspace.revealLeaf(leaf);
+  if (focus) {
+    app.workspace.setActiveLeaf(leaf, { focus: true });
+  }
+
+  return leaf;
+}
+
+export async function waitForWebViewerReady(
+  leaf: WorkspaceLeaf,
+  timeoutMs: number,
+  settleMs: number
+): Promise<WebViewerWebContents | null> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const view = leaf.view as WebViewerLikeView;
+    const contents = view.webview;
+
+    if (contents?.executeJavaScript) {
+      try {
+        const snapshot = await contents.executeJavaScript<{
+          href?: string;
+          readyState?: string;
+        }>("({ href: location.href, readyState: document.readyState })");
+
+        if (
+          snapshot?.href &&
+          snapshot.href !== 'about:blank' &&
+          (snapshot.readyState === 'interactive' || snapshot.readyState === 'complete')
+        ) {
+          await sleep(settleMs);
+          return contents;
+        }
+      } catch {
+        // The WebView is present but not dom-ready yet.
+      }
+    }
+
+    await sleep(250);
+  }
+
+  throw new Error(`Timed out waiting for Web Viewer to load after ${timeoutMs}ms`);
+}
+
+export function getWebViewerState(leaf: WorkspaceLeaf): WebViewerState | null {
+  if (leaf.view.getViewType() !== WEB_VIEWER_VIEW_TYPE) {
+    return null;
+  }
+
+  const view = leaf.view as WebViewerLikeView;
+  return view.getState?.() ?? null;
+}
+
+export function getWebViewerContents(leaf: WorkspaceLeaf): WebViewerWebContents | null {
+  if (leaf.view.getViewType() !== WEB_VIEWER_VIEW_TYPE) {
+    return null;
+  }
+
+  const view = leaf.view as WebViewerLikeView;
+  return view.webview ?? null;
+}
+
+export async function ensureParentFolderExists(vault: Vault, path: string): Promise<void> {
+  const lastSlash = path.lastIndexOf('/');
+  if (lastSlash === -1) {
+    return;
+  }
+
+  const parentPath = path.slice(0, lastSlash);
+  if (!parentPath || vault.getAbstractFileByPath(parentPath)) {
+    return;
+  }
+
+  try {
+    await vault.createFolder(parentPath);
+  } catch {
+    if (!(vault.getAbstractFileByPath(parentPath) instanceof TFolder)) {
+      throw new Error(`Failed to create directory: ${parentPath}`);
+    }
+  }
+}
+
+export function findCreatedMarkdownFile(
+  vault: Vault,
+  beforePaths: Set<string>,
+  startTimeMs: number
+): TFile | null {
+  const candidates = vault.getMarkdownFiles()
+    .filter((file) => !beforePaths.has(file.path) && file.stat.mtime >= startTimeMs - 5000)
+    .sort((a, b) => b.stat.mtime - a.stat.mtime);
+
+  return candidates[0] ?? null;
+}
+
+export function resolveUniqueMarkdownPath(vault: Vault, outputPath: string): string {
+  return resolveUniqueFilePath(vault, outputPath, 'md');
+}
+
+export function resolveUniqueFilePath(vault: Vault, outputPath: string, extension: string): string {
+  const normalized = normalizePath(outputPath);
+  const suffix = `.${extension}`;
+  const withoutExtension = normalized.endsWith(suffix)
+    ? normalized.slice(0, -suffix.length)
+    : normalized;
+  const basePath = `${withoutExtension}.${extension}`;
+
+  if (!vault.getAbstractFileByPath(basePath)) {
+    return basePath;
+  }
+
+  let counter = 1;
+  while (true) {
+    const candidate = `${withoutExtension} ${counter}.${extension}`;
+    if (!vault.getAbstractFileByPath(candidate)) {
+      return candidate;
+    }
+    counter += 1;
+  }
+}
+
+export function hasWebViewerSaveCommand(app: App): boolean {
+  return Boolean(app.commands.commands[WEB_VIEWER_SAVE_COMMAND_ID]);
+}
+
+export function buildDefaultWebCapturePath(
+  vault: Vault,
+  title: string | undefined,
+  extension: string,
+  folder = 'web-captures'
+): string {
+  const safeTitle = sanitizeName(title || 'web-capture');
+  return resolveUniqueFilePath(vault, `${normalizePath(folder)}/${safeTitle}`, extension);
+}
+
+export function toArrayBuffer(data: ArrayBuffer | SharedArrayBuffer | Uint8Array): ArrayBuffer {
+  if (data instanceof ArrayBuffer) {
+    return data;
+  }
+
+  const source = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const view = new Uint8Array(source.byteLength);
+  view.set(source);
+  return view.buffer;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}

--- a/src/services/agent/AgentRegistrationService.ts
+++ b/src/services/agent/AgentRegistrationService.ts
@@ -182,7 +182,7 @@ export class AgentRegistrationService implements AgentRegistrationServiceInterfa
           appsSettings,
           (agent) => this.agentManager.registerAgent(agent),
           (name) => this.agentManager.unregisterAgent(name),
-          this.app.vault
+          this.app
         );
         await appManager.loadInstalledApps();
         this.appManagerInstance = appManager;

--- a/src/services/apps/AppManager.ts
+++ b/src/services/apps/AppManager.ts
@@ -11,25 +11,26 @@ import { AppManifest, AppConfig, AppsSettings } from '../../types/apps/AppTypes'
 import { IAgent } from '../../agents/interfaces/IAgent';
 import { logger } from '../../utils/logger';
 import { ElevenLabsAgent } from '../../agents/apps/elevenlabs/ElevenLabsAgent';
-import { Vault } from 'obsidian';
+import { WebToolsAgent } from '../../agents/apps/webTools/WebToolsAgent';
+import { App } from 'obsidian';
 
 export class AppManager {
   private apps: Map<string, BaseAppAgent> = new Map();
   private appConfigs: Record<string, AppConfig>;
   private registerCallback: (agent: IAgent) => void;
   private unregisterCallback: (agentName: string) => void;
-  private vault: Vault | null;
+  private app: App | null;
 
   constructor(
     appsSettings: AppsSettings,
     onRegister: (agent: IAgent) => void,
     onUnregister: (agentName: string) => void,
-    vault?: Vault
+    app?: App
   ) {
     this.appConfigs = appsSettings.apps || {};
     this.registerCallback = onRegister;
     this.unregisterCallback = onUnregister;
-    this.vault = vault || null;
+    this.app = app || null;
   }
 
   /**
@@ -52,7 +53,7 @@ export class AppManager {
         const agent = factory();
         agent.setCredentials(config.credentials);
         if (config.settings) agent.setSettings(config.settings);
-        if (this.vault) agent.setVault(this.vault);
+        if (this.app) agent.setApp(this.app);
         this.apps.set(appId, agent);
         this.registerCallback(agent);
         logger.systemLog(`App loaded: ${appId}`);
@@ -85,7 +86,7 @@ export class AppManager {
       installedVersion: agent.manifest.version
     };
 
-    if (this.vault) agent.setVault(this.vault);
+    if (this.app) agent.setApp(this.app);
     this.apps.set(appId, agent);
     this.registerCallback(agent);
 
@@ -156,7 +157,7 @@ export class AppManager {
         const agent = factory();
         agent.setCredentials(this.appConfigs[appId].credentials);
         if (this.appConfigs[appId].settings) agent.setSettings(this.appConfigs[appId].settings!);
-        if (this.vault) agent.setVault(this.vault);
+        if (this.app) agent.setApp(this.app);
         this.apps.set(appId, agent);
         this.registerCallback(agent);
       }
@@ -232,6 +233,7 @@ export class AppManager {
 
     // === ADD NEW APPS HERE ===
     registry.set('elevenlabs', () => new ElevenLabsAgent());
+    registry.set('web-tools', () => new WebToolsAgent());
 
     return registry;
   }

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-03-29T12:20:12.780Z
+ * Generated: 2026-03-29T14:05:39.810Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";


### PR DESCRIPTION
## Summary
- add a desktop-only Web Tools app agent backed by Obsidian Web Viewer
- support opening webpages, saving markdown, capturing PNG/PDF, and extracting links
- require explicit output paths for file-producing capture tools and wire app agents to the full Obsidian app instance

## Testing
- npm run build
- verified in the live Code vault via Obsidian CLI eval:
  - extractLinks
  - captureToMarkdown
  - capturePagePng
  - capturePagePdf
