### PR TITLE
fix: remove node:stream import from mobile streaming fallback

### DIFF
--- a/src/services/llm/adapters/shared/ProviderHttpClient.ts
+++ b/src/services/llm/adapters/shared/ProviderHttpClient.ts
@@ -293,16 +293,15 @@ export class ProviderHttpClient {
       );
     }
 
-    // Wrap the buffered text as a minimal readable stream
-      const { Readable } = await import('node:stream');
-    const readable = new Readable({
-      read() {
-        this.push(Buffer.from(response.text, 'utf-8'));
-        this.push(null);
-      }
-    });
+    // Wrap the buffered text as a minimal async iterable (no Node.js deps)
+    async function* textIterator(): AsyncGenerator<string> {
+      yield response.text;
+    }
 
-    return readable;
+    // Return the async iterable cast to ReadableStream type.
+    // The consumer (processNodeStream) uses `for await (const chunk of stream)`
+    // which works with any AsyncIterable, not just Node.js Readable.
+    return textIterator() as unknown as NodeJS.ReadableStream;
   }
 
   private static async requestOnce<TJson = unknown>(


### PR DESCRIPTION
The mobile fallback path (requestStreamBufferedFallback) was importing
node:stream Readable, which crashes on Obsidian mobile since Node.js
built-ins don't exist. Replace with a simple async generator that yields
the buffered response text — the consumer (processNodeStream) uses
for-await-of which works with any AsyncIterable.

https://claude.ai/code/session_015jcgw3FaU98Gk1fE5jfDQW