### PR TITLE
Fix Node.js module loading in Electron renderer process

### DIFF
--- a/src/services/llm/adapters/shared/ProviderHttpClient.ts
+++ b/src/services/llm/adapters/shared/ProviderHttpClient.ts
@@ -11,6 +11,7 @@
 import { requestUrl } from 'obsidian';
 import { LLMProviderError } from '../types';
 import { hasNodeRuntime, isDesktop } from '../../../../utils/platform';
+import { desktopRequire } from '../../../../utils/desktopRequire';
 
 export interface ProviderHttpRequest {
   url: string;
@@ -187,10 +188,13 @@ export class ProviderHttpClient {
     const parsed = new URL(config.url);
     const isHttps = parsed.protocol === 'https:';
 
-    // Dynamically import Node.js modules (available in Electron)
-      const nodeModule = isHttps
-        ? await import('node:https')
-        : await import('node:http');
+    // Use require (not import) for Node.js built-ins in Electron renderer.
+    // Dynamic import('node:http') is treated as a URL fetch by the ESM loader,
+    // which triggers CORS errors in Obsidian's app:// origin. require() goes
+    // through Node's CommonJS resolver and works without network requests.
+    const nodeModule = isHttps
+      ? desktopRequire<typeof import('node:https')>('node:https')
+      : desktopRequire<typeof import('node:http')>('node:http');
 
     const timeoutMs = config.timeoutMs ?? 120_000;
 


### PR DESCRIPTION
## Summary
Replace dynamic `import()` with `require()` for Node.js built-in modules in the Electron renderer process to avoid CORS errors when loading HTTP/HTTPS modules.

## Key Changes
- Introduced `desktopRequire` utility function to load Node.js modules using CommonJS `require()` instead of ESM `import()`
- Updated `ProviderHttpClient` to use `desktopRequire()` when loading `node:http` and `node:https` modules
- Added explanatory comments documenting why `require()` is necessary for Node.js built-ins in Obsidian's app:// origin

## Implementation Details
The issue stems from Obsidian's Electron renderer treating dynamic `import('node:*')` statements as URL fetch requests through the ESM loader, which triggers CORS errors on the app:// origin. By using CommonJS `require()` instead, the requests go through Node's native resolver and work without network-level restrictions.

The change maintains type safety by using TypeScript generics (`desktopRequire<typeof import('node:https')>()`) to preserve proper typing for the loaded modules.

https://claude.ai/code/session_01DHFAoQgqgWxM27uy7NsiLo