### PR TITLE
refactor: split sqlite cache manager responsibilities

### DIFF
--- a/docs/plans/sqlite-cache-manager-refactor-plan.md
+++ b/docs/plans/sqlite-cache-manager-refactor-plan.md
@@ -1,0 +1,211 @@
+# SQLiteCacheManager Refactor Plan
+
+Generated: 2026-04-07
+Target file: `src/database/storage/SQLiteCacheManager.ts`
+Current size: 923 lines on `origin/main`
+Current size in worktree: 734 lines
+Worktree: `.worktrees/sqlite-cache-manager-refactor`
+Branch: `codex/sqlite-cache-manager-refactor`
+
+## Goal
+
+Reduce `SQLiteCacheManager` to a thin storage facade that owns lifecycle state and delegates:
+
+- WASM sqlite module bootstrapping and DB creation/loading
+- file persistence and corruption recovery
+- low-level typed statement/query execution
+- transaction coordination
+- maintenance/admin operations such as clear, rebuild, vacuum, and stats
+
+This refactor should also eliminate the current `@typescript-eslint/no-unsafe-*` failures caused by direct interaction with the loosely typed sqlite WASM API.
+
+## Progress Snapshot
+
+Completed so far in this worktree:
+
+- added direct unit coverage for `SQLiteCacheManager`
+- extracted `SQLiteWasmBridge`
+- extracted `SQLiteTransactionCoordinator`
+- extracted `SQLiteSyncStateStore`
+- extracted `SQLitePersistenceService`
+- reduced `SQLiteCacheManager` from `923` lines to `734` lines
+- eliminated the original `@typescript-eslint/no-unsafe-*` failures in `SQLiteCacheManager.ts`
+
+Current validation status:
+
+- targeted Jest suites pass:
+  - `tests/unit/SQLiteCacheManager.test.ts`
+  - `tests/unit/SQLiteTransactionCoordinator.test.ts`
+  - `tests/unit/SQLiteSyncStateStore.test.ts`
+  - `tests/unit/SQLitePersistenceService.test.ts`
+- focused `eslint` on the changed files passes
+- `tsc --noEmit --skipLibCheck` no longer reports any `SQLiteCacheManager` or `SQLiteWasmBridge` issues
+- remaining TypeScript/build blockers in this worktree are unrelated baseline issues:
+  - `src/services/workflows/WorkflowRunService.ts`
+  - `src/ui/chat/services/ModelAgentManager.ts`
+  - `src/core/PluginLifecycleManager.ts` `no-console` warning during lint
+
+## Current Responsibility Clusters
+
+### 1. WASM initialization and database open/load
+
+Methods:
+
+- `resolveSqliteWasmPath()`
+- `initialize()`
+- `getSqlite3OrThrow()`
+- `getDbOrThrow()`
+
+Problems:
+
+- mixes vault filesystem lookup, WASM binary loading, console suppression, module init, DB open/create, schema bootstrap, migration, and autosave timer startup
+- owned the most lint-heavy untyped API boundary before the bridge extraction
+
+### 2. File persistence and corruption recovery
+
+Methods:
+
+- `loadFromFile()`
+- `saveToFile()`
+- `recreateCorruptedDatabase()`
+- part of `close()`
+
+Problems:
+
+- deserialize/export logic is mixed with corruption recovery and save policy
+- file persistence is intertwined with raw DB lifecycle mutation
+
+### 3. Query and statement execution
+
+Methods:
+
+- `exec()`
+- `query()`
+- `queryOne()`
+- `run()`
+- internal `DatabaseAdapter`
+
+Problems:
+
+- low-level statement lifecycle used to be repeated inline
+- now routed through `SQLiteWasmBridge`, but the manager still owns too many lifecycle concerns around it
+
+### 4. Transaction coordination
+
+Methods:
+
+- `beginTransaction()`
+- `commit()`
+- `rollback()`
+- `transaction()`
+
+Status:
+
+- extracted to `SQLiteTransactionCoordinator`
+
+### 5. Sync/event/admin operations
+
+Methods:
+
+- `isEventApplied()`
+- `markEventApplied()`
+- `getAppliedEventsAfter()`
+- `getSyncState()`
+- `updateSyncState()`
+- `clearAllData()`
+- `rebuildFTSIndexes()`
+- `vacuum()`
+- `getStatistics()`
+- `getStats()`
+
+Status:
+
+- sync/event persistence extracted to `SQLiteSyncStateStore`
+- maintenance/admin operations still live in the manager
+
+## Existing Test Surface
+
+Direct coverage now includes:
+
+- `tests/unit/SQLiteCacheManager.test.ts`
+- `tests/unit/SQLiteTransactionCoordinator.test.ts`
+- `tests/unit/SQLiteSyncStateStore.test.ts`
+
+Indirect coverage:
+
+- repository tests that mock the cache interface, not the real implementation
+- `HybridStorageAdapter` tests with mocked sqlite cache
+- embedding/indexer tests that depend on the cache type but not the real WASM-backed implementation
+
+## Refactor Strategy
+
+### 1. Add a typed sqlite boundary first
+
+Collaborator:
+
+- `src/database/storage/SQLiteWasmBridge.ts`
+
+Status: Complete
+
+### 2. Extract file persistence and recovery
+
+Collaborator:
+
+- `src/database/storage/SQLitePersistenceService.ts`
+
+Status: Complete
+
+### 3. Extract transaction coordination
+
+Collaborator:
+
+- `src/database/storage/SQLiteTransactionCoordinator.ts`
+
+Status: Complete
+
+### 4. Extract sync/maintenance services
+
+Collaborators:
+
+- `src/database/storage/SQLiteSyncStateStore.ts`
+- `src/database/storage/SQLiteMaintenanceService.ts`
+
+Status:
+
+- sync state store complete
+- maintenance service pending
+
+## Recommended Next Step
+
+Extract `SQLiteMaintenanceService` next.
+
+Reason:
+
+- it is the largest remaining coherent block in `SQLiteCacheManager`
+- it will move destructive maintenance and statistics out of the manager
+- it should get the manager close to the final facade shape without forcing artificial micro-extractions
+
+Secondary next step after that:
+
+- decide whether the remaining manager size is acceptable after maintenance extraction or whether one final lifecycle/bootstrap split is still warranted
+
+## Exit Criteria
+
+- `SQLiteCacheManager.ts` drops below roughly 650 lines
+- repo-wide lint no longer fails on this file
+- public `IStorageBackend` and `ISQLiteCacheManager` behavior remains unchanged
+- corruption recovery and persistence semantics remain unchanged
+- transaction ordering semantics remain unchanged
+- no search behavior regressions
+
+## Stop Condition
+
+Stop once `SQLiteCacheManager` is clearly a facade over:
+
+- lifecycle/bootstrap state
+- typed sqlite execution
+- persistence
+- transactions
+- sync/admin helpers
+
+Do not keep splitting after that into tiny helper classes with no meaningful boundary.

--- a/src/database/storage/SQLiteCacheManager.ts
+++ b/src/database/storage/SQLiteCacheManager.ts
@@ -22,24 +22,25 @@
  * - Works in Electron renderer (no native bindings)
  */
 
-// Import the raw WASM sqlite3 module (has sqlite-vec compiled in)
-// esbuild alias resolves this to index.mjs which exports sqlite3InitModule
-import sqlite3InitModule from '@dao-xyz/sqlite3-vec/wasm';
-
 import { App } from 'obsidian';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { IStorageBackend, RunResult, DatabaseStats } from '../interfaces/IStorageBackend';
 import type { SyncState, ISQLiteCacheManager } from '../sync/SyncCoordinator';
 import { SQLiteSearchService } from './SQLiteSearchService';
 import { QueryParams } from '../repositories/base/BaseRepository';
+import {
+  SQLiteWasmBridge,
+  SQLiteWasmModule,
+  SQLiteDatabaseHandle
+} from './SQLiteWasmBridge';
+import { SQLiteTransactionCoordinator } from './SQLiteTransactionCoordinator';
+import { SQLiteSyncStateStore } from './SQLiteSyncStateStore';
+import { SQLitePersistenceService } from './SQLitePersistenceService';
+import { SQLiteMaintenanceService, SQLiteMaintenanceStatistics } from './SQLiteMaintenanceService';
 
 // Import schema from TypeScript module (esbuild compatible)
 import { SCHEMA_SQL } from '../schema/schema';
 import { SchemaMigrator } from '../schema/SchemaMigrator';
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
 
 export interface SQLiteCacheManagerOptions {
   app: App;
@@ -53,33 +54,23 @@ export interface QueryResult<T> {
   totalCount?: number;
 }
 
-type SQLite3Module = Awaited<ReturnType<typeof sqlite3InitModule>>;
-type SQLiteDatabase = InstanceType<SQLite3Module['oo1']['DB']>;
-
 /**
  * Database adapter that wraps raw WASM SQLite database to provide
  * exec() and run() methods for MigratableDatabase interface.
  */
 class DatabaseAdapter {
-  constructor(private rawDb: SQLiteDatabase) {}
+  constructor(
+    private readonly bridge: SQLiteWasmBridge,
+    private readonly rawDb: SQLiteDatabaseHandle
+  ) {}
 
   exec(sql: string): { values: unknown[][] }[] {
-    const stmt = this.rawDb.prepare(sql);
-    const results: unknown[][] = [];
-    while (stmt.step()) {
-      results.push(stmt.get([]) as unknown[]);
-    }
-    stmt.finalize();
+    const results = this.bridge.collectValues(this.rawDb, sql);
     return results.length > 0 ? [{ values: results }] : [];
   }
 
   run(sql: string, params?: QueryParams): void {
-    const stmt = this.rawDb.prepare(sql);
-    if (params?.length) {
-      stmt.bind(params);
-    }
-    stmt.step();
-    stmt.finalize();
+    this.bridge.executeStatement(this.rawDb, sql, params);
   }
 }
 
@@ -98,34 +89,61 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
   private app: App;
   private dbPath: string;  // Relative path within vault
   private wasmPath?: string;
-  private sqlite3: SQLite3Module | null = null;  // The sqlite3 WASM module
-  private db: SQLiteDatabase | null = null;  // The oo1.DB instance
+  private readonly bridge: SQLiteWasmBridge;
+  private sqlite3: SQLiteWasmModule | null = null;  // The sqlite3 WASM module
+  private db: SQLiteDatabaseHandle | null = null;  // The oo1.DB instance
   private isInitialized = false;
   private searchService: SQLiteSearchService;
   private hasUnsavedData = false;
   private autoSaveInterval: number;
   private autoSaveTimer: NodeJS.Timeout | null = null;
-
-  // Transaction management - prevent nested transactions
-  private transactionDepth = 0;
-  private transactionLock: Promise<void> = Promise.resolve();
+  private readonly transactionCoordinator: SQLiteTransactionCoordinator;
+  private readonly syncStateStore: SQLiteSyncStateStore;
+  private readonly persistenceService: SQLitePersistenceService;
+  private maintenanceService?: SQLiteMaintenanceService;
 
   constructor(options: SQLiteCacheManagerOptions) {
     this.app = options.app;
     this.dbPath = options.dbPath;
     this.wasmPath = options.wasmPath;
     this.autoSaveInterval = options.autoSaveInterval ?? 30000;  // 30 seconds default
+    this.bridge = new SQLiteWasmBridge();
+    this.transactionCoordinator = new SQLiteTransactionCoordinator();
+    this.persistenceService = new SQLitePersistenceService({
+      app: this.app,
+      dbPath: this.dbPath,
+      bridge: this.bridge
+    });
+    this.syncStateStore = new SQLiteSyncStateStore(
+      <T>(sql: string, params?: QueryParams) => this.query<T>(sql, params),
+      <T>(sql: string, params?: QueryParams) => this.queryOne<T>(sql, params),
+      (sql: string, params?: QueryParams) => this.run(sql, params)
+    );
     this.searchService = new SQLiteSearchService(this);
   }
 
-  private getSqlite3OrThrow(): SQLite3Module {
+  private getMaintenanceService(): SQLiteMaintenanceService {
+    if (!this.maintenanceService) {
+      this.maintenanceService = new SQLiteMaintenanceService({
+        app: this.app,
+        dbPath: this.dbPath,
+        bridge: this.bridge,
+        getDb: () => this.getDbOrThrow(),
+        queryOne: <T>(sql: string, params?: QueryParams) => this.queryOne<T>(sql, params),
+        transaction: <T>(fn: () => Promise<T>) => this.transaction(fn)
+      });
+    }
+    return this.maintenanceService;
+  }
+
+  private getSqlite3OrThrow(): SQLiteWasmModule {
     if (!this.sqlite3) {
       throw new Error('SQLite module not initialized');
     }
     return this.sqlite3;
   }
 
-  private getDbOrThrow(): SQLiteDatabase {
+  private getDbOrThrow(): SQLiteDatabaseHandle {
     if (!this.db) {
       throw new Error('Database not initialized');
     }
@@ -207,23 +225,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
       };
 
       try {
-        // External library types are incomplete - instantiateWasm is a valid option but not in InitOptions type
-        // Cast to unknown first to bypass strict type checking for the extended options
-        const initOptions = {
-          instantiateWasm: (imports: WebAssembly.Imports, successCallback: (instance: WebAssembly.Instance) => void) => {
-            WebAssembly.instantiate(wasmBinary, imports)
-              .then(result => {
-                successCallback(result.instance);
-              })
-              .catch(err => {
-                console.error('[SQLiteCacheManager] WASM instantiation failed:', err);
-              });
-            return {};
-          },
-          print: () => undefined,
-          printErr: (msg: string) => console.error('[SQLite]', msg)
-        } as unknown as Parameters<typeof sqlite3InitModule>[0];
-        this.sqlite3 = await sqlite3InitModule(initOptions);
+        this.sqlite3 = await this.bridge.initializeModule(wasmBinary);
       } finally {
         consoleRef.warn = originalWarn;
         consoleRef.log = originalLog;
@@ -244,15 +246,14 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
         await this.loadFromFile();
       } else {
         const sqlite3 = this.getSqlite3OrThrow();
-        const db = new sqlite3.oo1.DB(':memory:');
+        const db = this.persistenceService.createFreshDatabase(sqlite3, SCHEMA_SQL);
         this.db = db;
-        db.exec(SCHEMA_SQL);
         await this.saveToFile();
       }
 
       // Run schema migrations for existing databases
       // Wrap raw database in adapter to provide exec() and run() methods
-      const dbAdapter = new DatabaseAdapter(this.getDbOrThrow());
+      const dbAdapter = new DatabaseAdapter(this.bridge, this.getDbOrThrow());
       const migrator = new SchemaMigrator(dbAdapter);
       const migrationResult = await migrator.migrate();
       if (migrationResult.applied > 0) {
@@ -282,62 +283,9 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Includes corruption detection and auto-recovery
    */
   private async loadFromFile(): Promise<void> {
-    try {
-      // Read binary data from vault
-      const data = await this.app.vault.adapter.readBinary(this.dbPath);
-      const uint8 = new Uint8Array(data);
-
-      if (uint8.length === 0) {
-        // Empty file, create new database
-        const sqlite3 = this.getSqlite3OrThrow();
-        const db = new sqlite3.oo1.DB(':memory:');
-        this.db = db;
-        db.exec(SCHEMA_SQL);
-        return;
-      }
-
-      // Allocate memory for the database bytes
-      const sqlite3 = this.getSqlite3OrThrow();
-      const ptr = sqlite3.wasm.allocFromTypedArray(uint8);
-
-      // Create empty in-memory database
-      this.db = new sqlite3.oo1.DB(':memory:');
-      const db = this.getDbOrThrow();
-
-      // Deserialize the data into the database
-      const rc = sqlite3.capi.sqlite3_deserialize(
-        db,
-        'main',
-        ptr,
-        uint8.byteLength,
-        uint8.byteLength,
-        sqlite3.capi.SQLITE_DESERIALIZE_FREEONCLOSE |
-        sqlite3.capi.SQLITE_DESERIALIZE_RESIZEABLE
-      );
-
-      if (rc !== 0) {
-        throw new Error(`sqlite3_deserialize failed with code ${rc}`);
-      }
-
-      // Verify database integrity
-      try {
-        const integrityResult = db.selectValue('PRAGMA integrity_check');
-        if (integrityResult !== 'ok') {
-          const integrityMessage = typeof integrityResult === 'string'
-            ? integrityResult
-            : JSON.stringify(integrityResult) ?? 'unknown';
-          throw new Error(`Database integrity check failed: ${integrityMessage}`);
-        }
-      } catch {
-        await this.recreateCorruptedDatabase();
-        return;
-      }
-
-      this.hasUnsavedData = false;
-    } catch (error) {
-      console.error('[SQLiteCacheManager] Failed to load from file:', error);
-      await this.recreateCorruptedDatabase();
-    }
+    const sqlite3 = this.getSqlite3OrThrow();
+    this.db = await this.persistenceService.loadDatabase(sqlite3, SCHEMA_SQL);
+    this.hasUnsavedData = false;
   }
 
   /**
@@ -345,54 +293,28 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Deletes corrupt file and creates fresh database
    */
   private async recreateCorruptedDatabase(): Promise<void> {
+    const sqlite3 = this.getSqlite3OrThrow();
     if (this.db) {
       try {
-        this.db.close();
+        this.bridge.close(this.db);
       } catch {
         void 0;
       }
       this.db = null;
     }
 
-    try {
-      await this.app.vault.adapter.remove(this.dbPath);
-    } catch {
-      void 0;
-    }
-
-    const sqlite3 = this.getSqlite3OrThrow();
-    const db = new sqlite3.oo1.DB(':memory:');
-    this.db = db;
-    db.exec(SCHEMA_SQL);
-    await this.saveToFile();
+    this.db = await this.persistenceService.recreateCorruptedDatabase(sqlite3, SCHEMA_SQL);
+    this.hasUnsavedData = false;
   }
 
   /**
    * Save database to file using sqlite3_js_db_export
    */
   private async saveToFile(): Promise<void> {
-    try {
-      const db = this.getDbOrThrow();
-      const sqlite3 = this.getSqlite3OrThrow();
-      // Temporarily suppress console.log during WASM export to avoid "Heap resize" noise
-      const consoleRef = console;
-      const originalLog = consoleRef.log;
-      consoleRef.log = () => undefined;
-
-      let data: { buffer: ArrayBuffer };
-      try {
-        data = sqlite3.capi.sqlite3_js_db_export(db);
-      } finally {
-        consoleRef.log = originalLog;
-      }
-
-      await this.app.vault.adapter.writeBinary(this.dbPath, data.buffer);
-
-      this.hasUnsavedData = false;
-    } catch (error) {
-      console.error('[SQLiteCacheManager] Failed to save to file:', error);
-      throw error;
-    }
+    const db = this.getDbOrThrow();
+    const sqlite3 = this.getSqlite3OrThrow();
+    await this.persistenceService.saveDatabase(sqlite3, db);
+    this.hasUnsavedData = false;
   }
 
   /**
@@ -412,7 +334,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
       }
 
       if (this.db) {
-        this.db.close();
+        this.bridge.close(this.db);
         this.db = null;
       }
       this.isInitialized = false;
@@ -430,7 +352,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
     if (!this.db) return Promise.reject(new Error('Database not initialized'));
 
     try {
-      this.db.exec(sql);
+      this.bridge.exec(this.db, sql);
       this.hasUnsavedData = true;
       return Promise.resolve();
     } catch (error) {
@@ -444,20 +366,8 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    */
   query<T>(sql: string, params?: QueryParams): Promise<T[]> {
     try {
-      const db = this.getDbOrThrow();
-      const stmt = db.prepare(sql);
-      try {
-        if (params?.length) {
-          stmt.bind(params);
-        }
-        const results: T[] = [];
-        while (stmt.step()) {
-          results.push(stmt.get({}) as T);
-        }
-        return Promise.resolve(results);
-      } finally {
-        stmt.finalize();
-      }
+      const results = this.bridge.query<T>(this.getDbOrThrow(), sql, params);
+      return Promise.resolve(results);
     } catch (error) {
       console.error('[SQLiteCacheManager] Query failed:', error, { sql, params });
       throw error;
@@ -469,19 +379,8 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    */
   queryOne<T>(sql: string, params?: QueryParams): Promise<T | null> {
     try {
-      const db = this.getDbOrThrow();
-      const stmt = db.prepare(sql);
-      try {
-        if (params?.length) {
-          stmt.bind(params);
-        }
-        if (stmt.step()) {
-          return Promise.resolve(stmt.get({}) as T);
-        }
-        return Promise.resolve(null);
-      } finally {
-        stmt.finalize();
-      }
+      const result = this.bridge.queryOne<T>(this.getDbOrThrow(), sql, params);
+      return Promise.resolve(result);
     } catch (error) {
       console.error('[SQLiteCacheManager] QueryOne failed:', error, { sql, params });
       throw error;
@@ -496,19 +395,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
     try {
       const db = this.getDbOrThrow();
       const sqlite3 = this.getSqlite3OrThrow();
-      const stmt = db.prepare(sql);
-      try {
-        if (params?.length) {
-          stmt.bind(params);
-        }
-        stmt.stepReset();
-      } finally {
-        stmt.finalize();
-      }
-
-      // Get changes count and last insert rowid
-      const changes = db.changes();
-      const lastInsertRowid = Number(sqlite3.capi.sqlite3_last_insert_rowid(db));
+      const { changes, lastInsertRowid } = this.bridge.run(db, sqlite3, sql, params);
 
       this.hasUnsavedData = true;
       return Promise.resolve({ changes, lastInsertRowid });
@@ -522,7 +409,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Begin a transaction
    */
   beginTransaction(): Promise<void> {
-    this.getDbOrThrow().exec('BEGIN TRANSACTION');
+    this.bridge.exec(this.getDbOrThrow(), 'BEGIN TRANSACTION');
     return Promise.resolve();
   }
 
@@ -530,7 +417,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Commit a transaction
    */
   commit(): Promise<void> {
-    this.getDbOrThrow().exec('COMMIT');
+    this.bridge.exec(this.getDbOrThrow(), 'COMMIT');
     this.hasUnsavedData = true;
     return Promise.resolve();
   }
@@ -539,7 +426,7 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Rollback a transaction
    */
   rollback(): Promise<void> {
-    this.getDbOrThrow().exec('ROLLBACK');
+    this.bridge.exec(this.getDbOrThrow(), 'ROLLBACK');
     return Promise.resolve();
   }
 
@@ -548,37 +435,12 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Handles concurrent access via lock and nested transactions via depth tracking
    */
   async transaction<T>(fn: () => Promise<T>): Promise<T> {
-    // If already in a transaction, just run the function (no nesting)
-    if (this.transactionDepth > 0) {
-      return fn();
-    }
-
-    // Queue this transaction after any pending ones
-    let resolve: (() => void) | undefined;
-    const previousLock = this.transactionLock;
-    this.transactionLock = new Promise<void>((r) => { resolve = r; });
-
-    try {
-      // Wait for any pending transaction to complete
-      await previousLock;
-
-      this.transactionDepth++;
-      await this.beginTransaction();
-
-      try {
-        const result = await fn();
-        await this.commit();
-        return result;
-      } catch (error) {
-        await this.rollback();
-        throw error;
-      } finally {
-        this.transactionDepth--;
-      }
-    } finally {
-      // Release the lock for the next transaction
-      resolve?.();
-    }
+    return this.transactionCoordinator.run(
+      () => this.beginTransaction(),
+      () => this.commit(),
+      () => this.rollback(),
+      fn
+    );
   }
 
   // ==================== Higher-level query methods ====================
@@ -622,32 +484,21 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Check if an event has already been applied
    */
   async isEventApplied(eventId: string): Promise<boolean> {
-    const result = await this.queryOne<{ eventId: string }>(
-      'SELECT eventId FROM applied_events WHERE eventId = ?',
-      [eventId]
-    );
-    return result !== null;
+    return this.syncStateStore.isEventApplied(eventId);
   }
 
   /**
    * Mark an event as applied
    */
   async markEventApplied(eventId: string): Promise<void> {
-    await this.run(
-      'INSERT OR IGNORE INTO applied_events (eventId, appliedAt) VALUES (?, ?)',
-      [eventId, Date.now()]
-    );
+    await this.syncStateStore.markEventApplied(eventId);
   }
 
   /**
    * Get list of applied event IDs after a timestamp
    */
   async getAppliedEventsAfter(timestamp: number): Promise<string[]> {
-    const results = await this.query<{ eventId: string }>(
-      'SELECT eventId FROM applied_events WHERE appliedAt > ? ORDER BY appliedAt',
-      [timestamp]
-    );
-    return results.map(r => r.eventId);
+    return this.syncStateStore.getAppliedEventsAfter(timestamp);
   }
 
   // ==================== Sync state ====================
@@ -656,109 +507,29 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Get sync state for a device
    */
   async getSyncState(deviceId: string): Promise<SyncState | null> {
-    const result = await this.queryOne<{ deviceId: string; lastEventTimestamp: number; syncedFilesJson: string }>(
-      'SELECT deviceId, lastEventTimestamp, syncedFilesJson FROM sync_state WHERE deviceId = ?',
-      [deviceId]
-    );
-
-    if (!result) return null;
-
-      const fileTimestampsRaw: unknown = result.syncedFilesJson ? JSON.parse(result.syncedFilesJson) : {};
-      const fileTimestamps: Record<string, number> = {};
-      if (isRecord(fileTimestampsRaw)) {
-        for (const [key, value] of Object.entries(fileTimestampsRaw)) {
-          if (typeof value === 'number' && Number.isFinite(value)) {
-            fileTimestamps[key] = value;
-          }
-        }
-      }
-      return {
-        deviceId: result.deviceId,
-        lastEventTimestamp: result.lastEventTimestamp,
-        fileTimestamps
-      };
+    return this.syncStateStore.getSyncState(deviceId);
   }
 
   /**
    * Update sync state for a device
    */
   async updateSyncState(deviceId: string, lastEventTimestamp: number, fileTimestamps: Record<string, number>): Promise<void> {
-    await this.run(
-      `INSERT OR REPLACE INTO sync_state (deviceId, lastEventTimestamp, syncedFilesJson)
-       VALUES (?, ?, ?)`,
-      [deviceId, lastEventTimestamp, JSON.stringify(fileTimestamps)]
-    );
+    await this.syncStateStore.updateSyncState(deviceId, lastEventTimestamp, fileTimestamps);
   }
 
   // ==================== Data management ====================
 
-  /**
-   * Clear all data (for rebuilding from JSONL)
-   */
   async clearAllData(): Promise<void> {
-    await this.transaction(() => {
-      const db = this.getDbOrThrow();
-      db.exec(`
-        DELETE FROM task_note_links;
-        DELETE FROM task_dependencies;
-        DELETE FROM tasks;
-        DELETE FROM projects;
-        DELETE FROM messages;
-        DELETE FROM conversations;
-        DELETE FROM memory_traces;
-        DELETE FROM states;
-        DELETE FROM sessions;
-        DELETE FROM workspaces;
-        DELETE FROM applied_events;
-        DELETE FROM sync_state;
-      `);
-
-      // Drop and recreate vec0 virtual tables (cannot DELETE from vec0)
-      // Conversation embeddings
-      db.exec(`DROP TABLE IF EXISTS conversation_embeddings`);
-      db.exec(`CREATE VIRTUAL TABLE IF NOT EXISTS conversation_embeddings USING vec0(embedding float[384])`);
-      db.exec(`DELETE FROM conversation_embedding_metadata`);
-      db.exec(`DELETE FROM embedding_backfill_state`);
-      return Promise.resolve();
-    });
+    await this.getMaintenanceService().clearAllData();
   }
 
-  /**
-   * Rebuild FTS5 indexes after bulk data changes
-   */
   async rebuildFTSIndexes(): Promise<void> {
-    await this.transaction(() => {
-      const db = this.getDbOrThrow();
-      // Rebuild workspace FTS5
-      db.exec(`
-        INSERT INTO workspace_fts(workspace_fts) VALUES ('rebuild');
-      `);
-
-      // Rebuild conversation FTS5
-      db.exec(`
-        INSERT INTO conversation_fts(conversation_fts) VALUES ('rebuild');
-      `);
-
-      // Rebuild message FTS5
-      db.exec(`
-        INSERT INTO message_fts(message_fts) VALUES ('rebuild');
-      `);
-      return Promise.resolve();
-    });
+    await this.getMaintenanceService().rebuildFTSIndexes();
   }
 
-  /**
-   * Vacuum the database to reclaim space
-   */
-  vacuum(): Promise<void> {
-    try {
-      this.getDbOrThrow().exec('VACUUM');
-      this.hasUnsavedData = true;
-      return Promise.resolve();
-    } catch (error) {
-      console.error('[SQLiteCacheManager] Vacuum failed:', error);
-      throw error;
-    }
+  async vacuum(): Promise<void> {
+    await this.getMaintenanceService().vacuum();
+    this.hasUnsavedData = true;
   }
 
   // ==================== Full-text search ====================
@@ -797,51 +568,8 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
   /**
    * Get database statistics
    */
-  async getStatistics(): Promise<{
-    workspaces: number;
-    sessions: number;
-    states: number;
-    traces: number;
-    conversations: number;
-    messages: number;
-    appliedEvents: number;
-    conversationEmbeddings: number;
-    dbSizeBytes: number;
-  }> {
-    const stats = await Promise.all([
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM workspaces'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM sessions'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM states'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM memory_traces'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM conversations'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM messages'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM applied_events'),
-      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM conversation_embedding_metadata'),
-    ]);
-
-    // Get file size from filesystem
-    let dbSizeBytes = 0;
-    try {
-      const exists = await this.app.vault.adapter.exists(this.dbPath);
-      if (exists) {
-        const stat = await this.app.vault.adapter.stat(this.dbPath);
-        dbSizeBytes = stat?.size ?? 0;
-      }
-    } catch {
-      void 0;
-    }
-
-    return {
-      workspaces: stats[0]?.count ?? 0,
-      sessions: stats[1]?.count ?? 0,
-      states: stats[2]?.count ?? 0,
-      traces: stats[3]?.count ?? 0,
-      conversations: stats[4]?.count ?? 0,
-      messages: stats[5]?.count ?? 0,
-      appliedEvents: stats[6]?.count ?? 0,
-      conversationEmbeddings: stats[7]?.count ?? 0,
-      dbSizeBytes
-    };
+  async getStatistics(): Promise<SQLiteMaintenanceStatistics> {
+    return this.getMaintenanceService().getStatistics();
   }
 
   // ==================== Utilities ====================
@@ -894,30 +622,6 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
    * Get database statistics (IStorageBackend requirement)
    */
   async getStats(): Promise<DatabaseStats> {
-    const stats = await this.getStatistics();
-
-    // Count tables
-    const tableCountResult = await this.queryOne<{ count: number }>(
-      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table'"
-    );
-    const tableCount = tableCountResult?.count ?? 0;
-
-    return {
-      fileSize: stats.dbSizeBytes,
-      tableCount,
-      totalRows: stats.workspaces + stats.sessions + stats.states + stats.traces +
-                 stats.conversations + stats.messages,
-      tableCounts: {
-        workspaces: stats.workspaces,
-        sessions: stats.sessions,
-        states: stats.states,
-        memory_traces: stats.traces,
-        conversations: stats.conversations,
-        messages: stats.messages,
-        applied_events: stats.appliedEvents,
-        conversation_embedding_metadata: stats.conversationEmbeddings
-      },
-      walMode: false  // WASM doesn't use WAL mode
-    };
+    return this.getMaintenanceService().getStats();
   }
 }

--- a/src/database/storage/SQLiteMaintenanceService.ts
+++ b/src/database/storage/SQLiteMaintenanceService.ts
@@ -1,0 +1,158 @@
+import { App } from 'obsidian';
+
+import type { DatabaseStats } from '../interfaces/IStorageBackend';
+import type { QueryParams } from '../repositories/base/BaseRepository';
+import { SQLiteWasmBridge, SQLiteDatabaseHandle } from './SQLiteWasmBridge';
+
+export interface SQLiteMaintenanceStatistics {
+  workspaces: number;
+  sessions: number;
+  states: number;
+  traces: number;
+  conversations: number;
+  messages: number;
+  appliedEvents: number;
+  conversationEmbeddings: number;
+  dbSizeBytes: number;
+}
+
+interface SQLiteMaintenanceServiceOptions {
+  app: App;
+  dbPath: string;
+  bridge: SQLiteWasmBridge;
+  getDb: () => SQLiteDatabaseHandle;
+  queryOne: <T>(sql: string, params?: QueryParams) => Promise<T | null>;
+  transaction: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+export class SQLiteMaintenanceService {
+  private readonly app: App;
+  private readonly dbPath: string;
+  private readonly bridge: SQLiteWasmBridge;
+  private readonly getDb: () => SQLiteDatabaseHandle;
+  private readonly queryOne: <T>(sql: string, params?: QueryParams) => Promise<T | null>;
+  private readonly transaction: <T>(fn: () => Promise<T>) => Promise<T>;
+
+  constructor(options: SQLiteMaintenanceServiceOptions) {
+    this.app = options.app;
+    this.dbPath = options.dbPath;
+    this.bridge = options.bridge;
+    this.getDb = options.getDb;
+    this.queryOne = options.queryOne;
+    this.transaction = options.transaction;
+  }
+
+  async clearAllData(): Promise<void> {
+    await this.transaction(() => {
+      const db = this.getDb();
+      this.bridge.exec(db, `
+        DELETE FROM task_note_links;
+        DELETE FROM task_dependencies;
+        DELETE FROM tasks;
+        DELETE FROM projects;
+        DELETE FROM messages;
+        DELETE FROM conversations;
+        DELETE FROM memory_traces;
+        DELETE FROM states;
+        DELETE FROM sessions;
+        DELETE FROM workspaces;
+        DELETE FROM applied_events;
+        DELETE FROM sync_state;
+      `);
+
+      this.bridge.exec(db, 'DROP TABLE IF EXISTS conversation_embeddings');
+      this.bridge.exec(db, 'CREATE VIRTUAL TABLE IF NOT EXISTS conversation_embeddings USING vec0(embedding float[384])');
+      this.bridge.exec(db, 'DELETE FROM conversation_embedding_metadata');
+      this.bridge.exec(db, 'DELETE FROM embedding_backfill_state');
+      return Promise.resolve();
+    });
+  }
+
+  async rebuildFTSIndexes(): Promise<void> {
+    await this.transaction(() => {
+      const db = this.getDb();
+      this.bridge.exec(db, `
+        INSERT INTO workspace_fts(workspace_fts) VALUES ('rebuild');
+      `);
+      this.bridge.exec(db, `
+        INSERT INTO conversation_fts(conversation_fts) VALUES ('rebuild');
+      `);
+      this.bridge.exec(db, `
+        INSERT INTO message_fts(message_fts) VALUES ('rebuild');
+      `);
+      return Promise.resolve();
+    });
+  }
+
+  vacuum(): Promise<void> {
+    try {
+      this.bridge.exec(this.getDb(), 'VACUUM');
+      return Promise.resolve();
+    } catch (error) {
+      console.error('[SQLiteCacheManager] Vacuum failed:', error);
+      throw error;
+    }
+  }
+
+  async getStatistics(): Promise<SQLiteMaintenanceStatistics> {
+    const stats = await Promise.all([
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM workspaces'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM sessions'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM states'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM memory_traces'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM conversations'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM messages'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM applied_events'),
+      this.queryOne<{ count: number }>('SELECT COUNT(*) as count FROM conversation_embedding_metadata'),
+    ]);
+
+    let dbSizeBytes = 0;
+    try {
+      const exists = await this.app.vault.adapter.exists(this.dbPath);
+      if (exists) {
+        const stat = await this.app.vault.adapter.stat(this.dbPath);
+        dbSizeBytes = stat?.size ?? 0;
+      }
+    } catch {
+      void 0;
+    }
+
+    return {
+      workspaces: stats[0]?.count ?? 0,
+      sessions: stats[1]?.count ?? 0,
+      states: stats[2]?.count ?? 0,
+      traces: stats[3]?.count ?? 0,
+      conversations: stats[4]?.count ?? 0,
+      messages: stats[5]?.count ?? 0,
+      appliedEvents: stats[6]?.count ?? 0,
+      conversationEmbeddings: stats[7]?.count ?? 0,
+      dbSizeBytes
+    };
+  }
+
+  async getStats(): Promise<DatabaseStats> {
+    const stats = await this.getStatistics();
+    const tableCountResult = await this.queryOne<{ count: number }>(
+      "SELECT COUNT(*) as count FROM sqlite_master WHERE type='table'"
+    );
+    const tableCount = tableCountResult?.count ?? 0;
+
+    return {
+      fileSize: stats.dbSizeBytes,
+      tableCount,
+      totalRows: stats.workspaces + stats.sessions + stats.states + stats.traces +
+                 stats.conversations + stats.messages,
+      tableCounts: {
+        workspaces: stats.workspaces,
+        sessions: stats.sessions,
+        states: stats.states,
+        memory_traces: stats.traces,
+        conversations: stats.conversations,
+        messages: stats.messages,
+        applied_events: stats.appliedEvents,
+        conversation_embedding_metadata: stats.conversationEmbeddings
+      },
+      walMode: false
+    };
+  }
+}

--- a/src/database/storage/SQLitePersistenceService.ts
+++ b/src/database/storage/SQLitePersistenceService.ts
@@ -1,0 +1,93 @@
+import { App } from 'obsidian';
+
+import {
+  SQLiteWasmBridge,
+  SQLiteWasmModule,
+  SQLiteDatabaseHandle
+} from './SQLiteWasmBridge';
+
+interface SQLitePersistenceServiceOptions {
+  app: App;
+  dbPath: string;
+  bridge: SQLiteWasmBridge;
+}
+
+export class SQLitePersistenceService {
+  private readonly app: App;
+  private readonly dbPath: string;
+  private readonly bridge: SQLiteWasmBridge;
+
+  constructor(options: SQLitePersistenceServiceOptions) {
+    this.app = options.app;
+    this.dbPath = options.dbPath;
+    this.bridge = options.bridge;
+  }
+
+  async loadDatabase(sqlite3: SQLiteWasmModule, schemaSql: string): Promise<SQLiteDatabaseHandle> {
+    try {
+      const data = await this.app.vault.adapter.readBinary(this.dbPath);
+      const bytes = new Uint8Array(data);
+
+      if (bytes.length === 0) {
+        return this.createFreshDatabase(sqlite3, schemaSql);
+      }
+
+      const db = this.bridge.deserializeDatabase(sqlite3, bytes);
+
+      try {
+        const integrityResult = this.bridge.getIntegrityCheckResult(db);
+        if (integrityResult !== 'ok') {
+          const integrityMessage = typeof integrityResult === 'string'
+            ? integrityResult
+            : JSON.stringify(integrityResult) ?? 'unknown';
+          throw new Error(`Database integrity check failed: ${integrityMessage}`);
+        }
+      } catch {
+        return this.recreateCorruptedDatabase(sqlite3, schemaSql);
+      }
+
+      return db;
+    } catch (error) {
+      console.error('[SQLiteCacheManager] Failed to load from file:', error);
+      return this.recreateCorruptedDatabase(sqlite3, schemaSql);
+    }
+  }
+
+  async saveDatabase(sqlite3: SQLiteWasmModule, db: SQLiteDatabaseHandle): Promise<void> {
+    try {
+      const consoleRef = console;
+      const originalLog = consoleRef.log;
+      consoleRef.log = () => undefined;
+
+      let buffer: ArrayBuffer;
+      try {
+        buffer = this.bridge.exportDatabase(sqlite3, db);
+      } finally {
+        consoleRef.log = originalLog;
+      }
+
+      await this.app.vault.adapter.writeBinary(this.dbPath, buffer);
+    } catch (error) {
+      console.error('[SQLiteCacheManager] Failed to save to file:', error);
+      throw error;
+    }
+  }
+
+  async recreateCorruptedDatabase(sqlite3: SQLiteWasmModule, schemaSql: string): Promise<SQLiteDatabaseHandle> {
+    try {
+      await this.app.vault.adapter.remove(this.dbPath);
+    } catch {
+      void 0;
+    }
+
+    const db = this.createFreshDatabase(sqlite3, schemaSql);
+    await this.saveDatabase(sqlite3, db);
+    return db;
+  }
+
+  createFreshDatabase(sqlite3: SQLiteWasmModule, schemaSql: string): SQLiteDatabaseHandle {
+    const db = this.bridge.createMemoryDatabase(sqlite3);
+    this.bridge.exec(db, schemaSql);
+    return db;
+  }
+}

--- a/src/database/storage/SQLiteSyncStateStore.ts
+++ b/src/database/storage/SQLiteSyncStateStore.ts
@@ -1,0 +1,81 @@
+import type { QueryParams } from '../repositories/base/BaseRepository';
+import type { RunResult } from '../interfaces/IStorageBackend';
+import type { SyncState } from '../sync/SyncCoordinator';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+type QueryFn = <T>(sql: string, params?: QueryParams) => Promise<T[]>;
+type QueryOneFn = <T>(sql: string, params?: QueryParams) => Promise<T | null>;
+type RunFn = (sql: string, params?: QueryParams) => Promise<RunResult>;
+
+export class SQLiteSyncStateStore {
+  constructor(
+    private readonly query: QueryFn,
+    private readonly queryOne: QueryOneFn,
+    private readonly run: RunFn
+  ) {}
+
+  async isEventApplied(eventId: string): Promise<boolean> {
+    const result = await this.queryOne<{ eventId: string }>(
+      'SELECT eventId FROM applied_events WHERE eventId = ?',
+      [eventId]
+    );
+    return result !== null;
+  }
+
+  async markEventApplied(eventId: string): Promise<void> {
+    await this.run(
+      'INSERT OR IGNORE INTO applied_events (eventId, appliedAt) VALUES (?, ?)',
+      [eventId, Date.now()]
+    );
+  }
+
+  async getAppliedEventsAfter(timestamp: number): Promise<string[]> {
+    const results = await this.query<{ eventId: string }>(
+      'SELECT eventId FROM applied_events WHERE appliedAt > ? ORDER BY appliedAt',
+      [timestamp]
+    );
+    return results.map(result => result.eventId);
+  }
+
+  async getSyncState(deviceId: string): Promise<SyncState | null> {
+    const result = await this.queryOne<{ deviceId: string; lastEventTimestamp: number; syncedFilesJson: string }>(
+      'SELECT deviceId, lastEventTimestamp, syncedFilesJson FROM sync_state WHERE deviceId = ?',
+      [deviceId]
+    );
+
+    if (!result) {
+      return null;
+    }
+
+    const fileTimestampsRaw: unknown = result.syncedFilesJson ? JSON.parse(result.syncedFilesJson) : {};
+    const fileTimestamps: Record<string, number> = {};
+    if (isRecord(fileTimestampsRaw)) {
+      for (const [key, value] of Object.entries(fileTimestampsRaw)) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          fileTimestamps[key] = value;
+        }
+      }
+    }
+
+    return {
+      deviceId: result.deviceId,
+      lastEventTimestamp: result.lastEventTimestamp,
+      fileTimestamps
+    };
+  }
+
+  async updateSyncState(
+    deviceId: string,
+    lastEventTimestamp: number,
+    fileTimestamps: Record<string, number>
+  ): Promise<void> {
+    await this.run(
+      `INSERT OR REPLACE INTO sync_state (deviceId, lastEventTimestamp, syncedFilesJson)
+       VALUES (?, ?, ?)`,
+      [deviceId, lastEventTimestamp, JSON.stringify(fileTimestamps)]
+    );
+  }
+}

--- a/src/database/storage/SQLiteTransactionCoordinator.ts
+++ b/src/database/storage/SQLiteTransactionCoordinator.ts
@@ -1,0 +1,41 @@
+export class SQLiteTransactionCoordinator {
+  private transactionDepth = 0;
+  private transactionLock: Promise<void> = Promise.resolve();
+
+  async run<T>(
+    beginTransaction: () => Promise<void>,
+    commitTransaction: () => Promise<void>,
+    rollbackTransaction: () => Promise<void>,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    if (this.transactionDepth > 0) {
+      return fn();
+    }
+
+    let releaseLock: (() => void) | undefined;
+    const previousLock = this.transactionLock;
+    this.transactionLock = new Promise<void>(resolve => {
+      releaseLock = resolve;
+    });
+
+    try {
+      await previousLock;
+
+      this.transactionDepth++;
+      await beginTransaction();
+
+      try {
+        const result = await fn();
+        await commitTransaction();
+        return result;
+      } catch (error) {
+        await rollbackTransaction();
+        throw error;
+      } finally {
+        this.transactionDepth--;
+      }
+    } finally {
+      releaseLock?.();
+    }
+  }
+}

--- a/src/database/storage/SQLiteWasmBridge.ts
+++ b/src/database/storage/SQLiteWasmBridge.ts
@@ -1,0 +1,191 @@
+import sqlite3InitModule from '@dao-xyz/sqlite3-vec/wasm';
+
+import type { QueryParams } from '../repositories/base/BaseRepository';
+import type { RunResult } from '../interfaces/IStorageBackend';
+
+export interface SQLiteStatement {
+  bind(params: QueryParams): void;
+  step(): boolean;
+  stepReset(): void;
+  get(mode: unknown): unknown;
+  finalize(): void;
+}
+
+export interface SQLiteDatabaseHandle {
+  exec(sql: string): void;
+  prepare(sql: string): SQLiteStatement;
+  close(): void;
+  changes(): number;
+  selectValue(sql: string): unknown;
+}
+
+export interface SQLiteWasmModule {
+  oo1: {
+    DB: new (filename: string) => SQLiteDatabaseHandle;
+  };
+  wasm: {
+    allocFromTypedArray(data: Uint8Array): number;
+  };
+  capi: {
+    sqlite3_deserialize(
+      db: SQLiteDatabaseHandle,
+      schema: string,
+      ptr: number,
+      size: number,
+      maxSize: number,
+      flags: number
+    ): number;
+    sqlite3_js_db_export(db: SQLiteDatabaseHandle): { buffer: ArrayBuffer };
+    sqlite3_last_insert_rowid(db: SQLiteDatabaseHandle): number | bigint;
+    SQLITE_DESERIALIZE_FREEONCLOSE: number;
+    SQLITE_DESERIALIZE_RESIZEABLE: number;
+  };
+}
+
+interface SQLiteInitOptions {
+  instantiateWasm?: (
+    imports: WebAssembly.Imports,
+    successCallback: (instance: WebAssembly.Instance) => void
+  ) => Record<string, never>;
+  print?: (message: string) => void;
+  printErr?: (message: string) => void;
+}
+
+type SQLiteModuleFactory = (options?: SQLiteInitOptions) => Promise<SQLiteWasmModule>;
+
+const sqliteModuleFactory = sqlite3InitModule as unknown as SQLiteModuleFactory;
+
+export class SQLiteWasmBridge {
+  async initializeModule(wasmBinary: ArrayBuffer): Promise<SQLiteWasmModule> {
+    const initOptions: SQLiteInitOptions = {
+      instantiateWasm: (imports, successCallback) => {
+        WebAssembly.instantiate(wasmBinary, imports)
+          .then(result => {
+            successCallback(result.instance);
+          })
+          .catch(err => {
+            console.error('[SQLiteCacheManager] WASM instantiation failed:', err);
+          });
+        return {};
+      },
+      print: () => undefined,
+      printErr: (msg: string) => console.error('[SQLite]', msg)
+    };
+
+    return sqliteModuleFactory(initOptions);
+  }
+
+  createMemoryDatabase(module: SQLiteWasmModule): SQLiteDatabaseHandle {
+    return new module.oo1.DB(':memory:');
+  }
+
+  deserializeDatabase(module: SQLiteWasmModule, data: Uint8Array): SQLiteDatabaseHandle {
+    const ptr = module.wasm.allocFromTypedArray(data);
+    const db = this.createMemoryDatabase(module);
+    const rc = module.capi.sqlite3_deserialize(
+      db,
+      'main',
+      ptr,
+      data.byteLength,
+      data.byteLength,
+      module.capi.SQLITE_DESERIALIZE_FREEONCLOSE |
+      module.capi.SQLITE_DESERIALIZE_RESIZEABLE
+    );
+
+    if (rc !== 0) {
+      throw new Error(`sqlite3_deserialize failed with code ${rc}`);
+    }
+
+    return db;
+  }
+
+  exportDatabase(module: SQLiteWasmModule, db: SQLiteDatabaseHandle): ArrayBuffer {
+    return module.capi.sqlite3_js_db_export(db).buffer;
+  }
+
+  exec(db: SQLiteDatabaseHandle, sql: string): void {
+    db.exec(sql);
+  }
+
+  executeStatement(db: SQLiteDatabaseHandle, sql: string, params?: QueryParams): void {
+    const stmt = db.prepare(sql);
+    try {
+      if (params?.length) {
+        stmt.bind(params);
+      }
+      stmt.step();
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  collectValues(db: SQLiteDatabaseHandle, sql: string): unknown[][] {
+    const stmt = db.prepare(sql);
+    const results: unknown[][] = [];
+    try {
+      while (stmt.step()) {
+        results.push(stmt.get([]) as unknown[]);
+      }
+      return results;
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  query<T>(db: SQLiteDatabaseHandle, sql: string, params?: QueryParams): T[] {
+    const stmt = db.prepare(sql);
+    try {
+      if (params?.length) {
+        stmt.bind(params);
+      }
+      const results: T[] = [];
+      while (stmt.step()) {
+        results.push(stmt.get({}) as T);
+      }
+      return results;
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  queryOne<T>(db: SQLiteDatabaseHandle, sql: string, params?: QueryParams): T | null {
+    const stmt = db.prepare(sql);
+    try {
+      if (params?.length) {
+        stmt.bind(params);
+      }
+      if (!stmt.step()) {
+        return null;
+      }
+      return stmt.get({}) as T;
+    } finally {
+      stmt.finalize();
+    }
+  }
+
+  run(db: SQLiteDatabaseHandle, module: SQLiteWasmModule, sql: string, params?: QueryParams): RunResult {
+    const stmt = db.prepare(sql);
+    try {
+      if (params?.length) {
+        stmt.bind(params);
+      }
+      stmt.stepReset();
+    } finally {
+      stmt.finalize();
+    }
+
+    const rawRowId = module.capi.sqlite3_last_insert_rowid(db);
+    return {
+      changes: db.changes(),
+      lastInsertRowid: typeof rawRowId === 'bigint' ? Number(rawRowId) : rawRowId
+    };
+  }
+
+  getIntegrityCheckResult(db: SQLiteDatabaseHandle): unknown {
+    return db.selectValue('PRAGMA integrity_check');
+  }
+
+  close(db: SQLiteDatabaseHandle): void {
+    db.close();
+  }
+}

--- a/src/types/sqlite3-vec-wasm.d.ts
+++ b/src/types/sqlite3-vec-wasm.d.ts
@@ -1,0 +1,4 @@
+declare module '@dao-xyz/sqlite3-vec/wasm' {
+  const sqlite3InitModule: (options?: unknown) => Promise<unknown>;
+  export default sqlite3InitModule;
+}

--- a/tests/unit/SQLiteCacheManager.test.ts
+++ b/tests/unit/SQLiteCacheManager.test.ts
@@ -1,0 +1,342 @@
+import type { App } from 'obsidian';
+
+jest.mock('@dao-xyz/sqlite3-vec/wasm', () => jest.fn(), { virtual: true });
+
+import { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+import { SQLiteTransactionCoordinator } from '../../src/database/storage/SQLiteTransactionCoordinator';
+import { SQLiteSyncStateStore } from '../../src/database/storage/SQLiteSyncStateStore';
+import type { QueryParams } from '../../src/database/repositories/base/BaseRepository';
+
+interface DatabaseLike {
+  exec: jest.Mock<void, [string]>;
+}
+
+interface MutableSQLiteCacheManager extends SQLiteCacheManager {
+  app: App & {
+    vault: {
+      adapter: {
+        exists: jest.Mock<Promise<boolean>, [string]>;
+        stat: jest.Mock<Promise<{ size?: number } | null>, [string]>;
+      };
+    };
+  };
+  bridge: {
+    exec(db: DatabaseLike, sql: string): void;
+  };
+  transactionCoordinator: SQLiteTransactionCoordinator;
+  syncStateStore: SQLiteSyncStateStore;
+  db: DatabaseLike | null;
+  hasUnsavedData: boolean;
+  beginTransaction: jest.Mock<Promise<void>, []>;
+  commit: jest.Mock<Promise<void>, []>;
+  rollback: jest.Mock<Promise<void>, []>;
+  queryOne: jest.Mock<Promise<unknown>, [string, QueryParams?]>;
+  query: jest.Mock<Promise<unknown[]>, [string, QueryParams?]>;
+  transaction: <T>(fn: () => Promise<T>) => Promise<T>;
+}
+
+function createManager(): MutableSQLiteCacheManager {
+  const manager = Object.create(SQLiteCacheManager.prototype) as MutableSQLiteCacheManager;
+  manager.bridge = {
+    exec(db: DatabaseLike, sql: string) {
+      db.exec(sql);
+    }
+  };
+  manager.app = {
+    vault: {
+      adapter: {
+        exists: jest.fn(),
+        stat: jest.fn()
+      }
+    }
+  } as unknown as MutableSQLiteCacheManager['app'];
+  manager.transactionCoordinator = new SQLiteTransactionCoordinator();
+  manager.db = null;
+  manager.hasUnsavedData = false;
+  manager.beginTransaction = jest.fn().mockResolvedValue(undefined);
+  manager.commit = jest.fn().mockResolvedValue(undefined);
+  manager.rollback = jest.fn().mockResolvedValue(undefined);
+  manager.queryOne = jest.fn();
+  manager.query = jest.fn();
+  manager.syncStateStore = new SQLiteSyncStateStore(
+    <T>(sql: string, params?: QueryParams) => manager.query(sql, params) as Promise<T[]>,
+    <T>(sql: string, params?: QueryParams) => manager.queryOne(sql, params) as Promise<T | null>,
+    async () => ({ changes: 0, lastInsertRowid: 0 })
+  );
+  return manager;
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('SQLiteCacheManager', () => {
+  describe('transaction', () => {
+    it('serializes concurrent top-level transactions', async () => {
+      const manager = createManager();
+      const firstGate = createDeferred<void>();
+      const order: string[] = [];
+
+      manager.beginTransaction.mockImplementation(async () => {
+        order.push('begin');
+      });
+      manager.commit.mockImplementation(async () => {
+        order.push('commit');
+      });
+
+      const first = manager.transaction(async () => {
+        order.push('first-start');
+        await firstGate.promise;
+        order.push('first-end');
+        return 'first';
+      });
+
+      const second = manager.transaction(async () => {
+        order.push('second-start');
+        return 'second';
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(order).toEqual(['begin', 'first-start']);
+
+      firstGate.resolve();
+      await expect(first).resolves.toBe('first');
+      await expect(second).resolves.toBe('second');
+
+      expect(order).toEqual([
+        'begin',
+        'first-start',
+        'first-end',
+        'commit',
+        'begin',
+        'second-start',
+        'commit'
+      ]);
+      expect(manager.beginTransaction).toHaveBeenCalledTimes(2);
+      expect(manager.commit).toHaveBeenCalledTimes(2);
+      expect(manager.rollback).not.toHaveBeenCalled();
+    });
+
+    it('does not open a nested SQL transaction', async () => {
+      const manager = createManager();
+
+      await manager.transaction(async () => {
+        await manager.transaction(async () => {
+          return 'nested';
+        });
+        return 'outer';
+      });
+
+      expect(manager.beginTransaction).toHaveBeenCalledTimes(1);
+      expect(manager.commit).toHaveBeenCalledTimes(1);
+      expect(manager.rollback).not.toHaveBeenCalled();
+    });
+
+    it('rolls back when the transaction body throws', async () => {
+      const manager = createManager();
+
+      await expect(
+        manager.transaction(async () => {
+          throw new Error('boom');
+        })
+      ).rejects.toThrow('boom');
+
+      expect(manager.beginTransaction).toHaveBeenCalledTimes(1);
+      expect(manager.commit).not.toHaveBeenCalled();
+      expect(manager.rollback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getSyncState', () => {
+    it('parses sync-state JSON and keeps only finite numeric timestamps', async () => {
+      const manager = createManager();
+      manager.queryOne.mockResolvedValue({
+        deviceId: 'desktop',
+        lastEventTimestamp: 123,
+        syncedFilesJson: JSON.stringify({
+          'workspaces/a.jsonl': 50,
+          'conversations/b.jsonl': 'bad',
+          'tasks/c.jsonl': Number.POSITIVE_INFINITY,
+          'tasks/d.jsonl': 75
+        })
+      });
+
+      const result = await manager.getSyncState('desktop');
+
+      expect(manager.queryOne).toHaveBeenCalledWith(
+        'SELECT deviceId, lastEventTimestamp, syncedFilesJson FROM sync_state WHERE deviceId = ?',
+        ['desktop']
+      );
+      expect(result).toEqual({
+        deviceId: 'desktop',
+        lastEventTimestamp: 123,
+        fileTimestamps: {
+          'workspaces/a.jsonl': 50,
+          'tasks/d.jsonl': 75
+        }
+      });
+    });
+
+    it('returns null when no sync-state row exists', async () => {
+      const manager = createManager();
+      manager.queryOne.mockResolvedValue(null);
+
+      await expect(manager.getSyncState('desktop')).resolves.toBeNull();
+    });
+  });
+
+  describe('queryPaginated', () => {
+    it('computes pagination metadata and appends limit/offset params', async () => {
+      const manager = createManager();
+      manager.queryOne.mockResolvedValue({ count: 53 });
+      manager.query.mockResolvedValue([{ id: 'a' }, { id: 'b' }]);
+
+      const result = await manager.queryPaginated<{ id: string }>(
+        'SELECT * FROM messages WHERE conversationId = ? ORDER BY createdAt',
+        'SELECT COUNT(*) as count FROM messages WHERE conversationId = ?',
+        { page: 1, pageSize: 25 },
+        ['conv-1']
+      );
+
+      expect(manager.queryOne).toHaveBeenCalledWith(
+        'SELECT COUNT(*) as count FROM messages WHERE conversationId = ?',
+        ['conv-1']
+      );
+      expect(manager.query).toHaveBeenCalledWith(
+        'SELECT * FROM messages WHERE conversationId = ? ORDER BY createdAt LIMIT ? OFFSET ?',
+        ['conv-1', 25, 25]
+      );
+      expect(result).toEqual({
+        items: [{ id: 'a' }, { id: 'b' }],
+        page: 1,
+        pageSize: 25,
+        totalItems: 53,
+        totalPages: 3,
+        hasNextPage: true,
+        hasPreviousPage: true
+      });
+    });
+  });
+
+  describe('maintenance operations', () => {
+    it('clearAllData deletes domain tables and recreates vector tables inside a transaction', async () => {
+      const manager = createManager();
+      const dbExec = jest.fn<void, [string]>();
+      manager.db = { exec: dbExec };
+      const transactionSpy = jest
+        .spyOn(manager, 'transaction')
+        .mockImplementation(async <T>(fn: () => Promise<T>) => fn());
+
+      await manager.clearAllData();
+
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(dbExec).toHaveBeenCalledTimes(5);
+      expect(dbExec.mock.calls[0][0]).toContain('DELETE FROM task_note_links;');
+      expect(dbExec.mock.calls[0][0]).toContain('DELETE FROM sync_state;');
+      expect(dbExec.mock.calls[1][0]).toBe('DROP TABLE IF EXISTS conversation_embeddings');
+      expect(dbExec.mock.calls[2][0]).toBe('CREATE VIRTUAL TABLE IF NOT EXISTS conversation_embeddings USING vec0(embedding float[384])');
+      expect(dbExec.mock.calls[3][0]).toBe('DELETE FROM conversation_embedding_metadata');
+      expect(dbExec.mock.calls[4][0]).toBe('DELETE FROM embedding_backfill_state');
+    });
+
+    it('rebuildFTSIndexes issues rebuild statements inside a transaction', async () => {
+      const manager = createManager();
+      const dbExec = jest.fn<void, [string]>();
+      manager.db = { exec: dbExec };
+      const transactionSpy = jest
+        .spyOn(manager, 'transaction')
+        .mockImplementation(async <T>(fn: () => Promise<T>) => fn());
+
+      await manager.rebuildFTSIndexes();
+
+      expect(transactionSpy).toHaveBeenCalledTimes(1);
+      expect(dbExec).toHaveBeenCalledTimes(3);
+      expect(dbExec.mock.calls[0][0]).toContain("INSERT INTO workspace_fts(workspace_fts) VALUES ('rebuild');");
+      expect(dbExec.mock.calls[1][0]).toContain("INSERT INTO conversation_fts(conversation_fts) VALUES ('rebuild');");
+      expect(dbExec.mock.calls[2][0]).toContain("INSERT INTO message_fts(message_fts) VALUES ('rebuild');");
+    });
+
+    it('vacuum marks the database dirty and executes VACUUM', async () => {
+      const manager = createManager();
+      const dbExec = jest.fn<void, [string]>();
+      manager.db = { exec: dbExec };
+
+      await manager.vacuum();
+
+      expect(dbExec).toHaveBeenCalledWith('VACUUM');
+      expect(manager.hasUnsavedData).toBe(true);
+    });
+  });
+
+  describe('statistics', () => {
+    it('getStatistics returns row counts and db file size', async () => {
+      const manager = createManager();
+      manager.queryOne.mockImplementation(async (sql: string) => {
+        if (sql.includes('workspaces')) return { count: 1 };
+        if (sql.includes('sessions')) return { count: 2 };
+        if (sql.includes('states')) return { count: 3 };
+        if (sql.includes('memory_traces')) return { count: 4 };
+        if (sql.includes('conversations')) return { count: 5 };
+        if (sql.includes('messages')) return { count: 6 };
+        if (sql.includes('applied_events')) return { count: 7 };
+        if (sql.includes('conversation_embedding_metadata')) return { count: 8 };
+        return null;
+      });
+      manager.app.vault.adapter.exists.mockResolvedValue(true);
+      manager.app.vault.adapter.stat.mockResolvedValue({ size: 4096 });
+
+      await expect(manager.getStatistics()).resolves.toEqual({
+        workspaces: 1,
+        sessions: 2,
+        states: 3,
+        traces: 4,
+        conversations: 5,
+        messages: 6,
+        appliedEvents: 7,
+        conversationEmbeddings: 8,
+        dbSizeBytes: 4096
+      });
+    });
+
+    it('getStats returns file stats and row totals', async () => {
+      const manager = createManager();
+      manager.queryOne.mockImplementation(async (sql: string) => {
+        if (sql.includes('workspaces')) return { count: 1 };
+        if (sql.includes('sessions')) return { count: 2 };
+        if (sql.includes('states')) return { count: 3 };
+        if (sql.includes('memory_traces')) return { count: 4 };
+        if (sql.includes('conversations')) return { count: 5 };
+        if (sql.includes('messages')) return { count: 6 };
+        if (sql.includes('applied_events')) return { count: 7 };
+        if (sql.includes('conversation_embedding_metadata')) return { count: 8 };
+        if (sql.includes("sqlite_master")) return { count: 12 };
+        return null;
+      });
+      manager.app.vault.adapter.exists.mockResolvedValue(true);
+      manager.app.vault.adapter.stat.mockResolvedValue({ size: 4096 });
+
+      await expect(manager.getStats()).resolves.toEqual({
+        fileSize: 4096,
+        tableCount: 12,
+        totalRows: 1 + 2 + 3 + 4 + 5 + 6,
+        tableCounts: {
+          workspaces: 1,
+          sessions: 2,
+          states: 3,
+          memory_traces: 4,
+          conversations: 5,
+          messages: 6,
+          applied_events: 7,
+          conversation_embedding_metadata: 8
+        },
+        walMode: false
+      });
+    });
+  });
+});

--- a/tests/unit/SQLitePersistenceService.test.ts
+++ b/tests/unit/SQLitePersistenceService.test.ts
@@ -1,0 +1,93 @@
+import type { App } from 'obsidian';
+
+import { SQLitePersistenceService } from '../../src/database/storage/SQLitePersistenceService';
+import type {
+  SQLiteDatabaseHandle,
+  SQLiteWasmBridge,
+  SQLiteWasmModule
+} from '../../src/database/storage/SQLiteWasmBridge';
+
+interface MockAdapter {
+  readBinary: jest.Mock<Promise<ArrayBuffer>, [string]>;
+  writeBinary: jest.Mock<Promise<void>, [string, ArrayBuffer]>;
+  remove: jest.Mock<Promise<void>, [string]>;
+}
+
+function createService() {
+  const adapter: MockAdapter = {
+    readBinary: jest.fn(),
+    writeBinary: jest.fn().mockResolvedValue(undefined),
+    remove: jest.fn().mockResolvedValue(undefined)
+  };
+
+  const app = {
+    vault: {
+      adapter
+    }
+  } as unknown as App;
+
+  const db = {
+    exec: jest.fn<void, [string]>(),
+    prepare: jest.fn(),
+    close: jest.fn(),
+    changes: jest.fn(),
+    selectValue: jest.fn()
+  } as unknown as SQLiteDatabaseHandle;
+
+  const bridge = {
+    createMemoryDatabase: jest.fn().mockReturnValue(db),
+    exec: jest.fn(),
+    exportDatabase: jest.fn().mockReturnValue(new ArrayBuffer(8)),
+    deserializeDatabase: jest.fn().mockReturnValue(db),
+    getIntegrityCheckResult: jest.fn().mockReturnValue('ok')
+  } as unknown as SQLiteWasmBridge;
+
+  const sqlite3 = {} as SQLiteWasmModule;
+
+  return {
+    service: new SQLitePersistenceService({
+      app,
+      dbPath: '.nexus/cache.db',
+      bridge
+    }),
+    adapter,
+    bridge,
+    db,
+    sqlite3
+  };
+}
+
+describe('SQLitePersistenceService', () => {
+  it('creates a fresh schema database when the file is empty', async () => {
+    const { service, adapter, bridge, db, sqlite3 } = createService();
+    adapter.readBinary.mockResolvedValue(new ArrayBuffer(0));
+
+    const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+    expect(result).toBe(db);
+    expect(bridge.createMemoryDatabase).toHaveBeenCalledWith(sqlite3);
+    expect(bridge.exec).toHaveBeenCalledWith(db, 'CREATE TABLE test (id TEXT);');
+    expect(bridge.deserializeDatabase).not.toHaveBeenCalled();
+  });
+
+  it('exports the database buffer to the vault adapter on save', async () => {
+    const { service, adapter, bridge, db, sqlite3 } = createService();
+
+    await service.saveDatabase(sqlite3, db);
+
+    expect(bridge.exportDatabase).toHaveBeenCalledWith(sqlite3, db);
+    expect(adapter.writeBinary).toHaveBeenCalledWith('.nexus/cache.db', expect.any(ArrayBuffer));
+  });
+
+  it('recreates the database when integrity check fails', async () => {
+    const { service, adapter, bridge, db, sqlite3 } = createService();
+    adapter.readBinary.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+    bridge.getIntegrityCheckResult = jest.fn().mockReturnValue('corrupt') as typeof bridge.getIntegrityCheckResult;
+
+    const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+    expect(result).toBe(db);
+    expect(adapter.remove).toHaveBeenCalledWith('.nexus/cache.db');
+    expect(adapter.writeBinary).toHaveBeenCalledWith('.nexus/cache.db', expect.any(ArrayBuffer));
+  });
+});

--- a/tests/unit/SQLiteSyncStateStore.test.ts
+++ b/tests/unit/SQLiteSyncStateStore.test.ts
@@ -1,0 +1,72 @@
+import { SQLiteSyncStateStore } from '../../src/database/storage/SQLiteSyncStateStore';
+import type { QueryParams } from '../../src/database/repositories/base/BaseRepository';
+import type { RunResult } from '../../src/database/interfaces/IStorageBackend';
+
+describe('SQLiteSyncStateStore', () => {
+  function createStore() {
+    const query = jest.fn<Promise<unknown[]>, [string, QueryParams?]>();
+    const queryOne = jest.fn<Promise<unknown>, [string, QueryParams?]>();
+    const run = jest.fn<Promise<RunResult>, [string, QueryParams?]>();
+
+    return {
+      store: new SQLiteSyncStateStore(
+        <T>(sql: string, params?: QueryParams) => query(sql, params) as Promise<T[]>,
+        <T>(sql: string, params?: QueryParams) => queryOne(sql, params) as Promise<T | null>,
+        run
+      ),
+      query,
+      queryOne,
+      run
+    };
+  }
+
+  it('parses sync-state JSON and keeps only finite numeric timestamps', async () => {
+    const { store, queryOne } = createStore();
+    queryOne.mockResolvedValue({
+      deviceId: 'desktop',
+      lastEventTimestamp: 123,
+      syncedFilesJson: JSON.stringify({
+        'workspaces/a.jsonl': 50,
+        'conversations/b.jsonl': 'bad',
+        'tasks/c.jsonl': Number.POSITIVE_INFINITY,
+        'tasks/d.jsonl': 75
+      })
+    });
+
+    await expect(store.getSyncState('desktop')).resolves.toEqual({
+      deviceId: 'desktop',
+      lastEventTimestamp: 123,
+      fileTimestamps: {
+        'workspaces/a.jsonl': 50,
+        'tasks/d.jsonl': 75
+      }
+    });
+  });
+
+  it('returns applied event ids in timestamp order', async () => {
+    const { store, query } = createStore();
+    query.mockResolvedValue([
+      { eventId: 'a' },
+      { eventId: 'b' }
+    ]);
+
+    await expect(store.getAppliedEventsAfter(100)).resolves.toEqual(['a', 'b']);
+    expect(query).toHaveBeenCalledWith(
+      'SELECT eventId FROM applied_events WHERE appliedAt > ? ORDER BY appliedAt',
+      [100]
+    );
+  });
+
+  it('persists sync state as JSON', async () => {
+    const { store, run } = createStore();
+    run.mockResolvedValue({ changes: 1, lastInsertRowid: 0 });
+
+    await store.updateSyncState('desktop', 123, { 'workspaces/a.jsonl': 50 });
+
+    expect(run).toHaveBeenCalledWith(
+      `INSERT OR REPLACE INTO sync_state (deviceId, lastEventTimestamp, syncedFilesJson)
+       VALUES (?, ?, ?)`,
+      ['desktop', 123, '{"workspaces/a.jsonl":50}']
+    );
+  });
+});

--- a/tests/unit/SQLiteTransactionCoordinator.test.ts
+++ b/tests/unit/SQLiteTransactionCoordinator.test.ts
@@ -1,0 +1,124 @@
+import { SQLiteTransactionCoordinator } from '../../src/database/storage/SQLiteTransactionCoordinator';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('SQLiteTransactionCoordinator', () => {
+  it('serializes concurrent top-level transactions', async () => {
+    const coordinator = new SQLiteTransactionCoordinator();
+    const firstGate = createDeferred<void>();
+    const beginTransaction = jest.fn().mockResolvedValue(undefined);
+    const commitTransaction = jest.fn().mockResolvedValue(undefined);
+    const rollbackTransaction = jest.fn().mockResolvedValue(undefined);
+    const order: string[] = [];
+
+    const first = coordinator.run(
+      async () => {
+        order.push('begin');
+        await beginTransaction();
+      },
+      async () => {
+        order.push('commit');
+        await commitTransaction();
+      },
+      rollbackTransaction,
+      async () => {
+        order.push('first-start');
+        await firstGate.promise;
+        order.push('first-end');
+        return 'first';
+      }
+    );
+
+    const second = coordinator.run(
+      async () => {
+        order.push('begin');
+        await beginTransaction();
+      },
+      async () => {
+        order.push('commit');
+        await commitTransaction();
+      },
+      rollbackTransaction,
+      async () => {
+        order.push('second-start');
+        return 'second';
+      }
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(order).toEqual(['begin', 'first-start']);
+
+    firstGate.resolve();
+    await expect(first).resolves.toBe('first');
+    await expect(second).resolves.toBe('second');
+
+    expect(order).toEqual([
+      'begin',
+      'first-start',
+      'first-end',
+      'commit',
+      'begin',
+      'second-start',
+      'commit'
+    ]);
+    expect(beginTransaction).toHaveBeenCalledTimes(2);
+    expect(commitTransaction).toHaveBeenCalledTimes(2);
+    expect(rollbackTransaction).not.toHaveBeenCalled();
+  });
+
+  it('does not open nested SQL transactions', async () => {
+    const coordinator = new SQLiteTransactionCoordinator();
+    const beginTransaction = jest.fn().mockResolvedValue(undefined);
+    const commitTransaction = jest.fn().mockResolvedValue(undefined);
+    const rollbackTransaction = jest.fn().mockResolvedValue(undefined);
+
+    await coordinator.run(
+      beginTransaction,
+      commitTransaction,
+      rollbackTransaction,
+      async () => {
+        await coordinator.run(
+          beginTransaction,
+          commitTransaction,
+          rollbackTransaction,
+          async () => 'nested'
+        );
+        return 'outer';
+      }
+    );
+
+    expect(beginTransaction).toHaveBeenCalledTimes(1);
+    expect(commitTransaction).toHaveBeenCalledTimes(1);
+    expect(rollbackTransaction).not.toHaveBeenCalled();
+  });
+
+  it('rolls back when the transaction body throws', async () => {
+    const coordinator = new SQLiteTransactionCoordinator();
+    const beginTransaction = jest.fn().mockResolvedValue(undefined);
+    const commitTransaction = jest.fn().mockResolvedValue(undefined);
+    const rollbackTransaction = jest.fn().mockResolvedValue(undefined);
+
+    await expect(
+      coordinator.run(
+        beginTransaction,
+        commitTransaction,
+        rollbackTransaction,
+        async () => {
+          throw new Error('boom');
+        }
+      )
+    ).rejects.toThrow('boom');
+
+    expect(beginTransaction).toHaveBeenCalledTimes(1);
+    expect(commitTransaction).not.toHaveBeenCalled();
+    expect(rollbackTransaction).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- split SQLiteCacheManager into focused collaborators for WASM access, persistence, sync state, transactions, and maintenance
- add direct unit coverage for SQLiteCacheManager and the extracted services
- reduce SQLiteCacheManager below the large-file threshold

## Testing
- npx jest tests/unit/SQLiteCacheManager.test.ts tests/unit/SQLiteTransactionCoordinator.test.ts tests/unit/SQLiteSyncStateStore.test.ts tests/unit/SQLitePersistenceService.test.ts --runInBand
- npx eslint --no-warn-ignored src/database/storage/SQLiteCacheManager.ts src/database/storage/SQLiteMaintenanceService.ts src/database/storage/SQLitePersistenceService.ts src/database/storage/SQLiteSyncStateStore.ts src/database/storage/SQLiteTransactionCoordinator.ts src/database/storage/SQLiteWasmBridge.ts src/types/sqlite3-vec-wasm.d.ts tests/unit/SQLiteCacheManager.test.ts tests/unit/SQLitePersistenceService.test.ts tests/unit/SQLiteSyncStateStore.test.ts tests/unit/SQLiteTransactionCoordinator.test.ts