### PR TITLE
fix: wire project manager navigation to async loaders (#129)

### DIFF
--- a/src/components/workspace/ProjectsManagerView.ts
+++ b/src/components/workspace/ProjectsManagerView.ts
@@ -159,6 +159,25 @@ export class ProjectsManagerView {
         }
     }
 
+    async openNewProject(): Promise<boolean> {
+        const workspace = this.callbacks.getCurrentWorkspace();
+        if (!workspace?.id) {
+            new Notice('Save this workspace before creating a project');
+            return false;
+        }
+
+        if (!await this.getTaskService()) {
+            new Notice('Task service is not available yet');
+            return false;
+        }
+
+        this.currentProject = this.createProjectEditorState();
+        this.currentTasks = [];
+        this.editingTaskOriginal = null;
+        this.currentTask = null;
+        return true;
+    }
+
     openTaskDetail(task?: TaskMetadata): void {
         const workspace = this.callbacks.getCurrentWorkspace();
         if (!this.currentProject?.id || !workspace?.id) {

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -209,8 +209,8 @@ export class WorkspacesTab {
         return {
             onNavigateList: () => this.showWorkspaceList(),
             onNavigateDetail: () => this.showWorkspaceDetail(),
-            onNavigateProjects: () => this.showProjectsPage(),
-            onNavigateProjectDetail: () => this.showProjectPage(),
+            onNavigateProjects: () => { void this.openProjectsPage(); },
+            onNavigateProjectDetail: () => { void this.openNewProjectAndRender(); },
             onSaveWorkspace: () => this.saveCurrentWorkspace(),
             onDeleteWorkspace: () => this.deleteCurrentWorkspace(),
             onOpenWorkflowEditor: (index) => this.openWorkflowEditor(index),
@@ -239,16 +239,6 @@ export class WorkspacesTab {
         }
         this.currentView = 'detail';
         this.router.showDetail(this.currentWorkspace.id);
-    }
-
-    private showProjectsPage(): void {
-        this.currentView = 'projects';
-        this.render();
-    }
-
-    private showProjectPage(): void {
-        this.currentView = 'project-detail';
-        this.render();
     }
 
     // --- Workspace CRUD ---
@@ -346,6 +336,14 @@ export class WorkspacesTab {
         await this.projectsManager.openProjectDetail(project);
         this.currentView = 'project-detail';
         this.render();
+    }
+
+    private async openNewProjectAndRender(): Promise<void> {
+        const success = await this.projectsManager.openNewProject();
+        if (success) {
+            this.currentView = 'project-detail';
+            this.render();
+        }
     }
 
     // --- Workflow and file picker (already delegated to existing renderers) ---


### PR DESCRIPTION
The Project Manager UI in workspace settings had two broken flows:

1. "Manage projects" showed an empty list because onNavigateProjects was
   wired to showProjectsPage(), a sync stub that flipped the view without
   calling refreshProjects() first.
2. "+ New project" opened a blank page because onNavigateProjectDetail
   was wired to showProjectPage(), which never initialized
   currentProject, tripping the early return in renderProjectDetail().

The correct async entry points (openProjectsPage, openProjectDetailAndRender)
already existed but were never called from buildDetailCallbacks. This
rewires the callbacks, adds openNewProject() on ProjectsManagerView to
initialize a fresh editor state, adds openNewProjectAndRender() on
WorkspacesTab to drive it, and deletes the dead sync stubs.