### PR TITLE
fix: use robust 3-tier Node.js detection in GetStartedTab (#132)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nexus",
-    "version": "5.7.1",
+    "version": "5.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nexus",
-            "version": "5.7.1",
+            "version": "5.7.2",
             "license": "MIT",
             "dependencies": {
                 "@dao-xyz/sqlite3-vec": "^0.0.19",

--- a/src/settings/tabs/GetStartedTab.ts
+++ b/src/settings/tabs/GetStartedTab.ts
@@ -13,6 +13,7 @@ import { App, Setting, Notice, Platform, Component } from 'obsidian';
 import { BackButton } from '../components/BackButton';
 import { getPrimaryServerKey } from '../../constants/branding';
 import { ConfigStatus, getClaudeDesktopConfigPath, getConfigStatus } from '../getStartedStatus';
+import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
 
 type GetStartedView = 'paths' | 'internal-chat' | 'mcp-setup';
 type DesktopModuleMap = {
@@ -433,22 +434,8 @@ export class GetStartedTab {
             this.cachedNodePath = '';
             return '';
         }
-        try {
-            const { execSync: nodeExecSync } = this.loadDesktopModule('child_process');
-            const nodeFs = this.loadDesktopModule('fs');
-            const cmd = Platform.isWin ? 'where node' : 'which node';
-            const result = nodeExecSync(cmd, { encoding: 'utf-8', timeout: 5000 }).trim();
-            // `where` on Windows may return multiple lines; take the first
-            const firstLine = result.split('\n')[0].trim();
-            if (firstLine && nodeFs.existsSync(firstLine)) {
-                this.cachedNodePath = firstLine;
-                return firstLine;
-            }
-        } catch {
-            // Node not found in PATH
-        }
-        this.cachedNodePath = '';
-        return '';
+        this.cachedNodePath = resolveDesktopBinaryPath('node') ?? '';
+        return this.cachedNodePath;
     }
 
     private loadDesktopModule<TModuleName extends keyof DesktopModuleMap>(

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-04-09T16:05:55.864Z
+ * Generated: 2026-04-13T21:31:53.627Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";


### PR DESCRIPTION
GetStartedTab.resolveNodePath() only ran `which node`, which fails on
macOS GUI apps (Electron/Obsidian) because they run with a restricted
PATH that excludes Homebrew paths like /usr/local/bin and
/opt/homebrew/bin. Replace the hand-rolled detection with the existing
resolveDesktopBinaryPath() utility which checks: (1) current PATH,
(2) common install locations, and (3) login shell fallback.

https://claude.ai/code/session_01UCgvMp8k4h8H8PDTBSuR4E