### PR TITLE
[codex] Persist chat media model settings

### DIFF
--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -273,7 +273,8 @@ export class ToolBatchExecutionService {
     const { agent: agentName, tool: toolSlug } = call;
 
     const callWithAny = call as ToolCallParams & { parameters?: Record<string, unknown> };
-    const params = call.params || callWithAny.parameters || {};
+    const baseParams = call.params || callWithAny.parameters || {};
+    const params = this.applyContextDefaults(context, agentName, toolSlug, baseParams);
 
     if (!agentName) {
       const availableAgents = Array.from(this.agentRegistry.keys()).join(', ');
@@ -357,6 +358,31 @@ export class ToolBatchExecutionService {
         error: `Error executing ${agentName}_${toolSlug}: ${getErrorMessage(error)}`
       };
     }
+  }
+
+  private applyContextDefaults(
+    context: ToolContext,
+    agentName: string | undefined,
+    toolSlug: string | undefined,
+    params: Record<string, unknown>
+  ): Record<string, unknown> {
+    if (agentName === 'promptManager' && toolSlug === 'generateImage') {
+      return {
+        ...params,
+        provider: params.provider || context.imageProvider,
+        model: params.model || context.imageModel
+      };
+    }
+
+    if (agentName === 'ingestManager' && toolSlug === 'ingest') {
+      return {
+        ...params,
+        transcriptionProvider: params.transcriptionProvider || context.transcriptionProvider,
+        transcriptionModel: params.transcriptionModel || context.transcriptionModel
+      };
+    }
+
+    return params;
   }
 
   private formatUseToolResult(results: ToolCallResult[]): UseToolResult {

--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -2,10 +2,11 @@
  * ChatSettingsRenderer - Shared settings UI for DefaultsTab and ChatSettingsModal
  *
  * Renders identical UI in both places:
- * - Provider + Model (same section)
+ * - Chat provider + model
  * - Reasoning toggle + Effort slider
  * - Image generation settings
- * - Workspace + Agent
+ * - Transcription settings
+ * - Workspace + prompt
  * - Context notes
  *
  * The difference is only WHERE data is saved (via callbacks).
@@ -20,6 +21,11 @@ import { FilePickerRenderer } from '../workspace/FilePickerRenderer';
 import { isDesktop, isProviderCompatible } from '../../utils/platform';
 import { LLMSettingsNotifier } from '../../services/llm/LLMSettingsNotifier';
 import { renderModelDropdownSection } from './ModelDropdownRenderer';
+import {
+  getIngestCapabilityOptions,
+  normalizeIngestSelection
+} from '../../agents/ingestManager/tools/services/IngestCapabilityService';
+import { renderIngestModelDropdowns } from './IngestModelDropdownRenderer';
 
 /**
  * Current settings state
@@ -27,14 +33,14 @@ import { renderModelDropdownSection } from './ModelDropdownRenderer';
 export interface ChatSettings {
   provider: string;
   model: string;
-  // Agent Model - used for executePrompt when chat model is local
+  // Subagent model - used for executePrompt when chat model is local
   agentProvider?: string;
   agentModel?: string;
   thinking: {
     enabled: boolean;
     effort: ThinkingEffort;
   };
-  // Agent Model thinking settings (separate from chat model)
+  // Subagent model thinking settings (separate from chat model)
   agentThinking?: {
     enabled: boolean;
     effort: ThinkingEffort;
@@ -42,6 +48,8 @@ export interface ChatSettings {
   temperature: number; // 0.0-1.0, controls randomness
   imageProvider: 'google' | 'openrouter';
   imageModel: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
   workspaceId: string | null;
   promptId: string | null;
   contextNotes: string[];
@@ -143,10 +151,11 @@ export class ChatSettingsRenderer {
     this.container.empty();
     this.container.addClass('chat-settings-renderer');
 
-    // Vertical layout - order: Chat (with Reasoning), Agent, Image, Temp, Context
+    // Vertical layout - order: Chat (with Reasoning), Agent, Image, Transcription, Temp, Context
     this.renderModelSection(this.container);
     this.renderAgentModelSection(this.container);
     this.renderImageSection(this.container);
+    this.renderTranscriptionSection(this.container);
     this.renderTemperatureSection(this.container);
     this.renderContextSection(this.container);
   }
@@ -228,7 +237,7 @@ export class ChatSettingsRenderer {
 
   private renderModelSection(parent: HTMLElement): void {
     renderModelDropdownSection(parent, {
-      sectionTitle: 'Chat Model',
+      sectionTitle: 'Chat model',
       getProviders: () => this.getEnabledProviders(),
       getCurrentProvider: () => this.settings.provider,
       getCurrentModel: () => this.settings.model,
@@ -336,15 +345,15 @@ export class ChatSettingsRenderer {
     });
   }
 
-  // ========== AGENT MODEL SECTION ==========
+  // ========== SUBAGENT MODEL SECTION ==========
 
   /**
-   * Render Agent Model section - always shown, excludes local providers.
+   * Render Subagent model section - always shown, excludes local providers.
    * This model is used for executePrompt and other API-dependent operations.
    */
   private renderAgentModelSection(parent: HTMLElement): void {
     renderModelDropdownSection(parent, {
-      sectionTitle: 'Agent Model',
+      sectionTitle: 'Subagent model',
       description: {
         text: 'Cloud model for AI actions',
         infoTooltip: 'Saved prompts and automations require a cloud API.',
@@ -519,6 +528,62 @@ export class ChatSettingsRenderer {
           this.notifyChange();
         });
       });
+  }
+
+  // ========== TRANSCRIPTION SECTION ==========
+
+  private renderTranscriptionSection(parent: HTMLElement): void {
+    const section = parent.createDiv('csr-section');
+    section.createDiv('csr-section-header').setText('Transcription model');
+    const content = section.createDiv('csr-section-content');
+    content.createDiv({
+      cls: 'setting-item-description',
+      text: 'Loading transcription models...'
+    });
+
+    void getIngestCapabilityOptions(this.providerManager).then(capabilities => {
+      content.empty();
+      const normalizedSelection = normalizeIngestSelection(
+        capabilities.transcriptionProviders,
+        this.settings.transcriptionProvider,
+        this.settings.transcriptionModel
+      );
+
+      const changed = normalizedSelection.provider !== this.settings.transcriptionProvider
+        || normalizedSelection.model !== this.settings.transcriptionModel;
+
+      this.settings.transcriptionProvider = normalizedSelection.provider;
+      this.settings.transcriptionModel = normalizedSelection.model;
+
+      if (changed) {
+        this.notifyChange();
+      }
+
+      renderIngestModelDropdowns(content, {
+        labelPrefix: 'Transcription',
+        description: 'Model for audio transcription.',
+        providers: capabilities.transcriptionProviders,
+        getSelection: () => this.settings.transcriptionProvider && this.settings.transcriptionModel
+          ? {
+            provider: this.settings.transcriptionProvider,
+            model: this.settings.transcriptionModel
+          }
+          : undefined,
+        onChange: (provider, model) => {
+          this.settings.transcriptionProvider = provider;
+          this.settings.transcriptionModel = model;
+          this.notifyChange();
+        },
+        providerSettingName: 'Provider',
+        modelSettingName: 'Model'
+      });
+    }).catch(() => {
+      content.empty();
+      content.createDiv({
+        cls: 'setting-item-description',
+        text: 'Transcription models are not available.'
+      });
+    });
   }
 
   // ========== CONTEXT SECTION ==========

--- a/src/components/shared/IngestModelDropdownRenderer.ts
+++ b/src/components/shared/IngestModelDropdownRenderer.ts
@@ -1,0 +1,103 @@
+import { Setting } from 'obsidian';
+import {
+  IngestProviderOption,
+  normalizeIngestSelection
+} from '../../agents/ingestManager/tools/services/IngestCapabilityService';
+
+export interface IngestModelDropdownConfig {
+  labelPrefix: string;
+  description?: string;
+  providers: IngestProviderOption[];
+  getSelection: () => { provider: string; model: string } | undefined;
+  onChange: (provider: string | undefined, model: string | undefined) => Promise<void> | void;
+  providerSettingName?: string;
+  modelSettingName?: string;
+}
+
+export function renderIngestModelDropdowns(
+  container: HTMLElement,
+  config: IngestModelDropdownConfig
+): void {
+  let modelDropdown: HTMLSelectElement | null = null;
+
+  const updateModelOptions = (): void => {
+    if (!modelDropdown) {
+      return;
+    }
+
+    const selection = config.getSelection();
+    const providerId = selection?.provider;
+    const provider = config.providers.find(option => option.id === providerId);
+    const normalizedSelection = normalizeIngestSelection(
+      config.providers,
+      selection?.provider,
+      selection?.model
+    );
+
+    modelDropdown.empty();
+
+    if (!providerId || !provider || provider.models.length === 0) {
+      modelDropdown.createEl('option', {
+        value: '',
+        text: config.providers.length === 0
+          ? `No ${config.labelPrefix.toLowerCase()} models available`
+          : 'Select a provider first'
+      });
+      modelDropdown.disabled = true;
+      return;
+    }
+
+    provider.models.forEach(model => {
+      modelDropdown?.createEl('option', {
+        value: model.id,
+        text: model.name
+      });
+    });
+
+    modelDropdown.disabled = false;
+    modelDropdown.value = provider.models.some(model => model.id === normalizedSelection.model)
+      ? normalizedSelection.model || provider.models[0].id
+      : provider.models[0].id;
+  };
+
+  new Setting(container)
+    .setName(config.providerSettingName ?? `${config.labelPrefix} provider`)
+    .setDesc(config.description ?? '')
+    .addDropdown(dropdown => {
+      if (config.providers.length === 0) {
+        dropdown.addOption('', `No ${config.labelPrefix.toLowerCase()} providers available`);
+        dropdown.setDisabled(true);
+        return;
+      }
+
+      config.providers.forEach(provider => {
+        dropdown.addOption(provider.id, provider.name);
+      });
+
+      const normalizedSelection = normalizeIngestSelection(
+        config.providers,
+        config.getSelection()?.provider,
+        config.getSelection()?.model
+      );
+
+      dropdown.setValue(normalizedSelection.provider || config.providers[0].id);
+      dropdown.onChange((value) => {
+        const nextSelection = normalizeIngestSelection(config.providers, value, undefined);
+        void Promise.resolve(config.onChange(nextSelection.provider, nextSelection.model))
+          .then(updateModelOptions);
+      });
+    });
+
+  new Setting(container)
+    .setName(config.modelSettingName ?? `${config.labelPrefix} model`)
+    .addDropdown(dropdown => {
+      modelDropdown = dropdown.selectEl;
+      updateModelOptions();
+
+      dropdown.onChange((value) => {
+        const selection = config.getSelection();
+        void Promise.resolve(config.onChange(selection?.provider, value || undefined))
+          .then(updateModelOptions);
+      });
+    });
+}

--- a/src/components/shared/ModelDropdownRenderer.ts
+++ b/src/components/shared/ModelDropdownRenderer.ts
@@ -35,7 +35,7 @@ const PROVIDER_NAMES: Record<string, string> = {
 export { PROVIDER_NAMES };
 
 export interface ModelDropdownConfig {
-  /** Section header text (e.g., "Chat Model", "Agent Model") */
+  /** Section header text (e.g., "Chat model", "Subagent model") */
   sectionTitle: string;
 
   /** Optional description text below the header */

--- a/src/services/chat/ChatService.ts
+++ b/src/services/chat/ChatService.ts
@@ -378,6 +378,11 @@ export class ChatService {
       excludeFromMessageId?: string;
       enableThinking?: boolean;
       thinkingEffort?: 'low' | 'medium' | 'high';
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): AsyncGenerator<ChatStreamingChunk, void, unknown> {
     // Store current provider and session for backward compatibility

--- a/src/services/chat/DirectToolExecutor.ts
+++ b/src/services/chat/DirectToolExecutor.ts
@@ -78,6 +78,15 @@ export interface DirectToolResult {
     executionTime?: number;
 }
 
+export interface DirectToolExecutionContext {
+    sessionId?: string;
+    workspaceId?: string;
+    imageProvider?: 'google' | 'openrouter';
+    imageModel?: string;
+    transcriptionProvider?: string;
+    transcriptionModel?: string;
+}
+
 export interface DirectToolExecutorConfig {
     /** Agent provider - can be AgentRegistry, AgentRegistrationService, or any compatible provider */
     agentProvider: AgentProvider;
@@ -274,7 +283,7 @@ export class DirectToolExecutor {
     async executeTool(
         toolName: string,
         params: Record<string, unknown>,
-        context?: { sessionId?: string; workspaceId?: string }
+        context?: DirectToolExecutionContext
     ): Promise<unknown> {
         try {
             // Two-tool architecture: getTools and useTool
@@ -333,12 +342,17 @@ export class DirectToolExecutor {
                 || (paramsTyped.context?.workspaceId as string | undefined)
                 || 'default';
 
+            const paramsWithDefaults = this.applyChatMediaDefaults(agentName, modeName, params, context);
             const paramsWithContext = {
-                ...params,
+                ...paramsWithDefaults,
                 context: {
                     ...paramsTyped.context,
                     sessionId: effectiveSessionId,
-                    workspaceId: effectiveWorkspaceId
+                    workspaceId: effectiveWorkspaceId,
+                    imageProvider: paramsTyped.context?.imageProvider || context?.imageProvider,
+                    imageModel: paramsTyped.context?.imageModel || context?.imageModel,
+                    transcriptionProvider: paramsTyped.context?.transcriptionProvider || context?.transcriptionProvider,
+                    transcriptionModel: paramsTyped.context?.transcriptionModel || context?.transcriptionModel
                 }
             };
 
@@ -368,7 +382,7 @@ export class DirectToolExecutor {
      */
     private async handleGetTools(
         params: Record<string, unknown>,
-        context?: { sessionId?: string; workspaceId?: string }
+        context?: DirectToolExecutionContext
     ): Promise<unknown> {
         // Get toolManager agent to use its getTools implementation (with lazy init)
         const toolManagerAgent = await this.getAgentByNameAsync('toolManager');
@@ -394,7 +408,11 @@ export class DirectToolExecutor {
             context: {
                 ...paramsContext,
                 sessionId: context?.sessionId || paramsContext.sessionId || `session_${Date.now()}`,
-                workspaceId: context?.workspaceId || paramsContext.workspaceId || 'default'
+                workspaceId: context?.workspaceId || paramsContext.workspaceId || 'default',
+                imageProvider: context?.imageProvider || paramsContext.imageProvider,
+                imageModel: context?.imageModel || paramsContext.imageModel,
+                transcriptionProvider: context?.transcriptionProvider || paramsContext.transcriptionProvider,
+                transcriptionModel: context?.transcriptionModel || paramsContext.transcriptionModel
             }
         };
 
@@ -408,7 +426,7 @@ export class DirectToolExecutor {
      */
     private async handleUseTool(
         params: Record<string, unknown>,
-        context?: { sessionId?: string; workspaceId?: string },
+        context?: DirectToolExecutionContext,
         options?: {
             batchId?: string;
             onToolEvent?: (event: 'started' | 'completed', data: ToolEventData) => void;
@@ -430,7 +448,11 @@ export class DirectToolExecutor {
             context: {
                 ...paramsContext,
                 sessionId: context?.sessionId || paramsContext.sessionId || `session_${Date.now()}`,
-                workspaceId: context?.workspaceId || paramsContext.workspaceId || 'default'
+                workspaceId: context?.workspaceId || paramsContext.workspaceId || 'default',
+                imageProvider: context?.imageProvider || paramsContext.imageProvider,
+                imageModel: context?.imageModel || paramsContext.imageModel,
+                transcriptionProvider: context?.transcriptionProvider || paramsContext.transcriptionProvider,
+                transcriptionModel: context?.transcriptionModel || paramsContext.transcriptionModel
             }
         };
 
@@ -516,7 +538,7 @@ export class DirectToolExecutor {
      */
     async executeToolCalls(
         toolCalls: DirectToolCall[],
-        context?: { sessionId?: string; workspaceId?: string },
+        context?: DirectToolExecutionContext,
         onToolEvent?: (event: 'started' | 'completed', data: ToolEventData) => void
     ): Promise<DirectToolResult[]> {
         const results: DirectToolResult[] = [];
@@ -608,6 +630,35 @@ export class DirectToolExecutor {
         }
 
         return results;
+    }
+
+    private applyChatMediaDefaults(
+        agentName: string,
+        toolName: string,
+        params: Record<string, unknown>,
+        context?: DirectToolExecutionContext
+    ): Record<string, unknown> {
+        if (!context) {
+            return params;
+        }
+
+        if (agentName === 'promptManager' && toolName === 'generateImage') {
+            return {
+                ...params,
+                provider: params.provider || context.imageProvider,
+                model: params.model || context.imageModel
+            };
+        }
+
+        if (agentName === 'ingestManager' && toolName === 'ingest') {
+            return {
+                ...params,
+                transcriptionProvider: params.transcriptionProvider || context.transcriptionProvider,
+                transcriptionModel: params.transcriptionModel || context.transcriptionModel
+            };
+        }
+
+        return params;
     }
 
     /**

--- a/src/services/chat/StreamingResponseService.ts
+++ b/src/services/chat/StreamingResponseService.ts
@@ -39,6 +39,10 @@ export interface StreamingOptions {
   enableThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high';
   temperature?: number; // 0.0-1.0, controls randomness
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
 }
 
 export interface StreamingChunk {
@@ -202,6 +206,10 @@ export class StreamingResponseService {
         enableThinking: options?.enableThinking,
         thinkingEffort: options?.thinkingEffort,
         temperature: options?.temperature,
+        imageProvider: options?.imageProvider,
+        imageModel: options?.imageModel,
+        transcriptionProvider: options?.transcriptionProvider,
+        transcriptionModel: options?.transcriptionModel,
         // Responses API (OpenAI/LM Studio): Load persisted ID for conversation continuity
         responsesApiId: filteredConversation?.metadata?.responsesApiId
       };

--- a/src/services/llm/adapters/shared/ToolExecutionUtils.ts
+++ b/src/services/llm/adapters/shared/ToolExecutionUtils.ts
@@ -63,6 +63,15 @@ export interface ToolMetadata {
   }>;
 }
 
+export interface ToolExecutionContext {
+  sessionId?: string;
+  workspaceId?: string;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
+}
+
 /**
  * Interface for tool executors
  * DirectToolExecutor implements this interface
@@ -70,7 +79,7 @@ export interface ToolMetadata {
 export interface IToolExecutor {
   executeToolCalls(
     toolCalls: ToolCall[],
-    context?: { sessionId?: string; workspaceId?: string },
+    context?: ToolExecutionContext,
     onToolEvent?: (event: 'started' | 'completed', data: unknown) => void
   ): Promise<ToolResult[]>;
 }
@@ -90,7 +99,7 @@ export class ToolExecutionUtils {
     toolCalls: ToolCall[],
     provider: SupportedProvider,
     onToolEvent?: (event: 'started' | 'completed', data: unknown) => void,
-    context?: { sessionId?: string; workspaceId?: string }
+    context?: ToolExecutionContext
   ): Promise<ToolResult[]> {
     if (!toolExecutor) {
       return toolCalls.map(tc => ({

--- a/src/services/llm/core/ProviderMessageBuilder.ts
+++ b/src/services/llm/core/ProviderMessageBuilder.ts
@@ -86,6 +86,10 @@ export interface StreamingOptions {
   topP?: number;
   frequencyPenalty?: number;
   presencePenalty?: number;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
   enableThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high';
   // Responses API (OpenAI/LM Studio): ID from first response, reused for all continuations

--- a/src/services/llm/core/ToolContinuationService.ts
+++ b/src/services/llm/core/ToolContinuationService.ts
@@ -167,7 +167,14 @@ export class ToolContinuationService {
         mcpToolCalls,
         provider as SupportedProvider,
         generateOptions.onToolEvent,
-        { sessionId: options?.sessionId, workspaceId: options?.workspaceId }
+        {
+          sessionId: options?.sessionId,
+          workspaceId: options?.workspaceId,
+          imageProvider: options?.imageProvider,
+          imageModel: options?.imageModel,
+          transcriptionProvider: options?.transcriptionProvider,
+          transcriptionModel: options?.transcriptionModel
+        }
       );
 
       // Small delay to allow file system operations to complete (prevents race conditions)
@@ -378,7 +385,14 @@ export class ToolContinuationService {
         recursiveMcpToolCalls,
         provider as SupportedProvider,
         generateOptions.onToolEvent,
-        { sessionId: options?.sessionId, workspaceId: options?.workspaceId }
+        {
+          sessionId: options?.sessionId,
+          workspaceId: options?.workspaceId,
+          imageProvider: options?.imageProvider,
+          imageModel: options?.imageModel,
+          transcriptionProvider: options?.transcriptionProvider,
+          transcriptionModel: options?.transcriptionModel
+        }
       );
 
       // Small delay to allow file system operations to complete

--- a/src/settings/tabs/DefaultsTab.ts
+++ b/src/settings/tabs/DefaultsTab.ts
@@ -15,8 +15,8 @@ import { LLMProviderManager } from '../../services/llm/providers/ProviderManager
 import {
   getIngestCapabilityOptions,
   normalizeIngestSelection,
-  IngestProviderOption
 } from '../../agents/ingestManager/tools/services/IngestCapabilityService';
+import { renderIngestModelDropdowns } from '../../components/shared/IngestModelDropdownRenderer';
 
 export interface DefaultsTabServices {
   app: App;
@@ -96,6 +96,8 @@ export class DefaultsTab {
       temperature: llmSettings?.defaultTemperature ?? 0.5,
       imageProvider: llmSettings?.defaultImageModel?.provider || 'google',
       imageModel: llmSettings?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      transcriptionProvider: llmSettings?.defaultTranscriptionModel?.provider,
+      transcriptionModel: llmSettings?.defaultTranscriptionModel?.model,
       workspaceId: pluginSettings.defaultWorkspaceId || null,
       promptId: pluginSettings.defaultPromptId || null,
       contextNotes: pluginSettings.defaultContextNotes || []
@@ -142,6 +144,12 @@ export class DefaultsTab {
         provider: settings.imageProvider,
         model: settings.imageModel
       };
+      llmSettings.defaultTranscriptionModel = settings.transcriptionProvider && settings.transcriptionModel
+        ? {
+          provider: settings.transcriptionProvider,
+          model: settings.transcriptionModel
+        }
+        : undefined;
       pluginSettings.llmProviders = llmSettings;
     }
 
@@ -192,18 +200,8 @@ export class DefaultsTab {
 
     await this.renderIngestionSection(rendererContainer);
 
-    // Embeddings section (desktop only) - insert before Temperature
+    // Embeddings section (desktop only)
     if (!Platform.isMobile) {
-      // Find Temperature section to insert before it
-      const headers = rendererContainer.querySelectorAll('.csr-section-header');
-      let temperatureSection: Element | null = null;
-      for (const header of Array.from(headers)) {
-        if (header.textContent === 'Temperature') {
-          temperatureSection = header.parentElement;
-          break;
-        }
-      }
-
       const embeddingsSection = createDiv({ cls: 'csr-section' });
       const embeddingsHeader = embeddingsSection.createDiv({ cls: 'csr-section-header' });
       embeddingsHeader.setText('Embeddings');
@@ -222,12 +220,7 @@ export class DefaultsTab {
             });
         });
 
-      // Insert before Temperature, or append if not found
-      if (temperatureSection) {
-        rendererContainer.insertBefore(embeddingsSection, temperatureSection);
-      } else {
-        rendererContainer.appendChild(embeddingsSection);
-      }
+      rendererContainer.appendChild(embeddingsSection);
     }
   }
 
@@ -246,23 +239,11 @@ export class DefaultsTab {
       llmSettings.defaultOcrModel?.provider,
       llmSettings.defaultOcrModel?.model
     );
-    const normalizedTranscriptionSelection = normalizeIngestSelection(
-      capabilities.transcriptionProviders,
-      llmSettings.defaultTranscriptionModel?.provider,
-      llmSettings.defaultTranscriptionModel?.model
-    );
 
     if (normalizedOcrSelection.provider && normalizedOcrSelection.model) {
       llmSettings.defaultOcrModel = {
         provider: normalizedOcrSelection.provider,
         model: normalizedOcrSelection.model
-      };
-    }
-
-    if (normalizedTranscriptionSelection.provider && normalizedTranscriptionSelection.model) {
-      llmSettings.defaultTranscriptionModel = {
-        provider: normalizedTranscriptionSelection.provider,
-        model: normalizedTranscriptionSelection.model
       };
     }
 
@@ -337,142 +318,23 @@ export class DefaultsTab {
       ocrSettingsContainer.addClass('nexus-ingest-confirm-hidden');
     }
 
-    this.renderProviderModelDefaults(
+    renderIngestModelDropdowns(
       ocrSettingsContainer,
-      'Default OCR',
-      'Model for vision OCR when using vision mode.',
-      capabilities.ocrProviders,
-      () => llmSettings.defaultOcrModel,
-      async (provider, model) => {
-        llmSettings.defaultOcrModel = provider && model
-          ? { provider, model }
-          : undefined;
-        await this.services.settings.saveSettings();
-      }
-    );
-
-    this.renderProviderModelDefaults(
-      ingestionSettingsContainer,
-      'Default transcription',
-      'Model for audio transcription.',
-      capabilities.transcriptionProviders,
-      () => llmSettings.defaultTranscriptionModel,
-      async (provider, model) => {
-        llmSettings.defaultTranscriptionModel = provider && model
-          ? { provider, model }
-          : undefined;
-        await this.services.settings.saveSettings();
-      }
-    );
-
-    const temperatureSection = this.findSectionByHeader(parentEl, 'Temperature');
-    if (temperatureSection) {
-      parentEl.insertBefore(section, temperatureSection);
-    } else {
-      parentEl.appendChild(section);
-    }
-  }
-
-  private findSectionByHeader(parentEl: HTMLElement, headerText: string): HTMLElement | null {
-    const headers = parentEl.querySelectorAll('.csr-section-header');
-    for (const header of Array.from(headers)) {
-      if (header.textContent === headerText && header.parentElement instanceof HTMLElement) {
-        return header.parentElement;
-      }
-    }
-
-    return null;
-  }
-
-  private renderProviderModelDefaults(
-    container: HTMLElement,
-    labelPrefix: string,
-    description: string,
-    providers: IngestProviderOption[],
-    getSelection: () => { provider: string; model: string } | undefined,
-    onChange: (provider: string | undefined, model: string | undefined) => Promise<void>
-  ): void {
-    let modelDropdown: HTMLSelectElement | null = null;
-
-    const updateModelOptions = (): void => {
-      if (!modelDropdown) {
-        return;
-      }
-
-      const selection = getSelection();
-      const providerId = selection?.provider;
-      const provider = providers.find(option => option.id === providerId);
-      const normalizedSelection = normalizeIngestSelection(
-        providers,
-        selection?.provider,
-        selection?.model
-      );
-
-      modelDropdown.empty();
-
-      if (!providerId || !provider || provider.models.length === 0) {
-        modelDropdown.createEl('option', {
-          value: '',
-          text: providers.length === 0 ? `No ${labelPrefix.toLowerCase()} models available` : 'Select a provider first'
-        });
-        modelDropdown.disabled = true;
-        return;
-      }
-
-      const currentModelDropdown = modelDropdown;
-      provider.models.forEach(model => {
-        currentModelDropdown.createEl('option', {
-          value: model.id,
-          text: model.name
-        });
-      });
-
-      modelDropdown.disabled = false;
-      modelDropdown.value = provider.models.some(model => model.id === normalizedSelection.model)
-        ? normalizedSelection.model || provider.models[0].id
-        : provider.models[0].id;
-    };
-
-    new Setting(container)
-      .setName(`${labelPrefix} provider`)
-      .setDesc(description)
-      .addDropdown(dropdown => {
-        if (providers.length === 0) {
-          dropdown.addOption('', `No ${labelPrefix.toLowerCase()} providers available`);
-          dropdown.setDisabled(true);
-          return;
+      {
+        labelPrefix: 'Default OCR',
+        description: 'Model for vision OCR when using vision mode.',
+        providers: capabilities.ocrProviders,
+        getSelection: () => llmSettings.defaultOcrModel,
+        onChange: async (provider, model) => {
+          llmSettings.defaultOcrModel = provider && model
+            ? { provider, model }
+            : undefined;
+          await this.services.settings.saveSettings();
         }
+      }
+    );
 
-        providers.forEach(provider => {
-          dropdown.addOption(provider.id, provider.name);
-        });
-
-        const normalizedSelection = normalizeIngestSelection(
-          providers,
-          getSelection()?.provider,
-          getSelection()?.model
-        );
-
-        dropdown.setValue(normalizedSelection.provider || providers[0].id);
-        dropdown.onChange(async (value) => {
-          const nextSelection = normalizeIngestSelection(providers, value, undefined);
-          await onChange(nextSelection.provider, nextSelection.model);
-          updateModelOptions();
-        });
-      });
-
-    new Setting(container)
-      .setName(`${labelPrefix} model`)
-      .addDropdown(dropdown => {
-        modelDropdown = dropdown.selectEl;
-        updateModelOptions();
-
-        dropdown.onChange(async (value) => {
-          const selection = getSelection();
-          await onChange(selection?.provider, value || undefined);
-          updateModelOptions();
-        });
-      });
+    parentEl.appendChild(section);
   }
 
   /**

--- a/src/types/mcp/AgentTypes.ts
+++ b/src/types/mcp/AgentTypes.ts
@@ -71,6 +71,18 @@ export interface ToolContext {
 
   /** Optional rules/limits to follow (1-3 sentences) */
   constraints?: string;
+
+  /** Chat-scoped image provider preference for image tools */
+  imageProvider?: 'google' | 'openrouter';
+
+  /** Chat-scoped image model preference for image tools */
+  imageModel?: string;
+
+  /** Chat-scoped transcription provider preference for audio ingestion */
+  transcriptionProvider?: string;
+
+  /** Chat-scoped transcription model preference for audio ingestion */
+  transcriptionModel?: string;
 }
 
 /**

--- a/src/ui/chat/components/ChatSettingsModal.ts
+++ b/src/ui/chat/components/ChatSettingsModal.ts
@@ -142,8 +142,10 @@ export class ChatSettingsModal extends Modal {
         effort: agentThinking?.effort ?? 'medium'
       },
       temperature: temperature,
-      imageProvider: llmSettings?.defaultImageModel?.provider || 'google',
-      imageModel: llmSettings?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      imageProvider: this.modelAgentManager.getImageProvider() || llmSettings?.defaultImageModel?.provider || 'google',
+      imageModel: this.modelAgentManager.getImageModel() || llmSettings?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      transcriptionProvider: this.modelAgentManager.getTranscriptionProvider() || llmSettings?.defaultTranscriptionModel?.provider,
+      transcriptionModel: this.modelAgentManager.getTranscriptionModel() || llmSettings?.defaultTranscriptionModel?.model,
       workspaceId: this.modelAgentManager.getSelectedWorkspaceId(),
       promptId: prompt?.id || prompt?.name || null,
       contextNotes: [...contextNotes]
@@ -205,15 +207,13 @@ export class ChatSettingsModal extends Modal {
       await this.modelAgentManager.setContextNotes(settings.contextNotes);
 
       // Update image model
-      const plugin = getNexusPlugin<NexusPluginWithSettings>(this.app);
-      const llmSettings = plugin?.settings?.settings?.llmProviders;
-      if (llmSettings && plugin?.settings) {
-        llmSettings.defaultImageModel = {
-          provider: settings.imageProvider,
-          model: settings.imageModel
-        };
-        await plugin.settings.saveSettings();
-      }
+      this.modelAgentManager.setImageModel(settings.imageProvider, settings.imageModel);
+
+      // Update transcription model
+      this.modelAgentManager.setTranscriptionModel(
+        settings.transcriptionProvider || null,
+        settings.transcriptionModel || null
+      );
 
       // Save to conversation metadata
       if (this.conversationId) {

--- a/src/ui/chat/services/ChatSendCoordinator.ts
+++ b/src/ui/chat/services/ChatSendCoordinator.ts
@@ -21,6 +21,11 @@ export interface MessageExecutionOptions {
   sessionId?: string;
   enableThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high';
+  temperature?: number;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
 }
 
 interface ConversationManagerLike {

--- a/src/ui/chat/services/MessageAlternativeService.ts
+++ b/src/ui/chat/services/MessageAlternativeService.ts
@@ -72,6 +72,11 @@ export class MessageAlternativeService {
       systemPrompt?: string;
       workspaceId?: string;
       sessionId?: string;
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): Promise<void> {
     // Concurrent retry guard: if a retry is already in progress for this message, bail

--- a/src/ui/chat/services/MessageManager.ts
+++ b/src/ui/chat/services/MessageManager.ts
@@ -151,6 +151,11 @@ export class MessageManager {
       sessionId?: string;
       enableThinking?: boolean;
       thinkingEffort?: 'low' | 'medium' | 'high';
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     },
     metadata?: ReferenceMetadata
   ): Promise<void> {
@@ -233,6 +238,11 @@ export class MessageManager {
       sessionId?: string;
       enableThinking?: boolean;
       thinkingEffort?: 'low' | 'medium' | 'high';
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): Promise<void> {
     return this.trackGeneration(async () => {
@@ -270,6 +280,11 @@ export class MessageManager {
       systemPrompt?: string;
       workspaceId?: string;
       sessionId?: string;
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): Promise<void> {
     const userMessage = conversation.messages.find(msg => msg.id === userMessageId);
@@ -303,6 +318,11 @@ export class MessageManager {
       systemPrompt?: string;
       workspaceId?: string;
       sessionId?: string;
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): Promise<void> {
     try {
@@ -369,6 +389,11 @@ export class MessageManager {
       systemPrompt?: string;
       workspaceId?: string;
       sessionId?: string;
+      temperature?: number;
+      imageProvider?: 'google' | 'openrouter';
+      imageModel?: string;
+      transcriptionProvider?: string;
+      transcriptionModel?: string;
     }
   ): Promise<void> {
     await this.stateManager.updateMessageContent(conversation, messageId, newContent);

--- a/src/ui/chat/services/MessageStreamHandler.ts
+++ b/src/ui/chat/services/MessageStreamHandler.ts
@@ -52,6 +52,11 @@ export interface StreamOptions {
   abortSignal?: AbortSignal;
   enableThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high';
+  temperature?: number;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
 }
 
 export interface StreamResult {

--- a/src/ui/chat/services/ModelAgentConversationSettingsStore.ts
+++ b/src/ui/chat/services/ModelAgentConversationSettingsStore.ts
@@ -18,6 +18,10 @@ export interface ConversationSettingsMetadata {
   agentProvider?: string | null;
   agentModel?: string | null;
   agentThinking?: ThinkingSettings;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string | null;
+  transcriptionModel?: string | null;
 }
 
 export interface ConversationMetadataWithCompaction {

--- a/src/ui/chat/services/ModelAgentDefaultsResolver.ts
+++ b/src/ui/chat/services/ModelAgentDefaultsResolver.ts
@@ -15,6 +15,8 @@ interface PluginWithSettings {
         defaultTemperature?: number;
         agentModel?: { provider: string; model: string };
         agentThinking?: ThinkingSettings;
+        defaultImageModel?: { provider: 'google' | 'openrouter'; model: string };
+        defaultTranscriptionModel?: { provider: string; model: string };
       };
       defaultWorkspaceId?: string;
       defaultPromptId?: string;
@@ -33,6 +35,10 @@ export interface ModelAgentDefaultState {
   agentProvider: string | null;
   agentModel: string | null;
   agentThinkingSettings: ThinkingSettings;
+  imageProvider: 'google' | 'openrouter';
+  imageModel: string;
+  transcriptionProvider: string | null;
+  transcriptionModel: string | null;
   temperature: number;
 }
 
@@ -92,6 +98,10 @@ export class ModelAgentDefaultsResolver {
       agentProvider: llmProviders?.agentModel?.provider || null,
       agentModel: llmProviders?.agentModel?.model || null,
       agentThinkingSettings,
+      imageProvider: llmProviders?.defaultImageModel?.provider || 'google',
+      imageModel: llmProviders?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      transcriptionProvider: llmProviders?.defaultTranscriptionModel?.provider || null,
+      transcriptionModel: llmProviders?.defaultTranscriptionModel?.model || null,
       temperature: llmProviders?.defaultTemperature ?? 0.5
     };
   }

--- a/src/ui/chat/services/ModelAgentManager.ts
+++ b/src/ui/chat/services/ModelAgentManager.ts
@@ -69,6 +69,10 @@ export class ModelAgentManager {
   private agentProvider: string | null = null;
   private agentModel: string | null = null;
   private agentThinkingSettings: ThinkingSettings = { enabled: false, effort: 'medium' };
+  private imageProvider: 'google' | 'openrouter' = 'google';
+  private imageModel = 'gemini-2.5-flash-image';
+  private transcriptionProvider: string | null = null;
+  private transcriptionModel: string | null = null;
   private thinkingSettings: ThinkingSettings = { enabled: false, effort: 'medium' };
   private temperature = 0.5;
   private contextTokenTracker: ContextTokenTracker | null = null; // For token-limited models
@@ -242,6 +246,20 @@ export class ModelAgentManager {
       };
     }
 
+    // Restore image model
+    if ('imageProvider' in settings && settings.imageProvider) {
+      this.imageProvider = settings.imageProvider;
+    }
+    if ('imageModel' in settings && settings.imageModel) {
+      this.imageModel = settings.imageModel;
+    }
+
+    // Restore transcription model
+    if ('transcriptionProvider' in settings || 'transcriptionModel' in settings) {
+      this.transcriptionProvider = settings.transcriptionProvider || null;
+      this.transcriptionModel = settings.transcriptionModel || null;
+    }
+
     // Restore thinking settings
     if ('thinking' in settings && settings.thinking) {
       this.thinkingSettings = {
@@ -288,6 +306,10 @@ export class ModelAgentManager {
       this.agentProvider = defaultState.agentProvider;
       this.agentModel = defaultState.agentModel;
       this.agentThinkingSettings = { ...defaultState.agentThinkingSettings };
+      this.imageProvider = defaultState.imageProvider;
+      this.imageModel = defaultState.imageModel;
+      this.transcriptionProvider = defaultState.transcriptionProvider;
+      this.transcriptionModel = defaultState.transcriptionModel;
       this.temperature = defaultState.temperature;
 
       this.events.onPromptChanged(defaultState.selectedPrompt);
@@ -527,6 +549,50 @@ export class ModelAgentManager {
    */
   setAgentThinkingSettings(settings: ThinkingSettings): void {
     this.agentThinkingSettings = { ...settings };
+  }
+
+  /**
+   * Get image provider
+   */
+  getImageProvider(): 'google' | 'openrouter' {
+    return this.imageProvider;
+  }
+
+  /**
+   * Get image model
+   */
+  getImageModel(): string {
+    return this.imageModel;
+  }
+
+  /**
+   * Set image model (provider and model)
+   */
+  setImageModel(provider: 'google' | 'openrouter', model: string): void {
+    this.imageProvider = provider;
+    this.imageModel = model;
+  }
+
+  /**
+   * Get transcription provider
+   */
+  getTranscriptionProvider(): string | null {
+    return this.transcriptionProvider;
+  }
+
+  /**
+   * Get transcription model
+   */
+  getTranscriptionModel(): string | null {
+    return this.transcriptionModel;
+  }
+
+  /**
+   * Set transcription model (provider and model)
+   */
+  setTranscriptionModel(provider: string | null, model: string | null): void {
+    this.transcriptionProvider = provider;
+    this.transcriptionModel = model;
   }
 
   /**
@@ -775,7 +841,11 @@ export class ModelAgentManager {
       temperature: this.temperature,
       agentProvider: this.agentProvider,
       agentModel: this.agentModel,
-      agentThinking: this.agentThinkingSettings
+      agentThinking: this.agentThinkingSettings,
+      imageProvider: this.imageProvider,
+      imageModel: this.imageModel,
+      transcriptionProvider: this.transcriptionProvider,
+      transcriptionModel: this.transcriptionModel
     };
   }
 
@@ -790,6 +860,10 @@ export class ModelAgentManager {
       currentSystemPrompt: this.currentSystemPrompt,
       thinkingSettings: this.thinkingSettings,
       temperature: this.temperature,
+      imageProvider: this.imageProvider,
+      imageModel: this.imageModel,
+      transcriptionProvider: this.transcriptionProvider,
+      transcriptionModel: this.transcriptionModel,
       contextTokenTracker: this.compactionState.getContextTokenTracker(),
       compactionFrontier: this.compactionState.getCompactionFrontier(),
       latestCompactionRecord: this.compactionState.getLatestCompactionRecord()

--- a/src/ui/chat/services/ModelAgentPromptContextAssembler.ts
+++ b/src/ui/chat/services/ModelAgentPromptContextAssembler.ts
@@ -32,6 +32,10 @@ export interface ModelAgentPromptContextSnapshot {
   currentSystemPrompt: string | null;
   thinkingSettings: ThinkingSettings;
   temperature: number;
+  imageProvider: 'google' | 'openrouter';
+  imageModel: string;
+  transcriptionProvider: string | null;
+  transcriptionModel: string | null;
   contextTokenTracker: ContextTokenTrackerLike | null;
   compactionFrontier: CompactionFrontierRecord[];
   latestCompactionRecord: CompactedContext | null;
@@ -46,6 +50,10 @@ export interface ModelAgentMessageOptions {
   enableThinking?: boolean;
   thinkingEffort?: 'low' | 'medium' | 'high';
   temperature?: number;
+  imageProvider?: 'google' | 'openrouter';
+  imageModel?: string;
+  transcriptionProvider?: string;
+  transcriptionModel?: string;
 }
 
 interface ModelAgentPromptContextAssemblerDependencies {
@@ -89,7 +97,11 @@ export class ModelAgentPromptContextAssembler {
       sessionId,
       enableThinking: snapshot.thinkingSettings.enabled,
       thinkingEffort: snapshot.thinkingSettings.effort,
-      temperature: snapshot.temperature
+      temperature: snapshot.temperature,
+      imageProvider: snapshot.imageProvider,
+      imageModel: snapshot.imageModel,
+      transcriptionProvider: snapshot.transcriptionProvider || undefined,
+      transcriptionModel: snapshot.transcriptionModel || undefined
     };
   }
 

--- a/tests/unit/model-dropdown-characterization.test.ts
+++ b/tests/unit/model-dropdown-characterization.test.ts
@@ -6,7 +6,7 @@
  *   section div > header div > content div > Setting dropdowns
  *
  * Both render Provider + Model dropdowns with nearly identical logic.
- * The Agent Model section additionally filters out local providers.
+ * The Subagent model section additionally filters out local providers.
  *
  * These tests capture the structural pattern and key behavioral differences
  * that Wave 1b (ModelDropdownRenderer extraction) needs to preserve.
@@ -93,7 +93,7 @@ function createConfig(_container: unknown): ChatSettingsRendererConfig {
 }
 
 describe('ChatSettingsRenderer model section characterization', () => {
-  it('render() creates 5 sections in fixed order: Chat, Agent, Image, Temp, Context', () => {
+  it('render() creates sections in fixed order: Chat, Subagent, Image, Transcription, Temp, Context', () => {
     const container = createMockElement();
     const config = createConfig(container);
     const renderer = new ChatSettingsRenderer(container, config);
@@ -122,7 +122,7 @@ describe('ChatSettingsRenderer model section characterization', () => {
     expect(firstCall[0]).toBe('csr-section');
   });
 
-  it('renderModelSection header text is "Chat Model"', () => {
+  it('renderModelSection header text is "Chat model"', () => {
     const container = createMockElement();
     const config = createConfig(container);
     const renderer = new ChatSettingsRenderer(container, config);
@@ -134,12 +134,12 @@ describe('ChatSettingsRenderer model section characterization', () => {
     const sectionEl = container.createDiv.mock.results[0].value;
     expect(sectionEl.createDiv).toHaveBeenCalledWith('csr-section-header');
 
-    // The header element has setText called with 'Chat Model'
+    // The header element has setText called with 'Chat model'
     const headerEl = sectionEl.createDiv.mock.results[0].value;
-    expect(headerEl.setText).toHaveBeenCalledWith('Chat Model');
+    expect(headerEl.setText).toHaveBeenCalledWith('Chat model');
   });
 
-  it('renderAgentModelSection header text is "Agent Model"', () => {
+  it('renderAgentModelSection header text is "Subagent model"', () => {
     const container = createMockElement();
     const config = createConfig(container);
     const renderer = new ChatSettingsRenderer(container, config);
@@ -159,6 +159,6 @@ describe('ChatSettingsRenderer model section characterization', () => {
     const agentSectionIdx = allSectionCalls[1].idx;
     const agentSectionEl = container.createDiv.mock.results[agentSectionIdx].value;
     const agentHeaderEl = agentSectionEl.createDiv.mock.results[0].value;
-    expect(agentHeaderEl.setText).toHaveBeenCalledWith('Agent Model');
+    expect(agentHeaderEl.setText).toHaveBeenCalledWith('Subagent model');
   });
 });


### PR DESCRIPTION
## Summary
- adds a separate transcription model section to shared chat/default settings
- stores image and transcription model choices in per-conversation chat settings
- keeps ingestion-only controls in main Defaults while moving transcription out of ingestion
- threads chat-scoped media model defaults through native tool execution for image generation and audio ingestion

## Why
Chat-specific settings could not persist image/transcription model choices for the open conversation, and transcription was buried under ingestion defaults. This made the Defaults tab and chat settings modal drift and made media model behavior feel global even from chat settings.

## Validation
- npm run build
- npm test -- --runInBand tests/unit/model-dropdown-characterization.test.ts tests/unit/VoiceTypes.test.ts tests/unit/LLMTranscriptionService.test.ts tests/unit/ToolCallStateManager.test.ts tests/unit/ToolStatusPipeline.integration.test.ts