### PR TITLE
Trigger SQLite sync when JSONL files change via Obsidian Sync

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -21,11 +21,12 @@
  * - src/database/interfaces/IStorageAdapter.ts - Interface definition
  */
 
-import { App, Plugin } from 'obsidian';
+import { App, Events, EventRef, Plugin } from 'obsidian';
 import { IStorageAdapter, QueryOptions, ImportOptions } from '../interfaces/IStorageAdapter';
 import { JSONLWriter } from '../storage/JSONLWriter';
 import { SQLiteCacheManager } from '../storage/SQLiteCacheManager';
 import { SyncCoordinator } from '../sync/SyncCoordinator';
+import { JsonlVaultWatcher, ModifiedStream } from '../sync/JsonlVaultWatcher';
 import { QueryCache } from '../optimizations/QueryCache';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import {
@@ -97,6 +98,22 @@ export interface HybridStorageAdapterOptions {
   cacheMaxSize?: number;
 }
 
+/**
+ * Payload delivered to subscribers of the adapter's `external-sync` event.
+ * Fired after the JSONL vault watcher detects a change and the resulting
+ * reconciliation has been applied to SQLite.
+ */
+export interface ExternalSyncEvent {
+  /** Result of the reconciliation run that landed the remote JSONL events. */
+  result: SyncResult;
+  /**
+   * The logical streams that triggered this sync (deduped across the
+   * debounce window). UI consumers use this to decide whether content
+   * they are currently displaying needs to re-query from SQLite.
+   */
+  modified: ModifiedStream[];
+}
+
 export interface StartupHydrationState {
   phase: 'idle' | 'running' | 'complete' | 'error';
   isBlocking: boolean;
@@ -134,6 +151,18 @@ export class HybridStorageAdapter implements IStorageAdapter {
   private basePath: string;
   private initialized = false;
   private syncInterval?: NodeJS.Timeout;
+  /**
+   * Watches the plugin's vault data folder for JSONL changes landed by
+   * Obsidian Sync (or otherwise) and triggers reconciliation + emits the
+   * `external-sync` event. See JsonlVaultWatcher for design notes.
+   */
+  private jsonlVaultWatcher?: JsonlVaultWatcher;
+  /**
+   * Typed event bus for adapter consumers. Currently emits one event:
+   *   `external-sync` — payload: { result: SyncResult, modified: ModifiedStream[] }
+   * fired after a watcher-triggered sync completes.
+   */
+  private readonly externalEvents = new Events();
   private startupHydrationState: StartupHydrationState = {
     phase: 'idle',
     isBlocking: false,
@@ -362,6 +391,10 @@ export class HybridStorageAdapter implements IStorageAdapter {
         this.completeStartupHydration();
       }
 
+      // Watch the plugin data folder for JSONL changes landed by Obsidian
+      // Sync (or external tools). When something changes, reconcile SQLite
+      // and emit `external-sync` so open views can refresh.
+      this.startJsonlVaultWatcher();
     } catch (error) {
       console.error('[HybridStorageAdapter] Initialization failed:', error);
       this.initError = error as Error;
@@ -774,6 +807,9 @@ export class HybridStorageAdapter implements IStorageAdapter {
         this.syncInterval = undefined;
       }
 
+      // Stop the JSONL vault watcher and its before-write hook on the writer.
+      this.stopJsonlVaultWatcher();
+
       // Clear query cache
       this.queryCache.clear();
 
@@ -785,6 +821,87 @@ export class HybridStorageAdapter implements IStorageAdapter {
     } catch (error) {
       console.error('[HybridStorageAdapter] Error during close:', error);
       throw error;
+    }
+  }
+
+  // ============================================================================
+  // External sync: vault-event-driven reconciliation
+  // ============================================================================
+
+  /**
+   * Subscribe to external-sync events. Fired after the JSONL vault watcher
+   * detects a change (e.g. a Sync-pushed JSONL from another device) and
+   * the resulting reconciliation has been applied to SQLite. Subscribers
+   * use the `modified` stream list to decide whether their currently-viewed
+   * content needs to re-query.
+   *
+   * Returns an Obsidian EventRef. Pass it to `offExternalSync()` (or use
+   * the plugin's `registerEvent(ref)` for auto-cleanup on unload).
+   */
+  onExternalSync(callback: (event: ExternalSyncEvent) => void): EventRef {
+    // Obsidian's Events.on takes a variadic `unknown[]` handler; we narrow
+    // here by wrapping so callers get a typed API.
+    return this.externalEvents.on('external-sync', (...data: unknown[]) => {
+      callback(data[0] as ExternalSyncEvent);
+    });
+  }
+
+  /** Remove a subscription previously added via `onExternalSync`. */
+  offExternalSync(ref: EventRef): void {
+    this.externalEvents.offref(ref);
+  }
+
+  /**
+   * Start the JSONL vault watcher. Idempotent. Wires the before-write hook
+   * on `JSONLWriter` so self-writes don't echo back as sync triggers.
+   */
+  private startJsonlVaultWatcher(): void {
+    if (this.jsonlVaultWatcher) {
+      return;
+    }
+
+    const watcher = new JsonlVaultWatcher({
+      app: this.app,
+      dataPath: this.basePath,
+      onChange: async (modified) => {
+        await this.handleExternalJsonlChange(modified);
+      }
+    });
+
+    this.jsonlVaultWatcher = watcher;
+    this.jsonlWriter.setBeforeWriteHook((logicalPath) => {
+      watcher.suppressLogicalPath(logicalPath);
+    });
+
+    watcher.start();
+  }
+
+  /**
+   * Stop the watcher and tear down its hook. Safe if never started.
+   */
+  private stopJsonlVaultWatcher(): void {
+    if (!this.jsonlVaultWatcher) {
+      return;
+    }
+    this.jsonlWriter.setBeforeWriteHook(undefined);
+    this.jsonlVaultWatcher.stop();
+    this.jsonlVaultWatcher = undefined;
+  }
+
+  /**
+   * Reconcile after the watcher detects a modified stream set and emit
+   * `external-sync` so open UI can refresh only the affected content.
+   * Called by JsonlVaultWatcher's onChange callback.
+   */
+  private async handleExternalJsonlChange(modified: ModifiedStream[]): Promise<void> {
+    if (modified.length === 0) {
+      return;
+    }
+    try {
+      const result = await this.sync();
+      this.externalEvents.trigger('external-sync', { result, modified } satisfies ExternalSyncEvent);
+    } catch (error) {
+      console.error('[HybridStorageAdapter] External JSONL change sync failed:', error);
     }
   }
 
@@ -870,6 +987,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
     this.jsonlWriter.setBasePath(resolution.dataPath);
     this.jsonlWriter.setVaultEventStore(this.vaultEventStore);
     this.jsonlWriter.setVaultEventStoreReadEnabled(true);
+    this.jsonlVaultWatcher?.setDataPath(resolution.dataPath);
     this.queryCache.clear();
 
     return { ...result, switched: true };

--- a/src/database/storage/JSONLWriter.ts
+++ b/src/database/storage/JSONLWriter.ts
@@ -46,6 +46,18 @@ export interface JSONLWriterOptions {
 }
 
 /**
+ * Optional callback invoked just before `JSONLWriter` writes to a logical
+ * JSONL path. Used by `JsonlVaultWatcher` to suppress the echo modify
+ * event that would otherwise round-trip back through `vault.on('modify')`
+ * and trigger a pointless self-triggered sync.
+ *
+ * The callback receives the LOGICAL path (e.g. `conversations/conv_X.jsonl`),
+ * not the physical shard path — the watcher maps it to `(category, streamId)`
+ * and suppresses all shards for that stream for a short TTL.
+ */
+export type JSONLWriterBeforeWriteHook = (logicalPath: string) => void;
+
+/**
  * JSONL Writer for sync-safe append-only storage
  *
  * Provides methods to append events to JSONL files and read them back.
@@ -78,6 +90,7 @@ export class JSONLWriter {
   private basePath: string;
   private deviceId: string;
   private router: StorageRouter;
+  private beforeWriteHook?: JSONLWriterBeforeWriteHook;
   private readonly deviceIdStorageKey = 'claudesidian-device-id';
 
   constructor(options: JSONLWriterOptions) {
@@ -119,6 +132,30 @@ export class JSONLWriter {
 
   setVaultEventStoreReadEnabled(enabled: boolean): void {
     this.router.setVaultEventStoreReadEnabled(enabled);
+  }
+
+  /**
+   * Register (or clear) a callback fired just before each append. Used by
+   * the vault-event watcher to suppress echo modify events from the plugin's
+   * own writes. Pass `undefined` to remove a previously-registered hook.
+   */
+  setBeforeWriteHook(hook: JSONLWriterBeforeWriteHook | undefined): void {
+    this.beforeWriteHook = hook;
+  }
+
+  /**
+   * Invoke the registered before-write hook if any. Swallows errors from
+   * the hook so a misbehaving watcher never blocks a JSONL write.
+   */
+  private notifyBeforeWrite(logicalPath: string): void {
+    if (!this.beforeWriteHook) {
+      return;
+    }
+    try {
+      this.beforeWriteHook(logicalPath);
+    } catch (error) {
+      console.error('[JSONLWriter] beforeWrite hook threw:', error);
+    }
   }
 
   // ============================================================================
@@ -299,6 +336,7 @@ export class JSONLWriter {
         timestamp: Date.now(),
       } as T;
 
+      this.notifyBeforeWrite(relativePath);
       await this.router.appendEvent(relativePath, event);
       return event;
     } catch (error) {
@@ -334,6 +372,7 @@ export class JSONLWriter {
         timestamp: Date.now(),
       } as T));
 
+      this.notifyBeforeWrite(relativePath);
       await this.router.appendEvents(relativePath, events);
       return events;
     } catch (error) {

--- a/src/database/sync/JsonlVaultWatcher.ts
+++ b/src/database/sync/JsonlVaultWatcher.ts
@@ -1,0 +1,356 @@
+/**
+ * Location: src/database/sync/JsonlVaultWatcher.ts
+ *
+ * Watches vault file events under the plugin's storage data path and fires
+ * a callback whenever JSONL shards change. Lets the plugin reconcile its
+ * SQLite cache the moment Obsidian Sync lands a remote JSONL write — e.g.
+ * a chat written on desktop becomes visible on mobile without a restart.
+ *
+ * Why vault events (not polling):
+ * - As of v5.7.0+ storage lives under a regular vault folder (default
+ *   `Nexus/data/`), which means `vault.on('modify' | 'create' | 'delete'
+ *   | 'rename')` fires for it — including for writes landed by Obsidian
+ *   Sync. This is the canonical Obsidian API for detecting file changes.
+ *
+ * Self-write suppression:
+ * - The plugin itself appends to these JSONL shards during normal use
+ *   (saving messages, workspace updates, etc.), which would cause the
+ *   watcher to echo-trigger sync for no reason. `JSONLWriter` calls
+ *   `suppressFor(path)` just before each write so the watcher ignores
+ *   the corresponding modify event for a short TTL.
+ *
+ * Debounce:
+ * - Events are coalesced over a configurable window (default 2s) so
+ *   burst sync arrivals (many shards landing together) produce a single
+ *   `onChange` invocation with the union of modified streams.
+ *
+ * Related:
+ * - src/database/sync/SyncCoordinator.ts — the reconciliation target
+ * - src/database/adapters/HybridStorageAdapter.ts — owns + lifecycles this
+ * - src/database/storage/JSONLWriter.ts — invokes `suppressFor` pre-write
+ */
+
+import { App, EventRef, TAbstractFile, TFile, normalizePath } from 'obsidian';
+
+export type WatchedCategory = 'conversations' | 'workspaces' | 'tasks';
+
+/**
+ * A stream whose on-disk shards were observed to change during a debounce
+ * window. Callers use these to decide whether the currently-viewed content
+ * needs a refresh.
+ */
+export interface ModifiedStream {
+  category: WatchedCategory;
+  /** Raw stream id as written on disk, e.g. `conv_abc-123`, `ws_xyz`, `tasks_xyz`. */
+  streamId: string;
+  /** Domain id with category prefix stripped, e.g. `abc-123` (a conversationId) or `xyz` (a workspaceId). */
+  businessId: string;
+  /** Example relative path that triggered the change, e.g. `conversations/conv_abc-123/shard-000.jsonl`. */
+  samplePath: string;
+}
+
+export interface JsonlVaultWatcherOptions {
+  app: App;
+  /** Current plugin data path, e.g. `Nexus/data`. Can be updated via `setDataPath`. */
+  dataPath: string;
+  /**
+   * Fired (debounced) when one or more JSONL shards under `dataPath` change
+   * due to something other than this device's own writes. Implementations
+   * typically call `HybridStorageAdapter.sync()` and then re-render any
+   * currently-open views affected by `modified`.
+   */
+  onChange: (modified: ModifiedStream[]) => Promise<void> | void;
+  /** Coalesce window in ms. Default: 2000. */
+  debounceMs?: number;
+  /** Suppression TTL in ms for self-writes. Default: 3000. */
+  suppressTtlMs?: number;
+}
+
+const MATCH_SHARDED = /^(conversations|workspaces|tasks)\/([^/]+)\/shard-\d+\.jsonl$/;
+const MATCH_FLAT = /^(conversations|workspaces|tasks)\/([^/]+)\.jsonl$/;
+
+const BUSINESS_ID_PREFIX: Record<WatchedCategory, string> = {
+  conversations: 'conv_',
+  workspaces: 'ws_',
+  tasks: 'tasks_'
+};
+
+interface ParsedStreamPath {
+  category: WatchedCategory;
+  streamId: string;
+  businessId: string;
+}
+
+/**
+ * Parse a path (relative to the plugin's `dataPath`) into its category
+ * and stream id. Accepts both the sharded layout used by VaultEventStore
+ * (`<cat>/<streamId>/shard-NNN.jsonl`) and the legacy flat layout
+ * (`<cat>/<streamId>.jsonl`). Returns `null` for anything else (meta
+ * manifests, unrelated files, etc.).
+ */
+export function parseStreamPath(relativePath: string): ParsedStreamPath | null {
+  const normalized = normalizePath(relativePath).replace(/^\/+|\/+$/g, '');
+  const match = MATCH_SHARDED.exec(normalized) ?? MATCH_FLAT.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const category = match[1] as WatchedCategory;
+  const streamId = match[2];
+  const prefix = BUSINESS_ID_PREFIX[category];
+  const businessId = streamId.startsWith(prefix) ? streamId.slice(prefix.length) : streamId;
+  return { category, streamId, businessId };
+}
+
+/**
+ * Vault event-based JSONL watcher. See file header for design notes.
+ */
+export class JsonlVaultWatcher {
+  private readonly app: App;
+  private readonly onChange: (modified: ModifiedStream[]) => Promise<void> | void;
+  private readonly debounceMs: number;
+  private readonly suppressTtlMs: number;
+
+  private dataPath: string;
+  private running = false;
+  private eventRefs: EventRef[] = [];
+
+  /**
+   * Self-write suppression keyed by `${category}:${streamId}` → expiry ms.
+   * `JSONLWriter` doesn't know the physical shard path (that's owned by
+   * `ShardedJsonlStreamStore` and can rotate between shards), so suppression
+   * has to live at the logical stream level: suppress all shards belonging
+   * to a stream for a TTL window after the plugin writes to it.
+   */
+  private readonly suppressed = new Map<string, number>();
+
+  /** Accumulator of streams modified within the current debounce window. */
+  private readonly pending = new Map<string, ModifiedStream>();
+  private debounceTimer?: ReturnType<typeof setTimeout>;
+
+  private dispatching = false;
+  private dispatchQueued = false;
+
+  constructor(options: JsonlVaultWatcherOptions) {
+    this.app = options.app;
+    this.onChange = options.onChange;
+    this.debounceMs = options.debounceMs ?? 2000;
+    this.suppressTtlMs = options.suppressTtlMs ?? 3000;
+    this.dataPath = normalizeDataPath(options.dataPath);
+  }
+
+  /**
+   * Register vault event listeners. Idempotent.
+   */
+  start(): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+
+    const vault = this.app.vault;
+    this.eventRefs.push(
+      vault.on('modify', (file) => this.handleFileEvent(file)),
+      vault.on('create', (file) => this.handleFileEvent(file)),
+      vault.on('delete', (file) => this.handleFileEvent(file)),
+      vault.on('rename', (file, oldPath) => {
+        this.handleFileEvent(file);
+        // Also flag the old path in case it was a stream path we care about.
+        const parsed = this.parseRelative(oldPath);
+        if (parsed) {
+          this.recordModified(parsed, oldPath);
+          this.scheduleDispatch();
+        }
+      })
+    );
+  }
+
+  /**
+   * Detach all listeners and clear pending timers. Safe to call if never started.
+   */
+  stop(): void {
+    this.running = false;
+
+    for (const ref of this.eventRefs) {
+      this.app.vault.offref(ref);
+    }
+    this.eventRefs = [];
+
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+
+    this.pending.clear();
+    this.suppressed.clear();
+  }
+
+  /**
+   * Update the path being watched (e.g. after `relocateVaultRoot`). Does
+   * not re-register listeners — the filter just uses the new path going
+   * forward. Clears any pending accumulator from the previous location.
+   */
+  setDataPath(newDataPath: string): void {
+    this.dataPath = normalizeDataPath(newDataPath);
+    this.pending.clear();
+  }
+
+  /**
+   * Mark a logical stream as "about to be written by us" so imminent vault
+   * modify events for its shards are treated as echo and ignored. Invoked
+   * by `JSONLWriter.appendEvent(s)` before delegating to the router.
+   *
+   * Accepts either the logical path (e.g. `conversations/conv_abc.jsonl`)
+   * or a concrete shard path — both are parsed to `(category, streamId)`.
+   */
+  suppressLogicalPath(path: string, ttlMs = this.suppressTtlMs): void {
+    const parsed = parseStreamPath(stripDataPathPrefix(path, this.dataPath));
+    if (!parsed) {
+      return;
+    }
+    const key = suppressionKey(parsed.category, parsed.streamId);
+    this.suppressed.set(key, Date.now() + Math.max(0, ttlMs));
+  }
+
+  /**
+   * Test / manual hook: return whether the watcher is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // --- Internal ------------------------------------------------------------
+
+  private handleFileEvent(file: TAbstractFile | null): void {
+    if (!this.running || !file) {
+      return;
+    }
+
+    // Skip folders — shard paths always end in .jsonl files.
+    if (!(file instanceof TFile)) {
+      return;
+    }
+    if (file.extension !== 'jsonl') {
+      return;
+    }
+
+    const fullPath = normalizePath(file.path);
+    const parsed = this.parseRelative(fullPath);
+    if (!parsed) {
+      return;
+    }
+
+    if (this.isSuppressed(parsed.category, parsed.streamId)) {
+      return;
+    }
+
+    this.recordModified(parsed, fullPath);
+    this.scheduleDispatch();
+  }
+
+  private recordModified(parsed: ParsedStreamPath, fullPath: string): void {
+    const key = `${parsed.category}:${parsed.streamId}`;
+    if (!this.pending.has(key)) {
+      this.pending.set(key, {
+        category: parsed.category,
+        streamId: parsed.streamId,
+        businessId: parsed.businessId,
+        samplePath: fullPath
+      });
+    }
+  }
+
+  private parseRelative(fullVaultPath: string): ParsedStreamPath | null {
+    const normalized = normalizePath(fullVaultPath);
+    const prefix = `${this.dataPath}/`;
+    if (!normalized.startsWith(prefix)) {
+      return null;
+    }
+    const relative = normalized.slice(prefix.length);
+    return parseStreamPath(relative);
+  }
+
+  private isSuppressed(category: WatchedCategory, streamId: string): boolean {
+    const key = suppressionKey(category, streamId);
+    const expiry = this.suppressed.get(key);
+    if (expiry === undefined) {
+      return false;
+    }
+    if (Date.now() > expiry) {
+      this.suppressed.delete(key);
+      return false;
+    }
+    // Consume the suppression so later remote writes aren't silently
+    // dropped if Obsidian Sync lands quickly after ours. If the plugin
+    // appends multiple events to the same stream in rapid succession,
+    // `JSONLWriter` re-suppresses before each append.
+    this.suppressed.delete(key);
+    return true;
+  }
+
+  private scheduleDispatch(): void {
+    if (this.debounceTimer !== undefined) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      if (!this.running) {
+        return;
+      }
+      void this.dispatch();
+    }, this.debounceMs);
+  }
+
+  private async dispatch(): Promise<void> {
+    if (this.dispatching) {
+      // A dispatch is already running — record that more changes landed
+      // so we can fire again after it finishes (with whatever has
+      // accumulated in `pending` by then).
+      this.dispatchQueued = true;
+      return;
+    }
+
+    if (this.pending.size === 0) {
+      return;
+    }
+
+    const modified = Array.from(this.pending.values());
+    this.pending.clear();
+
+    this.dispatching = true;
+    try {
+      await this.onChange(modified);
+    } catch (error) {
+      console.error('[JsonlVaultWatcher] onChange callback failed:', error);
+    } finally {
+      this.dispatching = false;
+    }
+
+    if (this.dispatchQueued && this.running) {
+      this.dispatchQueued = false;
+      if (this.pending.size > 0) {
+        this.scheduleDispatch();
+      }
+    }
+  }
+}
+
+function normalizeDataPath(path: string): string {
+  return normalizePath(path).replace(/^\/+|\/+$/g, '');
+}
+
+function suppressionKey(category: WatchedCategory, streamId: string): string {
+  return `${category}:${streamId}`;
+}
+
+/**
+ * Accepts either a logical path (no dataPath prefix, e.g.
+ * `conversations/conv_abc.jsonl`) or a vault path (with dataPath prefix,
+ * e.g. `Nexus/data/conversations/conv_abc/shard-000.jsonl`) and returns
+ * the portion relative to `dataPath`. If the input looks logical already,
+ * it's returned unchanged.
+ */
+function stripDataPathPrefix(path: string, dataPath: string): string {
+  const normalized = normalizePath(path).replace(/^\/+|\/+$/g, '');
+  const prefix = `${dataPath}/`;
+  return normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized;
+}

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -25,6 +25,7 @@ import { v4 as uuidv4 } from '../../utils/uuid';
 import type { ServiceManager } from '../../core/ServiceManager';
 import type { WorkflowRunService } from '../../services/workflows/WorkflowRunService';
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
+import type { ExternalSyncEvent, HybridStorageAdapter } from '../../database/adapters/HybridStorageAdapter';
 
 export interface WorkspacesTabServices {
     app: App;
@@ -92,6 +93,70 @@ export class WorkspacesTab {
                 this.isLoading = false;
                 this.render();
             });
+        }
+
+        // Refresh the list / active detail when Obsidian Sync lands remote
+        // workspace or task JSONL changes from another device.
+        this.subscribeToExternalSync();
+    }
+
+    /**
+     * Subscribe to the HybridStorageAdapter `external-sync` event so the
+     * workspace list, active workspace detail, and projects pane stay
+     * current when remote edits arrive. Uses `services.component.registerEvent`
+     * for automatic cleanup when the tab's owning component unloads.
+     */
+    private subscribeToExternalSync(): void {
+        const component = this.services.component;
+        const serviceManager = this.services.serviceManager;
+        if (!component || !serviceManager) {
+            return;
+        }
+
+        // getServiceIfReady is sync; tolerate a not-yet-ready adapter —
+        // it just means no subscription (the tab will still reflect the
+        // initial load).
+        const adapter = serviceManager.getServiceIfReady<HybridStorageAdapter>('hybridStorageAdapter');
+        if (!adapter || typeof adapter.onExternalSync !== 'function') {
+            return;
+        }
+
+        const ref = adapter.onExternalSync((event) => {
+            void this.handleExternalSync(event);
+        });
+        component.registerEvent(ref);
+    }
+
+    /**
+     * Re-query and re-render whatever is currently visible. Specifically:
+     * - Any workspace changed → reload list and re-render current view.
+     * - Tasks for the currently-viewed workspace changed → refreshProjects.
+     */
+    private async handleExternalSync(event: ExternalSyncEvent): Promise<void> {
+        const workspaceChanges = event.modified.filter((m) => m.category === 'workspaces');
+        const taskChanges = event.modified.filter((m) => m.category === 'tasks');
+
+        if (workspaceChanges.length > 0) {
+            try {
+                await this.loadWorkspaces();
+                this.render();
+            } catch (error) {
+                console.error('[WorkspacesTab] Failed to refresh workspaces on external-sync:', error);
+            }
+        }
+
+        const currentWorkspaceId = this.currentWorkspace?.id;
+        if (
+            taskChanges.length > 0 &&
+            currentWorkspaceId &&
+            (this.currentView === 'projects' || this.currentView === 'project-detail' || this.currentView === 'task-detail') &&
+            taskChanges.some((m) => m.businessId === currentWorkspaceId)
+        ) {
+            try {
+                await this.projectsManager.refreshProjects();
+            } catch (error) {
+                console.error('[WorkspacesTab] Failed to refresh projects on external-sync:', error);
+            }
         }
     }
 

--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -57,7 +57,7 @@ import { getNexusPlugin } from '../../utils/pluginLocator';
 import { getWebLLMLifecycleManager } from '../../services/llm/adapters/webllm/WebLLMLifecycleManager';
 
 // Subagent infrastructure (delegated to SubagentController)
-import type { HybridStorageAdapter } from '../../database/adapters/HybridStorageAdapter';
+import type { HybridStorageAdapter, ExternalSyncEvent } from '../../database/adapters/HybridStorageAdapter';
 import type { ModelOption, PromptOption } from './types/SelectionTypes';
 import type { ToolEventData as ChatServiceToolEventData } from '../../services/chat/ToolCallService';
 import type { BranchViewContext } from './components/BranchHeader';
@@ -719,6 +719,67 @@ export class ChatView extends ItemView {
         }
       })
     );
+
+    // Refresh conversation list / active conversation when Obsidian Sync
+    // lands JSONL updates from another device. The adapter has already
+    // reconciled SQLite by the time this fires — we just re-query.
+    this.subscribeToExternalSync();
+  }
+
+  /**
+   * Subscribe to the HybridStorageAdapter `external-sync` event so
+   * desktop→mobile chat changes (and vice versa) appear without a
+   * manual refresh. The subscription is registered with `registerEvent`
+   * so it auto-detaches when the view unloads.
+   */
+  private subscribeToExternalSync(): void {
+    const plugin = getNexusPlugin<NexusPlugin>(this.app);
+    const adapter = plugin?.getServiceIfReady<HybridStorageAdapter>('hybridStorageAdapter') ?? null;
+    if (!adapter || typeof adapter.onExternalSync !== 'function') {
+      return;
+    }
+
+    const ref = adapter.onExternalSync((event) => {
+      void this.handleExternalSync(event);
+    });
+    this.registerEvent(ref);
+  }
+
+  /**
+   * Handle an external-sync event:
+   * - If any conversation stream changed, reload the conversation list
+   *   (a new conversation may have arrived, titles may be stale, etc.).
+   * - If the *currently-open* conversation was one of the modified
+   *   streams, re-select it to pull the new messages from SQLite.
+   *
+   * Other categories (workspaces, tasks) are handled by their own views.
+   */
+  private async handleExternalSync(event: ExternalSyncEvent): Promise<void> {
+    if (!this.conversationManager) {
+      return;
+    }
+
+    const conversationChanges = event.modified.filter((m) => m.category === 'conversations');
+    if (conversationChanges.length === 0) {
+      return;
+    }
+
+    try {
+      // Refresh list first so the sidebar reflects any new arrivals.
+      await this.conversationManager.loadConversations();
+
+      // If the user is currently viewing one of the changed conversations,
+      // re-select it so new messages show up in the main pane.
+      const current = this.conversationManager.getCurrentConversation();
+      if (current) {
+        const hitCurrent = conversationChanges.some((m) => m.businessId === current.id);
+        if (hitCurrent) {
+          await this.conversationManager.selectConversation(current);
+        }
+      }
+    } catch (error) {
+      console.error('[ChatView] Failed to apply external-sync refresh:', error);
+    }
   }
 
   /**

--- a/tests/unit/JsonlVaultWatcher.test.ts
+++ b/tests/unit/JsonlVaultWatcher.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for JsonlVaultWatcher — verifies vault-event-driven JSONL change
+ * detection, debouncing, and self-write suppression.
+ */
+
+import { TFile } from 'obsidian';
+import {
+  JsonlVaultWatcher,
+  ModifiedStream,
+  parseStreamPath
+} from '../../src/database/sync/JsonlVaultWatcher';
+
+/**
+ * Minimal Obsidian-like app stub exposing just the `vault.on()` /
+ * `vault.offref()` surface the watcher uses. Event callbacks are stored
+ * by event name so tests can fire synthetic events at will.
+ */
+type VaultEvent = 'modify' | 'create' | 'delete' | 'rename';
+type EventHandler = (...args: unknown[]) => void;
+
+function createMockApp() {
+  const handlers = new Map<VaultEvent, Set<EventHandler>>([
+    ['modify', new Set()],
+    ['create', new Set()],
+    ['delete', new Set()],
+    ['rename', new Set()]
+  ]);
+
+  const offref = jest.fn((ref: unknown) => {
+    const r = ref as { _event: VaultEvent; _fn: EventHandler };
+    handlers.get(r._event)?.delete(r._fn);
+  });
+
+  const on = jest.fn((event: VaultEvent, fn: EventHandler) => {
+    handlers.get(event)?.add(fn);
+    return { _event: event, _fn: fn };
+  });
+
+  const fire = (event: VaultEvent, ...args: unknown[]) => {
+    for (const fn of handlers.get(event) ?? []) {
+      fn(...args);
+    }
+  };
+
+  return {
+    app: {
+      vault: { on, offref }
+    },
+    fire,
+    handlers
+  };
+}
+
+function makeTFile(path: string): TFile {
+  const file = Object.create(TFile.prototype);
+  const name = path.split('/').pop() ?? path;
+  file.path = path;
+  file.name = name;
+  file.basename = name.replace(/\.[^/.]+$/, '');
+  file.extension = name.split('.').pop() ?? '';
+  return file;
+}
+
+describe('parseStreamPath', () => {
+  it('parses sharded conversation paths', () => {
+    expect(parseStreamPath('conversations/conv_abc-123/shard-000.jsonl')).toEqual({
+      category: 'conversations',
+      streamId: 'conv_abc-123',
+      businessId: 'abc-123'
+    });
+  });
+
+  it('parses flat conversation paths (legacy layout)', () => {
+    expect(parseStreamPath('conversations/conv_abc-123.jsonl')).toEqual({
+      category: 'conversations',
+      streamId: 'conv_abc-123',
+      businessId: 'abc-123'
+    });
+  });
+
+  it('parses sharded workspace paths and strips ws_ prefix', () => {
+    expect(parseStreamPath('workspaces/ws_work-1/shard-002.jsonl')).toEqual({
+      category: 'workspaces',
+      streamId: 'ws_work-1',
+      businessId: 'work-1'
+    });
+  });
+
+  it('parses task paths and strips tasks_ prefix', () => {
+    expect(parseStreamPath('tasks/tasks_work-1/shard-000.jsonl')).toEqual({
+      category: 'tasks',
+      streamId: 'tasks_work-1',
+      businessId: 'work-1'
+    });
+  });
+
+  it('returns null for unrelated paths', () => {
+    expect(parseStreamPath('conversations/_meta/storage-manifest.json')).toBeNull();
+    expect(parseStreamPath('some/other/file.jsonl')).toBeNull();
+    expect(parseStreamPath('conversations/not-a-shard.txt')).toBeNull();
+  });
+});
+
+describe('JsonlVaultWatcher', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function build(overrides: { debounceMs?: number; suppressTtlMs?: number } = {}) {
+    const onChange = jest.fn().mockResolvedValue(undefined);
+    const { app, fire } = createMockApp();
+    const watcher = new JsonlVaultWatcher({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: app as any,
+      dataPath: 'Nexus/data',
+      onChange,
+      debounceMs: overrides.debounceMs ?? 100,
+      suppressTtlMs: overrides.suppressTtlMs ?? 500
+    });
+    return { watcher, fire, onChange };
+  }
+
+  it('registers vault listeners on start and releases them on stop', () => {
+    const onChange = jest.fn();
+    const { app } = createMockApp();
+    const watcher = new JsonlVaultWatcher({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: app as any,
+      dataPath: 'Nexus/data',
+      onChange
+    });
+
+    watcher.start();
+    expect(app.vault.on).toHaveBeenCalledTimes(4);
+
+    watcher.stop();
+    expect(app.vault.offref).toHaveBeenCalledTimes(4);
+  });
+
+  it('fires onChange for a modified JSONL shard after debounce', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    expect(onChange).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const modified: ModifiedStream[] = onChange.mock.calls[0][0];
+    expect(modified).toHaveLength(1);
+    expect(modified[0]).toMatchObject({
+      category: 'conversations',
+      streamId: 'conv_abc',
+      businessId: 'abc'
+    });
+  });
+
+  it('ignores files outside the data path', async () => {
+    const { watcher, fire, onChange } = build();
+    watcher.start();
+
+    fire('modify', makeTFile('Unrelated/conv_abc/shard-000.jsonl'));
+    fire('modify', makeTFile('Daily Notes/2026-04-15.md'));
+
+    await jest.advanceTimersByTimeAsync(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-jsonl files inside the data path', async () => {
+    const { watcher, fire, onChange } = build();
+    watcher.start();
+
+    fire('modify', makeTFile('Nexus/data/_meta/storage-manifest.json'));
+
+    await jest.advanceTimersByTimeAsync(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('debounces bursts of modifies into a single onChange call', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    for (let i = 0; i < 5; i++) {
+      fire('modify', makeTFile(`Nexus/data/conversations/conv_${i}/shard-000.jsonl`));
+    }
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const modified: ModifiedStream[] = onChange.mock.calls[0][0];
+    expect(modified).toHaveLength(5);
+  });
+
+  it('deduplicates the same stream modified multiple times in one window', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    // Two writes to different shards of the same logical stream
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-001.jsonl'));
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toHaveLength(1);
+  });
+
+  it('suppresses echoes from self-writes via suppressLogicalPath', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    // Plugin is about to write — suppress imminent modify events.
+    watcher.suppressLogicalPath('conversations/conv_abc.jsonl');
+
+    // The physical shard write lands. It's suppressed; no dispatch.
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('only suppresses one event per suppressLogicalPath call', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    watcher.suppressLogicalPath('conversations/conv_abc.jsonl');
+
+    // First modify: consumed by suppression.
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    // Second modify (e.g. remote write lands right after): NOT suppressed.
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('expires suppression after TTL', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 50, suppressTtlMs: 100 });
+    watcher.start();
+
+    watcher.suppressLogicalPath('conversations/conv_abc.jsonl');
+    await jest.advanceTimersByTimeAsync(200); // past TTL
+
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    await jest.advanceTimersByTimeAsync(50);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('still fires onChange for remote streams even if another was suppressed', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 100 });
+    watcher.start();
+
+    watcher.suppressLogicalPath('conversations/conv_self.jsonl');
+    fire('modify', makeTFile('Nexus/data/conversations/conv_self/shard-000.jsonl'));
+    fire('modify', makeTFile('Nexus/data/conversations/conv_remote/shard-000.jsonl'));
+
+    await jest.advanceTimersByTimeAsync(100);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const modified: ModifiedStream[] = onChange.mock.calls[0][0];
+    expect(modified).toHaveLength(1);
+    expect(modified[0].streamId).toBe('conv_remote');
+  });
+
+  it('queues a follow-up dispatch when changes land during an ongoing onChange', async () => {
+    const onChange = jest.fn<Promise<void>, [ModifiedStream[]]>();
+    const { app, fire } = createMockApp();
+    const watcher = new JsonlVaultWatcher({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: app as any,
+      dataPath: 'Nexus/data',
+      onChange,
+      debounceMs: 50,
+      suppressTtlMs: 1000
+    });
+
+    // First onChange resolves only when we tell it to.
+    let resolveFirst: (() => void) | undefined;
+    onChange.mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveFirst = resolve; })
+    );
+    onChange.mockImplementationOnce(() => Promise.resolve());
+
+    watcher.start();
+
+    fire('modify', makeTFile('Nexus/data/conversations/conv_a/shard-000.jsonl'));
+    await jest.advanceTimersByTimeAsync(50);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // While first dispatch is in-flight, a new change lands.
+    fire('modify', makeTFile('Nexus/data/conversations/conv_b/shard-000.jsonl'));
+    await jest.advanceTimersByTimeAsync(50);
+
+    // Second dispatch shouldn't run yet — first is still pending.
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // Complete first, follow-up should dispatch.
+    resolveFirst?.();
+    await Promise.resolve();
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(50);
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+    const secondBatch = onChange.mock.calls[1][0];
+    expect(secondBatch.map((s) => s.streamId)).toEqual(['conv_b']);
+  });
+
+  it('handles rename events for both old and new paths', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 50 });
+    watcher.start();
+
+    fire(
+      'rename',
+      makeTFile('Nexus/data/conversations/conv_new/shard-000.jsonl'),
+      'Nexus/data/conversations/conv_old/shard-000.jsonl'
+    );
+
+    await jest.advanceTimersByTimeAsync(50);
+    const modified: ModifiedStream[] = onChange.mock.calls[0][0];
+    const streamIds = modified.map((m) => m.streamId).sort();
+    expect(streamIds).toEqual(['conv_new', 'conv_old']);
+  });
+
+  it('does not fire after stop()', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 50 });
+    watcher.start();
+
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    watcher.stop();
+    await jest.advanceTimersByTimeAsync(100);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('supports updating dataPath via setDataPath', async () => {
+    const { watcher, fire, onChange } = build({ debounceMs: 50 });
+    watcher.start();
+
+    watcher.setDataPath('OtherFolder/data');
+
+    // Old path no longer matches.
+    fire('modify', makeTFile('Nexus/data/conversations/conv_abc/shard-000.jsonl'));
+    await jest.advanceTimersByTimeAsync(50);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // New path matches.
+    fire('modify', makeTFile('OtherFolder/data/conversations/conv_xyz/shard-000.jsonl'));
+    await jest.advanceTimersByTimeAsync(50);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0][0].streamId).toBe('conv_xyz');
+  });
+});


### PR DESCRIPTION
Add a JsonlVaultWatcher that listens to vault.on('modify'|'create'|
'delete'|'rename') for files under the plugin data path (default
Nexus/data/). When Obsidian Sync lands a remote JSONL shard — e.g.
a chat written on desktop is pushed to mobile — the watcher debounces
(2s), triggers HybridStorageAdapter.sync() to reconcile SQLite, then
emits an 'external-sync' event carrying the modified stream set.

Self-write echoes are suppressed: JSONLWriter notifies the watcher
(via a new beforeWrite hook) immediately before each append so the
plugin's own writes don't cause pointless round-trip sync calls.

UI subscribers refresh only what they're viewing:
- ChatView reloads the conversation list on any conversation change
  and re-selects the current conversation if its id is in the
  modified set (pulling new messages from the now-updated SQLite).
- WorkspacesTab reloads the workspace list on any workspace change
  and calls refreshProjects() when tasks for the currently-viewed
  workspace arrive.

https://claude.ai/code/session_01JDm1sgpHe3PTmC6HRzm3MB