### PR TITLE
feat(llm): add Claude Opus 4.7 to model registries

### DIFF
--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
@@ -35,6 +35,22 @@ export const ANTHROPIC_CLAUDE_CODE_MODELS: ModelSpec[] = [
   },
   {
     provider: 'anthropic-claude-code',
+    name: 'Claude Opus 4.7',
+    apiName: 'claude-opus-4-7',
+    contextWindow: 200000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
     name: 'Claude Opus 4.6',
     apiName: 'claude-opus-4-6',
     contextWindow: 200000,

--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -1,6 +1,6 @@
 /**
  * Anthropic Model Specifications
- * Updated March 2026 with Claude Sonnet 4.6
+ * Updated April 2026 with Claude Opus 4.7
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -15,6 +15,43 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     maxTokens: 64000,
     inputCostPerMillion: 1.00,
     outputCostPerMillion: 5.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Claude Opus 4.7
+  {
+    provider: 'anthropic',
+    name: 'Claude Opus 4.7',
+    apiName: 'claude-opus-4-7',
+    contextWindow: 200000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Claude Opus 4.7 (1M context)
+  {
+    provider: 'anthropic',
+    name: 'Claude Opus 4.7 (1M)',
+    apiName: 'claude-opus-4-7',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    betaHeaders: ['context-1m-2025-08-07'],
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -310,6 +310,38 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   // Anthropic models via OpenRouter
   {
     provider: 'openrouter',
+    name: 'Claude Opus 4.7',
+    apiName: 'anthropic/claude-opus-4.7',
+    contextWindow: 200000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'Claude Opus 4.7 (1M)',
+    apiName: 'anthropic/claude-opus-4.7',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Claude Opus 4.6',
     apiName: 'anthropic/claude-opus-4.6',
     contextWindow: 200000,


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to Anthropic direct, OpenRouter, and Anthropic-Claude-Code model registries
- Mirrors the Opus 4.6 shape exactly ($5/$25 per M, 128K maxTokens, full capability flags)
- Adds 1M-context variants for Anthropic (with `context-1m-2025-08-07` beta header) and OpenRouter (matching existing 4.6 pattern — OpenRouter normalizes 1M server-side, no beta header needed)

## Verification (live API)
Both endpoints confirmed working with the newly-added IDs:
- **Anthropic direct** — `claude-opus-4-7` alias resolves and responds
- **OpenRouter** — `anthropic/claude-opus-4.7` returns 1M context as default; upstream model ID is `claude-4.7-opus-20260416`; pricing matches registry entry ($5/$25 per M tokens verified against response `usage.cost`)

## Test plan
- [x] `npm run build` passes clean (TypeScript)
- [x] Anthropic direct live call succeeded
- [x] OpenRouter live call succeeded; cost/context matches registry
- [ ] Reload plugin in Obsidian and confirm Opus 4.7 appears in model selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)