### PR TITLE
chore(chat): strip dead addEventListener fallbacks (invariant tightening)

### DIFF
--- a/src/ui/chat/components/BranchHeader.ts
+++ b/src/ui/chat/components/BranchHeader.ts
@@ -37,7 +37,7 @@ export class BranchHeader {
   constructor(
     private container: HTMLElement,
     private callbacks: BranchHeaderCallbacks,
-    private component?: Component
+    private component: Component
   ) {}
 
   /**
@@ -111,11 +111,7 @@ export class BranchHeader {
       this.callbacks.onNavigateToParent();
     };
 
-    if (this.component) {
-      this.component.registerDomEvent(backBtn, 'click', handleBack);
-    } else {
-      backBtn.addEventListener('click', handleBack);
-    }
+    this.component.registerDomEvent(backBtn, 'click', handleBack);
 
     // Branch info container
     const info = header.createDiv('nexus-branch-info');
@@ -152,15 +148,9 @@ export class BranchHeader {
         });
         const subagentId = metadata.subagentId;
         const onCancel = this.callbacks.onCancel;
-        if (this.component) {
-          this.component.registerDomEvent(cancelBtn, 'click', () => {
-            onCancel(subagentId);
-          });
-        } else {
-          cancelBtn.addEventListener('click', () => {
-            onCancel(subagentId);
-          });
-        }
+        this.component.registerDomEvent(cancelBtn, 'click', () => {
+          onCancel(subagentId);
+        });
       }
 
       if (metadata.state === 'max_iterations' && this.callbacks.onContinue) {
@@ -171,15 +161,9 @@ export class BranchHeader {
         });
         const branchId = this.context.branchId;
         const onContinue = this.callbacks.onContinue;
-        if (this.component) {
-          this.component.registerDomEvent(continueBtn, 'click', () => {
-            onContinue(branchId);
-          });
-        } else {
-          continueBtn.addEventListener('click', () => {
-            onContinue(branchId);
-          });
-        }
+        this.component.registerDomEvent(continueBtn, 'click', () => {
+          onContinue(branchId);
+        });
       }
     } else {
       // Human branch

--- a/src/ui/chat/components/MessageBranchNavigator.ts
+++ b/src/ui/chat/components/MessageBranchNavigator.ts
@@ -23,7 +23,7 @@ export class MessageBranchNavigator {
   constructor(
     container: HTMLElement,
     private events: MessageBranchNavigatorEvents,
-    private component?: Component
+    private component: Component
   ) {
     this.container = container;
     this.createBranchNavigator();
@@ -58,16 +58,8 @@ export class MessageBranchNavigator {
     });
     setIcon(this.nextButton, 'chevron-right');
 
-    // Event listeners
-    const prevHandler = () => this.handlePreviousAlternative();
-    const nextHandler = () => this.handleNextAlternative();
-    if (this.component) {
-      this.component.registerDomEvent(this.prevButton, 'click', prevHandler);
-      this.component.registerDomEvent(this.nextButton, 'click', nextHandler);
-    } else {
-      this.prevButton.addEventListener('click', prevHandler);
-      this.nextButton.addEventListener('click', nextHandler);
-    }
+    this.component.registerDomEvent(this.prevButton, 'click', () => this.handlePreviousAlternative());
+    this.component.registerDomEvent(this.nextButton, 'click', () => this.handleNextAlternative());
   }
 
   /**
@@ -197,12 +189,6 @@ export class MessageBranchNavigator {
     return this.container.hasClass('message-branch-navigator-visible');
   }
 
-  /**
-   * Clean up resources.
-   * Note: Event listeners registered via component.registerDomEvent() are
-   * automatically cleaned up when the Obsidian Component unloads, so no
-   * manual removeEventListener calls are needed here.
-   */
   destroy(): void {
     this.container.empty();
     this.currentMessage = null;

--- a/src/ui/chat/components/ToolInspectionModal.ts
+++ b/src/ui/chat/components/ToolInspectionModal.ts
@@ -43,15 +43,14 @@ export class ToolInspectionModal extends Modal {
   private nextCursor: string | undefined;
   private isLoading = false;
   private isDisposed = false;
-  private scrollHandler: (() => void) | null = null;
-  private readonly cleanupComponent: Component | null;
+  private readonly component: Component;
 
-  constructor(app: App, options: ToolInspectionModalOptions, component?: Component) {
+  constructor(app: App, options: ToolInspectionModalOptions, component: Component) {
     super(app);
     this.conversationId = options.conversationId;
     this.historySource = options.historySource;
     this.pageSize = options.pageSize ?? DEFAULT_PAGE_SIZE;
-    this.cleanupComponent = component ?? null;
+    this.component = component;
   }
 
   onOpen(): void {
@@ -68,16 +67,11 @@ export class ToolInspectionModal extends Modal {
     this.emptyEl = shellEl.createDiv({ cls: 'tool-inspection-empty' });
     this.loadingEl = shellEl.createDiv({ cls: 'tool-inspection-loading' });
 
-    this.scrollHandler = () => {
+    this.component.registerDomEvent(this.scrollEl, 'scroll', () => {
       if (this.scrollEl.scrollTop <= SCROLL_THRESHOLD_PX) {
         void this.loadPreviousPage();
       }
-    };
-    if (this.cleanupComponent) {
-      this.cleanupComponent.registerDomEvent(this.scrollEl, 'scroll', this.scrollHandler);
-    } else {
-      this.scrollEl.addEventListener('scroll', this.scrollHandler);
-    }
+    });
 
     this.setLoadingState(true, 'Loading tool history...');
     void this.loadInitialPages();
@@ -85,10 +79,6 @@ export class ToolInspectionModal extends Modal {
 
   onClose(): void {
     this.isDisposed = true;
-    if (this.scrollHandler && this.scrollEl && !this.cleanupComponent) {
-      this.scrollEl.removeEventListener('scroll', this.scrollHandler);
-    }
-    this.scrollHandler = null;
     this.modalEl.removeClass('tool-inspection-modal');
     this.contentEl.empty();
   }

--- a/src/ui/chat/components/helpers/MessageBubbleBranchNavigatorBinder.ts
+++ b/src/ui/chat/components/helpers/MessageBubbleBranchNavigatorBinder.ts
@@ -4,7 +4,7 @@ import { ConversationMessage } from '../../../../types/chat/ChatTypes';
 import { MessageBranchNavigator, MessageBranchNavigatorEvents } from '../MessageBranchNavigator';
 
 interface MessageBubbleBranchNavigatorBinderDependencies {
-  component?: Component;
+  component: Component;
   onMessageAlternativeChanged?: (messageId: string, alternativeIndex: number) => void;
 }
 

--- a/tests/unit/ToolInspectionModal.test.ts
+++ b/tests/unit/ToolInspectionModal.test.ts
@@ -18,7 +18,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { App, createMockElement } from 'obsidian';
+import { App, Component, createMockElement } from 'obsidian';
 import type { ChatMessage } from '../../src/types/chat/ChatTypes';
 import type { PaginatedResult } from '../../src/types/pagination/PaginationTypes';
 
@@ -75,6 +75,10 @@ function makeApp(): App {
   return new App();
 }
 
+function makeComponent(): Component {
+  return new Component();
+}
+
 describe('ToolInspectionModal — lifecycle', () => {
   it('starts with isDisposed=false after onOpen and flips to true after onClose', async () => {
     const app = makeApp();
@@ -83,7 +87,7 @@ describe('ToolInspectionModal — lifecycle', () => {
       conversationId: 'conv-1',
       historySource: history as never,
       pageSize: 10,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     // Flush the initial load microtask
@@ -104,7 +108,7 @@ describe('ToolInspectionModal — lifecycle', () => {
       conversationId: 'conv-2',
       historySource: history as never,
       pageSize: 25,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -122,7 +126,7 @@ describe('ToolInspectionModal — lifecycle', () => {
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-3',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -151,7 +155,7 @@ describe('ToolInspectionModal — initial load', () => {
       conversationId: 'conv-4',
       historySource: history as never,
       pageSize: 10,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     // Allow the awaited getToolCallMessagesForConversation to resolve
@@ -173,7 +177,7 @@ describe('ToolInspectionModal — initial load', () => {
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-5',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -191,7 +195,7 @@ describe('ToolInspectionModal — initial load', () => {
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-6',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     expect(() => modal.onOpen()).not.toThrow();
     await Promise.resolve();
@@ -227,7 +231,7 @@ describe('ToolInspectionModal — loadPreviousPage (infinite scroll up)', () => 
       conversationId: 'conv-7',
       historySource: history as never,
       pageSize: 10,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -261,7 +265,7 @@ describe('ToolInspectionModal — loadPreviousPage (infinite scroll up)', () => 
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-8',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -283,7 +287,7 @@ describe('ToolInspectionModal — loadPreviousPage (infinite scroll up)', () => 
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-9',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -314,7 +318,7 @@ describe('ToolInspectionModal — isDisposed guards on async paths', () => {
     const modal = new ToolInspectionModal(app, {
       conversationId: 'conv-disposed',
       historySource: history as never,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     // Close BEFORE the fetch resolves
@@ -357,7 +361,7 @@ describe('ToolInspectionModal — isDisposed guards on async paths', () => {
       conversationId: 'conv-dispose-2',
       historySource: history as never,
       pageSize: 10,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();
@@ -413,7 +417,7 @@ describe('ToolInspectionModal — mergeMessages de-dup + sort', () => {
       conversationId: 'conv-merge',
       historySource: history as never,
       pageSize: 10,
-    });
+    }, makeComponent());
 
     modal.onOpen();
     await Promise.resolve();


### PR DESCRIPTION
## Summary
Post-merge glass-chrome audit (PR #131 + followups) found the same "raw addEventListener fallback" dead-code pattern in three glass-chrome components. Callers always pass `component`, so the `else { addEventListener(...) }` branches never executed — but they are latent leak vectors and violate the project's "use `registerDomEvent`, never `addEventListener`" rule.

This PR ships Bundle A from the audit — invariant tightening across 3 files.

## Changes
- **`ToolInspectionModal.ts`** — `component` param required; fallback + scrollHandler field + raw `removeEventListener` teardown all removed. Folds scroll-handler consolidation (audit #20).
- **`MessageBranchNavigator.ts`** — `component` required; `else`-branch removed; stale `destroy()` comment claiming "no manual removeEventListener needed" removed.
- **`BranchHeader.ts`** — `component` required; 3 `else`-branch fallbacks removed (back/cancel/continue buttons).
- **`MessageBubbleBranchNavigatorBinder.ts`** — `deps.component` promoted from optional to required (TS propagation from MessageBranchNavigator signature change). Sole caller passes `this`.
- **`tests/unit/ToolInspectionModal.test.ts`** — `makeComponent()` factory + 12 instantiations updated.

Caller verification completed for every fallback deletion — all three components' sole call-sites (`ChatView.ts:924`, `MessageBubbleBranchNavigatorBinder.ts:33`, `ChatBranchViewCoordinator.ts:284`) pass `component`. No behavior change.

Net: **−80 / +44 lines**.

## Audit findings addressed
- Architect M3 — dead raw-`addEventListener` fallback in `ToolInspectionModal`
- Frontend M5 — `else { addEventListener }` in `MessageBranchNavigator` + `BranchHeader`
- Frontend M6 — `ToolInspectionModal` scroll handler dual registration paths
- Frontend D1 — inaccurate `MessageBranchNavigator.destroy` comment

Full audit reports: `docs/review/glass-chrome-{architect,frontend,qa,test}-review.md`.

## Test plan
- [x] `npm run build` clean (0 TS errors)
- [x] 21/21 relevant unit tests pass
- [ ] Manual smoke: open chat, open tool inspection modal, navigate branch history, observe no console noise and cleanup on view close

🤖 Generated with [Claude Code](https://claude.com/claude-code)