### PR TITLE
chore(chat): component lifecycle cleanup (Architect M1 + Frontend M2/M9)

### DIFF
--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -484,7 +484,7 @@ export class ChatView extends ItemView {
     if (!container) {
       return;
     }
-    this.layoutElements = ChatLayoutBuilder.buildLayout(container);
+    this.layoutElements = ChatLayoutBuilder.buildLayout(container, this);
   }
 
   /**

--- a/src/ui/chat/builders/ChatLayoutBuilder.ts
+++ b/src/ui/chat/builders/ChatLayoutBuilder.ts
@@ -13,7 +13,7 @@
  * following the Builder pattern for complex UI construction.
  */
 
-import { setIcon } from 'obsidian';
+import { Component, setIcon } from 'obsidian';
 
 export interface ChatLayoutElements {
   messageContainer: HTMLElement;
@@ -35,7 +35,7 @@ export class ChatLayoutBuilder {
   /**
    * Build the complete chat interface layout
    */
-  static buildLayout(container: HTMLElement): ChatLayoutElements {
+  static buildLayout(container: HTMLElement, component: Component): ChatLayoutElements {
     container.empty();
     container.addClass('chat-view-container');
 
@@ -44,7 +44,7 @@ export class ChatLayoutBuilder {
     const mainContainer = chatLayout.createDiv('chat-main');
 
     // Experimental warning banner
-    this.createWarningBanner(mainContainer);
+    this.createWarningBanner(mainContainer, component);
 
     // Header
     const { chatTitle, hamburgerButton, settingsButton } = this.createHeader(mainContainer);
@@ -127,7 +127,7 @@ export class ChatLayoutBuilder {
   /**
    * Create experimental warning banner with auto-hide
    */
-  private static createWarningBanner(container: HTMLElement): void {
+  private static createWarningBanner(container: HTMLElement, component: Component): void {
     const warningBanner = container.createDiv('chat-experimental-warning');
 
     warningBanner.createEl('span', { cls: 'warning-icon', text: '⚠️' });
@@ -161,6 +161,7 @@ export class ChatLayoutBuilder {
     if (warningBanner.parentElement) {
       observer.observe(warningBanner.parentElement, { childList: true });
     }
+    component.register(() => observer.disconnect());
   }
 
   /**

--- a/src/ui/chat/components/MessageBubble.ts
+++ b/src/ui/chat/components/MessageBubble.ts
@@ -50,8 +50,6 @@ export class MessageBubble extends Component {
       component: this,
       getMessage: () => this.message,
       getElement: () => this.element,
-      getToolBubbleElement: () => null,
-      getTextBubbleElement: () => this.textBubbleElement,
       getImageBubbleElement: () => this.imageBubbleElement,
       setImageBubbleElement: (element) => {
         this.imageBubbleElement = element;

--- a/src/ui/chat/components/MessageBubble.ts
+++ b/src/ui/chat/components/MessageBubble.ts
@@ -443,6 +443,7 @@ export class MessageBubble extends Component {
 
     const loader = new ThinkingLoader();
     this.thinkingLoader = loader;
+    this.addChild(loader);
     loader.start(container);
   }
 

--- a/src/ui/chat/components/helpers/MessageBubbleImageRenderer.ts
+++ b/src/ui/chat/components/helpers/MessageBubbleImageRenderer.ts
@@ -7,8 +7,6 @@ interface MessageBubbleImageRendererDependencies {
   component: Component;
   getMessage: () => ConversationMessage;
   getElement: () => HTMLElement | null;
-  getToolBubbleElement: () => HTMLElement | null;
-  getTextBubbleElement: () => HTMLElement | null;
   getImageBubbleElement: () => HTMLElement | null;
   setImageBubbleElement: (element: HTMLElement | null) => void;
 }
@@ -54,16 +52,7 @@ export class MessageBubbleImageRenderer {
       return;
     }
 
-    const toolBubbleElement = this.deps.getToolBubbleElement();
-    const textBubbleElement = this.deps.getTextBubbleElement();
-
-    if (toolBubbleElement && textBubbleElement) {
-      hostElement.insertBefore(imageBubble, textBubbleElement);
-    } else if (toolBubbleElement) {
-      hostElement.appendChild(imageBubble);
-    } else {
-      hostElement.appendChild(imageBubble);
-    }
+    hostElement.appendChild(imageBubble);
 
     this.deps.setImageBubbleElement(imageBubble);
   }


### PR DESCRIPTION
## Summary
Bundle "Wave 4" from the glass-chrome audit (PR #131 + followups). Three pure-TS component-lifecycle fixes.

## Changes

### Architect M1 — delete vestigial `getToolBubbleElement` dep (commit `ac83cbbb`)
- `MessageBubble.ts:53` wired `getToolBubbleElement: () => null`; two unreachable branches at `MessageBubbleImageRenderer.ts:57-66` were residue from the pre-glass tool-bubble layout.
- Removes the dep + unreachable branches; collapses the `if/else-if` to an unconditional `hostElement.appendChild(imageBubble)`.
- Adjacent dead interface field `getTextBubbleElement` (only read inside the removed branch) also removed — same dead-code cluster.

### Frontend M2 + M9 — component-lifecycle cleanup (commit `1959321e`)
- **M9: `ThinkingLoader`** extends `Component` but was manually `new`'d without being plugged into the parent tree. Added `this.addChild(loader)` in `MessageBubble.startThinkingLoader` so `onunload` fires on parent teardown (and the loader's `registerInterval` cleanups run).
- **M2: `ChatLayoutBuilder.createWarningBanner`** only disconnected its MutationObserver on banner-removal. Added a `component: Component` parameter to `buildLayout` + `createWarningBanner`, and wired `component.register(() => observer.disconnect())` as an additional safety net (idempotent — existing banner-removal disconnect path remains). `ChatView.ts` updated to pass `this` to `buildLayout`.

## Audit findings addressed
- Architect M1 — vestigial `getToolBubbleElement` dep
- Frontend M2 — MutationObserver cleanup
- Frontend M9 — `ThinkingLoader` lifecycle

## Notes
Net: **−19 / +8 lines**, 4 files. No whitespace churn.

## Test plan
- [x] `npm run build` clean
- [x] 14/14 relevant unit tests pass
- [ ] Manual smoke: trigger thinking loader, trigger warning banner, observe no console noise and cleanup on view teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)