### PR TITLE
refactor(ui): extract ManagedTimeoutTracker + tighten Component-param contracts

### DIFF
--- a/src/ui/chat/components/AgentStatusMenu.ts
+++ b/src/ui/chat/components/AgentStatusMenu.ts
@@ -11,6 +11,7 @@
  */
 
 import { setIcon, Component, Events } from 'obsidian';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 import type { SubagentExecutor } from '../../../services/chat/SubagentExecutor';
 import type { SubagentExecutorEvents } from '../../../types/branch/BranchTypes';
 
@@ -74,16 +75,17 @@ export class AgentStatusMenu {
   private eventRef: ReturnType<Events['on']> | null = null;
   private hasShownSuccess = false; // Track if green state was shown
   private isShowingSpinner = false; // Track current icon state
-  private manualClickHandler: (() => void) | null = null;
-  private manualClickTarget: HTMLElement | null = null;
+  private timeouts: ManagedTimeoutTracker;
 
   constructor(
     private container: HTMLElement,
     private subagentExecutor: SubagentExecutor | null,
     private callbacks: AgentStatusMenuCallbacks,
-    private component?: Component,
+    private component: Component,
     private insertBefore?: HTMLElement // Insert before this element (e.g., settings button)
-  ) {}
+  ) {
+    this.timeouts = new ManagedTimeoutTracker(component);
+  }
 
   /**
    * Create and render the status menu button
@@ -110,17 +112,10 @@ export class AgentStatusMenu {
     this.badgeEl = badge;
 
     // Click handler - clears success state when modal opens
-    const clickHandler = () => {
+    this.component.registerDomEvent(button, 'click', () => {
       this.clearSuccessState();
       this.callbacks.onOpenModal();
-    };
-    if (this.component) {
-      this.component.registerDomEvent(button, 'click', clickHandler);
-    } else {
-      this.manualClickHandler = clickHandler;
-      this.manualClickTarget = button;
-      button.addEventListener('click', clickHandler);
-    }
+    });
 
     this.element = button;
 
@@ -236,26 +231,16 @@ export class AgentStatusMenu {
     if (!this.element) return;
 
     this.element.addClass('nexus-agent-completion-pulse');
-    setTimeout(() => {
-      this.element?.removeClass('nexus-agent-completion-pulse');
-    }, 1000);
+    this.timeouts.setTimeout(() => this.element?.removeClass('nexus-agent-completion-pulse'), 1000);
   }
 
   /**
    * Cleanup
    */
   cleanup(): void {
-    // Unsubscribe from events
     if (this.eventRef) {
       getSubagentEventBus().offref(this.eventRef);
       this.eventRef = null;
-    }
-
-    // Remove manually attached click handler if component was not provided
-    if (this.manualClickHandler && this.manualClickTarget) {
-      this.manualClickTarget.removeEventListener('click', this.manualClickHandler);
-      this.manualClickHandler = null;
-      this.manualClickTarget = null;
     }
 
     this.element?.remove();

--- a/src/ui/chat/components/ChatInput.ts
+++ b/src/ui/chat/components/ChatInput.ts
@@ -12,6 +12,7 @@ import { MessageEnhancement } from './suggesters/base/SuggesterInterfaces';
 import { MessageEnhancer } from '../services/MessageEnhancer';
 import { isMobile, isIOS } from '../../../utils/platform';
 import { ChatVoiceInputController, ChatVoiceInputState } from '../controllers/ChatVoiceInputController';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 
 export class ChatInput {
   private element: HTMLElement | null = null;
@@ -33,6 +34,7 @@ export class ChatInput {
   private nativeKeyboardOffset = 0;
   private keyboardViewportBaselineHeight = 0;
   private keyboardEditorHeight = 0;
+  private timeouts: ManagedTimeoutTracker | null = null;
 
   constructor(
     private container: HTMLElement,
@@ -47,6 +49,9 @@ export class ChatInput {
     private getHasConversation?: () => boolean,
     private component?: Component
   ) {
+    if (component) {
+      this.timeouts = new ManagedTimeoutTracker(component);
+    }
     this.render();
   }
 
@@ -128,10 +133,15 @@ export class ChatInput {
 
     // iOS: keep the focused input visible while the keyboard animates.
     const focusHandler = () => {
-      setTimeout(() => {
+      const run = () => {
         this.updateKeyboardViewportOffset();
         this.inputElement?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      }, 300);
+      };
+      if (this.timeouts) {
+        this.timeouts.setTimeout(run, 300);
+      } else {
+        setTimeout(run, 300);
+      }
     };
 
     // Register events with component for auto-cleanup

--- a/src/ui/chat/components/toolStatusLine.ts
+++ b/src/ui/chat/components/toolStatusLine.ts
@@ -1,4 +1,5 @@
 import type { Component } from 'obsidian';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 
 export interface ToolStatusEntry {
   text: string;
@@ -10,12 +11,10 @@ export class ToolStatusLine {
   private lastUpdate = 0;
   private queuedEntry: ToolStatusEntry | null = null;
   private pendingTimeout: ReturnType<typeof setTimeout> | null = null;
-  private animationTimeouts = new Set<ReturnType<typeof setTimeout>>();
+  private timeouts: ManagedTimeoutTracker;
 
   constructor(private readonly slot: HTMLElement, component: Component) {
-    // Ensure Obsidian Component teardown cancels every pending timeout,
-    // even if the caller forgets to invoke clear() explicitly.
-    component.register(() => this.clear());
+    this.timeouts = new ManagedTimeoutTracker(component);
   }
 
   public update(text: string, state: ToolStatusEntry['state']): void {
@@ -25,7 +24,7 @@ export class ToolStatusLine {
     if (this.lastUpdate !== 0 && elapsed < 400) {
       this.queuedEntry = entry;
       if (!this.pendingTimeout) {
-        this.pendingTimeout = setTimeout(() => {
+        this.pendingTimeout = this.timeouts.setTimeout(() => {
           this.pendingTimeout = null;
           if (this.queuedEntry) {
             const queued = this.queuedEntry;
@@ -41,14 +40,8 @@ export class ToolStatusLine {
   }
 
   public clear(): void {
-    if (this.pendingTimeout) {
-      clearTimeout(this.pendingTimeout);
-      this.pendingTimeout = null;
-    }
-    for (const id of this.animationTimeouts) {
-      clearTimeout(id);
-    }
-    this.animationTimeouts.clear();
+    this.pendingTimeout = null;
+    this.timeouts.clear();
     this.queuedEntry = null;
     this.lastUpdate = 0;
     if (this.currentSlot) {
@@ -57,21 +50,13 @@ export class ToolStatusLine {
     }
   }
 
-  private trackAnimationTimeout(fn: () => void, ms: number): void {
-    const id = setTimeout(() => {
-      this.animationTimeouts.delete(id);
-      fn();
-    }, ms);
-    this.animationTimeouts.add(id);
-  }
-
   private forceUpdate(entry: ToolStatusEntry): void {
     this.lastUpdate = Date.now();
 
     if (this.currentSlot) {
       const oldSlot = this.currentSlot;
       oldSlot.classList.add('exiting');
-      this.trackAnimationTimeout(() => oldSlot.remove(), 200);
+      this.timeouts.setTimeout(() => oldSlot.remove(), 200);
     }
 
     const nextSlot = this.slot.createEl('div', {
@@ -80,7 +65,7 @@ export class ToolStatusLine {
     });
 
     this.currentSlot = nextSlot;
-    this.trackAnimationTimeout(() => {
+    this.timeouts.setTimeout(() => {
       nextSlot.removeClass('entering');
       nextSlot.addClass('active');
     }, 100);

--- a/src/ui/chat/controllers/NexusLoadingController.ts
+++ b/src/ui/chat/controllers/NexusLoadingController.ts
@@ -7,15 +7,18 @@
  */
 
 import { Component } from 'obsidian';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 
 /**
  * Controller for Nexus/WebLLM and database loading overlays
  */
 export class NexusLoadingController extends Component {
   private overlayEl: HTMLElement | null = null;
+  private timeouts: ManagedTimeoutTracker;
 
   constructor(private containerEl: HTMLElement) {
     super();
+    this.timeouts = new ManagedTimeoutTracker(this);
     this.findOverlayElement();
   }
 
@@ -74,8 +77,7 @@ export class NexusLoadingController extends Component {
 
     this.overlayEl.removeClass('is-visible');
 
-    // Wait for transition then hide
-    setTimeout(() => {
+    this.timeouts.setTimeout(() => {
       const overlayEl = this.overlayEl;
       if (!overlayEl) return;
 
@@ -140,7 +142,7 @@ export class NexusLoadingController extends Component {
     if (!this.overlayEl) return;
 
     this.overlayEl.removeClass('is-visible');
-    setTimeout(() => {
+    this.timeouts.setTimeout(() => {
       const overlayEl = this.overlayEl;
       if (!overlayEl) return;
 

--- a/src/ui/chat/controllers/UIStateController.ts
+++ b/src/ui/chat/controllers/UIStateController.ts
@@ -3,6 +3,7 @@
  */
 
 import { setIcon, Component } from 'obsidian';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 
 export interface UIStateControllerEvents {
   onSidebarToggled: (visible: boolean) => void;
@@ -11,21 +12,18 @@ export interface UIStateControllerEvents {
 export class UIStateController {
   private sidebarVisible = false;
   private onOpenSettings?: () => void;
-  private manualListeners: Array<{ element: HTMLElement; handler: () => void }> = [];
+  private timeouts: ManagedTimeoutTracker;
 
   constructor(
     private containerEl: HTMLElement,
     private events: UIStateControllerEvents,
-    private component?: Component
-  ) {}
+    private component: Component
+  ) {
+    this.timeouts = new ManagedTimeoutTracker(component);
+  }
 
   private registerClickHandler(element: HTMLElement, handler: () => void): void {
-    if (this.component) {
-      this.component.registerDomEvent(element, 'click', handler);
-    } else {
-      this.manualListeners.push({ element, handler });
-      element.addEventListener('click', handler);
-    }
+    this.component.registerDomEvent(element, 'click', handler);
   }
 
   /**
@@ -158,10 +156,7 @@ export class UIStateController {
       const errorEl = container.createDiv('chat-error');
       errorEl.textContent = message;
       
-      // Auto-remove after 5 seconds
-      setTimeout(() => {
-        errorEl.remove();
-      }, 5000);
+      this.timeouts.setTimeout(() => errorEl.remove(), 5000);
     }
   }
 
@@ -208,13 +203,7 @@ export class UIStateController {
     }
   }
 
-  /**
-   * Clean up event listeners
-   */
   cleanup(): void {
-    for (const { element, handler } of this.manualListeners) {
-      element.removeEventListener('click', handler);
-    }
-    this.manualListeners = [];
+    // Event listeners are cleaned up via component.registerDomEvent on Component teardown.
   }
 }

--- a/src/ui/chat/utils/ManagedTimeoutTracker.ts
+++ b/src/ui/chat/utils/ManagedTimeoutTracker.ts
@@ -1,0 +1,27 @@
+import type { Component } from 'obsidian';
+
+export class ManagedTimeoutTracker {
+  private ids = new Set<ReturnType<typeof setTimeout>>();
+
+  constructor(component: Component) {
+    // Ensure Component teardown cancels all pending timeouts automatically,
+    // even if the caller forgets to invoke clear() explicitly.
+    component.register(() => this.clear());
+  }
+
+  setTimeout(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+    const id = setTimeout(() => {
+      this.ids.delete(id);
+      callback();
+    }, delayMs);
+    this.ids.add(id);
+    return id;
+  }
+
+  clear(): void {
+    for (const id of this.ids) {
+      clearTimeout(id);
+    }
+    this.ids.clear();
+  }
+}

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-04-15T11:40:44.131Z
+ * Generated: 2026-04-17T00:01:44.620Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/unit/ManagedTimeoutTracker.test.ts
+++ b/tests/unit/ManagedTimeoutTracker.test.ts
@@ -1,0 +1,106 @@
+import { Component } from 'obsidian';
+import { ManagedTimeoutTracker } from '../../src/ui/chat/utils/ManagedTimeoutTracker';
+
+describe('ManagedTimeoutTracker', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('setTimeout', () => {
+    it('returns the same id that platform setTimeout would return', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb = jest.fn();
+      const id = tracker.setTimeout(cb, 100);
+      // The id must be truthy and clearTimeout-compatible (number in browsers, Timeout object in Node/Jest)
+      expect(id).toBeTruthy();
+      expect(() => clearTimeout(id)).not.toThrow();
+    });
+
+    it('executes callback after delay', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb = jest.fn();
+      tracker.setTimeout(cb, 500);
+      expect(cb).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(500);
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('tracks multiple ids independently', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      tracker.setTimeout(cb1, 100);
+      tracker.setTimeout(cb2, 200);
+      jest.advanceTimersByTime(100);
+      expect(cb1).toHaveBeenCalledTimes(1);
+      expect(cb2).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(100);
+      expect(cb2).toHaveBeenCalledTimes(1);
+    });
+
+    it('self-removes id from set after firing so set does not grow unboundedly', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb = jest.fn();
+      tracker.setTimeout(cb, 50);
+      jest.advanceTimersByTime(50);
+      // After firing, clear() should be a no-op (no pending ids)
+      expect(() => tracker.clear()).not.toThrow();
+    });
+  });
+
+  describe('clear', () => {
+    it('cancels all pending timeouts', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb1 = jest.fn();
+      const cb2 = jest.fn();
+      tracker.setTimeout(cb1, 100);
+      tracker.setTimeout(cb2, 200);
+      tracker.clear();
+      jest.runAllTimers();
+      expect(cb1).not.toHaveBeenCalled();
+      expect(cb2).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — calling clear twice does not throw', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      tracker.setTimeout(jest.fn(), 100);
+      tracker.clear();
+      expect(() => tracker.clear()).not.toThrow();
+    });
+
+    it('is idempotent on empty tracker', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      expect(() => tracker.clear()).not.toThrow();
+    });
+  });
+
+  describe('Component lifecycle integration', () => {
+    it('registers a cleanup callback via component.register', () => {
+      const component = new Component();
+      const spy = jest.spyOn(component, 'register');
+      new ManagedTimeoutTracker(component);
+      expect(spy).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('Component unload triggers clear — cancels pending timeouts', () => {
+      const component = new Component();
+      const tracker = new ManagedTimeoutTracker(component);
+      const cb = jest.fn();
+      tracker.setTimeout(cb, 500);
+      component.unload();
+      jest.runAllTimers();
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Wave 2 of the glass-chrome audit remediation. Extracts the Set-based setTimeout-tracking pattern originally introduced in commit `8d881e6d` (plug setTimeout leaks in ToolStatusLine) into a shared helper, then migrates all 5 sites that had the same fire-and-forget pattern. Second commit promotes two component params from optional to required as a natural consistency cleanup.

## Changes

### Commit 1 (`56e1faf1`) — extract + migrate (Frontend M1/M3/M4/M7 + the original 8d881e6d site)
- **New**: `src/ui/chat/utils/ManagedTimeoutTracker.ts` — accepts `Component` in ctor; tracks timeout IDs in a `Set`; `setTimeout()` returns platform id; `clear()` cancels all pending; auto-registers `clear` via `component.register()` so Component teardown fires it automatically. No `clearOne` (unused at every call site). No `setInterval` support (no call site uses intervals).
- **New**: `tests/unit/ManagedTimeoutTracker.test.ts` — 9 tests. Fake timers; covers multiple ids, clear idempotency, Component unload firing clear, platform id return.
- **Migrated 5 sites**:
  - `src/ui/chat/components/toolStatusLine.ts` (original inline `8d881e6d` implementation — replaced with helper call)
  - `src/ui/chat/controllers/NexusLoadingController.ts` (uses `this` as Component — class already extends Component)
  - `src/ui/chat/components/AgentStatusMenu.ts` (optional `component` kept — see commit 2)
  - `src/ui/chat/controllers/UIStateController.ts` (optional `component` kept — see commit 2)
  - `src/ui/chat/components/ChatInput.ts` — **focus handler setTimeout only**; keyboard-viewport cascade intentionally untouched (scope of pending task #17, separate PR)

### Commit 2 (`a57b7e8c`) — promote Component params (Architect-adjacent cleanup)
- `AgentStatusMenu` and `UIStateController` had `component?: Component` (optional). Both have exactly one call site; both callers always pass component. Promoted the params to required, removed null-tracker conditionals, bare-setTimeout fallbacks, dead `manualClickHandler` fields, and manual `removeEventListener` cleanup in both classes.
- Matches the invariant-tightening already shipped in PR #145 for the branch components.

## Audit findings addressed
- Frontend M1 — `NexusLoadingController` untracked setTimeouts
- Frontend M3 — `AgentStatusMenu.showCompletionPulse` unbounded setTimeout
- Frontend M4 — `UIStateController.showError` untracked setTimeout
- Frontend M7 — `ChatInput.focusHandler` raw setTimeout
- + DRY upgrade on the original 8d881e6d site

## Notes
**Whitespace hygiene**: `ChatInput.ts` and `NexusLoadingController.ts` in this repo have mixed CRLF+LF line endings; the Edit tool's LF-normalization produced ~1200 lines of whitespace churn on first attempt. Fixed via byte-level Python patch that preserves exact line endings. `git diff --stat` now matches `git diff -w --stat` to within 2 lines (the 2-line residual is pre-existing CRLF noise in `toolStatusLine.ts` and `UIStateController.ts`, not introduced by this PR — confirmed against `6a5944c5`).

Net: **+175 / −71 lines (functional)**, 8 files.

## Test plan
- [x] `npm run build` clean
- [x] `npm run test` — 9/9 ManagedTimeoutTracker tests pass; no new failures (1 pre-existing `ModelAgentManager.test.ts:242` failure unrelated)
- [ ] Manual smoke: trigger `NexusLoadingController` overlays, `AgentStatusMenu` completion pulse, `UIStateController.showError` timeout dismiss — confirm cleanup on view teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)