### PR TITLE
refactor(chat): extract ChatKeyboardViewportController + rAF-throttle scroll handler (Wave 5)

### DIFF
--- a/src/ui/chat/components/ChatInput.ts
+++ b/src/ui/chat/components/ChatInput.ts
@@ -13,6 +13,7 @@ import { MessageEnhancer } from '../services/MessageEnhancer';
 import { isMobile, isIOS } from '../../../utils/platform';
 import { ChatVoiceInputController, ChatVoiceInputState } from '../controllers/ChatVoiceInputController';
 import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
+import { ChatKeyboardViewportController } from '../controllers/ChatKeyboardViewportController';
 
 export class ChatInput {
   private element: HTMLElement | null = null;
@@ -27,14 +28,8 @@ export class ChatInput {
   private voiceInputState: ChatVoiceInputState = 'idle';
   private voiceInputController: ChatVoiceInputController | null = null;
   private voiceVisualResizeObserver: ResizeObserver | null = null;
-  private keyboardViewportRoot: HTMLElement | null = null;
-  private keyboardViewportFrame: number | null = null;
-  private keyboardViewportCleanup: (() => void) | null = null;
-  private keyboardViewportTimers: number[] = [];
-  private nativeKeyboardOffset = 0;
-  private keyboardViewportBaselineHeight = 0;
-  private keyboardEditorHeight = 0;
   private timeouts: ManagedTimeoutTracker | null = null;
+  private keyboardViewportController: ChatKeyboardViewportController | null = null;
 
   constructor(
     private container: HTMLElement,
@@ -132,9 +127,10 @@ export class ChatInput {
     };
 
     // iOS: keep the focused input visible while the keyboard animates.
+    // The controller's own focus handler schedules settling probes at
+    // 0/60/180/320ms so we only need to scroll the input into view here.
     const focusHandler = () => {
       const run = () => {
-        this.updateKeyboardViewportOffset();
         this.inputElement?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       };
       if (this.timeouts) {
@@ -278,13 +274,14 @@ export class ChatInput {
     this.inputElement.style.removeProperty('--chat-input-height');
 
     // Set height limits - matches CSS min/max heights
-    const keyboardActive = isMobile() && this.keyboardViewportRoot?.hasClass('chat-keyboard-active');
+    const keyboardActive = isMobile() && (this.keyboardViewportController?.isActive() ?? false);
+    const keyboardEditorHeight = this.keyboardViewportController?.getEditorHeight() ?? 0;
     const visualHeight = window.visualViewport?.height ?? window.innerHeight;
-    const keyboardMinHeight = this.keyboardEditorHeight > 0
-      ? this.keyboardEditorHeight
+    const keyboardMinHeight = keyboardEditorHeight > 0
+      ? keyboardEditorHeight
       : Math.min(280, Math.max(185, Math.round(visualHeight * 0.42)));
-    const keyboardMaxHeight = this.keyboardEditorHeight > 0
-      ? this.keyboardEditorHeight
+    const keyboardMaxHeight = keyboardEditorHeight > 0
+      ? keyboardEditorHeight
       : Math.min(320, Math.max(235, Math.round(visualHeight * 0.54)));
     const minHeight = keyboardActive ? keyboardMinHeight : isMobile() ? 64 : 72;
     const maxHeight = keyboardActive ? keyboardMaxHeight : isMobile() ? 160 : 200;
@@ -467,16 +464,8 @@ export class ChatInput {
    * Cleanup resources
    */
   cleanup(): void {
-    if (this.keyboardViewportFrame !== null && typeof window !== 'undefined') {
-      window.cancelAnimationFrame(this.keyboardViewportFrame);
-      this.keyboardViewportFrame = null;
-    }
-
-    this.clearKeyboardViewportTimers();
-    this.keyboardViewportCleanup?.();
-    this.keyboardViewportCleanup = null;
-    this.nativeKeyboardOffset = 0;
-    this.resetKeyboardViewportOffset();
+    this.keyboardViewportController?.detach();
+    this.keyboardViewportController = null;
     this.voiceVisualResizeObserver?.disconnect();
     this.voiceVisualResizeObserver = null;
     this.voiceInputController?.cleanup();
@@ -495,213 +484,19 @@ export class ChatInput {
   }
 
   private initializeKeyboardViewportHandling(): void {
-    if (!this.component || typeof window === 'undefined') {
+    if (!this.component || !this.inputElement) {
       return;
     }
 
-    this.keyboardViewportCleanup?.();
-    this.keyboardViewportRoot = this.container.closest('.chat-main');
-    this.keyboardViewportBaselineHeight = window.innerHeight;
-    if (!this.keyboardViewportRoot) {
-      return;
-    }
-
-    const scheduleUpdate = () => this.scheduleKeyboardViewportOffsetUpdate();
-    const scheduleSettledUpdates = () => this.scheduleKeyboardViewportSettledUpdates();
-    const handleNativeKeyboardShow = (event: CapacitorKeyboardEvent) => {
-      this.updateNativeKeyboardOffset(event);
-      this.scheduleKeyboardViewportSettledUpdates();
-    };
-    const handleNativeKeyboardHide = () => {
-      this.nativeKeyboardOffset = 0;
-      this.clearKeyboardViewportTimers();
-      window.setTimeout(() => {
-        this.keyboardViewportBaselineHeight = window.innerHeight;
-        this.resetKeyboardViewportOffset();
-      }, 160);
-    };
-    const clearOffset = () => {
-      window.setTimeout(() => {
-        if (!this.inputElement?.matches(':focus')) {
-          if (this.sendButton && document.activeElement === this.sendButton) {
-            this.sendButton.blur();
-          }
-          this.nativeKeyboardOffset = 0;
-          this.keyboardViewportBaselineHeight = window.innerHeight;
-          this.resetKeyboardViewportOffset();
-        }
-      }, 120);
-    };
-
-    window.visualViewport?.addEventListener('resize', scheduleSettledUpdates);
-    window.visualViewport?.addEventListener('scroll', scheduleUpdate);
-
-    const cleanup = () => {
-      window.visualViewport?.removeEventListener('resize', scheduleSettledUpdates);
-      window.visualViewport?.removeEventListener('scroll', scheduleUpdate);
-      this.clearKeyboardViewportTimers();
-      this.resetKeyboardViewportOffset();
-    };
-    this.keyboardViewportCleanup = cleanup;
-    this.component.register(cleanup);
-
-    this.component.registerDomEvent(this.inputElement as HTMLElement, 'focus', scheduleSettledUpdates);
-    this.component.registerDomEvent(this.inputElement as HTMLElement, 'blur', clearOffset);
-    this.component.registerDomEvent(window, 'resize', scheduleSettledUpdates);
-    this.component.registerDomEvent(window, 'orientationchange', scheduleSettledUpdates);
-    this.component.registerDomEvent(window, 'keyboardWillShow', handleNativeKeyboardShow);
-    this.component.registerDomEvent(window, 'keyboardDidShow', handleNativeKeyboardShow);
-    this.component.registerDomEvent(window, 'keyboardWillHide', handleNativeKeyboardHide);
-    this.component.registerDomEvent(window, 'keyboardDidHide', handleNativeKeyboardHide);
-    this.updateKeyboardViewportOffset();
-  }
-
-  private scheduleKeyboardViewportSettledUpdates(): void {
-    this.clearKeyboardViewportTimers();
-    this.scheduleKeyboardViewportOffsetUpdate();
-
-    for (const delay of [60, 180, 320]) {
-      const timer = window.setTimeout(() => {
-        this.keyboardViewportTimers = this.keyboardViewportTimers.filter((timerId) => timerId !== timer);
-        this.scheduleKeyboardViewportOffsetUpdate();
-      }, delay);
-      this.keyboardViewportTimers.push(timer);
-    }
-  }
-
-  private scheduleKeyboardViewportOffsetUpdate(): void {
-    if (this.keyboardViewportFrame !== null) {
-      window.cancelAnimationFrame(this.keyboardViewportFrame);
-    }
-
-    this.keyboardViewportFrame = window.requestAnimationFrame(() => {
-      this.keyboardViewportFrame = null;
-      this.updateKeyboardViewportOffset();
+    this.keyboardViewportController?.detach();
+    this.keyboardViewportController = new ChatKeyboardViewportController({
+      container: this.container,
+      inputElement: this.inputElement,
+      getSendButton: () => this.sendButton,
+      onOffsetChanged: () => this.autoResizeInput(),
+      component: this.component,
     });
-  }
-
-  private updateKeyboardViewportOffset(): void {
-    if (!this.keyboardViewportRoot || typeof window === 'undefined') {
-      return;
-    }
-
-    const currentOffset = this.getCurrentKeyboardOffset();
-    const inputBottom = this.container.getBoundingClientRect().bottom + currentOffset;
-    const keyboardTop = this.getKeyboardTop();
-    const visualViewportOffset = keyboardTop !== null
-      ? Math.max(0, inputBottom - keyboardTop)
-      : 0;
-    const keyboardOffset = visualViewportOffset > 1 ? visualViewportOffset : this.nativeKeyboardOffset;
-    const roundedOffset = Math.ceil(keyboardOffset);
-
-    if (roundedOffset > 1) {
-      this.keyboardViewportRoot.addClass('chat-keyboard-active');
-      const liftOffset = Math.max(0, roundedOffset - 22);
-      this.keyboardViewportRoot.style.setProperty('--chat-keyboard-offset', `${liftOffset}px`);
-      this.updateKeyboardEditorHeight(keyboardTop);
-      this.autoResizeInput();
-    } else {
-      this.resetKeyboardViewportOffset();
-    }
-  }
-
-  private resetKeyboardViewportOffset(): void {
-    this.keyboardViewportRoot?.removeClass('chat-keyboard-active');
-    this.keyboardViewportRoot?.style.removeProperty('--chat-keyboard-offset');
-    this.keyboardViewportRoot?.style.removeProperty('--chat-keyboard-editor-height');
-    this.keyboardEditorHeight = 0;
-    this.autoResizeInput();
-  }
-
-  private updateNativeKeyboardOffset(event: CapacitorKeyboardEvent): void {
-    const keyboardHeight = this.getKeyboardHeight(event);
-    if (keyboardHeight <= 0 || typeof window === 'undefined') {
-      this.nativeKeyboardOffset = 0;
-      return;
-    }
-
-    if (this.keyboardViewportBaselineHeight <= 0) {
-      this.keyboardViewportBaselineHeight = window.innerHeight;
-    }
-
-    const layoutResizeAmount = Math.max(0, this.keyboardViewportBaselineHeight - window.innerHeight);
-    this.nativeKeyboardOffset = Math.max(0, keyboardHeight - layoutResizeAmount);
-  }
-
-  private getKeyboardHeight(event: CapacitorKeyboardEvent): number {
-    const directHeight = event.keyboardHeight;
-    if (typeof directHeight === 'number' && Number.isFinite(directHeight)) {
-      return Math.round(directHeight);
-    }
-
-    const detailHeight = event.detail?.keyboardHeight;
-    if (typeof detailHeight === 'number' && Number.isFinite(detailHeight)) {
-      return Math.round(detailHeight);
-    }
-
-    return 0;
-  }
-
-  private clearKeyboardViewportTimers(): void {
-    if (typeof window === 'undefined') {
-      this.keyboardViewportTimers = [];
-      return;
-    }
-
-    for (const timer of this.keyboardViewportTimers) {
-      window.clearTimeout(timer);
-    }
-    this.keyboardViewportTimers = [];
-  }
-
-  private getCurrentKeyboardOffset(): number {
-    if (!this.keyboardViewportRoot) {
-      return 0;
-    }
-
-    const rawOffset = window.getComputedStyle(this.keyboardViewportRoot).getPropertyValue('--chat-keyboard-offset');
-    const parsedOffset = Number.parseFloat(rawOffset);
-    return Number.isFinite(parsedOffset) ? parsedOffset : 0;
-  }
-
-  private getKeyboardTop(): number | null {
-    if (!this.keyboardViewportRoot || typeof window === 'undefined') {
-      return null;
-    }
-
-    if (window.visualViewport) {
-      return window.visualViewport.height + window.visualViewport.offsetTop;
-    }
-
-    if (this.nativeKeyboardOffset > 0) {
-      return this.keyboardViewportRoot.getBoundingClientRect().bottom - this.nativeKeyboardOffset;
-    }
-
-    return null;
-  }
-
-  private updateKeyboardEditorHeight(keyboardTop: number | null): void {
-    if (!this.keyboardViewportRoot || keyboardTop === null) {
-      this.keyboardEditorHeight = 0;
-      this.keyboardViewportRoot?.style.removeProperty('--chat-keyboard-editor-height');
-      return;
-    }
-
-    const header = this.keyboardViewportRoot.querySelector('.chat-header');
-    const branchHeaderContainer = this.keyboardViewportRoot.querySelector('.nexus-branch-header-container');
-    const statusBarContainer = this.keyboardViewportRoot.querySelector('.tool-status-bar-container');
-
-    const headerBottom = header?.getBoundingClientRect().bottom ?? this.keyboardViewportRoot.getBoundingClientRect().top;
-    const branchBottom = branchHeaderContainer && branchHeaderContainer.childElementCount > 0
-      ? branchHeaderContainer.getBoundingClientRect().bottom
-      : headerBottom;
-    const topBoundary = Math.max(headerBottom, branchBottom);
-    const statusHeight = statusBarContainer?.getBoundingClientRect().height ?? 0;
-    const availableHeight = keyboardTop - topBoundary - statusHeight - 18;
-    const clampedHeight = Math.max(150, Math.min(320, Math.round(availableHeight)));
-
-    this.keyboardEditorHeight = clampedHeight;
-    this.keyboardViewportRoot.style.setProperty('--chat-keyboard-editor-height', `${clampedHeight}px`);
+    this.keyboardViewportController.attach();
   }
 
   private canUseVoiceInput(): boolean {

--- a/src/ui/chat/components/ToolInspectionModal.ts
+++ b/src/ui/chat/components/ToolInspectionModal.ts
@@ -44,6 +44,8 @@ export class ToolInspectionModal extends Modal {
   private isLoading = false;
   private isDisposed = false;
   private readonly component: Component;
+  private scrollHandler: (() => void) | null = null;
+  private pendingScrollFrame: number | null = null;
 
   constructor(app: App, options: ToolInspectionModalOptions, component: Component) {
     super(app);
@@ -67,11 +69,21 @@ export class ToolInspectionModal extends Modal {
     this.emptyEl = shellEl.createDiv({ cls: 'tool-inspection-empty' });
     this.loadingEl = shellEl.createDiv({ cls: 'tool-inspection-loading' });
 
-    this.component.registerDomEvent(this.scrollEl, 'scroll', () => {
-      if (this.scrollEl.scrollTop <= SCROLL_THRESHOLD_PX) {
-        void this.loadPreviousPage();
+    this.scrollHandler = () => {
+      if (this.pendingScrollFrame !== null) {
+        return;
       }
-    });
+      this.pendingScrollFrame = requestAnimationFrame(() => {
+        this.pendingScrollFrame = null;
+        if (this.isDisposed) {
+          return;
+        }
+        if (this.scrollEl.scrollTop <= SCROLL_THRESHOLD_PX) {
+          void this.loadPreviousPage();
+        }
+      });
+    };
+    this.component.registerDomEvent(this.scrollEl, 'scroll', this.scrollHandler);
 
     this.setLoadingState(true, 'Loading tool history...');
     void this.loadInitialPages();
@@ -79,6 +91,11 @@ export class ToolInspectionModal extends Modal {
 
   onClose(): void {
     this.isDisposed = true;
+    if (this.pendingScrollFrame !== null) {
+      cancelAnimationFrame(this.pendingScrollFrame);
+      this.pendingScrollFrame = null;
+    }
+    this.scrollHandler = null;
     this.modalEl.removeClass('tool-inspection-modal');
     this.contentEl.empty();
   }

--- a/src/ui/chat/controllers/ChatKeyboardViewportController.ts
+++ b/src/ui/chat/controllers/ChatKeyboardViewportController.ts
@@ -1,0 +1,306 @@
+/**
+ * ChatKeyboardViewportController
+ *
+ * Owns all iOS/Android on-screen-keyboard viewport handling for the chat input:
+ * - visualViewport resize/scroll reconciliation
+ * - Capacitor keyboardWill / keyboardDid event wiring
+ * - `.chat-keyboard-active` toggling + `--chat-keyboard-offset` /
+ *   `--chat-keyboard-editor-height` CSS custom properties on `.chat-main`
+ * - Post-event settling probes (the OS reports visualViewport height in
+ *   stages during keyboard animation; we re-measure at settled-enough ticks)
+ *
+ * Extracted from ChatInput to keep that component focused on input/send/suggesters.
+ * ChatInput still owns `autoResizeInput()` — the controller notifies it through
+ * the `onOffsetChanged` callback so the textarea can re-measure against the new
+ * keyboard-reduced available height.
+ */
+
+import { Component } from 'obsidian';
+
+const SETTLING_DELAYS_MS = [60, 180, 320];
+const NATIVE_HIDE_BASELINE_REFRESH_MS = 160;
+const BLUR_CLEAR_DELAY_MS = 120;
+const EDITOR_HEIGHT_MIN_PX = 150;
+const EDITOR_HEIGHT_MAX_PX = 320;
+const EDITOR_HEIGHT_BOTTOM_PADDING_PX = 18;
+const KEYBOARD_OFFSET_LIFT_REDUCTION_PX = 22;
+
+export interface ChatKeyboardViewportOptions {
+  /** Input container element (used for getBoundingClientRect on the input row). */
+  container: HTMLElement;
+  /** The contenteditable input — focus/blur listeners + :focus checks. */
+  inputElement: HTMLElement;
+  /** Resolves the send button (may be null during early render). */
+  getSendButton: () => HTMLButtonElement | null;
+  /** Called after every offset change so ChatInput can re-run autoResizeInput(). */
+  onOffsetChanged: () => void;
+  /** Obsidian Component — used for registerDomEvent + register(cleanup). */
+  component: Component;
+}
+
+export class ChatKeyboardViewportController {
+  private readonly options: ChatKeyboardViewportOptions;
+  private root: HTMLElement | null = null;
+  private pendingFrame: number | null = null;
+  private settlingTimers: number[] = [];
+  private baselineInnerHeight = 0;
+  private nativeKeyboardOffset = 0;
+  private editorHeight = 0;
+  private teardown: (() => void) | null = null;
+
+  constructor(options: ChatKeyboardViewportOptions) {
+    this.options = options;
+  }
+
+  attach(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    this.teardown?.();
+    this.root = this.options.container.closest('.chat-main');
+    this.baselineInnerHeight = window.innerHeight;
+    if (!this.root) {
+      return;
+    }
+
+    const { component, inputElement } = this.options;
+
+    const scheduleUpdate = () => this.scheduleOffsetUpdate();
+    const scheduleSettled = () => this.scheduleSettledUpdates();
+    const handleNativeShow = (event: CapacitorKeyboardEvent) => {
+      this.updateNativeKeyboardOffset(event);
+      this.scheduleSettledUpdates();
+    };
+    const handleNativeHide = () => {
+      this.nativeKeyboardOffset = 0;
+      this.clearSettlingTimers();
+      window.setTimeout(() => {
+        this.baselineInnerHeight = window.innerHeight;
+        this.resetOffset();
+      }, NATIVE_HIDE_BASELINE_REFRESH_MS);
+    };
+    const handleBlur = () => {
+      window.setTimeout(() => {
+        if (inputElement.matches(':focus')) {
+          return;
+        }
+        const sendButton = this.options.getSendButton();
+        if (sendButton && document.activeElement === sendButton) {
+          sendButton.blur();
+        }
+        this.nativeKeyboardOffset = 0;
+        this.baselineInnerHeight = window.innerHeight;
+        this.resetOffset();
+      }, BLUR_CLEAR_DELAY_MS);
+    };
+
+    // visualViewport listeners use raw addEventListener because the Obsidian
+    // Component API doesn't expose registerDomEvent for the VisualViewport type.
+    // We tear them down explicitly via component.register(cleanup).
+    window.visualViewport?.addEventListener('resize', scheduleSettled);
+    window.visualViewport?.addEventListener('scroll', scheduleUpdate);
+
+    this.teardown = () => {
+      window.visualViewport?.removeEventListener('resize', scheduleSettled);
+      window.visualViewport?.removeEventListener('scroll', scheduleUpdate);
+      this.cancelPendingFrame();
+      this.clearSettlingTimers();
+      this.resetOffset();
+    };
+    component.register(this.teardown);
+
+    component.registerDomEvent(inputElement, 'focus', scheduleSettled);
+    component.registerDomEvent(inputElement, 'blur', handleBlur);
+    component.registerDomEvent(window, 'resize', scheduleSettled);
+    component.registerDomEvent(window, 'orientationchange', scheduleSettled);
+    component.registerDomEvent(window, 'keyboardWillShow', handleNativeShow);
+    component.registerDomEvent(window, 'keyboardDidShow', handleNativeShow);
+    component.registerDomEvent(window, 'keyboardWillHide', handleNativeHide);
+    component.registerDomEvent(window, 'keyboardDidHide', handleNativeHide);
+
+    this.updateOffset();
+  }
+
+  detach(): void {
+    this.cancelPendingFrame();
+    this.clearSettlingTimers();
+    this.teardown?.();
+    this.teardown = null;
+    this.nativeKeyboardOffset = 0;
+    this.resetOffset();
+  }
+
+  isActive(): boolean {
+    return this.root?.hasClass('chat-keyboard-active') ?? false;
+  }
+
+  getEditorHeight(): number {
+    return this.editorHeight;
+  }
+
+  /**
+   * Schedule a single offset recomputation on the next animation frame.
+   * Coalesces bursts of visualViewport scroll events into one measurement.
+   */
+  private scheduleOffsetUpdate(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    if (this.pendingFrame !== null) {
+      return;
+    }
+    this.pendingFrame = window.requestAnimationFrame(() => {
+      this.pendingFrame = null;
+      this.updateOffset();
+    });
+  }
+
+  /**
+   * Run offset updates at staged delays to catch the full visualViewport
+   * settle window — iOS reports intermediate heights during keyboard
+   * animation, so a single rAF after the triggering event often samples a
+   * mid-animation state. Delays: immediate rAF + [60, 180, 320]ms.
+   */
+  private scheduleSettledUpdates(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    this.clearSettlingTimers();
+    this.scheduleOffsetUpdate();
+    for (const delay of SETTLING_DELAYS_MS) {
+      const timerId = window.setTimeout(() => {
+        this.settlingTimers = this.settlingTimers.filter((id) => id !== timerId);
+        this.scheduleOffsetUpdate();
+      }, delay);
+      this.settlingTimers.push(timerId);
+    }
+  }
+
+  private cancelPendingFrame(): void {
+    if (this.pendingFrame !== null && typeof window !== 'undefined') {
+      window.cancelAnimationFrame(this.pendingFrame);
+    }
+    this.pendingFrame = null;
+  }
+
+  private clearSettlingTimers(): void {
+    if (typeof window !== 'undefined') {
+      for (const timerId of this.settlingTimers) {
+        window.clearTimeout(timerId);
+      }
+    }
+    this.settlingTimers = [];
+  }
+
+  private updateOffset(): void {
+    if (!this.root || typeof window === 'undefined') {
+      return;
+    }
+
+    const currentOffset = this.readCurrentOffset();
+    const inputBottom = this.options.container.getBoundingClientRect().bottom + currentOffset;
+    const keyboardTop = this.getKeyboardTop();
+    const visualViewportOffset = keyboardTop !== null
+      ? Math.max(0, inputBottom - keyboardTop)
+      : 0;
+    const keyboardOffset = visualViewportOffset > 1 ? visualViewportOffset : this.nativeKeyboardOffset;
+    const roundedOffset = Math.ceil(keyboardOffset);
+
+    if (roundedOffset > 1) {
+      this.root.addClass('chat-keyboard-active');
+      const liftOffset = Math.max(0, roundedOffset - KEYBOARD_OFFSET_LIFT_REDUCTION_PX);
+      this.root.style.setProperty('--chat-keyboard-offset', `${liftOffset}px`);
+      this.updateEditorHeight(keyboardTop);
+      this.options.onOffsetChanged();
+    } else {
+      this.resetOffset();
+    }
+  }
+
+  private resetOffset(): void {
+    this.root?.removeClass('chat-keyboard-active');
+    this.root?.style.removeProperty('--chat-keyboard-offset');
+    this.root?.style.removeProperty('--chat-keyboard-editor-height');
+    this.editorHeight = 0;
+    this.options.onOffsetChanged();
+  }
+
+  private updateNativeKeyboardOffset(event: CapacitorKeyboardEvent): void {
+    const keyboardHeight = this.getKeyboardHeight(event);
+    if (keyboardHeight <= 0 || typeof window === 'undefined') {
+      this.nativeKeyboardOffset = 0;
+      return;
+    }
+
+    if (this.baselineInnerHeight <= 0) {
+      this.baselineInnerHeight = window.innerHeight;
+    }
+
+    const layoutResizeAmount = Math.max(0, this.baselineInnerHeight - window.innerHeight);
+    this.nativeKeyboardOffset = Math.max(0, keyboardHeight - layoutResizeAmount);
+  }
+
+  private getKeyboardHeight(event: CapacitorKeyboardEvent): number {
+    const directHeight = event.keyboardHeight;
+    if (typeof directHeight === 'number' && Number.isFinite(directHeight)) {
+      return Math.round(directHeight);
+    }
+
+    const detailHeight = event.detail?.keyboardHeight;
+    if (typeof detailHeight === 'number' && Number.isFinite(detailHeight)) {
+      return Math.round(detailHeight);
+    }
+
+    return 0;
+  }
+
+  private readCurrentOffset(): number {
+    if (!this.root || typeof window === 'undefined') {
+      return 0;
+    }
+    const rawOffset = window.getComputedStyle(this.root).getPropertyValue('--chat-keyboard-offset');
+    const parsedOffset = Number.parseFloat(rawOffset);
+    return Number.isFinite(parsedOffset) ? parsedOffset : 0;
+  }
+
+  private getKeyboardTop(): number | null {
+    if (!this.root || typeof window === 'undefined') {
+      return null;
+    }
+
+    if (window.visualViewport) {
+      return window.visualViewport.height + window.visualViewport.offsetTop;
+    }
+
+    if (this.nativeKeyboardOffset > 0) {
+      return this.root.getBoundingClientRect().bottom - this.nativeKeyboardOffset;
+    }
+
+    return null;
+  }
+
+  private updateEditorHeight(keyboardTop: number | null): void {
+    if (!this.root || keyboardTop === null) {
+      this.editorHeight = 0;
+      this.root?.style.removeProperty('--chat-keyboard-editor-height');
+      return;
+    }
+
+    const header = this.root.querySelector('.chat-header');
+    const branchHeaderContainer = this.root.querySelector('.nexus-branch-header-container');
+    const statusBarContainer = this.root.querySelector('.tool-status-bar-container');
+
+    const headerBottom = header?.getBoundingClientRect().bottom ?? this.root.getBoundingClientRect().top;
+    const branchBottom = branchHeaderContainer && branchHeaderContainer.childElementCount > 0
+      ? branchHeaderContainer.getBoundingClientRect().bottom
+      : headerBottom;
+    const topBoundary = Math.max(headerBottom, branchBottom);
+    const statusHeight = statusBarContainer?.getBoundingClientRect().height ?? 0;
+    const availableHeight = keyboardTop - topBoundary - statusHeight - EDITOR_HEIGHT_BOTTOM_PADDING_PX;
+    const clampedHeight = Math.max(EDITOR_HEIGHT_MIN_PX, Math.min(EDITOR_HEIGHT_MAX_PX, Math.round(availableHeight)));
+
+    this.editorHeight = clampedHeight;
+    this.root.style.setProperty('--chat-keyboard-editor-height', `${clampedHeight}px`);
+  }
+}


### PR DESCRIPTION
## Summary
Final wave of the glass-chrome audit remediation. Two tasks bundled because both touch chat UI internals but have no file overlap.

## Changes

### Task #23 — rAF-throttle `ToolInspectionModal` scroll handler (commit `711a65a6`)
- Wrap the pagination threshold check at `ToolInspectionModal.ts:71-80` behind `requestAnimationFrame`. Single pending-frame guard — new scroll ticks during an outstanding frame are no-ops. `onClose` cancels any pending frame.
- Preserves threshold + pagination semantics exactly; just reduces check frequency to ≤60Hz.
- **Note on tier**: Frontend-reviewer originally classified this as **Future** with qualifier ***"out of scope for post-merge fix — defer to next UX pass."*** User overrode to queue. Tier-label preserved verbatim in review docs; orchestrator disagreement logged explicitly at dispatch time.

### Task #17 — Extract `ChatKeyboardViewportController` from `ChatInput` (commit `67573015`)
- **New**: `src/ui/chat/controllers/ChatKeyboardViewportController.ts` (306 lines). Owns iOS/Android `visualViewport` listeners, keyboard offset math, `.chat-keyboard-active` class toggling, settling-probe scheduling, CSS custom property updates.
  - Contract: `attach()` / `detach()` / `isActive()` / `getEditorHeight()`.
  - Takes DOM refs + a `Component` in ctor; auto-registers teardown via `component.register(...)`.
  - Uses existing CSS custom properties (`--chat-keyboard-offset`, `--chat-keyboard-editor-height`) and toggles the existing `.chat-keyboard-active` class on `.chat-main` — zero style-layer change.
- **`ChatInput.ts` thinned from 767 → 562 lines** (target ~560). Removes 7 private fields + 9 private methods; replaces with a single `keyboardViewportController` field and delegation in `initializeKeyboardViewportHandling()`, `cleanup()`, and `autoResizeInput()`'s keyboard-active branch.
- **F2 folded** (Frontend F2 — ***"not a bug — flagged for refinement"***): the hand-rolled 3-`setTimeout` settling cascade is preserved as-is on the timing side (60/180/320ms delays unchanged — iOS visualViewport stages height reports during keyboard animation; dropping a probe risks mid-animation sampling). Cleanup is structural: named constant `SETTLING_DELAYS_MS`, all triggers route through `scheduleSettledUpdates()`, rAF-coalescing added to `scheduleOffsetUpdate()` to collapse bursts of scroll/resize events into a single frame of measurement work (new efficiency, behaviorally equivalent).
- Removed a redundant `updateKeyboardViewportOffset()` call in ChatInput's iOS `focusHandler` — the controller's own focus listener covers the same settling cadence.

## Audit findings addressed
- Architect M4 — `ChatInput` mobile keyboard logic extractable
- Frontend F2 — 3-setTimeout cascade shape (folded into the extraction)
- Frontend F1 — `ToolInspectionModal` scroll handler not rAF-throttled (user-overridden from Future to near-term)

## Line-ending hygiene
`ChatInput.ts` has mixed CRLF+LF line endings. Edits applied via byte-level Python `bytes.replace()` with `assert count == 1` guards to avoid the Edit tool's LF-normalization churn. Final diff: `git diff --stat` matches `git diff -w --stat` exactly on `ChatInput.ts` (247 raw == 247 functional). One small iteration on the controller file itself (a JSDoc closure issue caught by `tsc --noEmit`) was fixed via Edit tool since that file is LF-only.

## Test plan
- [x] `npm run build` — clean (2 pre-existing Logger.ts lint warnings, unrelated)
- [x] `tsc --noEmit -p tsconfig.json` — clean
- [x] Jest: 2147 pass, 9 skipped, 1 pre-existing `ModelAgentManager.test.ts:242` failure (unrelated — verified failing on parent commit)
- [ ] Manual smoke on iOS Safari + Android Chrome: focus chat input, confirm keyboard does not cover the textarea, watch for settling-cascade regression during rapid keyboard open/close cycles (this is the MEDIUM uncertainty flagged by the implementer — rAF coalescing of bursts is new behavior)

## Uncertainties flagged by implementer
- **[MEDIUM]** Android visualViewport behavior under aggressive soft-keyboard cycles — new rAF-coalescing of scroll/resize events. Suggest live Android Chrome test before merge.
- **[LOW]** Removing the redundant `updateKeyboardViewportOffset()` call in iOS `focusHandler` — safe because `initializeKeyboardViewportHandling` runs during `render()` before any focus event, so the controller's focus listener covers the same ground. Defensive check only.

Net: **+341 / −226 functional lines**, 3 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)