### PR TITLE
fix(ui): flatten message action button hover + simplify copy feedback + mobile branch-nav clustering

### DIFF
--- a/src/ui/chat/components/MessageBubble.ts
+++ b/src/ui/chat/components/MessageBubble.ts
@@ -457,13 +457,11 @@ export class MessageBubble extends Component {
     }
 
     const originalTitle = button.getAttribute('title') || '';
-    setIcon(button, 'check');
     button.setAttribute('title', 'Copied!');
     button.classList.add('copy-success');
 
     this.copyFeedbackTimeout = setTimeout(() => {
       this.copyFeedbackTimeout = null;
-      setIcon(button, 'copy');
       button.setAttribute('title', originalTitle);
       button.classList.remove('copy-success');
     }, 1500);

--- a/styles.css
+++ b/styles.css
@@ -999,7 +999,7 @@ body.theme-light .message-content {
     display: flex;
     align-items: center;
     justify-content: flex-start;
-    gap: 0.36rem;
+    gap: 0.18rem;
     margin-top: 0.14rem;
     padding: 0;
     line-height: 1;
@@ -1023,14 +1023,14 @@ body.theme-light .message-content {
     box-sizing: border-box;
     padding: 0 1.08rem;
     justify-content: flex-end;
-    gap: 0.22rem;
+    gap: 0.11rem;
     margin-top: -3px;
     margin-left: 0;
     overflow: visible;
 }
 
 .message-container.message-user .message-action-btn {
-    transform: translateY(-1px);
+    transform: translateY(4px);
 }
 
 /* Assistant row: full width, padded to match content inset, left-aligned.
@@ -1067,14 +1067,11 @@ body.theme-light .message-content {
 }
 
 .message-action-btn:hover {
-    background: var(--background-modifier-hover);
     color: var(--text-normal);
 }
 
 .message-action-btn.copy-success {
-    background: var(--text-success);
-    color: white;
-    transform: scale(1.1);
+    color: var(--text-success);
 }
 
 .message-edit-textarea {
@@ -3330,7 +3327,6 @@ a:hover {
 /* Subtle hover effect for branch buttons */
 .message-action-btn.message-branch-prev:hover:not(:disabled),
 .message-action-btn.message-branch-next:hover:not(:disabled) {
-  background: var(--background-modifier-hover);
   color: var(--text-accent);
 }
 
@@ -5661,7 +5657,7 @@ body.is-mobile .message-container.message-user .message-actions-external {
 }
 
 body.is-mobile .message-container.message-user .message-action-btn {
-    transform: translateY(-3px);
+    transform: translateY(2px);
 }
 
 /* Assistant messages: keep in corner but smaller on mobile */
@@ -5669,6 +5665,7 @@ body.is-mobile .message-container.message-assistant .message-actions-external {
     top: 0.25rem;
     right: 0.25rem;
     padding: 0 0.78rem;
+    justify-content: flex-start;
 }
 
 body.is-mobile .message-container.message-assistant .message-action-btn {


### PR DESCRIPTION
## Summary
UI polish pass on chat message action buttons based on user feedback from live mobile testing.

## Changes

- **Flatten hover/active state on `.message-action-btn`** — dropped `background: var(--background-modifier-hover)` on `:hover`; color change on hover preserved for feedback. Same fix applied to `.message-action-btn.message-branch-prev:hover / .message-action-btn.message-branch-next:hover` — same visual problem, same fix. Eliminates the grey pill-circle that was floating over the edge of the user chat bubble.
- **Simplify copy feedback** — dropped the `setIcon(button, 'check')` swap in `MessageBubble.showCopyFeedback` and the revert on `'copy'`; icon stays `copy` throughout. Replaced the `.copy-success` CSS (was `background: var(--text-success) + color: white + transform: scale(1.1)`) with a quiet `color: var(--text-success)` flash. Tooltip still updates to "Copied!" for a11y; 1500ms revert preserved.
- **Nudge user-message action buttons down** — `.message-container.message-user .message-action-btn` `transform: translateY(-1px)` → `translateY(4px)`. Mobile variant adjusted proportionally (`-3px` → `2px`).
- **Tighten gap between action buttons** — `.message-actions-external` base gap `0.36rem` → `0.18rem`; user variant `0.22rem` → `0.11rem`. Mobile already tight at 2px, unchanged.
- **Cluster mobile assistant branch nav** — added `justify-content: flex-start` to `body.is-mobile .message-container.message-assistant .message-actions-external`. Previously copy + `<` + `1/2` + `>` stretched across the viewport; now cluster left. If this alone proves insufficient in testing, follow-up is `width: fit-content` on the same selector.

Net: 6 / 11 lines, 2 files (`styles.css`, `src/ui/chat/components/MessageBubble.ts`). No CRLF churn.

## Test plan
- [x] `npm run build` clean
- [x] `npm run test` — MessageBubble suite green
- [ ] Manual: on mobile, press refresh/edit icons under user message — no grey pill floating over bubble
- [ ] Manual: click copy on assistant message — icon stays as copy glyph; subtle green color flash; no green pill, no scale, no checkmark
- [ ] Manual: assistant with 2+ branches on mobile — copy + `<` + `1/2` + `>` cluster left instead of spreading across viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)