### PR TITLE
fix(chat): shrink mobile .message-action-btn from 44x44 to 32x32

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -5617,8 +5617,8 @@ body.is-mobile .chat-send-button {
 
 /* Message action buttons - 44px touch targets for phones */
 body.is-mobile .message-action-btn {
-    width: 44px;
-    height: 44px;
+    width: 32px;
+    height: 32px;
     padding: 0;
     --icon-size: 16px;
 }


### PR DESCRIPTION
## Summary
Single two-line CSS change. Root cause of the "<     x/y>" spread on mobile branch nav (and the edit/retry gap under user messages): `body.is-mobile .message-action-btn` was 44×44, but the icon inside is 16×16. Invisible touch-target padding of ~14px per side made the row look spread-out — the chevron icon sits at one edge of a 44×44 box, the `1/2` text has no touch padding, then the next chevron sits at the left edge of another 44×44 box.

## Change
`styles.css:5619`:
```css
body.is-mobile .message-action-btn {
    width: 32px;   /* was 44px */
    height: 32px;  /* was 44px */
    padding: 0;
    --icon-size: 16px;
}
```

32×32 is still tappable (Twitter/Instagram use ~32–36 for similar secondary action rows); primary actions in the plugin like the send button remain at their larger size.

## Test plan
- [x] `npm run build` clean
- [ ] Manual mobile: `<` `1/2` `>` clusters tightly (previously spread across ~180px)
- [ ] Manual mobile: edit/retry icons under user message cluster tightly (previously pushed apart)
- [ ] Tap-test: buttons still feel comfortable to press one-handed; if they feel too small, bump to 36×36 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)