### PR TITLE
fix(chat): shrink branch-nav buttons to 20x20 to cluster tight to the x/y indicator

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3328,6 +3328,14 @@ a:hover {
   color: var(--text-faint);
 }
 
+/* Branch nav buttons sit as a tight cluster around the indicator — shrink to
+   icon-size so the 12px chevron isn't dwarfed by touch-target padding. */
+.message-action-btn.message-branch-prev,
+.message-action-btn.message-branch-next {
+  width: 20px;
+  height: 20px;
+}
+
 /* Dark mode adjustments */
 .theme-dark .message-branch-navigator {
   border-right-color: var(--background-modifier-border-hover);


### PR DESCRIPTION
## Summary
Follow-up to PR #153. The 44→32 mobile shrink helped but the real cause of the \"<     1/2    >\" spread was that the prev/next chevron buttons inherit the full `.message-action-btn` size (28 desktop / 32 mobile) while their icon is only 12px. The icon gets centered inside the button, creating ~8-10px of phantom padding on each side — the right-padding of `<` pushes the `1/2` indicator away; the left-padding of `>` pushes it back. Net effect: visible gaps that only exist because of invisible padding.

## Change
Adds a branch-nav-specific size rule in styles.css:

```css
.message-action-btn.message-branch-prev,
.message-action-btn.message-branch-next {
    width: 20px;
    height: 20px;
}
```

Applies to both desktop and mobile. 20px leaves ~4px padding around the 12px chevron — visually balanced, cluster tight.

## Test plan
- [x] `npm run build` clean
- [ ] Manual: `< 1/2 >` clusters tight on both desktop and mobile
- [ ] Copy + edit/retry buttons unchanged (still 28px desktop / 32px mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)