### PR TITLE
fix(chat): edge-align branch-nav chevrons to cluster tight to the x/y indicator

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3328,12 +3328,27 @@ a:hover {
   color: var(--text-faint);
 }
 
-/* Branch nav buttons sit as a tight cluster around the indicator — shrink to
-   icon-size so the 12px chevron isn't dwarfed by touch-target padding. */
+/* Branch nav buttons keep a usable click target (24px) but the chevron is
+   aligned to the edge nearest the indicator so there's no visible free space
+   between chevron and "x/y". Prev's chevron hugs the button's right edge;
+   next's chevron hugs the button's left edge. */
 .message-action-btn.message-branch-prev,
 .message-action-btn.message-branch-next {
-  width: 20px;
-  height: 20px;
+  width: 24px;
+  height: 24px;
+}
+.message-action-btn.message-branch-prev {
+  justify-content: flex-end;
+}
+.message-action-btn.message-branch-next {
+  justify-content: flex-start;
+}
+/* Mobile touch-target override — restore comfortable tap size but keep the
+   edge-align so the chevrons still cluster tightly to the indicator. */
+body.is-mobile .message-action-btn.message-branch-prev,
+body.is-mobile .message-action-btn.message-branch-next {
+  width: 32px;
+  height: 32px;
 }
 
 /* Dark mode adjustments */


### PR DESCRIPTION
## Summary
Third attempt at the mobile `< x/y >` spread. PR #153 (44→32 message action btn) and #154 (20×20 branch nav) were both shrinking the WRONG axis — the issue was never button size, it was **flex centering** of a 12px chevron inside its button, leaving free space on each side of the icon. The "padding" between `<` and the indicator was actually the chevron icon being horizontally-centered inside a wider button — that free space on the chevron's *right* side is what pushed it away from `1/2`.

## Fix
Keep usable click targets (24px desktop, 32px mobile) but align the chevron to the **inside edge** of its button:

- `.message-branch-prev` → `justify-content: flex-end` (chevron hugs right edge, next to `1/2`)
- `.message-branch-next` → `justify-content: flex-start` (chevron hugs left edge, next to `1/2`)

Visually:
```
Before (centered):              After (edge-aligned):
[   <   ][1/2][   >   ]         [    <][1/2][>    ]
 gap gap       gap gap                 ↑ tight cluster ↑
```

Free space in the button falls on the *outside* of the nav cluster where nothing's rendered, so you never see it.

## Also reverts
PR #154's 20×20 desktop downsize — goes back to 24×24 so the chevrons aren't dwarfed.

## Test plan
- [x] `npm run build` clean
- [ ] Manual mobile: `<` `1/2` `>` cluster tight, chevron tips visually touching the indicator margins
- [ ] Manual desktop: same, with slightly larger (24px) buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)