### PR TITLE
Chat UI polish sweep (retrospective): 8 commits 7add923c → c4fab2ff [already on main, documentation only]

### DIFF
--- a/src/ui/chat/components/MessageBubble.ts
+++ b/src/ui/chat/components/MessageBubble.ts
@@ -135,7 +135,7 @@ export class MessageBubble extends Component {
       // Edit button for user messages
       if (this.onEdit) {
         const editBtn = actions.createEl('button', {
-          cls: 'message-action-btn clickable-icon',
+          cls: 'message-action-btn clickable-icon nexus-user-msg-action',
           attr: { title: 'Edit message', 'aria-label': 'Edit message' }
         });
         setIcon(editBtn, 'edit');
@@ -149,7 +149,7 @@ export class MessageBubble extends Component {
 
       // Retry button for user messages
       const retryBtn = actions.createEl('button', {
-        cls: 'message-action-btn clickable-icon',
+        cls: 'message-action-btn clickable-icon nexus-user-msg-action',
         attr: { title: 'Retry message', 'aria-label': 'Retry message' }
       });
       setIcon(retryBtn, 'rotate-ccw');

--- a/styles.css
+++ b/styles.css
@@ -965,7 +965,7 @@ body.theme-light .message-content {
 }
 
 .message-container.message-assistant {
-    margin-top: 1.1rem;
+    margin-top: 1.7rem;
 }
 
 .message-header {
@@ -1038,7 +1038,7 @@ body.theme-light .message-content {
 .message-container.message-assistant .message-actions-external {
     width: 100%;
     box-sizing: border-box;
-    padding: 0 1.08rem;
+    padding: 0 1.4rem;
 }
 
 /* Action button — ported from .mock-device--glass .minimal-action-btn

--- a/styles.css
+++ b/styles.css
@@ -3360,17 +3360,10 @@ body.is-mobile .message-action-btn.message-branch-next {
   height: 32px;
 }
 
-/* Dark mode adjustments */
-.theme-dark .message-branch-navigator {
-  border-right-color: var(--background-modifier-border-hover);
-}
-
 /* Mobile responsive */
 @media (max-width: 768px) {
   .message-branch-navigator {
     gap: 2px;
-    padding-right: 6px;
-    margin-right: 6px;
   }
 
   .message-branch-indicator {

--- a/styles.css
+++ b/styles.css
@@ -1028,8 +1028,13 @@ body.theme-light .message-content {
     overflow: visible;
 }
 
-.message-container.message-user .message-action-btn {
-    transform: translateY(8px);
+/* Needs compound-class specificity + !important to beat an equal-specificity
+   rule elsewhere in the cascade that was silently pinning transform — found
+   via nuclear-value diagnostic: plain .message-container.message-user
+   .message-action-btn { transform: translateY(Npx) } at (0,0,3,0) was not
+   applying, but this selector at (0,0,5,0)+!important wins. */
+.message-container.message-user .message-action-btn.message-action-btn.clickable-icon {
+    transform: translateY(8px) !important;
 }
 
 /* Assistant row: full width, padded to match content inset, left-aligned.
@@ -3289,8 +3294,8 @@ a:hover {
 .message-branch-navigator {
   display: flex;
   align-items: center;
-  gap: 4px;
-  margin-left: -6px;
+  gap: 2px;
+  margin-left: -4px;
 }
 
 .message-branch-navigator-hidden {
@@ -3335,14 +3340,13 @@ a:hover {
   color: var(--text-faint);
 }
 
-/* Branch nav buttons keep a usable click target (24px) but the chevron is
-   aligned to the edge nearest the indicator so there's no visible free space
-   between chevron and "x/y". Prev's chevron hugs the button's right edge;
-   next's chevron hugs the button's left edge. */
+/* Branch nav buttons: sized close to the 12px chevron so there's no phantom
+   padding inside. Chevron edge-aligned toward the indicator (flex-end/start)
+   eliminates the remaining ~2px wasted space. Mobile bumps to 24 for tap. */
 .message-action-btn.message-branch-prev,
 .message-action-btn.message-branch-next {
-  width: 24px;
-  height: 24px;
+  width: 16px;
+  height: 16px;
 }
 /* !important + extra class repeat to outweigh Obsidian's .clickable-icon
    justify-content: center default (which otherwise re-centers the chevron). */
@@ -3356,8 +3360,8 @@ a:hover {
    edge-align so the chevrons still cluster tightly to the indicator. */
 body.is-mobile .message-action-btn.message-branch-prev,
 body.is-mobile .message-action-btn.message-branch-next {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
 }
 
 /* Mobile responsive */

--- a/styles.css
+++ b/styles.css
@@ -5679,7 +5679,7 @@ body.is-mobile .message-container.message-user .message-action-btn {
 body.is-mobile .message-container.message-assistant .message-actions-external {
     top: 0.25rem;
     right: 0.25rem;
-    padding: 0 0.78rem;
+    padding: 0 1.1rem;
     justify-content: flex-start;
     width: fit-content;
 }
@@ -5884,7 +5884,7 @@ body.is-mobile .message-container.message-assistant .message-bubble {
 }
 
 body.is-mobile .message-container.message-assistant {
-    margin-top: 0.35rem;
+    margin-top: 1.7rem;
 }
 
 body.is-mobile .tool-status-bar {

--- a/styles.css
+++ b/styles.css
@@ -1028,13 +1028,12 @@ body.theme-light .message-content {
     overflow: visible;
 }
 
-/* Needs compound-class specificity + !important to beat an equal-specificity
-   rule elsewhere in the cascade that was silently pinning transform — found
-   via nuclear-value diagnostic: plain .message-container.message-user
-   .message-action-btn { transform: translateY(Npx) } at (0,0,3,0) was not
-   applying, but this selector at (0,0,5,0)+!important wins. */
-.message-container.message-user .message-action-btn.message-action-btn.clickable-icon {
-    transform: translateY(8px) !important;
+/* User-message action buttons (edit, retry) get a plugin-unique class from
+   MessageBubble.ts so we can drop the transform without fighting any other
+   cascade (Obsidian's .clickable-icon or equivalent). Clean (0,0,1,0) —
+   nothing else targets this class. */
+.nexus-user-msg-action {
+    transform: translateY(8px);
 }
 
 /* Assistant row: full width, padded to match content inset, left-aligned.

--- a/styles.css
+++ b/styles.css
@@ -1023,18 +1023,15 @@ body.theme-light .message-content {
     padding: 0 1.08rem;
     justify-content: flex-end;
     gap: 0.11rem;
-    margin-top: -3px;
+    margin-top: 10px;
     margin-left: 0;
     overflow: visible;
 }
 
 /* User-message action buttons (edit, retry) get a plugin-unique class from
-   MessageBubble.ts so we can drop the transform without fighting any other
-   cascade (Obsidian's .clickable-icon or equivalent). Clean (0,0,1,0) —
-   nothing else targets this class. */
-.nexus-user-msg-action {
-    transform: translateY(16px);
-}
+   MessageBubble.ts — reserved for future styling that might need to bypass
+   cascade fighting. Currently no declarations; layout spacing lives on the
+   parent .message-actions-external via margin-top. */
 
 /* Assistant row: full width, padded to match content inset, left-aligned.
    Mockup line 2292-2297. */
@@ -5670,7 +5667,7 @@ body.is-mobile .message-container.message-user .message-actions-external {
     gap: 0;
     height: 24px;
     min-height: 24px;
-    margin-top: -7px;
+    margin-top: 10px;
     padding: 0 0.72rem;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -965,7 +965,7 @@ body.theme-light .message-content {
 }
 
 .message-container.message-assistant {
-    margin-top: 0.28rem;
+    margin-top: 1.1rem;
 }
 
 .message-header {
@@ -1033,7 +1033,7 @@ body.theme-light .message-content {
    cascade (Obsidian's .clickable-icon or equivalent). Clean (0,0,1,0) —
    nothing else targets this class. */
 .nexus-user-msg-action {
-    transform: translateY(8px);
+    transform: translateY(16px);
 }
 
 /* Assistant row: full width, padded to match content inset, left-aligned.

--- a/styles.css
+++ b/styles.css
@@ -965,7 +965,7 @@ body.theme-light .message-content {
 }
 
 .message-container.message-assistant {
-    margin-top: 1.7rem;
+    margin-top: 1.4rem;
 }
 
 .message-header {
@@ -1038,7 +1038,8 @@ body.theme-light .message-content {
 .message-container.message-assistant .message-actions-external {
     width: 100%;
     box-sizing: border-box;
-    padding: 0 1.4rem;
+    padding: 0 1.2rem;
+    margin-top: 4px;
 }
 
 /* Action button — ported from .mock-device--glass .minimal-action-btn
@@ -5679,9 +5680,10 @@ body.is-mobile .message-container.message-user .message-action-btn {
 body.is-mobile .message-container.message-assistant .message-actions-external {
     top: 0.25rem;
     right: 0.25rem;
-    padding: 0 1.1rem;
+    padding: 0 0.95rem;
     justify-content: flex-start;
     width: fit-content;
+    margin-top: 4px;
 }
 
 body.is-mobile .message-container.message-assistant .message-action-btn {
@@ -5884,7 +5886,7 @@ body.is-mobile .message-container.message-assistant .message-bubble {
 }
 
 body.is-mobile .message-container.message-assistant {
-    margin-top: 1.7rem;
+    margin-top: 1.4rem;
 }
 
 body.is-mobile .tool-status-bar {


### PR DESCRIPTION
## Summary (retrospective)
This PR is for **documentation / audit only** — the 8 commits below already shipped directly to `main` as hot-fix iterations during live mobile testing. Opening this PR against a base-branch (`retrospective-base-chat-ui-polish` pinned at `75027371`, the pre-arc commit) so the arc is visible as a single reviewable unit in the repo's PR history. **This PR will be closed without merging** — merging would duplicate work already on main.

## Context
All these commits were direct-pushed to main during an interactive session refining mobile chat UI. Follows PRs #151–#155 and incorporates user feedback from live testing on an iOS Obsidian install (Professor Synapse vault).

## The 8 commits

| Commit | Summary |
|---|---|
| `7add923c` | Pull branch-nav cluster left + drop user action icons lower (strips vestigial padding/margin/border on `.message-branch-navigator`; bumps user-action translateY 4→8px) |
| `118cb740` | Specificity-beat user-message action transform + small nav left-pull (nuclear-value diagnostic found transform was being overridden at equal specificity) |
| `de109996` | **Refactor to plugin-unique class** — added `nexus-user-msg-action` class to edit/retry buttons in `MessageBubble.ts`; dropped `!important` + 5-class compound selector hack in favor of `.nexus-user-msg-action { ... }` at clean (0,0,1,0) specificity |
| `b5cc003a` | Bump user-action drop + add breathing room above assistant message |
| `0050c13b` | Switch from `transform: translateY` to `margin-top` on `.message-actions-external` so assistant message flows with correct spacing (not overlap) |
| `a5bb672f` | More breathing room above assistant + indent actions-external to text |
| `b5fa8208` | Apply the same spacing changes on mobile variants (desktop rules at `(0,0,3,0)` were silently beaten by mobile rules at `(0,0,3,0)`+`body.is-mobile`) |
| `c4fab2ff` | Tune assistant message spacing — less above (1.7→1.4rem), nudge copy/nav slightly right + down for text alignment |

## Key lessons locked in during this arc
1. **CRLF file hygiene** — `ChatInput.ts`, `NexusLoadingController.ts`, `MessageBubble.ts` have mixed CRLF+LF line endings. Edit tool normalizes to LF and produces ~1000 line whitespace diffs. **Fix**: byte-level Python patches with `bytes.replace()` + `assert count == 1` guards preserving `\r\n`.
2. **Cascade fights** — Obsidian's bundled `.clickable-icon` defaults can silently override plugin CSS at equal specificity. **Architecturally correct fix**: plugin-unique class on the button (e.g., `.nexus-user-msg-action`) — not `!important`, not compound-class hacks.
3. **Mobile specificity** — `body.is-mobile .message-container.message-assistant` `(0,0,3,0)` beats the non-prefixed desktop rule `(0,0,2,0)`. Always pair desktop + mobile rule changes together.

## Files touched across the arc
- `styles.css` — 7 of 8 commits
- `src/ui/chat/components/MessageBubble.ts` — 1 commit (`de109996`, class addition via byte-level patch)

## Disposition
🔒 **Do not merge.** Closing after review. Commits already live on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)