### PR TITLE
fix(toolmanager): CLI parser family audit (#160, #162, #163) — 8 bugs + display-path coverage

### DIFF
--- a/src/agents/contentManager/tools/write.ts
+++ b/src/agents/contentManager/tools/write.ts
@@ -54,8 +54,17 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
       const { content, overwrite = false } = params;
       let { path } = params;
 
-      // Normalize empty/root paths - generate a filename if only directory is specified
-      if (!path || path === '/' || path === '.') {
+      // Reject empty/whitespace path explicitly. Silently rewriting '' to
+      // untitled-<timestamp>.md in the vault root hid callers that had
+      // dropped the path by mistake and left orphan files behind.
+      if (typeof path !== 'string' || path.trim() === '') {
+        return this.prepareResult(false, undefined,
+          'path must be a non-empty string. Pass "/" or "." to let Obsidian pick a filename in the vault root.'
+        );
+      }
+
+      // Normalize root/dot paths - generate a filename if only directory is specified
+      if (path === '/' || path === '.') {
         const timestamp = Date.now();
         path = `untitled-${timestamp}.md`;
       } else if (path.endsWith('/') || path.endsWith('.')) {

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -213,8 +213,8 @@ function coerceValue(raw: string, type: string): unknown {
     const trimmed = raw.trim();
     if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
       try {
-        const parsed = JSON.parse(trimmed);
-        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (Array.isArray(parsed) && parsed.every((item: unknown) => typeof item === 'string')) {
           return parsed;
         }
       } catch {

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -115,13 +115,28 @@ export function splitTopLevelSegments(input: string): string[] {
 }
 
 function unescapeQuotedContent(value: string): string {
-  return value
-    .replace(/\\n/g, '\n')
-    .replace(/\\r/g, '\r')
-    .replace(/\\t/g, '\t')
-    .replace(/\\"/g, '"')
-    .replace(/\\'/g, '\'')
-    .replace(/\\\\/g, '\\');
+  // Single-pass scan so `\\` consumes the backslash first. A sequential
+  // .replace() chain would let `\\n` collide with `\n` when the double
+  // backslash ran last.
+  let out = '';
+  for (let i = 0; i < value.length; i += 1) {
+    if (value[i] !== '\\' || i + 1 >= value.length) {
+      out += value[i];
+      continue;
+    }
+    const next = value[i + 1];
+    switch (next) {
+      case 'n': out += '\n'; break;
+      case 'r': out += '\r'; break;
+      case 't': out += '\t'; break;
+      case '"': out += '"'; break;
+      case '\'': out += '\''; break;
+      case '\\': out += '\\'; break;
+      default: out += '\\' + next;
+    }
+    i += 1;
+  }
+  return out;
 }
 
 export function tokenize(input: string): string[] {

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -501,7 +501,17 @@ export class ToolCliNormalizer {
         }
 
         if (arg.type === 'boolean') {
-          params[arg.name] = true;
+          // §C.2/§C.3: accept an unquoted `true`/`false` literal as the flag
+          // value if it follows the flag. Quoted literals stay as positional
+          // values (so `--bool "true"` means bool=true + positional "true",
+          // matching typical shell semantics).
+          const peek = tokens[index + 1];
+          if (peek && !peek.wasQuoted && (peek.value === 'true' || peek.value === 'false')) {
+            params[arg.name] = peek.value === 'true';
+            index += 1;
+          } else {
+            params[arg.name] = true;
+          }
           continue;
         }
 
@@ -513,6 +523,18 @@ export class ToolCliNormalizer {
         params[arg.name] = coerceValue(next.value, arg.type);
         index += 1;
         continue;
+      }
+
+      // §G.1/§G.2: skip positional slots already filled by named flags, so a
+      // mixed call like `content write --path "x.md" "body"` fills `content`
+      // with "body" instead of overwriting `path`. If every slot is filled,
+      // the fall-through below raises "Too many positional arguments" (which
+      // replaces the previous silent overwrite bug).
+      while (
+        positionalIndex < positionalArgs.length &&
+        params[positionalArgs[positionalIndex].name] !== undefined
+      ) {
+        positionalIndex += 1;
       }
 
       const positional = positionalArgs[positionalIndex];

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -235,7 +235,7 @@ function coerceValue(raw: string, type: string): unknown {
         // Fall through to CSV split for malformed JSON.
       }
     }
-    return raw.split(',').map(part => part.trim()).filter(Boolean);
+    return splitCsvRespectingQuotes(raw);
   }
 
   if (type === 'object') {
@@ -247,6 +247,62 @@ function coerceValue(raw: string, type: string): unknown {
   }
 
   return raw;
+}
+
+/**
+ * Split a CSV-style string into items, respecting quote pairs as item-internal
+ * literals. A `,` inside a `"..."` or `'...'` region is preserved; a `,` outside
+ * any quote acts as the separator. Outer quotes wrapping an item are stripped.
+ *
+ * Backward compatible with bare CSV: `"a,b,c"` (no internal quoting) still
+ * yields `["a", "b", "c"]`. Issue: ProfSynapse/nexus#163.
+ *
+ * Examples:
+ *   `a,b,c`           → ["a", "b", "c"]
+ *   `"a, b",c`        → ["a, b", "c"]
+ *   `"a,b","c,d"`     → ["a,b", "c,d"]
+ *   `'one, two',three`→ ["one, two", "three"]
+ */
+export function splitCsvRespectingQuotes(input: string): string[] {
+  const items: string[] = [];
+  let current = '';
+  let quote: '"' | '\'' | null = null;
+  let escaped = false;
+
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === '\\') {
+      current += char;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === '\'') {
+      quote = char;
+      continue;
+    }
+    if (char === ',') {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) items.push(trimmed);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  const trimmed = current.trim();
+  if (trimmed.length > 0) items.push(trimmed);
+  return items;
 }
 
 /**

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -187,6 +187,17 @@ function coerceValue(raw: string, type: string): unknown {
   }
 
   if (type.startsWith('array<')) {
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed) && parsed.every(item => typeof item === 'string')) {
+          return parsed;
+        }
+      } catch {
+        // Fall through to CSV split for malformed JSON.
+      }
+    }
     return raw.split(',').map(part => part.trim()).filter(Boolean);
   }
 

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -139,16 +139,24 @@ function unescapeQuotedContent(value: string): string {
   return out;
 }
 
-export function tokenize(input: string): string[] {
-  const tokens: string[] = [];
+export interface QuotedToken {
+  value: string;
+  wasQuoted: boolean;
+}
+
+export function tokenizeWithMeta(input: string): QuotedToken[] {
+  const tokens: QuotedToken[] = [];
   let current = '';
   let quote: '"' | '\'' | null = null;
   let escaped = false;
-  // Tracks whether we have started a token during the current run — needed so
-  // that a bare `""` emits an empty-string token rather than being silently
+  // `hasToken` tracks whether we have started a token during the current run
+  // so a bare `""` emits an empty-string token rather than being silently
   // dropped (which would let downstream flag/positional parsing consume the
-  // wrong next token).
+  // wrong next token). `wasQuoted` tracks whether any quote opened in the
+  // current token — used downstream to distinguish a positional value whose
+  // text happens to start with `--` from a real flag.
   let hasToken = false;
+  let wasQuoted = false;
 
   for (const char of input) {
     if (escaped) {
@@ -175,14 +183,16 @@ export function tokenize(input: string): string[] {
     if (char === '"' || char === '\'') {
       quote = char;
       hasToken = true;
+      wasQuoted = true;
       continue;
     }
 
     if (/\s/.test(char)) {
       if (hasToken || current.length > 0) {
-        tokens.push(unescapeQuotedContent(current));
+        tokens.push({ value: unescapeQuotedContent(current), wasQuoted });
         current = '';
         hasToken = false;
+        wasQuoted = false;
       }
       continue;
     }
@@ -192,10 +202,14 @@ export function tokenize(input: string): string[] {
   }
 
   if (hasToken || current.length > 0) {
-    tokens.push(unescapeQuotedContent(current));
+    tokens.push({ value: unescapeQuotedContent(current), wasQuoted });
   }
 
   return tokens;
+}
+
+export function tokenize(input: string): string[] {
+  return tokenizeWithMeta(input).map(token => token.value);
 }
 
 function coerceValue(raw: string, type: string): unknown {
@@ -256,26 +270,28 @@ export interface CliDisplaySegment {
  */
 export function parseCliForDisplay(toolString: string): CliDisplaySegment[] {
   return splitTopLevelSegments(toolString).flatMap(segment => {
-    const tokens = tokenize(segment);
+    const tokens = tokenizeWithMeta(segment);
     if (tokens.length < 2) {
       return [];
     }
-    const [agent, tool, ...rest] = tokens;
+    const [agentToken, toolToken, ...rest] = tokens;
     const parameters: Record<string, unknown> = {};
+    const looksLikeFlag = (token: QuotedToken): boolean =>
+      !token.wasQuoted && token.value.startsWith('--');
     for (let i = 0; i < rest.length; i += 1) {
       const token = rest[i];
-      if (token.startsWith('--')) {
-        const key = token.slice(2);
+      if (looksLikeFlag(token)) {
+        const key = token.value.slice(2);
         const next = rest[i + 1];
-        if (next === undefined || next.startsWith('--')) {
+        if (next === undefined || looksLikeFlag(next)) {
           parameters[key] = true;
         } else {
-          parameters[key] = next;
+          parameters[key] = next.value;
           i += 1;
         }
       }
     }
-    return [{ agent, tool, parameters }];
+    return [{ agent: agentToken.value, tool: toolToken.value, parameters }];
   });
 }
 
@@ -435,14 +451,14 @@ export class ToolCliNormalizer {
   }
 
   private parseCommandSegment(segment: string): ToolCallParams {
-    const tokens = tokenize(segment);
+    const tokens = tokenizeWithMeta(segment);
     if (tokens.length < 2) {
       throw new Error(`Invalid command "${segment}". Expected "agent tool-name [flags...]"`);
     }
 
-    const resolved = this.resolveTarget(tokens[0], tokens[1]);
+    const resolved = this.resolveTarget(tokens[0].value, tokens[1].value);
     if (!resolved.toolSlug) {
-      throw new Error(`Command "${segment}" is missing a tool name after "${tokens[0]}".`);
+      throw new Error(`Command "${segment}" is missing a tool name after "${tokens[0].value}".`);
     }
 
     const agent = this.agentRegistry.get(resolved.agentName);
@@ -463,8 +479,9 @@ export class ToolCliNormalizer {
 
     for (let index = 2; index < tokens.length; index += 1) {
       const token = tokens[index];
-      if (token.startsWith('--')) {
-        const normalizedFlag = token.slice(2);
+      const isFlag = !token.wasQuoted && token.value.startsWith('--');
+      if (isFlag) {
+        const normalizedFlag = token.value.slice(2);
         if (CONTEXT_FLAG_NAMES.has(normalizedFlag)) {
           throw new Error(`Do not include --${normalizedFlag} inside "tool". Keep context fields at the top level of useTools/getTools.`);
         }
@@ -472,15 +489,15 @@ export class ToolCliNormalizer {
         if (normalizedFlag.startsWith('no-')) {
           const boolArg = cliSchema.arguments.find(arg => arg.flag === `--${normalizedFlag.slice(3)}` && arg.type === 'boolean');
           if (!boolArg) {
-            throw new Error(`Unknown flag "${token}" for ${resolved.agentName}.${resolved.toolSlug}. Call getTools first to inspect supported flags.`);
+            throw new Error(`Unknown flag "${token.value}" for ${resolved.agentName}.${resolved.toolSlug}. Call getTools first to inspect supported flags.`);
           }
           params[boolArg.name] = false;
           continue;
         }
 
-        const arg = cliSchema.arguments.find(item => item.flag === token);
+        const arg = cliSchema.arguments.find(item => item.flag === token.value);
         if (!arg) {
-          throw new Error(`Unknown flag "${token}" for ${resolved.agentName}.${resolved.toolSlug}. Call getTools first to inspect supported flags.`);
+          throw new Error(`Unknown flag "${token.value}" for ${resolved.agentName}.${resolved.toolSlug}. Call getTools first to inspect supported flags.`);
         }
 
         if (arg.type === 'boolean') {
@@ -490,10 +507,10 @@ export class ToolCliNormalizer {
 
         const next = tokens[index + 1];
         if (next === undefined) {
-          throw new Error(`Flag "${token}" requires a value.`);
+          throw new Error(`Flag "${token.value}" requires a value.`);
         }
 
-        params[arg.name] = coerceValue(next, arg.type);
+        params[arg.name] = coerceValue(next.value, arg.type);
         index += 1;
         continue;
       }
@@ -503,7 +520,7 @@ export class ToolCliNormalizer {
         throw new Error(`Too many positional arguments for ${resolved.agentName}.${resolved.toolSlug}. Call getTools first to inspect supported flags.`);
       }
 
-      params[positional.name] = coerceValue(token, positional.type);
+      params[positional.name] = coerceValue(token.value, positional.type);
       positionalIndex += 1;
     }
 

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -144,6 +144,11 @@ export function tokenize(input: string): string[] {
   let current = '';
   let quote: '"' | '\'' | null = null;
   let escaped = false;
+  // Tracks whether we have started a token during the current run — needed so
+  // that a bare `""` emits an empty-string token rather than being silently
+  // dropped (which would let downstream flag/positional parsing consume the
+  // wrong next token).
+  let hasToken = false;
 
   for (const char of input) {
     if (escaped) {
@@ -169,21 +174,24 @@ export function tokenize(input: string): string[] {
 
     if (char === '"' || char === '\'') {
       quote = char;
+      hasToken = true;
       continue;
     }
 
     if (/\s/.test(char)) {
-      if (current.length > 0) {
+      if (hasToken || current.length > 0) {
         tokens.push(unescapeQuotedContent(current));
         current = '';
+        hasToken = false;
       }
       continue;
     }
 
     current += char;
+    hasToken = true;
   }
 
-  if (current.length > 0) {
+  if (hasToken || current.length > 0) {
     tokens.push(unescapeQuotedContent(current));
   }
 

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-04-17T20:39:15.053Z
+ * Generated: 2026-04-19T09:45:07.939Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/unit/ContentWriteGuard.test.ts
+++ b/tests/unit/ContentWriteGuard.test.ts
@@ -1,0 +1,132 @@
+/**
+ * tests/unit/ContentWriteGuard.test.ts — tool-layer guards for
+ * `contentManager.write`. Previously an empty-string path was silently
+ * rewritten to `untitled-<timestamp>.md` at the vault root, leaving orphan
+ * files behind when an LLM or parser dropped the path by mistake. The tool
+ * now rejects empty/whitespace paths explicitly.
+ *
+ * Bypasses the CLI parser via `calls:` so the guard is exercised in
+ * isolation from any parser behavior.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHeadlessAgentStack, HeadlessAgentStackResult } from '../eval/headless/HeadlessAgentStack';
+import { TestVaultManager } from '../eval/headless/TestVaultManager';
+
+const TEST_CONTEXT = {
+  workspaceId: 'test-ws',
+  sessionId: 'test-session',
+  memory: 'ContentWrite guard regression test session.',
+  goal: 'Verify contentManager.write rejects empty paths.',
+};
+
+interface CallResult {
+  success: boolean;
+  error?: string;
+}
+
+// ToolBatchExecutionService.formatUseToolResult flattens single-call results
+// to the top level; multi-call results nest under `data.results`. Normalize
+// to the flat shape here so tests don't care.
+function getCallResult(result: unknown): CallResult {
+  const r = result as { success?: boolean; error?: string; data?: { results?: CallResult[] } };
+  if (r.data?.results && Array.isArray(r.data.results) && r.data.results.length > 0) {
+    return r.data.results[0];
+  }
+  return { success: r.success ?? false, error: r.error };
+}
+
+describe('contentManager.write — empty-path guard', () => {
+  let stack: HeadlessAgentStackResult;
+  let vaultManager: TestVaultManager;
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = path.join(os.tmpdir(), `nexus-write-guard-${Date.now()}`);
+    vaultManager = new TestVaultManager(testDir);
+    vaultManager.reset();
+    vaultManager.seed({});
+
+    stack = await createHeadlessAgentStack({
+      basePath: testDir,
+      vaultName: 'write-guard-vault',
+    });
+  }, 30000);
+
+  afterAll(() => {
+    vaultManager.cleanup();
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects empty string path with a clear error', async () => {
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      calls: [
+        { agent: 'contentManager', tool: 'write', params: { path: '', content: 'body' } },
+      ],
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(call.error).toMatch(/path must be a non-empty string/);
+  });
+
+  it('rejects whitespace-only path', async () => {
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      calls: [
+        { agent: 'contentManager', tool: 'write', params: { path: '   ', content: 'body' } },
+      ],
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(call.error).toMatch(/path must be a non-empty string/);
+  });
+
+  it('does not create any orphan file when path is empty', async () => {
+    await stack.useTools({
+      ...TEST_CONTEXT,
+      calls: [
+        { agent: 'contentManager', tool: 'write', params: { path: '', content: 'body' } },
+      ],
+    });
+
+    // No untitled-*.md should have been created at vault root.
+    const rootEntries = fs.readdirSync(testDir);
+    const orphans = rootEntries.filter(name => name.startsWith('untitled-') && name.endsWith('.md'));
+    expect(orphans).toEqual([]);
+  });
+
+  it('still accepts "/" as a "pick a filename in vault root" shortcut', async () => {
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      calls: [
+        { agent: 'contentManager', tool: 'write', params: { path: '/', content: 'body' } },
+      ],
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const rootEntries = fs.readdirSync(testDir);
+    const generated = rootEntries.filter(name => name.startsWith('untitled-') && name.endsWith('.md'));
+    expect(generated.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('still accepts normal paths', async () => {
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      calls: [
+        { agent: 'contentManager', tool: 'write', params: { path: 'notes/regular.md', content: 'hello' } },
+      ],
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const written = fs.readFileSync(path.join(testDir, 'notes/regular.md'), 'utf-8');
+    expect(written).toBe('hello');
+  });
+});

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -699,24 +699,43 @@ describe('parser characterization — CLI migration audit', () => {
     expect(call.params.enabled).toBe(true);
   });
 
-  // DOCUMENTED BUG — §C.2: bool flag with explicit value is positional drift.
-  // Parser consumes `--enabled` as bare → true, then sees `true` as a positional
-  // but numericAgent_convert has no positional slots → "Too many positional"
-  // throw. Users expect CLI-parity with `--flag value` form. Defer: needs a
-  // parseBooleanValue helper on boolean flags (2–3 sites touched).
-  it.skip('C.2: --enabled followed by literal "true" — value should be accepted', () => {
+  // §C.2: bool flag followed by unquoted `true` literal — accepts as value.
+  it('C.2: --enabled followed by literal "true" — value accepted', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'numeric convert --enabled true',
     });
     expect(call.params.enabled).toBe(true);
   });
 
-  // DOCUMENTED BUG — §C.3: same root cause as C.2, for `false` literal.
-  it.skip('C.3: --enabled followed by literal "false" — value should be accepted', () => {
+  // §C.3: same logic, `false` literal.
+  it('C.3: --enabled followed by literal "false" — value accepted', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'numeric convert --enabled false',
     });
     expect(call.params.enabled).toBe(false);
+  });
+
+  // §C.2/§C.3 guardrail: a *quoted* `"true"` after a bool flag stays as a
+  // positional (matching shell semantics). Since numericAgent_convert has no
+  // positional slots, this must raise "Too many positional arguments" — the
+  // quoting signals user intent of literal string, not boolean value.
+  it('C.2 quoted: --enabled "true" keeps bool=true and treats "true" as positional', () => {
+    const err = captureError(() =>
+      makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --enabled "true"',
+      })
+    );
+    expect(err.message).toMatch(/Too many positional arguments/);
+  });
+
+  // §C.2 edge: next token that is neither `true` nor `false` stays positional.
+  it('C.2 non-bool next: --enabled followed by non-bool literal leaves bool=true', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --enabled --count 3',
+    });
+    // --enabled = true (next token is another flag), --count = 3
+    expect(call.params.enabled).toBe(true);
+    expect(call.params.count).toBe(3);
   });
 
   it('C.4: negative number coerced as negative integer', () => {
@@ -803,12 +822,9 @@ describe('parser characterization — CLI migration audit', () => {
   });
 
   // G — positionals
-  // DOCUMENTED BUG — §G.1: flag sets path via --path, but positional "body"
-  // overwrites path (slot 0) instead of filling the remaining required slot
-  // (content, slot 1). Root cause: positionalIndex advances independently of
-  // which slots are already filled by flags. Fix requires cross-referencing
-  // flag-set args with positional slots in parseCommandSegment.
-  it.skip('G.1: flag set first, then positional fills remaining required slot', () => {
+  // §G.1: flag fills a slot first; positionals skip flag-filled slots and land
+  // on the next unfilled one. No silent overwrite.
+  it('G.1: flag set first, then positional fills remaining required slot', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'content write --path "x.md" "body"',
     });
@@ -816,15 +832,26 @@ describe('parser characterization — CLI migration audit', () => {
     expect(call.params.content).toBe('body');
   });
 
-  // DOCUMENTED BUG — §G.2: same root cause as G.1. An extra positional after
-  // a flag-set arg silently overwrites the flag value instead of erroring.
-  it.skip('G.2: extra positional should not silently overwrite flag-set arg', () => {
+  // §G.2: extra positional beyond remaining unfilled slots raises "Too many
+  // positional" instead of silently overwriting a flag-set value.
+  it('G.2: extra positional after flag+content raises Too many positional', () => {
     const err = captureError(() =>
       makeNormalizer().normalizeExecutionCalls({
-        tool: 'content write --path "a.md" "b.md" "body"',
+        tool: 'content write --path "a.md" "body" "extra"',
       })
     );
-    expect(err.message).toMatch(/Too many positional|already set|overwrite/);
+    expect(err.message).toMatch(/Too many positional arguments/);
+  });
+
+  // §G.1/§G.2 guardrail: flag after positional also respects slot state.
+  // First positional fills path (slot 0), then --content sets content, then
+  // no more positionals — all required slots filled via legal routes.
+  it('G.1 reverse: positional first then --flag fills content slot', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "x.md" --content "body"',
+    });
+    expect(call.params.path).toBe('x.md');
+    expect(call.params.content).toBe('body');
   });
 
   it('G.3: positional omitted raises missing-required-arg for that slot', () => {

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -19,7 +19,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { createHeadlessAgentStack, HeadlessAgentStackResult } from '../eval/headless/HeadlessAgentStack';
 import { TestVaultManager } from '../eval/headless/TestVaultManager';
-import { ToolCliNormalizer } from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import { ToolCliNormalizer, parseCliForDisplay } from '../../src/agents/toolManager/services/ToolCliNormalizer';
 import type { IAgent } from '../../src/agents/interfaces/IAgent';
 import type { ITool } from '../../src/agents/interfaces/ITool';
 
@@ -919,5 +919,47 @@ describe('parser characterization — CLI migration audit', () => {
       makeNormalizer().normalizeExecutionCalls({ tool: 'content write --path "a.md"' })
     );
     expect(err.message).toMatch(/Missing required argument "content"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCliForDisplay — streaming-phase preview path
+// ---------------------------------------------------------------------------
+//
+// `parseCliForDisplay` is the registry-free classifier used by the chat UI
+// (accordion bubbles, status bar) to render in-flight tool calls before the
+// executor resolves them. It shares `tokenizeWithMeta` + `unescapeQuotedContent`
+// with `parseCommandSegment`, so the wasQuoted / A.4 / D.2 fixes need to
+// surface here too. These tests pin that the display path inherits the
+// upstream fixes correctly.
+describe('parseCliForDisplay — display-path inheritance of parser fixes', () => {
+  it('#160: quoted positional starting with -- is not surfaced as a flag', () => {
+    const [segment] = parseCliForDisplay('content write "f.md" "---\nfront: matter\n---\nbody"');
+    expect(segment.agent).toBe('content');
+    expect(segment.tool).toBe('write');
+    // The display-path classifier only collects flags into `parameters`. The
+    // positional should not appear as a flag named `---\n...`.
+    expect(Object.keys(segment.parameters)).toEqual([]);
+  });
+
+  it('#160: literal "--content" string in a quoted positional is not surfaced as a flag', () => {
+    const [segment] = parseCliForDisplay('content write "f.md" "--content"');
+    expect(Object.keys(segment.parameters)).toEqual([]);
+  });
+
+  it('A.4: literal backslash-n in a quoted flag value displays unescaped to a real newline', () => {
+    const [segment] = parseCliForDisplay('content write --content "line1\\nline2"');
+    expect(segment.parameters.content).toBe('line1\nline2');
+  });
+
+  it('D.2: empty quoted flag value displays as empty string (not consuming next token)', () => {
+    const [segment] = parseCliForDisplay('content write --path "" --content "body"');
+    expect(segment.parameters.path).toBe('');
+    expect(segment.parameters.content).toBe('body');
+  });
+
+  it('flag without value displays as boolean true', () => {
+    const [segment] = parseCliForDisplay('storage list --recursive');
+    expect(segment.parameters.recursive).toBe(true);
   });
 });

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -608,6 +608,66 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       expect(call.params.content).toBe('normal content');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // array<string> CSV split — quote-aware (issue #163)
+  // -------------------------------------------------------------------------
+  //
+  // CSV fallback for array<string> values respects outer quote pairs as
+  // item-internal literals. A comma inside "..." or '...' is preserved; only
+  // commas outside any quoted region act as separators. Backward compatible
+  // with bare CSV.
+
+  describe('coerceValue — array<string> quote-aware CSV split', () => {
+    it('bare CSV without quotes still splits on every comma (no regression)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths "a,b,c"',
+      });
+      expect(call.params.paths).toEqual(['a', 'b', 'c']);
+    });
+
+    it('inner double quotes protect commas — issue #163 main repro', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths \'"a, b",c\'',
+      });
+      expect(call.params.paths).toEqual(['a, b', 'c']);
+    });
+
+    it('multiple quoted items each preserve their internal commas', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths \'"a,b","c,d"\'',
+      });
+      expect(call.params.paths).toEqual(['a,b', 'c,d']);
+    });
+
+    it('inner single quotes also protect commas', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: "storage archive --paths \"'one, two',three\"",
+      });
+      expect(call.params.paths).toEqual(['one, two', 'three']);
+    });
+
+    it('JSON array path still works (existing behavior, no regression)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths \'["a, b","c"]\'',
+      });
+      expect(call.params.paths).toEqual(['a, b', 'c']);
+    });
+
+    it('mixed quoted + unquoted items', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths \'plain,"with, comma",last\'',
+      });
+      expect(call.params.paths).toEqual(['plain', 'with, comma', 'last']);
+    });
+
+    it('empty items are filtered (preserves existing filter(Boolean) behavior)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths "a,,b,"',
+      });
+      expect(call.params.paths).toEqual(['a', 'b']);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -551,6 +551,63 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       expect(result).toEqual(calls);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Quoted positional values that look like flags — Bug #1 regression pins
+  // -------------------------------------------------------------------------
+  //
+  // Parser must not misclassify a *quoted* positional token whose text starts
+  // with `--` (or `---`, `----`, etc.) as a CLI flag. Quoting carries intent:
+  // quoted tokens stay positional regardless of leading characters. Regression
+  // was accidentally reintroduced during the tokenize refactor that added
+  // `hasToken` (D.2 fix) without preserving `wasQuoted` metadata.
+
+  describe('normalizeExecutionCalls — positional values that look like flags', () => {
+    it('accepts quoted positional starting with --- (YAML frontmatter)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write "notes/fm.md" "---\\nkey: value\\n---\\nbody"',
+      });
+      expect(call.params.path).toBe('notes/fm.md');
+      expect(call.params.content).toBe('---\nkey: value\n---\nbody');
+    });
+
+    it('accepts quoted positional equal to --content (literal flag-looking text)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write "notes/weird.md" "--content"',
+      });
+      expect(call.params.path).toBe('notes/weird.md');
+      expect(call.params.content).toBe('--content');
+    });
+
+    it('accepts quoted positional starting with -- that does not match any flag', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write "notes/dash.md" "--no-such-flag"',
+      });
+      expect(call.params.content).toBe('--no-such-flag');
+    });
+
+    it('explicit named flags still work when value starts with --- (no regression)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write --path "notes/named.md" --content "---\\nheader"',
+      });
+      expect(call.params.path).toBe('notes/named.md');
+      expect(call.params.content).toBe('---\nheader');
+    });
+
+    it('unquoted -- prefix still classifies as a flag (no regression)', () => {
+      const err = captureError(() =>
+        makeNormalizer().normalizeExecutionCalls({ tool: 'content read --bogus 1 --path foo.md' })
+      );
+      expect(err.message).toMatch(/Unknown flag "--bogus" for contentManager\.read/);
+    });
+
+    it('plain-content positional without -- prefix still succeeds (baseline)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write "notes/plain.md" "normal content"',
+      });
+      expect(call.params.content).toBe('normal content');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -492,16 +492,16 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
   // -------------------------------------------------------------------------
 
   describe('normalizeExecutionCalls — edge cases', () => {
-    it('drops empty quoted tokens — tokenizer does not emit "" as a value', () => {
-      // Characterization (see review M1): the tokenizer only pushes a token
-      // when `current.length > 0`. A bare `""` produces no token, so an
-      // empty-string positional slot is silently skipped. Here
-      // `content write "" "body"` becomes tokens `['content','write','body']`
-      // — only `path` gets the value and `content` is missing.
-      const err = captureError(() =>
-        makeNormalizer().normalizeExecutionCalls({ tool: 'content write "" "body"' })
-      );
-      expect(err.message).toMatch(/Missing required argument "content" for contentManager\.write/);
+    it('preserves empty quoted tokens — bare "" emits empty string', () => {
+      // After the D.2 fix in tokenize(), a bare `""` emits an empty-string
+      // token instead of being silently dropped. `content write "" "body"`
+      // becomes tokens `['content','write','','body']` — path='' fills slot 0,
+      // content='body' fills slot 1, both required args set.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write "" "body"',
+      });
+      expect(call.params.path).toBe('');
+      expect(call.params.content).toBe('body');
     });
 
     it('accepts single-quoted tokens equivalently to double-quoted tokens', () => {
@@ -679,12 +679,15 @@ describe('parser characterization — CLI migration audit', () => {
   });
 
   // D — empties
-  it('D.1: empty quoted positional raises missing-required-arg', () => {
-    // Duplicates existing L450 characterization; pinned here for migration completeness.
-    const err = captureError(() =>
-      makeNormalizer().normalizeExecutionCalls({ tool: 'content write "" "body"' })
-    );
-    expect(err.message).toMatch(/Missing required argument "content" for contentManager\.write/);
+  it('D.1: empty quoted positional fills slot with empty string', () => {
+    // After D.2 fix: bare "" emits an empty-string token, so path='' and the
+    // following "body" fills content. Parser has no domain knowledge of path
+    // validity — domain validation belongs to the tool, not the parser.
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "" "body"',
+    });
+    expect(call.params.path).toBe('');
+    expect(call.params.content).toBe('body');
   });
 
   it('D.2: empty quoted flag value does not silently consume next token', () => {

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -552,3 +552,217 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// CLI migration audit — 25 characterization cases (A.1–G.3).
+// Each `it` asserts what the parser SHOULD do. Initial audit state:
+//   CHAR (passing, current behavior is correct):
+//     A.1, A.2, A.3, B.1–B.5, C.1, C.4, C.5, C.6, D.1, D.3, E.1, E.2, E.3, F.1, G.3
+//   Fixed in this PR (originally failing, now passing):
+//     A.4 (unescape ordering), D.2 (empty-quote token emission)
+//   DOCUMENTED BUG (failing, intentionally not fixed — see PR description):
+//     C.2, C.3 (bool flag explicit value), G.1, G.2 (flag/positional conflict)
+// ---------------------------------------------------------------------------
+
+describe('parser characterization — CLI migration audit', () => {
+  // A — quoting & escapes
+  it('A.1: nested double quotes preserve inner quotes', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "say \\"hi\\""',
+    });
+    expect(call.params.content).toBe('say "hi"');
+  });
+
+  it('A.2: single-quoted tokens work equivalently to double-quoted', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: "content write 'a.md' 'hello'",
+    });
+    expect(call.params.path).toBe('a.md');
+    expect(call.params.content).toBe('hello');
+  });
+
+  it('A.3: mixed quotes preserve literal apostrophes inside double quotes', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: `content write 'a.md' "body has 'inner'"`,
+    });
+    expect(call.params.content).toBe("body has 'inner'");
+  });
+
+  it('A.4: literal backslash+n in content stays as two chars (not newline)', () => {
+    // CLI input: content write "a.md" "foo\\nbar"  (token content = foo\\nbar, 9 chars)
+    // Correct parse: foo\nbar (8 chars: f,o,o,\,n,b,a,r) — the double-backslash
+    // consumes the single-backslash first, then `n` stays literal.
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "foo\\\\nbar"',
+    });
+    expect(call.params.content).toBe('foo\\nbar');
+  });
+
+  // B — whitespace & unicode
+  it('B.1: leading/trailing whitespace in command is tolerated', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: '   content read "a.md"   ',
+    });
+    expect(call.params.path).toBe('a.md');
+  });
+
+  it('B.2: multiple spaces between tokens collapse to delimiters', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content     read    "a.md"',
+    });
+    expect(call.params.path).toBe('a.md');
+  });
+
+  it('B.3: tab whitespace separates tokens', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content\tread\t"a.md"',
+    });
+    expect(call.params.path).toBe('a.md');
+  });
+
+  it('B.4: unicode text passes through unchanged', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "café ☕ ñoño"',
+    });
+    expect(call.params.content).toBe('café ☕ ñoño');
+  });
+
+  it('B.5: emoji passes through unchanged', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "hello 🎉 world 👋"',
+    });
+    expect(call.params.content).toBe('hello 🎉 world 👋');
+  });
+
+  // C — numbers & booleans
+  it('C.1: boolean bare flag yields true', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --enabled',
+    });
+    expect(call.params.enabled).toBe(true);
+  });
+
+  it('C.2: --enabled followed by literal "true" — value should be accepted', () => {
+    // Correct: --enabled true → enabled=true, no positional consumed.
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --enabled true',
+    });
+    expect(call.params.enabled).toBe(true);
+  });
+
+  it('C.3: --enabled followed by literal "false" — value should be accepted', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --enabled false',
+    });
+    expect(call.params.enabled).toBe(false);
+  });
+
+  it('C.4: negative number coerced as negative integer', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --count -5',
+    });
+    expect(call.params.count).toBe(-5);
+  });
+
+  it('C.5: large integer within Number precision is preserved', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --count 9999999999',
+    });
+    expect(call.params.count).toBe(9999999999);
+  });
+
+  it('C.6: float with fractional part coerced to number', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --factor 3.14159',
+    });
+    expect(call.params.factor).toBeCloseTo(3.14159);
+  });
+
+  // D — empties
+  it('D.1: empty quoted positional raises missing-required-arg', () => {
+    // Duplicates existing L450 characterization; pinned here for migration completeness.
+    const err = captureError(() =>
+      makeNormalizer().normalizeExecutionCalls({ tool: 'content write "" "body"' })
+    );
+    expect(err.message).toMatch(/Missing required argument "content" for contentManager\.write/);
+  });
+
+  it('D.2: empty quoted flag value does not silently consume next token', () => {
+    // Correct: --label "" → label=''; --tags "a" → tags=['a'].
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --label "" --tags "a"',
+    });
+    expect(call.params.label).toBe('');
+    expect(call.params.tags).toEqual(['a']);
+  });
+
+  it('D.3: omitted optional flag stays undefined', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --factor 1.5',
+    });
+    expect(call.params.factor).toBe(1.5);
+    expect(call.params.count).toBeUndefined();
+    expect(call.params.enabled).toBeUndefined();
+  });
+
+  // E — multi-command
+  it('E.1: comma inside quoted content does not split segments', () => {
+    const calls = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "alpha, beta, gamma"',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].params.content).toBe('alpha, beta, gamma');
+  });
+
+  it('E.2: comma inside JSON array-flag value does not split segments', () => {
+    const calls = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --tags \'["a, with comma","b"]\'',
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].params.tags).toEqual(['a, with comma', 'b']);
+  });
+
+  it('E.3: command-like tokens inside quoted content stay literal', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write "a.md" "content read fake"',
+    });
+    expect(call.params.content).toBe('content read fake');
+  });
+
+  // F — objects
+  it('F.1: JSON object flag value is parsed via JSON.parse', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'numeric convert --config \'{"nested":{"a":1}}\'',
+    });
+    expect(call.params.config).toEqual({ nested: { a: 1 } });
+  });
+
+  // G — positionals
+  it('G.1: flag set first, then positional fills remaining required slot', () => {
+    // Correct: --path "x.md" fills `path`; subsequent positional "body" should
+    // skip the already-filled `path` slot and fill `content`.
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'content write --path "x.md" "body"',
+    });
+    expect(call.params.path).toBe('x.md');
+    expect(call.params.content).toBe('body');
+  });
+
+  it('G.2: extra positional should not silently overwrite flag-set arg', () => {
+    // Correct: either throw (too many) or keep flag-set value. Current parser
+    // silently overwrites — treat as a bug.
+    const err = captureError(() =>
+      makeNormalizer().normalizeExecutionCalls({
+        tool: 'content write --path "a.md" "b.md" "body"',
+      })
+    );
+    expect(err.message).toMatch(/Too many positional|already set|overwrite/);
+  });
+
+  it('G.3: positional omitted raises missing-required-arg for that slot', () => {
+    const err = captureError(() =>
+      makeNormalizer().normalizeExecutionCalls({ tool: 'content write --path "a.md"' })
+    );
+    expect(err.message).toMatch(/Missing required argument "content"/);
+  });
+});

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -642,15 +642,20 @@ describe('parser characterization — CLI migration audit', () => {
     expect(call.params.enabled).toBe(true);
   });
 
-  it('C.2: --enabled followed by literal "true" — value should be accepted', () => {
-    // Correct: --enabled true → enabled=true, no positional consumed.
+  // DOCUMENTED BUG — §C.2: bool flag with explicit value is positional drift.
+  // Parser consumes `--enabled` as bare → true, then sees `true` as a positional
+  // but numericAgent_convert has no positional slots → "Too many positional"
+  // throw. Users expect CLI-parity with `--flag value` form. Defer: needs a
+  // parseBooleanValue helper on boolean flags (2–3 sites touched).
+  it.skip('C.2: --enabled followed by literal "true" — value should be accepted', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'numeric convert --enabled true',
     });
     expect(call.params.enabled).toBe(true);
   });
 
-  it('C.3: --enabled followed by literal "false" — value should be accepted', () => {
+  // DOCUMENTED BUG — §C.3: same root cause as C.2, for `false` literal.
+  it.skip('C.3: --enabled followed by literal "false" — value should be accepted', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'numeric convert --enabled false',
     });
@@ -741,9 +746,12 @@ describe('parser characterization — CLI migration audit', () => {
   });
 
   // G — positionals
-  it('G.1: flag set first, then positional fills remaining required slot', () => {
-    // Correct: --path "x.md" fills `path`; subsequent positional "body" should
-    // skip the already-filled `path` slot and fill `content`.
+  // DOCUMENTED BUG — §G.1: flag sets path via --path, but positional "body"
+  // overwrites path (slot 0) instead of filling the remaining required slot
+  // (content, slot 1). Root cause: positionalIndex advances independently of
+  // which slots are already filled by flags. Fix requires cross-referencing
+  // flag-set args with positional slots in parseCommandSegment.
+  it.skip('G.1: flag set first, then positional fills remaining required slot', () => {
     const [call] = makeNormalizer().normalizeExecutionCalls({
       tool: 'content write --path "x.md" "body"',
     });
@@ -751,9 +759,9 @@ describe('parser characterization — CLI migration audit', () => {
     expect(call.params.content).toBe('body');
   });
 
-  it('G.2: extra positional should not silently overwrite flag-set arg', () => {
-    // Correct: either throw (too many) or keep flag-set value. Current parser
-    // silently overwrites — treat as a bug.
+  // DOCUMENTED BUG — §G.2: same root cause as G.1. An extra positional after
+  // a flag-set arg silently overwrites the flag value instead of erroring.
+  it.skip('G.2: extra positional should not silently overwrite flag-set arg', () => {
     const err = captureError(() =>
       makeNormalizer().normalizeExecutionCalls({
         tool: 'content write --path "a.md" "b.md" "body"',

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -443,6 +443,51 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
   });
 
   // -------------------------------------------------------------------------
+  // array<string> JSON syntax — Bug #2 fix
+  // -------------------------------------------------------------------------
+  // Previous behavior: `array<string>` values were always split on `,`, so
+  // items containing literal commas could not be expressed. Fix accepts a
+  // JSON-array prefix (`[...]`) of strings and falls back to CSV split
+  // otherwise — strictly additive, zero breakage for the old syntax.
+
+  describe('normalizeExecutionCalls — array<string> JSON syntax (Bug #2)', () => {
+    it('parses JSON array and preserves literal commas inside items', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --tags \'["alpha, with comma","beta"]\'',
+      });
+      expect(call.params.tags).toEqual(['alpha, with comma', 'beta']);
+    });
+
+    it('falls back to CSV split when JSON parse fails', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --tags "[broken"',
+      });
+      expect(call.params.tags).toEqual(['[broken']);
+    });
+
+    it('preserves existing CSV syntax (no regression)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --tags "a,b,c"',
+      });
+      expect(call.params.tags).toEqual(['a', 'b', 'c']);
+    });
+
+    it('empty JSON array yields empty array', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --tags "[]"',
+      });
+      expect(call.params.tags).toEqual([]);
+    });
+
+    it('single-item JSON array with unicode is preserved', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'numeric convert --tags \'["só um"]\'',
+      });
+      expect(call.params.tags).toEqual(['só um']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Edge cases — quoting, escapes, multi-command
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Resolves the CLI parser family audit reported by @gcp007-ops in #160, #162,
and #163. Ports the reporter's fix sequence from
[`gcp007-ops/nexus`](https://github.com/gcp007-ops/nexus/tree/fix/parser-cli-family-audit)
in bisect-clean order, plus fills one gap the audit missed: zero coverage on
the `parseCliForDisplay` streaming-phase preview path.

The deferred heredoc (`<<<...>>>`) + greedy-fallback proposal from the #160
follow-up is intentionally **not** included — it adds new user-facing syntax
that warrants a separate design discussion. Plan at
`docs/plans/cli-parser-fixes-plan.md`.

Closes #160, #162, #163.

## Bugs fixed

| Issue | Bug | Fix shape |
|---|---|---|
| #160 | Quoted positionals starting with `--` (YAML frontmatter, literal `"--content"`) misclassified as unknown flags | New `QuotedToken` + `tokenizeWithMeta`; classify as flag only when `!wasQuoted && value.startsWith('--')` |
| #162 A.4 | `\\n` (literal backslash + n) silently rewritten to a newline by sequential `.replace()` chain ordering hazard | Single-pass scan in `unescapeQuotedContent`: when `\\` is seen, consume the next char alongside |
| #162 D.2 | Bare `""` emitted no token; `--label "" --tags "a"` fell apart silently | Track `hasToken` so empty quoted sections still emit a token |
| #162 Bug #2 | `array<string>` had no way to express items containing literal commas | Accept JSON-array literal (`'["a, b","c"]'`) before CSV fallback |
| #162 C.2 / C.3 | `--bool true` / `--bool false` threw "Too many positional arguments" | Bool branch peeks next token; consumes unquoted `true`/`false` as value |
| #162 G.1 / G.2 | Flag-filled positional slot was overwritten by following positional (silent corruption) or threw spurious "Missing required argument" | Skip slots already filled by named flags before assigning positional |
| #162 smoke | `contentManager.write` accepted empty path, fell back to Obsidian's `untitled-<ts>.md` silent creation | 3-line guard rejects empty/whitespace path with explicit error |
| #163 | `array<string>` CSV fallback split on every comma regardless of inner quoting (silent item corruption) | New `splitCsvRespectingQuotes` helper scans char-by-char respecting `"..."` and `'...'` |

## Commits

11 commits. The first 10 are cherry-picked verbatim from
@gcp007-ops's branch, preserving authorship. The last is the
`parseCliForDisplay` gap fill + auto-regenerated connectorContent.

```
816ed5d fix(toolmanager): accept JSON array syntax for array<string> flag values
208530e test(toolmanager): characterize CLI parser cases A.1–G.3 (25 cases)
52ddd77 fix(toolmanager): reorder unescapeQuotedContent so \\ consumes first
e0817a8 fix(toolmanager): emit empty-string token for bare "" in tokenize
22f959a docs(toolmanager): skip C.2/C.3/G.1/G.2 with DOCUMENTED-BUG comments
32b7207 chore(toolmanager): tighten JSON.parse typing in coerceValue
d6b2b32 fix(toolmanager): restore wasQuoted metadata so positional values starting with -- stay positional
488d5a0 fix(contentmanager): reject empty/whitespace path in write tool
215a77a fix(toolmanager): accept explicit bool values + guard positional-over-flag conflicts
c5cd72c fix(toolmanager): array<string> CSV split respects outer quotes (#163)
1f32ca9 test(toolmanager): add parseCliForDisplay display-path coverage
```

The `216a77a` commit (C.2/C.3/G.1/G.2) flips the `it.skip` markers added by
`22f959a` into live tests — see commits in order for the full migration story.

## Validation

- [x] `node_modules/.bin/jest tests/unit/ToolManagerCliSyntax.test.ts tests/unit/ContentWriteGuard.test.ts` → **95 passed** (90 from cherry-pick + 5 new display-path tests)
- [x] `node_modules/.bin/tsc --noEmit --skipLibCheck` → clean
- [x] `npm run build` → clean (lint + tsc + esbuild + connector regeneration)
- [x] Full suite: 2290 passed, 11 skipped, 2 pre-existing failures (`ModelAgentManager` per CLAUDE.md tech-debt; `PKCEUtils` flaky under concurrent workers — passes in isolation, unrelated to this PR)
- [ ] Maintainer manual smoke (5 cases the reporter validated end-to-end on their fork after deploy):
  1. `content write "_Inbox/smoke.md" "---\nkey: value\n---\nbody"` — file created with frontmatter (#160)
  2. `memory create-state ... --next-steps '["first, with comma","second"]'` — 3 items, literal commas preserved (Bug #2 + #163)
  3. `content write "_Inbox/a.md" "pre\\\\npost"` — file bytes `5c 6e` (literal `\n`, not newline) (A.4)
  4. `memory create-state ... --active-files "" --next-steps '["next"]'` — `activeFiles=[]`, `nextSteps=["next"]` (D.2)
  5. `content write "" "body"` — explicit "path must be a non-empty string" error (smoke guard)

## Out of scope

- **Heredoc (`<<<...>>>`) + greedy fallback** from the #160 follow-up
  (`gcp007-ops/nexus@1f8c5fab`). Adds new user-facing CLI syntax + a
  heuristic recovery path. Worth separate design discussion. Reporter
  themselves flagged it as "open questions for design feedback".
- **Issue #159** (`workspaceId` envelope propagation) — already addressed
  by #164.

## Credit

All parser fixes authored by @gcp007-ops on
[`gcp007-ops/nexus:fix/parser-cli-family-audit`](https://github.com/gcp007-ops/nexus/tree/fix/parser-cli-family-audit)
and `gcp007-ops/nexus:main`. Original commit authorship preserved via
cherry-pick. The reporter declined to open a PR per their preferred
workflow; this PR is the upstream port + display-path gap fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)