### PR TITLE
fix(tool-manager,set-property): parse oneOf array option + merge-promote scalar into array (#172)

### DIFF
--- a/src/agents/contentManager/tools/setProperty.ts
+++ b/src/agents/contentManager/tools/setProperty.ts
@@ -10,6 +10,69 @@ function isStringArray(value: unknown): value is string[] {
 }
 
 /**
+ * Outcome of a merge-mode decision for `setProperty`. Extracted as a pure
+ * function so every branch (including the scalar-into-array promotion added
+ * for #172) is covered by unit tests without needing an Obsidian App mock.
+ */
+export type MergeResult =
+  | { kind: 'replace'; value: unknown }
+  | { kind: 'error'; message: string };
+
+/**
+ * Decide what a merge-mode `setProperty` call should write, given the current
+ * frontmatter value and the new input. Pure: no side effects, no IO.
+ *
+ * Branches:
+ *   - `existing` absent → replace with incoming value.
+ *   - both `string[]` → union with dedup (order preserved).
+ *   - array existing + scalar incoming → promote scalar to `[value]` and
+ *     union-dedup. Fix for #172: previously errored with a type-mismatch and
+ *     made single-item append via CLI impossible.
+ *   - scalar existing + array incoming → error. Semantically ambiguous (is
+ *     the existing scalar one of the new items, or should it be discarded?).
+ *   - both scalars, or both arrays of a non-string shape → replace. The
+ *     latter is a pre-#172 characterization: non-string-array merge is a
+ *     silent replace rather than an error or union. Preserving existing
+ *     behavior to keep the fix narrowly scoped.
+ */
+export function computeMergeResult(existing: unknown, value: unknown): MergeResult {
+  if (existing === undefined || existing === null) {
+    return { kind: 'replace', value };
+  }
+
+  if (isStringArray(existing) && isStringArray(value)) {
+    const merged = [...existing];
+    for (const item of value) {
+      if (!merged.includes(item)) {
+        merged.push(item);
+      }
+    }
+    return { kind: 'replace', value: merged };
+  }
+
+  if (Array.isArray(existing) && !Array.isArray(value)) {
+    const merged = [...existing];
+    if (!merged.includes(value)) {
+      merged.push(value);
+    }
+    return { kind: 'replace', value: merged };
+  }
+
+  if (Array.isArray(existing) !== Array.isArray(value)) {
+    return {
+      kind: 'error',
+      message:
+        `Cannot merge: existing value is ${Array.isArray(existing) ? 'array' : 'scalar'} ` +
+        `but new value is ${Array.isArray(value) ? 'array' : 'scalar'}. ` +
+        `Use mode "replace" to overwrite, or ensure both values are the same type.`,
+    };
+  }
+
+  // Scalar + Scalar (or array + non-string-array): replace.
+  return { kind: 'replace', value };
+}
+
+/**
  * Location: src/agents/contentManager/tools/setProperty.ts
  *
  * Tool for setting frontmatter properties on notes.
@@ -67,40 +130,12 @@ export class SetPropertyTool extends BaseTool<SetPropertyParams, SetPropertyResu
 
       await this.app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
         if (mode === 'merge') {
-          const existing = frontmatter[property];
-
-          if (existing === undefined || existing === null) {
-            frontmatter[property] = value;
-          } else if (isStringArray(existing) && isStringArray(value)) {
-            const merged = [...existing];
-            const newList = value;
-            for (const item of newList) {
-              if (!merged.includes(item)) {
-                merged.push(item);
-              }
-            }
-            frontmatter[property] = merged;
-          } else if (Array.isArray(existing) && !Array.isArray(value)) {
-            // Appending a single item to an array field is semantically
-            // unambiguous — promote scalar to [value] and union-dedup. Without
-            // this, `set-property tags "new" --mode merge` over an existing
-            // array errored, forcing a `content write --overwrite` of the
-            // whole file.
-            const merged = [...existing];
-            if (!merged.includes(value)) {
-              merged.push(value);
-            }
-            frontmatter[property] = merged;
-          } else if (Array.isArray(existing) !== Array.isArray(value)) {
-            mergeError =
-              `Cannot merge: existing value is ${Array.isArray(existing) ? 'array' : 'scalar'} ` +
-              `but new value is ${Array.isArray(value) ? 'array' : 'scalar'}. ` +
-              `Use mode "replace" to overwrite, or ensure both values are the same type.`;
+          const outcome = computeMergeResult(frontmatter[property], value);
+          if (outcome.kind === 'error') {
+            mergeError = outcome.message;
             return;
-          } else {
-            // Scalar + Scalar: equivalent to replace
-            frontmatter[property] = value;
           }
+          frontmatter[property] = outcome.value;
         } else {
           frontmatter[property] = value;
         }

--- a/src/agents/contentManager/tools/setProperty.ts
+++ b/src/agents/contentManager/tools/setProperty.ts
@@ -80,6 +80,17 @@ export class SetPropertyTool extends BaseTool<SetPropertyParams, SetPropertyResu
               }
             }
             frontmatter[property] = merged;
+          } else if (Array.isArray(existing) && !Array.isArray(value)) {
+            // Appending a single item to an array field is semantically
+            // unambiguous — promote scalar to [value] and union-dedup. Without
+            // this, `set-property tags "new" --mode merge` over an existing
+            // array errored, forcing a `content write --overwrite` of the
+            // whole file.
+            const merged = [...existing];
+            if (!merged.includes(value)) {
+              merged.push(value);
+            }
+            frontmatter[property] = merged;
           } else if (Array.isArray(existing) !== Array.isArray(value)) {
             mergeError =
               `Cannot merge: existing value is ${Array.isArray(existing) ? 'array' : 'scalar'} ` +

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -70,6 +70,20 @@ function getSchemaType(schema: Record<string, unknown>): string {
   if (typeof schema.type === 'string') {
     return schema.type;
   }
+  // `oneOf` with an array option (e.g. `setProperty.value`) previously fell
+  // through to `unknown`, which meant `coerceValue` had no branch to hit and
+  // returned the raw string verbatim. A CSV multi-item input like `"a,b,c"`
+  // therefore reached the tool as the literal string `"a,b,c"` instead of the
+  // array the caller intended. Flag oneOf-with-array here so coerceValue can
+  // branch on whether the raw looks like a JSON array literal or a CSV.
+  if (Array.isArray(schema.oneOf)) {
+    const hasArrayOption = schema.oneOf.some(
+      (opt: unknown) => isRecord(opt) && opt.type === 'array'
+    );
+    if (hasArrayOption) {
+      return 'oneOfArray';
+    }
+  }
   return 'unknown';
 }
 
@@ -287,6 +301,29 @@ function coerceValue(raw: string, type: string): unknown {
     } catch {
       return raw;
     }
+  }
+
+  if (type === 'oneOfArray') {
+    // `oneOf: [string|number|boolean, array<string>]` slot. JSON array literal
+    // wins first; otherwise split on top-level commas. A single-item result
+    // collapses to a scalar (the outer quotes were already stripped by the
+    // tokenizer / CSV splitter) so the caller sees a string, not `["x"]`.
+    // Multi-item results become `string[]` for the array branch of oneOf.
+    const trimmed = raw.trim();
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (Array.isArray(parsed)) {
+          return parsed;
+        }
+      } catch {
+        // Malformed JSON → fall through to CSV split.
+      }
+    }
+    const items = splitCsvRespectingQuotes(raw);
+    if (items.length >= 2) return items;
+    if (items.length === 1) return items[0];
+    return raw;
   }
 
   return raw;

--- a/tests/unit/SetPropertyMerge.test.ts
+++ b/tests/unit/SetPropertyMerge.test.ts
@@ -1,0 +1,191 @@
+/**
+ * tests/unit/SetPropertyMerge.test.ts — unit coverage for the pure merge
+ * decision used by `SetPropertyTool.execute`.
+ *
+ * The tool runs the decision inside `fileManager.processFrontMatter`, but
+ * `computeMergeResult` is a pure function of (existing, value), so each
+ * branch can be asserted directly without an Obsidian App mock.
+ *
+ * Issue #172 added the scalar-into-array promotion branch. The rest of the
+ * cases here are characterization of pre-#172 behavior, locked in so future
+ * refactors don't silently alter merge semantics.
+ */
+import { computeMergeResult } from '../../src/agents/contentManager/tools/setProperty';
+
+describe('computeMergeResult — merge-mode decision (SetPropertyTool, Issue #172)', () => {
+  describe('missing-existing branch', () => {
+    it('treats undefined existing as a replace with scalar value', () => {
+      expect(computeMergeResult(undefined, 'tag-a')).toEqual({
+        kind: 'replace',
+        value: 'tag-a',
+      });
+    });
+
+    it('treats null existing as a replace with scalar value', () => {
+      expect(computeMergeResult(null, 42)).toEqual({
+        kind: 'replace',
+        value: 42,
+      });
+    });
+
+    it('treats undefined existing as a replace with array value (no promotion needed)', () => {
+      expect(computeMergeResult(undefined, ['a', 'b'])).toEqual({
+        kind: 'replace',
+        value: ['a', 'b'],
+      });
+    });
+  });
+
+  describe('string[] + string[] — union with dedup, order preserved', () => {
+    it('unions two disjoint string arrays in existing-then-new order', () => {
+      expect(computeMergeResult(['a', 'b'], ['c', 'd'])).toEqual({
+        kind: 'replace',
+        value: ['a', 'b', 'c', 'd'],
+      });
+    });
+
+    it('drops items already present, keeps order stable', () => {
+      // 'b' is duplicated; dedup preserves the existing-first ordering so the
+      // second 'b' from `value` is skipped, not promoted to the end.
+      expect(computeMergeResult(['a', 'b', 'c'], ['b', 'd', 'a'])).toEqual({
+        kind: 'replace',
+        value: ['a', 'b', 'c', 'd'],
+      });
+    });
+
+    it('handles empty existing + non-empty new', () => {
+      expect(computeMergeResult([], ['a'])).toEqual({
+        kind: 'replace',
+        value: ['a'],
+      });
+    });
+
+    it('handles non-empty existing + empty new (no-op union)', () => {
+      expect(computeMergeResult(['a', 'b'], [])).toEqual({
+        kind: 'replace',
+        value: ['a', 'b'],
+      });
+    });
+
+    it('handles fully-overlapping input as a no-op', () => {
+      expect(computeMergeResult(['a', 'b'], ['b', 'a'])).toEqual({
+        kind: 'replace',
+        value: ['a', 'b'],
+      });
+    });
+  });
+
+  describe('array existing + scalar new — #172 scalar-promote branch', () => {
+    it('appends a new scalar string to an existing array', () => {
+      expect(computeMergeResult(['a', 'b'], 'c')).toEqual({
+        kind: 'replace',
+        value: ['a', 'b', 'c'],
+      });
+    });
+
+    it('skips a scalar already present (dedup)', () => {
+      expect(computeMergeResult(['a', 'b'], 'b')).toEqual({
+        kind: 'replace',
+        value: ['a', 'b'],
+      });
+    });
+
+    it('promotes onto an empty array (first-item case)', () => {
+      expect(computeMergeResult([], 'first')).toEqual({
+        kind: 'replace',
+        value: ['first'],
+      });
+    });
+
+    it('allows mixed-type append — number scalar onto string array', () => {
+      // Intentional: frontmatter mixing is legal YAML, and strict-type
+      // validation lives downstream. The merge helper's job is to preserve
+      // the scalar-append operation without losing data.
+      expect(computeMergeResult(['a', 'b'], 1)).toEqual({
+        kind: 'replace',
+        value: ['a', 'b', 1],
+      });
+    });
+
+    it('appends onto an existing mixed-type array', () => {
+      // The `!isStringArray` check on `existing` does NOT gate this branch,
+      // so number[]/mixed[] also accept scalar appends. Locked in as a
+      // deliberate relaxation from the string-only union path above.
+      expect(computeMergeResult([1, 'two', 3], 'four')).toEqual({
+        kind: 'replace',
+        value: [1, 'two', 3, 'four'],
+      });
+    });
+
+    it('skips duplicate non-string scalar (strict equality)', () => {
+      expect(computeMergeResult([1, 2, 3], 2)).toEqual({
+        kind: 'replace',
+        value: [1, 2, 3],
+      });
+    });
+  });
+
+  describe('scalar existing + array new — error branch', () => {
+    it('errors with a type-mismatch message', () => {
+      const result = computeMergeResult('solo', ['a', 'b']);
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message).toMatch(/existing value is scalar/);
+        expect(result.message).toMatch(/new value is array/);
+        expect(result.message).toMatch(/mode "replace"/);
+      }
+    });
+
+    it('errors even when existing scalar equals one of the new items (no upgrade path)', () => {
+      // Semantically ambiguous: is the existing scalar one of the new items
+      // or should it be discarded? Issue #172 deliberately scoped the fix to
+      // scalar-into-array only; the inverse stays an explicit error.
+      const result = computeMergeResult('a', ['a', 'b']);
+      expect(result.kind).toBe('error');
+    });
+  });
+
+  describe('scalar + scalar — replace', () => {
+    it('replaces with the new scalar (not an error, not a merge)', () => {
+      expect(computeMergeResult('old', 'new')).toEqual({
+        kind: 'replace',
+        value: 'new',
+      });
+    });
+
+    it('replaces across scalar types (string → number)', () => {
+      expect(computeMergeResult('42', 42)).toEqual({
+        kind: 'replace',
+        value: 42,
+      });
+    });
+
+    it('replaces boolean values', () => {
+      expect(computeMergeResult(true, false)).toEqual({
+        kind: 'replace',
+        value: false,
+      });
+    });
+  });
+
+  describe('array existing + non-string array new — pre-#172 characterization', () => {
+    // These cases do NOT hit the string[]+string[] union branch (isStringArray
+    // fails) nor the scalar-promote branch (value IS an array) nor the
+    // error branch (both are arrays). They fall through to the trailing
+    // replace. Pinned here so future refactors don't silently alter behavior;
+    // changing this is a separate scoped decision beyond #172.
+    it('replaces when existing is string[] and new is number[] (no union)', () => {
+      expect(computeMergeResult(['a'], [1, 2])).toEqual({
+        kind: 'replace',
+        value: [1, 2],
+      });
+    });
+
+    it('replaces when both arrays are mixed type (no union)', () => {
+      expect(computeMergeResult([1, 'two'], ['three', 4])).toEqual({
+        kind: 'replace',
+        value: ['three', 4],
+      });
+    });
+  });
+});

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -625,6 +625,80 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       });
       expect(call.params.value).toBe('multi, comma');
     });
+
+    it('empty JSON array literal yields empty array', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[]"',
+      });
+      expect(call.params.value).toEqual([]);
+    });
+
+    it('JSON array with non-string items preserves parsed types', () => {
+      // oneOf allows number/boolean/string scalars in its non-array arms.
+      // When the caller explicitly writes a JSON array, we honor the parsed
+      // types verbatim — downstream schema validation decides whether the
+      // mix is acceptable for a given slot. This is a characterization pin:
+      // no per-item coercion is applied to the array branch.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[1,2,3]"',
+      });
+      expect(call.params.value).toEqual([1, 2, 3]);
+    });
+
+    it('empty-string value preserved as empty scalar (not dropped, not empty array)', () => {
+      // `splitCsvRespectingQuotes("")` returns `[]`, which the oneOfArray
+      // branch treats as the empty-length fall-through: return raw. This
+      // avoids silently coercing a missing value to `[]` (which would
+      // masquerade as a successful write).
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop ""',
+      });
+      expect(call.params.value).toBe('');
+    });
+
+    it('whitespace-only value preserved as raw scalar', () => {
+      // Trimmed items drop; zero items means no CSV match, so we return the
+      // raw whitespace unchanged. Parity with the EC-4 rule for numeric
+      // slots (whitespace-only is not silently coerced to 0/empty-array).
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "   "',
+      });
+      expect(call.params.value).toBe('   ');
+    });
+
+    it('bracket-wrapped malformed JSON falls through to CSV split', () => {
+      // `[a,b,c]` wraps in brackets so the JSON branch is attempted, fails
+      // on unquoted identifiers, and falls through to splitCsvRespectingQuotes.
+      // Outer brackets stay attached to the first/last items. Matches the
+      // array<string> branch's fallback behavior (see Bug #2 characterization).
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[a,b,c]"',
+      });
+      expect(call.params.value).toEqual(['[a', 'b', 'c]']);
+    });
+
+    it('bracket-prefix-only (no closing bracket) skips JSON and splits as CSV', () => {
+      // Starts with `[` but doesn't end with `]` → the JSON branch's
+      // startsWith/endsWith gate is not satisfied, so JSON.parse is never
+      // attempted. The single-item CSV result collapses to scalar.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[broken"',
+      });
+      expect(call.params.value).toBe('[broken');
+    });
+
+    it('numeric-looking scalar stays a string (parser does not second-guess oneOf branch)', () => {
+      // oneOf includes {type: 'number'}, but the CLI parser has no way to
+      // know which branch the caller intended. Single-item CSV result is
+      // returned as a string; downstream schema validation (or the receiving
+      // tool) handles type coercion if it wants. Pinned to prevent a well-
+      // meaning "smart" coercion from sneaking in later and changing
+      // behavior for existing callers that expect strings.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "42"',
+      });
+      expect(call.params.value).toBe('42');
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -229,10 +229,34 @@ function buildStubRegistry(): Map<string, IAgent> {
     }),
   ]);
 
+  // oneOfAgent → setProp(value: oneOf[string|number|boolean|array<string>], required)
+  // Mirrors the real `contentManager.setProperty.value` schema so the CLI
+  // coercion path for issue #172 is exercised end-to-end through
+  // `normalizeExecutionCalls` without depending on the full ContentManager
+  // agent. Alias is `one-of` (see `toKebabCase`).
+  const oneOfAgent = makeStubAgent('oneOfAgent', [
+    makeStubTool('setProp', {
+      type: 'object',
+      properties: {
+        value: {
+          oneOf: [
+            { type: 'string' },
+            { type: 'number' },
+            { type: 'boolean' },
+            { type: 'array', items: { type: 'string' } },
+          ],
+          description: 'Value to set (scalar or array of strings)',
+        },
+      },
+      required: ['value'],
+    }),
+  ]);
+
   return new Map<string, IAgent>([
     ['contentManager', contentAgent],
     ['storageManager', storageAgent],
     ['numericAgent', coerceAgent],
+    ['oneOfAgent', oneOfAgent],
     ['toolManager', makeStubAgent('toolManager', [])], // excluded from --help
   ]);
 }
@@ -270,7 +294,7 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
     it('"--help" expands to all agents except toolManager', () => {
       const result = makeNormalizer().normalizeDiscoveryRequests({ tool: '--help' });
       const agents = result.map(r => r.agent).sort();
-      expect(agents).toEqual(['contentManager', 'numericAgent', 'storageManager']);
+      expect(agents).toEqual(['contentManager', 'numericAgent', 'oneOfAgent', 'storageManager']);
     });
 
     it('throws on unknown agent token', () => {
@@ -556,6 +580,50 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
         tool: 'numeric convert --tags \'["só um"]\'',
       });
       expect(call.params.tags).toEqual(['só um']);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #172: `oneOf: [string|number|boolean, array<string>]` slot.
+  // Previously `getSchemaType` had no branch for `oneOf`, so the type marker
+  // fell through to `'unknown'` and `coerceValue` returned `raw` verbatim.
+  // A multi-item CSV like `"a,b,c"` reached the tool as the literal string
+  // `"a,b,c"` and corrupted the frontmatter. Fix: detect oneOf-with-array,
+  // return marker `oneOfArray`, and branch in coerceValue on JSON array
+  // literal vs CSV split vs single-item scalar.
+  // -------------------------------------------------------------------------
+
+  describe('normalizeExecutionCalls — oneOf array|scalar coercion (Issue #172)', () => {
+    it('single segment preserves raw scalar string (no array wrap)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "single-tag"',
+      });
+      expect(call.params.value).toBe('single-tag');
+    });
+
+    it('CSV multi-segment coerces to string[] (fix target for #172)', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "a,b,c"',
+      });
+      expect(call.params.value).toEqual(['a', 'b', 'c']);
+    });
+
+    it('JSON array literal coerces to string[]', () => {
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop \'["alpha","beta","gamma"]\'',
+      });
+      expect(call.params.value).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('outer-quoted item with internal comma collapses to scalar', () => {
+      // Shell tokenizer strips the outer single quotes, leaving
+      // `"multi, comma"`. splitCsvRespectingQuotes then honors the inner
+      // double quotes and yields a single item, so the oneOfArray branch
+      // collapses to a scalar string (precedent: #163 splitCsvRespectingQuotes).
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop \'"multi, comma"\'',
+      });
+      expect(call.params.value).toBe('multi, comma');
     });
   });
 


### PR DESCRIPTION
The `content set-property` CLI silently dropped multi-item CSV input for
array frontmatter fields. Two independent gaps chained together:

1. `ToolCliNormalizer.getSchemaType` had no branch for `oneOf`, so the
   `value` slot of `setProperty` fell through to the `'unknown'` type
   marker. `coerceValue` had no matching branch and returned the raw
   string verbatim, so `"a,b,c"` arrived at the tool as the literal
   string `"a,b,c"` instead of `["a", "b", "c"]`.

2. When the parser gap was sidestepped (single-item merge), the merge
   branch in `SetPropertyTool.execute` rejected scalar-into-array as a
   type mismatch — making it impossible to append one item to an array
   frontmatter field without falling back to `content write --overwrite`
   of the whole file.

Fix:
- Detect `oneOf` with an array option in `getSchemaType` → new marker
  `oneOfArray`.
- `coerceValue` adds a branch: JSON array literal `[...]` → array;
  otherwise `splitCsvRespectingQuotes` and branch by length (≥2 → array
  of strings; ==1 → scalar with outer quotes already stripped). Reuses
  the quote-aware CSV splitter from #163.
- `SetPropertyTool.execute` merge mode promotes scalar `value` to
  `[value]` when `existing` is an array and union-dedups.

Tests: 4 regression pins in `tests/unit/ToolManagerCliSyntax.test.ts`
covering single-segment scalar, multi-segment CSV, JSON array literal,
and outer-quoted-with-internal-comma → scalar. Suite: 2353 pass
(1 pre-existing `ModelAgentManager` flake unrelated to this change).