### PR TITLE
fix/feat(tool-manager): duplicate-guard + live schema refresh

### DIFF
--- a/src/agents/promptManager/services/CustomPromptStorageService.ts
+++ b/src/agents/promptManager/services/CustomPromptStorageService.ts
@@ -65,6 +65,7 @@ export class CustomPromptStorageService {
     private db: MigratableDatabase | null;
     private settings: Settings;
     private migrated = false;
+    private onChange: (() => void) | null = null;
 
     constructor(rawDb: DatabaseInput, settings: Settings) {
         // Wrap raw db in adapter if provided
@@ -79,6 +80,27 @@ export class CustomPromptStorageService {
         }
         this.settings = settings;
         this.initialize();
+    }
+
+    /**
+     * Register a change listener fired after any prompt mutation (create/update/delete/toggle/setEnabled).
+     * Best-effort notification for consumers that need to refresh derived data (e.g. ToolManager schema).
+     * Replaces any previously registered listener. Pass null to detach.
+     */
+    setOnChange(listener: (() => void) | null): void {
+        this.onChange = listener;
+    }
+
+    /**
+     * Fire the change listener safely — errors are swallowed so mutations never fail due to listener bugs.
+     */
+    private notifyChange(): void {
+        if (!this.onChange) return;
+        try {
+            this.onChange();
+        } catch (error) {
+            console.error('[CustomPromptStorageService] onChange listener threw:', error);
+        }
     }
 
     /**
@@ -285,6 +307,7 @@ export class CustomPromptStorageService {
         customPromptsSettings.prompts.push(newPrompt);
         await this.settings.saveSettings();
 
+        this.notifyChange();
         return newPrompt;
     }
 
@@ -352,6 +375,8 @@ export class CustomPromptStorageService {
 
         prompts[index] = { ...prompts[index], ...updates };
         await this.settings.saveSettings();
+
+        this.notifyChange();
     }
 
     /**
@@ -376,6 +401,7 @@ export class CustomPromptStorageService {
         if (index !== -1) {
             prompts.splice(index, 1);
             await this.settings.saveSettings();
+            this.notifyChange();
         }
     }
 
@@ -410,6 +436,7 @@ export class CustomPromptStorageService {
     async setEnabled(enabled: boolean): Promise<void> {
         this.ensureCustomPromptsSettings().enabled = enabled;
         await this.settings.saveSettings();
+        this.notifyChange();
     }
 
     /**

--- a/src/agents/toolManager/toolManager.ts
+++ b/src/agents/toolManager/toolManager.ts
@@ -99,6 +99,9 @@ export class ToolManagerAgent extends BaseAgent {
   }
 
   registerDynamicAgent(agent: IAgent): void {
+    if (this.allAgents.has(agent.name)) {
+      throw new Error(`Agent ${agent.name} is already registered`);
+    }
     this.allAgents.set(agent.name, agent);
     this.getToolsTool.refreshDescription();
   }

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -38,6 +38,7 @@ export class WorkspaceService {
   private sessionService: WorkspaceSessionService;
   private stateService: WorkspaceStateService;
   private systemGuidesProvider: SystemGuidesWorkspaceProvider | null;
+  private onChange: (() => void) | null = null;
 
   constructor(
     private plugin: Plugin,
@@ -77,6 +78,29 @@ export class WorkspaceService {
         addSession: (wId, data) => this.addSession(wId, data)
       }
     );
+  }
+
+  /**
+   * Register a change listener fired after any workspace-level mutation
+   * (create/update/delete). Best-effort hook for consumers that need to refresh
+   * derived data (e.g. ToolManager getTools description). Replaces any previously
+   * registered listener. Pass null to detach.
+   */
+  setOnChange(listener: (() => void) | null): void {
+    this.onChange = listener;
+  }
+
+  /**
+   * Fire the change listener safely — errors are swallowed so mutations never
+   * fail due to listener bugs.
+   */
+  private notifyChange(): void {
+    if (!this.onChange) return;
+    try {
+      this.onChange();
+    } catch (error) {
+      console.error('[WorkspaceService] onChange listener threw:', error);
+    }
   }
 
   /**
@@ -316,6 +340,12 @@ export class WorkspaceService {
    * Create new workspace (writes file + updates index)
    */
   async createWorkspace(data: Partial<IndividualWorkspace>): Promise<IndividualWorkspace> {
+    const result = await this.createWorkspaceInternal(data);
+    this.notifyChange();
+    return result;
+  }
+
+  private async createWorkspaceInternal(data: Partial<IndividualWorkspace>): Promise<IndividualWorkspace> {
     // Use new adapter if available and ready (avoids blocking on SQLite initialization)
     const adapterForCreate = this.getReadyAdapter();
     if (adapterForCreate) {
@@ -397,7 +427,7 @@ export class WorkspaceService {
    */
   async updateWorkspace(id: string, updates: Partial<IndividualWorkspace>): Promise<void> {
     this.ensureSystemWorkspaceMutable(id);
-    return withDualBackend(
+    await withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
         const hybridUpdates: Partial<HybridTypes.WorkspaceMetadata> = {};
@@ -444,6 +474,7 @@ export class WorkspaceService {
         await this.indexManager.updateWorkspaceInIndex(updatedWorkspace);
       }
     );
+    this.notifyChange();
   }
 
   /**
@@ -473,7 +504,7 @@ export class WorkspaceService {
    */
   async deleteWorkspace(id: string): Promise<void> {
     this.ensureSystemWorkspaceMutable(id);
-    return withDualBackend(
+    await withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
         await adapter.deleteWorkspace(id);
@@ -483,6 +514,7 @@ export class WorkspaceService {
         await this.indexManager.removeWorkspaceFromIndex(id);
       }
     );
+    this.notifyChange();
   }
 
   // ============================================================================

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -436,11 +436,23 @@ export class AgentInitializationService {
   }
 
   /**
+   * Get the internal CustomPromptStorageService instance used to build SchemaData.
+   * Returns undefined if not set (plugin settings were unavailable at init time).
+   * Callers use this to register change listeners for live schema refresh.
+   */
+  getCustomPromptStorage(): CustomPromptStorageService | undefined {
+    return this.customPromptStorage;
+  }
+
+  /**
    * Build schema data for ToolManager
    * Fetches workspaces, custom agents, and vault root structure
    * Non-blocking: uses JSONL/data.json fallback if SQLite isn't ready
+   *
+   * Also invoked by AgentRegistrationService to rebuild SchemaData on mutation
+   * events so the getTools description stays fresh after startup.
    */
-  private async buildSchemaData(): Promise<{
+  async buildSchemaData(): Promise<{
     workspaces: { name: string; description?: string }[];
     customAgents: { name: string; description?: string }[];
     vaultRoot: string[];

--- a/src/services/agent/AgentRegistrationService.ts
+++ b/src/services/agent/AgentRegistrationService.ts
@@ -8,7 +8,7 @@
  * Dependencies: AgentInitializationService, AgentValidationService
  */
 
-import { App, Plugin, Events } from 'obsidian';
+import { App, Plugin, Events, TAbstractFile } from 'obsidian';
 import NexusPlugin from '../../main';
 import { AgentManager } from '../AgentManager';
 import type { ServiceManager } from '../../core/ServiceManager';
@@ -21,6 +21,8 @@ import type { AppManager } from '../apps/AppManager';
 import type { IAgent } from '../../agents/interfaces/IAgent';
 import { ToolManagerAgent } from '../../agents/toolManager/toolManager';
 import type { MemorySettings } from '../../types';
+import { WorkspaceService } from '../WorkspaceService';
+import { PromptManagerAgent } from '../../agents/promptManager/promptManager';
 
 export interface AgentRegistrationServiceInterface {
   /**
@@ -94,6 +96,109 @@ export class AgentRegistrationService implements AgentRegistrationServiceInterfa
       }
     } catch {
       // ToolManager is not available during early startup, which is fine.
+    }
+  }
+
+  /**
+   * Get the ToolManagerAgent from the agent registry, or null if unavailable.
+   * ToolManager may be absent during early startup or if PHASE 4 init failed.
+   */
+  private getToolManagerAgent(): ToolManagerAgent | null {
+    try {
+      const toolManager = this.agentManager.getAgent('toolManager');
+      return toolManager instanceof ToolManagerAgent ? toolManager : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Rebuild SchemaData from the current project state and push it to ToolManager
+   * so the getTools description stays fresh after startup. Best-effort: swallows
+   * errors so mutation paths never fail due to a schema refresh.
+   *
+   * Fire-and-forget by default — callers on hot save paths should not await.
+   */
+  private refreshToolManagerSchema(): void {
+    const toolManager = this.getToolManagerAgent();
+    if (!toolManager) return;
+
+    void (async () => {
+      try {
+        const schemaData = await this.initializationService.buildSchemaData();
+        toolManager.refreshSchemaData(schemaData);
+      } catch (error) {
+        // Best-effort: stale schema is acceptable; failing the mutation isn't.
+        logger.systemWarn(`Failed to refresh ToolManager schema: ${(error as Error).message}`);
+      }
+    })();
+  }
+
+  /**
+   * Attach change listeners to WorkspaceService, CustomPromptStorageService, and
+   * the vault root so ToolManager's getTools description tracks project state.
+   *
+   * Invoked after PHASE 4 (ToolManager init) so all dependencies are available.
+   * Called from doInitializeAllAgents; no external caller should invoke this.
+   */
+  private wireSchemaRefreshListeners(): void {
+    // Workspaces — single shared instance via ServiceManager.
+    try {
+      if (this.serviceManager) {
+        const workspaceService = this.serviceManager.getServiceIfReady<WorkspaceService>('workspaceService');
+        if (workspaceService) {
+          workspaceService.setOnChange(() => this.refreshToolManagerSchema());
+        }
+      }
+    } catch (error) {
+      logger.systemWarn(`Failed to wire WorkspaceService change listener: ${(error as Error).message}`);
+    }
+
+    // Custom agents — mutations run through PromptManagerAgent.storageService (the
+    // instance the tool handlers write to). The AgentInitializationService holds
+    // a separate reader instance used by buildSchemaData; they share the underlying
+    // data.json + SQLite store, so wiring the mutation instance is sufficient.
+    try {
+      const promptManager = this.agentManager.getAgent('promptManager');
+      if (promptManager instanceof PromptManagerAgent) {
+        promptManager.getStorageService().setOnChange(() => this.refreshToolManagerSchema());
+      }
+
+      // Also wire the reader instance if it exists and is a separate object — cheap
+      // defensive coverage for settings-panel mutations that might hit that path.
+      const readerStorage = this.initializationService.getCustomPromptStorage();
+      if (readerStorage && (!(promptManager instanceof PromptManagerAgent)
+        || readerStorage !== promptManager.getStorageService())) {
+        readerStorage.setOnChange(() => this.refreshToolManagerSchema());
+      }
+    } catch (error) {
+      logger.systemWarn(`Failed to wire CustomPromptStorageService change listener: ${(error as Error).message}`);
+    }
+
+    // Vault root — listen for top-level file/folder create/delete/rename so the
+    // `Vault: [...]` hint in getTools tracks actual structure. Obsidian's vault
+    // events fire for the whole tree, so filter to root-level children only.
+    try {
+      const isRootChild = (file: TAbstractFile | null | undefined): boolean => {
+        if (!file) return false;
+        // Root children have paths with no '/' separator (e.g. 'Inbox' or 'note.md')
+        // whereas nested files look like 'Folder/note.md'.
+        return !file.path.includes('/');
+      };
+      const handler = (file: TAbstractFile): void => {
+        if (isRootChild(file)) this.refreshToolManagerSchema();
+      };
+      const renameHandler = (file: TAbstractFile, oldPath: string): void => {
+        if (isRootChild(file) || !oldPath.includes('/')) this.refreshToolManagerSchema();
+      };
+
+      // Register via plugin.registerEvent so they unhook on plugin unload.
+      const pluginWithRegister = this.plugin as Plugin;
+      pluginWithRegister.registerEvent(this.app.vault.on('create', handler));
+      pluginWithRegister.registerEvent(this.app.vault.on('delete', handler));
+      pluginWithRegister.registerEvent(this.app.vault.on('rename', renameHandler));
+    } catch (error) {
+      logger.systemWarn(`Failed to wire vault root listeners for schema refresh: ${(error as Error).message}`);
     }
   }
 
@@ -217,6 +322,10 @@ export class AgentRegistrationService implements AgentRegistrationServiceInterfa
 
       // PHASE 4: ToolManager MUST be last (needs all other agents including apps)
       await this.safeInitialize('toolManager', () => this.initializationService.initializeToolManager());
+
+      // PHASE 5: Wire change listeners for live SchemaData refresh. Non-fatal —
+      // listener registration failures log a warning but don't break init.
+      this.wireSchemaRefreshListeners();
 
       logger.systemLog('Using native chatbot UI instead of ChatAgent');
 

--- a/tests/unit/ToolManagerDynamicRegistry.test.ts
+++ b/tests/unit/ToolManagerDynamicRegistry.test.ts
@@ -99,6 +99,15 @@ describe('ToolManagerAgent dynamic registry updates', () => {
     });
   });
 
+  it('throws when the same agent name is registered twice', () => {
+    const toolManager = createToolManager();
+    toolManager.registerDynamicAgent(new StubAgent());
+
+    expect(() => toolManager.registerDynamicAgent(new StubAgent())).toThrow(
+      'Agent webTools is already registered'
+    );
+  });
+
   it('removes dynamically unregistered agents from discovery', async () => {
     const toolManager = createToolManager();
     toolManager.registerDynamicAgent(new StubAgent());

--- a/tests/unit/ToolManagerSchemaRefresh.test.ts
+++ b/tests/unit/ToolManagerSchemaRefresh.test.ts
@@ -1,0 +1,265 @@
+/**
+ * ToolManager schema refresh wiring tests.
+ *
+ * Verifies that mutation events on WorkspaceService and CustomPromptStorageService
+ * fire registered change listeners so AgentRegistrationService can rebuild the
+ * SchemaData pushed into ToolManagerAgent.refreshSchemaData().
+ *
+ * Scope: service-level listener firing only. Full end-to-end wiring through
+ * AgentRegistrationService requires a live plugin + ServiceManager, which is
+ * covered by manual integration testing in the running plugin.
+ */
+
+import { App } from 'obsidian';
+import { ToolManagerAgent, SchemaData } from '../../src/agents/toolManager/toolManager';
+import { WorkspaceService } from '../../src/services/WorkspaceService';
+import { CustomPromptStorageService } from '../../src/agents/promptManager/services/CustomPromptStorageService';
+import type { IStorageAdapter } from '../../src/database/interfaces/IStorageAdapter';
+import type { WorkspaceMetadata as HybridWorkspaceMetadata } from '../../src/types/storage/HybridStorageTypes';
+import type { Settings } from '../../src/types';
+
+function makeAdapter(overrides: Partial<IStorageAdapter> = {}): IStorageAdapter {
+  return {
+    isReady: jest.fn().mockReturnValue(true),
+    isQueryReady: jest.fn().mockReturnValue(true),
+    createWorkspace: jest.fn().mockResolvedValue('ws-1'),
+    updateWorkspace: jest.fn().mockResolvedValue(undefined),
+    deleteWorkspace: jest.fn().mockResolvedValue(undefined),
+    getWorkspace: jest.fn().mockResolvedValue(null),
+    ...overrides
+  } as unknown as IStorageAdapter;
+}
+
+function makeWorkspaceService(adapter: IStorageAdapter): WorkspaceService {
+  return new WorkspaceService(
+    { app: new App() } as never,
+    {} as never,
+    {} as never,
+    adapter
+  );
+}
+
+function makeSettings(): Settings {
+  // Minimal Settings-shaped stub: the storage service only reads settings.customPrompts
+  // and calls saveSettings() for data.json persistence.
+  const store: { settings: { customPrompts?: { enabled: boolean; prompts: unknown[] } } } = {
+    settings: { customPrompts: { enabled: true, prompts: [] } }
+  };
+  return {
+    settings: store.settings,
+    saveSettings: jest.fn().mockResolvedValue(undefined)
+  } as unknown as Settings;
+}
+
+describe('WorkspaceService.setOnChange', () => {
+  it('fires the listener after createWorkspace', async () => {
+    const service = makeWorkspaceService(makeAdapter());
+    const listener = jest.fn();
+    service.setOnChange(listener);
+
+    await service.createWorkspace({ name: 'New Workspace' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after updateWorkspace', async () => {
+    const existing: HybridWorkspaceMetadata = {
+      id: 'ws-1',
+      name: 'Existing',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true
+    };
+    const adapter = makeAdapter({
+      getWorkspace: jest.fn().mockResolvedValue(existing)
+    });
+    const service = makeWorkspaceService(adapter);
+    const listener = jest.fn();
+    service.setOnChange(listener);
+
+    await service.updateWorkspace('ws-1', { description: 'Updated' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after deleteWorkspace', async () => {
+    const service = makeWorkspaceService(makeAdapter());
+    const listener = jest.fn();
+    service.setOnChange(listener);
+
+    await service.deleteWorkspace('ws-1');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows listener errors so mutations still succeed', async () => {
+    const service = makeWorkspaceService(makeAdapter());
+    service.setOnChange(() => {
+      throw new Error('listener blew up');
+    });
+
+    // Should not throw despite the listener's error.
+    await expect(service.createWorkspace({ name: 'Safe' })).resolves.toBeDefined();
+  });
+
+  it('detaches when set to null', async () => {
+    const service = makeWorkspaceService(makeAdapter());
+    const listener = jest.fn();
+    service.setOnChange(listener);
+    service.setOnChange(null);
+
+    await service.createWorkspace({ name: 'Silent' });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe('CustomPromptStorageService.setOnChange', () => {
+  it('fires the listener after createPrompt', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    const listener = jest.fn();
+    storage.setOnChange(listener);
+
+    await storage.createPrompt({
+      name: 'Persona A',
+      description: 'desc',
+      prompt: 'system prompt body',
+      isEnabled: true
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after updatePrompt', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    const created = await storage.createPrompt({
+      name: 'Persona B',
+      description: '',
+      prompt: 'body',
+      isEnabled: true
+    });
+    const listener = jest.fn();
+    storage.setOnChange(listener);
+
+    await storage.updatePrompt(created.id, { description: 'new desc' });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after deletePrompt', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    const created = await storage.createPrompt({
+      name: 'Persona C',
+      description: '',
+      prompt: 'body',
+      isEnabled: true
+    });
+    const listener = jest.fn();
+    storage.setOnChange(listener);
+
+    await storage.deletePrompt(created.id);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after togglePrompt (via updatePrompt)', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    const created = await storage.createPrompt({
+      name: 'Persona D',
+      description: '',
+      prompt: 'body',
+      isEnabled: true
+    });
+    const listener = jest.fn();
+    storage.setOnChange(listener);
+
+    await storage.togglePrompt(created.id);
+
+    // togglePrompt delegates to updatePrompt so the listener fires once.
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires the listener after setEnabled', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    const listener = jest.fn();
+    storage.setOnChange(listener);
+
+    await storage.setEnabled(false);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows listener errors so mutations still succeed', async () => {
+    const storage = new CustomPromptStorageService(null, makeSettings());
+    storage.setOnChange(() => {
+      throw new Error('listener blew up');
+    });
+
+    await expect(storage.createPrompt({
+      name: 'Safe Persona',
+      description: '',
+      prompt: 'body',
+      isEnabled: true
+    })).resolves.toMatchObject({ name: 'Safe Persona' });
+  });
+});
+
+describe('ToolManagerAgent.refreshSchemaData integration', () => {
+  function createToolManager(schemaData: SchemaData): ToolManagerAgent {
+    return new ToolManagerAgent(new App(), new Map(), schemaData);
+  }
+
+  it('updates the getTools description when refreshSchemaData is called', () => {
+    const toolManager = createToolManager({
+      workspaces: [],
+      customAgents: [],
+      vaultRoot: []
+    });
+    const before = toolManager.getTool('getTools')?.description ?? '';
+    expect(before).not.toContain('renamed-ws');
+
+    toolManager.refreshSchemaData({
+      workspaces: [{ name: 'renamed-ws' }],
+      customAgents: [{ name: 'new-persona' }],
+      vaultRoot: ['Inbox', 'Projects']
+    });
+
+    const after = toolManager.getTool('getTools')?.description ?? '';
+    expect(after).toContain('renamed-ws');
+    expect(after).toContain('new-persona');
+    expect(after).toContain('Inbox');
+  });
+
+  it('simulates a mutation→refresh cycle end-to-end at the data layer', async () => {
+    // Mimic the AgentRegistrationService.refreshToolManagerSchema wiring:
+    // a listener builds fresh SchemaData and pushes it into ToolManager.
+    const toolManager = createToolManager({
+      workspaces: [],
+      customAgents: [],
+      vaultRoot: []
+    });
+
+    const workspaces: { name: string; description?: string }[] = [];
+    const buildSchema = (): SchemaData => ({
+      workspaces: [...workspaces],
+      customAgents: [],
+      vaultRoot: []
+    });
+
+    const workspaceService = makeWorkspaceService(makeAdapter({
+      createWorkspace: jest.fn().mockImplementation((data: HybridWorkspaceMetadata) => {
+        workspaces.push({ name: data.name });
+        return Promise.resolve(data.id ?? 'ws-generated');
+      })
+    }));
+    workspaceService.setOnChange(() => {
+      toolManager.refreshSchemaData(buildSchema());
+    });
+
+    await workspaceService.createWorkspace({ id: 'ws-alpha', name: 'Alpha Workspace' });
+
+    const description = toolManager.getTool('getTools')?.description ?? '';
+    expect(description).toContain('Alpha Workspace');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two soft follow-ups from the 5.8.4 architect review. Issue #174 (event-based refactor) remains deferred per user decision — pinned in CLAUDE.md.

### Issue 1 — duplicate-name guard on `registerDynamicAgent` (commit 1c207409)

`AgentManager.registerAgent` throws on duplicate name; the parallel `ToolManagerAgent.registerDynamicAgent` silently overwrote via `Map.set`. If `registerDynamicAgent` is ever called directly (bypassing `syncToolManagerAgent`), the two registries desync silently. Mirrored the throw so behavior is aligned. Real-world flow via `AppManager` always unregisters first, so this is defensive.

### Issue 2 — wire `refreshSchemaData` into mutation sites (commit 066593d6)

`refreshSchemaData` shipped in 5.8.4 with no caller. The `getTools` description is **teaching material for the LLM** (workspace IDs, custom agent names, top-level vault folders as hints) — it must stay current.

**Wired** (5 sources):
- `WorkspaceService.createWorkspace / updateWorkspace / deleteWorkspace`
- `CustomPromptStorageService.createPrompt / updatePrompt / deletePrompt / setEnabled` (on both the PromptManagerAgent-owned and reader instances)
- Obsidian `vault.on('create' | 'delete' | 'rename')` filtered to root-level paths

**Not wired** (rationale in commit body):
- `WorkspaceService.updateLastAccessed` — fires on every access, not schema-relevant
- `WorkspaceSessionService` / `WorkspaceStateService` — affect sessions/states/traces, not SchemaData fields
- Plugin settings `vaultRoot` assignments — vaultRoot is derived at refresh time from `app.vault.getRoot().children`, covered by the vault event listeners

**Design notes**:
- Direct-call via `setOnChange(fn)` post-construction hook, not an event bus — matches the existing `syncToolManagerAgent` pattern. No new subsystem.
- Fire-and-forget refresh — never blocks save paths.
- `setOnChange` replaces any existing listener. Today `AgentRegistrationService` is the sole consumer. Future multi-listener support can either evolve this or migrate to the event-bus refactor tracked in #174.

**Refactoring**:
- `WorkspaceService.createWorkspace` → public wrapper + private `createWorkspaceInternal` so `notifyChange` fires once regardless of which internal return path produced the workspace.
- `AgentInitializationService.buildSchemaData` widened `private → public` so `AgentRegistrationService.refreshToolManagerSchema` can rebuild fresh `SchemaData` on demand.

## Test plan

- [x] `npm run lint:obsidian` — clean
- [x] `npm run build` — clean (tsc + esbuild)
- [x] `npm test -- --testPathPattern="ToolManager|Workspace|Prompt"` — 247 pass across 13 suites (includes 13 new cases in `ToolManagerSchemaRefresh.test.ts`)
- [x] `npm test -- --testPathPattern=ToolManagerDynamicRegistry` — 3 pass (includes new duplicate-guard case)
- [ ] Manual smoke in Obsidian — create a workspace, confirm `getTools` description updates on next invocation

## Out of scope

- Issue 3 / #174 — event-based `AgentManager` refactor. Deferred until a second dynamic registrar lands (remote MCP loader, plugin-extension agent, etc.). Pinned in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)