### PR TITLE
[codex] Auto-refresh task board on updates

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -546,12 +546,31 @@ export class TaskService {
     if (!task) throw new Error(`Task "${taskId}" not found`);
 
     await this.taskRepo.addNoteLink(taskId, notePath, linkType);
+
+    this.notifyTaskBoard({
+      workspaceId: task.workspaceId,
+      entity: 'task',
+      action: 'updated',
+      taskId,
+      projectId: task.projectId
+    });
   }
 
   async unlinkNote(taskId: string, notePath: string): Promise<void> {
     await this.ensureQueryReady();
 
+    const task = await this.taskRepo.getById(taskId);
     await this.taskRepo.removeNoteLink(taskId, notePath);
+
+    if (task) {
+      this.notifyTaskBoard({
+        workspaceId: task.workspaceId,
+        entity: 'task',
+        action: 'updated',
+        taskId,
+        projectId: task.projectId
+      });
+    }
   }
 
   async getNoteLinks(taskId: string): Promise<NoteLink[]> {

--- a/src/ui/tasks/TaskBoardView.ts
+++ b/src/ui/tasks/TaskBoardView.ts
@@ -4,6 +4,7 @@ import {
   type ViewStateResult
 } from 'obsidian';
 import type NexusPlugin from '../../main';
+import type { ExternalSyncEvent, HybridStorageAdapter } from '../../database/adapters/HybridStorageAdapter';
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
 import type { TaskStatus } from '../../database/repositories/interfaces/ITaskRepository';
 import type { WorkspaceMetadata } from '../../types/storage/StorageTypes';
@@ -44,6 +45,7 @@ export class TaskBoardView extends ItemView {
   private projectSelect: HTMLSelectElement | null = null;
   private collapsedSwimlanes = new Set<string>();
   private hasRegisteredTaskBoardEvents = false;
+  private hasRegisteredExternalSync = false;
   private editCoordinator: TaskBoardEditCoordinator;
   private renderer: TaskBoardRenderer;
   private syncCoordinator: TaskBoardSyncCoordinator;
@@ -146,6 +148,7 @@ export class TaskBoardView extends ItemView {
     this.statsContainer = null;
     this.projectSelect = null;
     this.hasRegisteredTaskBoardEvents = false;
+    this.hasRegisteredExternalSync = false;
   }
 
   private get contentContainer(): HTMLElement {
@@ -202,6 +205,16 @@ export class TaskBoardView extends ItemView {
         void this.handleTaskBoardEvent(event);
       }));
       this.hasRegisteredTaskBoardEvents = true;
+    }
+
+    if (!this.hasRegisteredExternalSync) {
+      const adapter = this.plugin.getServiceIfReady<HybridStorageAdapter>('hybridStorageAdapter');
+      if (adapter?.onExternalSync) {
+        this.registerEvent(adapter.onExternalSync((event) => {
+          void this.handleExternalSync(event);
+        }));
+        this.hasRegisteredExternalSync = true;
+      }
     }
   }
 
@@ -427,6 +440,21 @@ export class TaskBoardView extends ItemView {
 
   private async handleTaskBoardEvent(event: TaskBoardDataChangedEvent): Promise<void> {
     await this.syncCoordinator.handleTaskBoardEvent(event);
+  }
+
+  private async handleExternalSync(event: ExternalSyncEvent): Promise<void> {
+    const hasWorkspaceChanges = event.modified.some((entry) => entry.category === 'workspaces');
+    const taskWorkspaceIds = Array.from(new Set(
+      event.modified
+        .filter((entry) => entry.category === 'tasks')
+        .map((entry) => entry.businessId)
+    ));
+
+    if (!hasWorkspaceChanges && taskWorkspaceIds.length === 0) {
+      return;
+    }
+
+    await this.syncCoordinator.handleExternalSync(taskWorkspaceIds, hasWorkspaceChanges);
   }
 
   private async syncFromEvent(event?: TaskBoardDataChangedEvent): Promise<void> {

--- a/src/ui/tasks/services/TaskBoardSyncCoordinator.ts
+++ b/src/ui/tasks/services/TaskBoardSyncCoordinator.ts
@@ -73,6 +73,34 @@ export class TaskBoardSyncCoordinator {
     await this.syncFromEvent(event);
   }
 
+  async handleExternalSync(taskWorkspaceIds: string[], hasWorkspaceChanges: boolean): Promise<void> {
+    if (this.deps.getIsClosing() || !this.deps.getIsReady()) {
+      return;
+    }
+
+    const filterState = this.deps.getFilterState();
+    const isRelevantWorkspace = hasWorkspaceChanges ||
+      taskWorkspaceIds.length === 0 ||
+      !filterState.workspaceId ||
+      filterState.workspaceId === 'all' ||
+      taskWorkspaceIds.includes(filterState.workspaceId);
+
+    if (!isRelevantWorkspace) {
+      return;
+    }
+
+    if (this.deps.getIsEditModalOpen() || this.deps.getDragTaskId() || this.deps.getIsSyncingBoardData()) {
+      this.deps.setPendingEvent({
+        workspaceId: taskWorkspaceIds[0] ?? filterState.workspaceId ?? 'all',
+        entity: hasWorkspaceChanges ? 'project' : 'task',
+        action: 'updated'
+      });
+      return;
+    }
+
+    await this.syncFromEvent();
+  }
+
   async flushPendingEvent(): Promise<void> {
     const pendingEvent = this.deps.getPendingEvent();
     if (!pendingEvent) {

--- a/tests/unit/TaskBoardSyncCoordinator.test.ts
+++ b/tests/unit/TaskBoardSyncCoordinator.test.ts
@@ -132,4 +132,43 @@ describe('TaskBoardSyncCoordinator', () => {
     expect(renderBoard).toHaveBeenCalledTimes(2);
     expect(refreshColumns).not.toHaveBeenCalled();
   });
+
+  it('reloads the board for relevant external sync updates', async () => {
+    const coordinator = createCoordinator();
+
+    await coordinator.handleExternalSync(['ws-1'], false);
+
+    expect(loadBoardData).toHaveBeenCalledTimes(1);
+    expect(renderBoard).toHaveBeenCalledTimes(1);
+    expect(refreshColumns).not.toHaveBeenCalled();
+  });
+
+  it('ignores unrelated external sync updates', async () => {
+    const coordinator = createCoordinator();
+
+    await coordinator.handleExternalSync(['ws-2'], false);
+
+    expect(loadBoardData).not.toHaveBeenCalled();
+    expect(renderBoard).not.toHaveBeenCalled();
+  });
+
+  it('defers external sync updates while the edit modal is open', async () => {
+    isEditModalOpen = true;
+    const coordinator = createCoordinator();
+
+    await coordinator.handleExternalSync(['ws-1'], false);
+
+    expect(pendingEvent).toEqual({
+      workspaceId: 'ws-1',
+      entity: 'task',
+      action: 'updated'
+    });
+    expect(loadBoardData).not.toHaveBeenCalled();
+
+    isEditModalOpen = false;
+    await coordinator.flushPendingEvent();
+
+    expect(loadBoardData).toHaveBeenCalledTimes(1);
+    expect(refreshColumns).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -12,6 +12,7 @@ import { DAGService } from '../../src/agents/taskManager/services/DAGService';
 import type { IProjectRepository, ProjectMetadata } from '../../src/database/repositories/interfaces/IProjectRepository';
 import type { ITaskRepository, TaskMetadata } from '../../src/database/repositories/interfaces/ITaskRepository';
 import { PaginatedResult } from '../../src/types/pagination/PaginationTypes';
+import type { TaskBoardNotifier } from '../../src/agents/taskManager/services/TaskService';
 
 // ============================================================================
 // Mock Factories
@@ -98,13 +99,17 @@ describe('TaskService', () => {
   let taskRepo: jest.Mocked<ITaskRepository>;
   let dagService: DAGService;
   let waitForQueryReady: jest.Mock<Promise<boolean>, []>;
+  let taskBoardNotifier: jest.Mocked<TaskBoardNotifier>;
 
   beforeEach(() => {
     projectRepo = createMockProjectRepo();
     taskRepo = createMockTaskRepo();
     dagService = new DAGService();
     waitForQueryReady = jest.fn().mockResolvedValue(true);
-    service = new TaskService(projectRepo, taskRepo, dagService, undefined, undefined, waitForQueryReady);
+    taskBoardNotifier = {
+      notify: jest.fn()
+    };
+    service = new TaskService(projectRepo, taskRepo, dagService, undefined, taskBoardNotifier, waitForQueryReady);
   });
 
   describe('query readiness gating', () => {
@@ -792,6 +797,13 @@ describe('TaskService', () => {
       await service.linkNote('task-1', 'path/to/note.md', 'reference');
 
       expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-1', 'path/to/note.md', 'reference');
+      expect(taskBoardNotifier.notify).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        entity: 'task',
+        action: 'updated',
+        taskId: 'task-1',
+        projectId: 'proj-1'
+      });
     });
 
     it('should throw if task not found', async () => {
@@ -813,8 +825,18 @@ describe('TaskService', () => {
 
   describe('unlinkNote', () => {
     it('should delegate to repository', async () => {
+      taskRepo.getById.mockResolvedValue(createMockTask());
+
       await service.unlinkNote('task-1', 'path.md');
+
       expect(taskRepo.removeNoteLink).toHaveBeenCalledWith('task-1', 'path.md');
+      expect(taskBoardNotifier.notify).toHaveBeenCalledWith({
+        workspaceId: 'ws-1',
+        entity: 'task',
+        action: 'updated',
+        taskId: 'task-1',
+        projectId: 'proj-1'
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- subscribe the task board view to storage external-sync events so open boards refresh when task streams change
- route external syncs through the existing task board sync coordinator so refreshes still defer during edit and drag flows
- emit task-board update notifications for note link mutations so card metadata stays live

## Root cause
The task board only refreshed from in-process TaskBoardEvents, so changes that arrived through the storage sync path did not trigger a board reload. Note-link edits also bypassed board notifications, leaving card metadata stale until the view was reopened.

## Validation
- npm test -- TaskService.test.ts TaskBoardSyncCoordinator.test.ts
- npm run build
