### PR TITLE
feat(openrouter): add gpt-5.4-image-2 image model

### DIFF
--- a/src/services/llm/adapters/openrouter/OpenRouterImageAdapter.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterImageAdapter.ts
@@ -78,6 +78,7 @@ export class OpenRouterImageAdapter extends BaseImageAdapter {
     'gemini-3-pro-image-preview' as ImageModel,
     'gemini-3.1-flash-image-preview' as ImageModel,
     'gpt-5-image' as ImageModel,
+    'gpt-5.4-image-2' as ImageModel,
     'flux-2-pro' as ImageModel,
     'flux-2-flex' as ImageModel
   ];
@@ -94,6 +95,7 @@ export class OpenRouterImageAdapter extends BaseImageAdapter {
     'gemini-3-pro-image-preview': 'google/gemini-3-pro-image-preview',
     'gemini-3.1-flash-image-preview': 'google/gemini-3.1-flash-image-preview',
     'gpt-5-image': 'openai/gpt-5-image',
+    'gpt-5.4-image-2': 'openai/gpt-5.4-image-2',
     // Add other image-capable models as they become available
     'flux-2-pro': 'black-forest-labs/flux.2-pro',
     'flux-2-flex': 'black-forest-labs/flux.2-flex'
@@ -369,6 +371,7 @@ export class OpenRouterImageAdapter extends BaseImageAdapter {
       'gemini-3-pro-image-preview': 0.08,
       'gemini-3.1-flash-image-preview': 0.04,
       'gpt-5-image': 0.08,
+      'gpt-5.4-image-2': 0.08,
       'flux-2-pro': 0.05,
       'flux-2-flex': 0.03
     };
@@ -464,6 +467,25 @@ export class OpenRouterImageAdapter extends BaseImageAdapter {
           imageGeneration: 0.08,
           currency: 'USD',
           lastUpdated: '2026-02-26'
+        }
+      },
+      {
+        id: 'gpt-5.4-image-2',
+        name: 'GPT-5.4 Image 2 (via OpenRouter)',
+        contextWindow: 272000,
+        maxOutputTokens: 128000,
+        supportsJSON: false,
+        supportsImages: true,
+        supportsFunctions: false,
+        supportsStreaming: false,
+        supportsThinking: false,
+        supportsImageGeneration: true,
+        pricing: {
+          inputPerMillion: 8,
+          outputPerMillion: 15,
+          imageGeneration: 0.08,
+          currency: 'USD',
+          lastUpdated: '2026-04-24'
         }
       },
       {

--- a/src/services/llm/types/ImageTypes.ts
+++ b/src/services/llm/types/ImageTypes.ts
@@ -244,6 +244,7 @@ export type ImageModel =
   | 'gemini-3-pro-image-preview' // Google Nano Banana Pro (advanced)
   | 'gemini-3.1-flash-image-preview' // Google Nano Banana 2 (flash speed, pro quality)
   | 'gpt-5-image'                    // OpenAI GPT-5 Image (OpenRouter only)
+  | 'gpt-5.4-image-2'                // OpenAI GPT-5.4 Image 2 (OpenRouter only)
   | 'flux-2-pro'                     // Black Forest Labs FLUX.2 Pro (OpenRouter only)
   | 'flux-2-flex';                   // Black Forest Labs FLUX.2 Flex (OpenRouter only)
 


### PR DESCRIPTION
## Summary

- Adds OpenAI's new `gpt-5.4-image-2` multimodal image-generation model as an OpenRouter option.
- Wired into `OpenRouterImageAdapter` only — matches precedent of `gpt-5-image`, `flux-*`, `dall-e-*`, `gemini-*-image-preview` (image models live in the image adapter, not the chat `ModelSpec` registry).
- Token pricing pulled verbatim from OpenRouter API (`$8/M` input, `$15/M` output, 272K context). Per-image rate mirrored from `gpt-5-image` (`$0.08`) — OpenRouter publishes no per-image field for this model; flagged for pre-release verification.

## Files

- `src/services/llm/types/ImageTypes.ts` — `ImageModel` union extended with `'gpt-5.4-image-2'`
- `src/services/llm/adapters/openrouter/OpenRouterImageAdapter.ts` — 4 insertion points: `supportedModels`, `modelMap`, `getImageModelPricing`, `listModels` `ModelInfo` entry

## Not in this PR (out of scope)

- Default-model hardcodes (`gemini-2.5-flash-image` in ModelAgentManager, DefaultsTab, etc. — ~6 sites). Users must manually select the new model. Change default in a separate PR if/when desired.
- Chat-registry (`OpenRouterModels.ts`) entry intentionally NOT added — OpenRouter image models do not appear in that file per established precedent.

## Test plan

- [ ] `npm run build` clean (verified locally: eslint + tsc + esbuild + connector-content gen all pass)
- [ ] Manual: select `GPT-5.4 Image 2 (via OpenRouter)` in image-generation UI and confirm `generateImage` tool routes to `openai/gpt-5.4-image-2` with `modalities: ["image", "text"]`
- [ ] Verify per-image pricing display before release (mirrored estimate — may need adjustment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)