### PR TITLE
test(content-replace): harden NFD fixture + add byte-distinctness sanity (#183 follow-up)

### DIFF
--- a/tests/unit/ReplaceTool.test.ts
+++ b/tests/unit/ReplaceTool.test.ts
@@ -516,10 +516,22 @@ describe('ReplaceTool', () => {
   // both for the line-range check and for the sliding-window fallback.
   // ========================================================================
   describe('Unicode normalization tolerance', () => {
-    // Visually: "é defensiva" / "hipótese" / "não" / "Ré" / "determinação"
-    // The two strings are visually identical; bytes differ.
+    // Both lines render identically as "O pedido (e.3) é defensiva: cogita a
+    // hipótese" — the bytes differ. We use explicit escape sequences for the
+    // NFD line so that no editor / Prettier pass / git filter can quietly re-
+    // compose it into NFC and turn the tests below into tautologies.
+    //   NFC: é = U+00E9, ó = U+00F3                (one code point each)
+    //   NFD: é = U+0065 U+0301, ó = U+006F U+0301  (base + combining acute)
     const NFC_LINE = 'O pedido (e.3) é defensiva: cogita a hipótese';
-    const NFD_LINE = 'O pedido (e.3) é defensiva: cogita a hipótese';
+    const NFD_LINE = 'O pedido (e.3) \u0065\u0301 defensiva: cogita a hip\u006F\u0301tese';
+
+    it('test fixtures are byte-distinct (sanity)', () => {
+      // If this fails, the constants above have been collapsed to the same
+      // Unicode form — every test in this block would then reduce to NFC===NFC
+      // and silently pass even if the comparator's NFC tolerance regresses.
+      expect(NFC_LINE).not.toBe(NFD_LINE);
+      expect(NFC_LINE.normalize('NFC')).toBe(NFD_LINE.normalize('NFC'));
+    });
 
     it('matches when file is NFC and oldContent is NFD (real-world repro)', async () => {
       mockFileContent = `head\n${NFC_LINE}\ntail`;


### PR DESCRIPTION
## Summary

Two-part hardening for the Unicode normalization tests added in #183. The fix in #183 itself is correct; this follow-up closes a fragility in the test suite.

The pre-existing `NFC_LINE` / `NFD_LINE` constants were byte-distinct in the committed source (verified: line 521 NFC, line 522 NFD with U+0301 combining acute), but the byte-distinctness depended on git / editor / Prettier never silently NFC-composing the source file. If that ever happened — even once, in any future tooling pass — every test in the `Unicode normalization tolerance` block would silently collapse to `NFC === NFC` and pass even if the comparator's NFC tolerance regressed.

This PR removes that dependency on disk-byte fidelity:

1. **Replace the NFD-form literal with explicit `é` / `ó` escape sequences.** The JS interpreter now constructs the NFD codepoints from escapes regardless of how the source file is encoded on disk. No editor or filter can quietly homogenize the fixture into NFC.

2. **Add `test fixtures are byte-distinct (sanity)`** asserting `NFC_LINE !== NFD_LINE` AND `NFC_LINE.normalize('NFC') === NFD_LINE.normalize('NFC')`. If a future change rot the fixtures back to identical bytes, this case fails loudly instead of letting the rest of the block become a tautology.

This was the missing seventh test bullet from #183's PR description (the description listed it; the diff didn't include it).

## Test plan

- [x] `tests/unit/ReplaceTool.test.ts`: 34/34 pass (33 from #183 base + 1 new sanity guard)
- [x] Byte-form verification: `NFD_LINE` codepoints after JS unescape = `[0x301, 0x301]`, `unicodedata.is_normalized('NFD', s) == True`
- [x] `tsc --noEmit --skipLibCheck` clean
- [x] No production code touched — test file only


---
_Generated by [Claude Code](https://claude.ai/code/session_01DBzqN7wjWu6NkEoezhuBU4)_