### PR TITLE
Guard frontmatter writes and NFKC replace matching

### DIFF
--- a/src/agents/contentManager/tools/replace.ts
+++ b/src/agents/contentManager/tools/replace.ts
@@ -29,14 +29,11 @@ function normalizeCRLF(text: string): string {
 /**
  * Normalize line endings AND Unicode form for the equality check only.
  *
- * NFC tolerance: an LLM-authored `oldContent` may arrive in a different
- * Unicode normalization form than what `vault.read()` returns — same code
- * points, different bytes — typically when accented PT-BR text round-trips
- * through a pipeline that NFD-decomposes (legacy Cocoa APIs, some JSON
- * encoders, copy-paste through certain editors). Pre-NFC, the comparator
- * was strict byte-equality and silently failed with "Content not found"
- * even though the visible content was identical, forcing the operator to
- * escalate to overwrite (which violates the minimum-edit rule).
+ * Compatibility (NFKC) tolerance: an LLM-authored `oldContent` may arrive
+ * in a different Unicode normalization form than what `vault.read()` returns.
+ * This covers both canonical drift (NFC vs NFD accents) and compatibility
+ * drift such as ordinal indicators (`º` -> `o`, `ª` -> `a`), ellipsis
+ * (`…` -> `...`), and NBSP (`\u00A0` -> regular space).
  *
  * We normalize ONLY for the comparison, not for the rebuild — the file's
  * original normalization form is preserved in the parts the operator did
@@ -45,7 +42,7 @@ function normalizeCRLF(text: string): string {
  * strict" without converting the whole file behind the operator's back.
  */
 function normalizeForCompare(text: string): string {
-  return normalizeCRLF(text).normalize('NFC');
+  return normalizeCRLF(text).normalize('NFKC');
 }
 
 /**
@@ -168,7 +165,7 @@ export class ReplaceTool extends BaseTool<ReplaceParams, ReplaceResult> {
       }
 
       // Extract content at the specified line range and compare with oldContent.
-      // Compare in NFC form so an oldContent that decomposed somewhere in the
+      // Compare in NFKC form so an oldContent that decomposed somewhere in the
       // pipeline (LLM tokenizer, JSON layer, copy-paste) still matches the file.
       const targetContent = fileLines.slice(startLine - 1, endLine).join('\n');
       const normalizedTarget = normalizeForCompare(targetContent);
@@ -176,7 +173,7 @@ export class ReplaceTool extends BaseTool<ReplaceParams, ReplaceResult> {
 
       if (normalizedTarget !== normalizedOld) {
         // Content mismatch — search the entire file for where it actually is.
-        // Use normalized search lines (CRLF + NFC) so the fallback survives the
+        // Use normalized search lines (CRLF + NFKC) so the fallback survives the
         // same drift the line-range check tolerates.
         const searchLines = normalizedOld.split('\n');
         const matches = findContentInLines(fileLines, searchLines);

--- a/src/agents/contentManager/tools/write.ts
+++ b/src/agents/contentManager/tools/write.ts
@@ -6,6 +6,60 @@ import { createErrorMessage } from '../../../utils/errorUtils';
 import type { ToolStatusTense } from '../../interfaces/ITool';
 import { labelFileOp, verbs } from '../../utils/toolStatusLabels';
 
+interface YamlParseError {
+  message?: string;
+  linePos?: Array<{ line: number; col: number }>;
+}
+
+/**
+ * Validate leading Obsidian frontmatter without rewriting caller bytes.
+ * A valid block is either empty or a YAML mapping/object; malformed YAML,
+ * lists, and scalar document roots are rejected because Obsidian properties
+ * are map-shaped.
+ */
+async function validateFrontmatter(content: string): Promise<string | null> {
+  const withoutBom = content.replace(/^\uFEFF/, '');
+  const match = withoutBom.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+
+  if (!match) {
+    return null;
+  }
+
+  const frontmatterBody = match[1];
+
+  try {
+    const { parse } = await import('yaml');
+    const parsed: unknown = parse(frontmatterBody);
+
+    if (parsed === null || parsed === undefined) {
+      return null;
+    }
+
+    if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return 'Frontmatter must be a YAML mapping of property names to values. Use setProperty for metadata changes.';
+    }
+
+    return null;
+  } catch (error) {
+    return formatFrontmatterError(error, frontmatterBody);
+  }
+}
+
+function formatFrontmatterError(error: unknown, frontmatterBody: string): string {
+  const yamlError = error as YamlParseError;
+  const pos = yamlError.linePos?.[0];
+  const line = pos?.line ?? 1;
+  const col = pos?.col ?? 1;
+  const offendingLine = frontmatterBody.split('\n')[line - 1]?.slice(0, 120) ?? '';
+  const message = yamlError.message ?? 'Parse error';
+
+  return [
+    `Frontmatter is invalid YAML at line ${line}, column ${col}: ${message}`,
+    offendingLine ? `Offending line: ${offendingLine}` : null,
+    'Hint: quote values that contain reserved YAML syntax such as ": ", "#", leading "- ", brackets, or unmatched quotes.',
+  ].filter((part): part is string => part !== null).join('\n');
+}
+
 /**
  * Location: src/agents/contentManager/tools/write.ts
  *
@@ -75,6 +129,11 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
 
       if (content === undefined || content === null) {
         return this.prepareResult(false, undefined, 'Content is required');
+      }
+
+      const frontmatterError = await validateFrontmatter(content);
+      if (frontmatterError) {
+        return this.prepareResult(false, undefined, frontmatterError);
       }
 
       // Normalize path (remove leading slash)

--- a/tests/unit/ContentWriteGuard.test.ts
+++ b/tests/unit/ContentWriteGuard.test.ts
@@ -120,3 +120,191 @@ describe('contentManager.write — empty-path guard', () => {
     expect(written).toBe('hello');
   });
 });
+
+describe('contentManager.write — frontmatter guard', () => {
+  let stack: HeadlessAgentStackResult;
+  let vaultManager: TestVaultManager;
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = path.join(os.tmpdir(), `nexus-write-frontmatter-${Date.now()}`);
+    vaultManager = new TestVaultManager(testDir);
+    vaultManager.reset();
+    vaultManager.seed({});
+
+    stack = await createHeadlessAgentStack({
+      basePath: testDir,
+      vaultName: 'write-frontmatter-vault',
+    });
+  }, 30000);
+
+  afterAll(() => {
+    vaultManager.cleanup();
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects unquoted colon syntax inside a frontmatter value', async () => {
+    const content = [
+      '---',
+      'fonte: Texto com (subitem: que tem dois pontos)',
+      'status: ativo',
+      '---',
+      '',
+      '# Repro',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/invalid-colon.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(call.error).toContain('Frontmatter is invalid YAML');
+    expect(call.error).toContain('fonte: Texto com');
+    expect(fs.existsSync(path.join(testDir, 'notes/invalid-colon.md'))).toBe(false);
+  });
+
+  it('rejects malformed YAML frontmatter', async () => {
+    const content = [
+      '---',
+      'title: "Unclosed',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/unclosed-quote.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(call.error).toContain('Frontmatter is invalid YAML');
+  });
+
+  it('rejects non-mapping frontmatter documents', async () => {
+    const listContent = [
+      '---',
+      '- status',
+      '- ativo',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/list-frontmatter.md" ${JSON.stringify(listContent)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(call.error).toContain('Frontmatter must be a YAML mapping');
+  });
+
+  it('accepts empty frontmatter', async () => {
+    const content = [
+      '---',
+      '---',
+      '',
+      'Body',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/empty-frontmatter.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const written = fs.readFileSync(path.join(testDir, 'notes/empty-frontmatter.md'), 'utf-8');
+    expect(written).toBe(content);
+  });
+
+  it('writes valid mapped frontmatter byte-for-byte', async () => {
+    const content = [
+      '---',
+      '# keep this comment',
+      'status: ativo',
+      'fonte: "Texto com (subitem: que tem dois pontos)"',
+      'aliases:',
+      '  - "Primeiro alias"',
+      '---',
+      '',
+      '# Titulo',
+      '',
+      'Body',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/valid-frontmatter.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const written = fs.readFileSync(path.join(testDir, 'notes/valid-frontmatter.md'), 'utf-8');
+    expect(written).toBe(content);
+  });
+
+  it('accepts content without leading frontmatter', async () => {
+    const content = '# No frontmatter\n\nBody: with a colon is fine.';
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/no-frontmatter.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const written = fs.readFileSync(path.join(testDir, 'notes/no-frontmatter.md'), 'utf-8');
+    expect(written).toBe(content);
+  });
+
+  it('does not treat body delimiters as frontmatter', async () => {
+    const content = [
+      '# Body delimiter',
+      '',
+      '---',
+      'fonte: Texto com (subitem: que tem dois pontos)',
+      '---',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/body-delimiter.md" ${JSON.stringify(content)}`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(true);
+    const written = fs.readFileSync(path.join(testDir, 'notes/body-delimiter.md'), 'utf-8');
+    expect(written).toBe(content);
+  });
+
+  it('does not overwrite an existing file when incoming frontmatter is invalid', async () => {
+    const existingPath = path.join(testDir, 'notes/existing.md');
+    fs.mkdirSync(path.dirname(existingPath), { recursive: true });
+    fs.writeFileSync(existingPath, 'original', 'utf-8');
+
+    const invalidContent = [
+      '---',
+      'fonte: Texto com (subitem: que tem dois pontos)',
+      '---',
+      '',
+      'replacement',
+    ].join('\n');
+
+    const result = await stack.useTools({
+      ...TEST_CONTEXT,
+      tool: `content write "notes/existing.md" ${JSON.stringify(invalidContent)} --overwrite true`,
+    });
+
+    const call = getCallResult(result);
+    expect(call.success).toBe(false);
+    expect(fs.readFileSync(existingPath, 'utf-8')).toBe('original');
+  });
+});

--- a/tests/unit/ReplaceTool.test.ts
+++ b/tests/unit/ReplaceTool.test.ts
@@ -639,4 +639,114 @@ describe('ReplaceTool', () => {
       expect(mockFileContent).toBe('line 1\nCHANGED\nline 3');
     });
   });
+
+  describe('Unicode compatibility normalization tolerance', () => {
+    const cases = [
+      {
+        name: 'masculine ordinal indicator',
+        fileLine: 'A multa do art. 1.026, §2º do CPC',
+        oldContent: 'A multa do art. 1.026, §2o do CPC',
+      },
+      {
+        name: 'feminine ordinal indicator',
+        fileLine: 'A 1ª instância julgou o pedido',
+        oldContent: 'A 1a instância julgou o pedido',
+      },
+      {
+        name: 'ellipsis',
+        fileLine: 'A parte deve… pagar',
+        oldContent: 'A parte deve... pagar',
+      },
+      {
+        name: 'non-breaking space',
+        fileLine: 'valor\u00A0devido',
+        oldContent: 'valor devido',
+      },
+    ];
+
+    it.each(cases)('matches compatibility-normalized oldContent for $name', async ({ fileLine, oldContent }) => {
+      mockFileContent = `head\n${fileLine}\ntail`;
+      const result = await tool.execute({
+        ...baseParams,
+        path: 'test/note.md',
+        oldContent,
+        newContent: 'CHANGED',
+        startLine: 2,
+        endLine: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockFileContent).toBe('head\nCHANGED\ntail');
+    });
+
+    it('finds compatibility-normalized content via sliding-window fallback', async () => {
+      mockFileContent = 'head\nfiller\nA multa do art. 1.026, §2º do CPC\ntail';
+      const result = await tool.execute({
+        ...baseParams,
+        path: 'test/note.md',
+        oldContent: 'A multa do art. 1.026, §2o do CPC',
+        newContent: 'CHANGED',
+        startLine: 1,
+        endLine: 1,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Found at lines 3-3');
+      expect(mockFileContent).toBe('head\nfiller\nA multa do art. 1.026, §2º do CPC\ntail');
+    });
+
+    it('preserves untouched file bytes and writes newContent verbatim', async () => {
+      const preservedPrefix = 'prefix com ordinal §2º';
+      const replacement = 'novo texto com NBSP\u00A0preservado';
+      mockFileContent = `${preservedPrefix}\nA parte deve… pagar\ntail`;
+
+      const result = await tool.execute({
+        ...baseParams,
+        path: 'test/note.md',
+        oldContent: 'A parte deve... pagar',
+        newContent: replacement,
+        startLine: 2,
+        endLine: 2,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockFileContent).toBe(`${preservedPrefix}\n${replacement}\ntail`);
+      expect(mockFileContent).toContain('§2º');
+      expect(mockFileContent).toContain('\u00A0');
+    });
+
+    it('reports multiple locations for duplicate compatibility-equivalent matches', async () => {
+      mockFileContent = '§2º\n§2o\nother';
+      const result = await tool.execute({
+        ...baseParams,
+        path: 'test/note.md',
+        oldContent: '§2o',
+        newContent: 'CHANGED',
+        startLine: 3,
+        endLine: 3,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Found at multiple locations');
+      expect(result.error).toContain('lines 1-1');
+      expect(result.error).toContain('lines 2-2');
+      expect(mockFileContent).toBe('§2º\n§2o\nother');
+    });
+
+    it('regression: genuinely absent compatibility-normalized content still fails', async () => {
+      mockFileContent = 'head\nA parte deve… pagar\ntail';
+      const result = await tool.execute({
+        ...baseParams,
+        path: 'test/note.md',
+        oldContent: 'texto ausente',
+        newContent: 'CHANGED',
+        startLine: 2,
+        endLine: 2,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Content not found');
+      expect(mockFileContent).toBe('head\nA parte deve… pagar\ntail');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- validate leading Obsidian frontmatter in content write before create/overwrite
- reject malformed or non-mapping frontmatter without rewriting valid bytes
- compare content replace ranges with NFKC tolerance for compatibility-normalized text
- add focused coverage for YAML frontmatter guards and ordinal/ellipsis/NBSP replace matching

## Validation
- npm test -- --runTestsByPath tests/unit/ReplaceTool.test.ts tests/unit/ContentWriteGuard.test.ts --runInBand
- npm run build
- npm test -- --runInBand (fails only at existing unrelated ModelAgentManager.test.ts:242 metadata expectation; 2433 passed, 9 skipped)