### PR TITLE
[codex] Add GPT-5.5 model support

### DIFF
--- a/.claude/skills/nexus-model-updates/SKILL.md
+++ b/.claude/skills/nexus-model-updates/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: nexus-model-updates
+description: Add, update, or verify Nexus LLM provider model definitions. Use when adding newly released models, changing OpenAI/OpenRouter/Codex/GitHub Copilot/Anthropic/Google model metadata, updating provider defaults, or live-testing whether a model ID works through the reusable provider smoke test.
+---
+
+# Nexus Model Updates
+
+Use this skill whenever a task changes Nexus model availability, model prices, context windows, capabilities, defaults, or live provider compatibility.
+
+## Research First
+
+Verify new or changed cloud models against primary sources before editing. Prefer official provider docs, model pages, pricing pages, or API model listings. For OpenAI model work, use the `openai-docs` skill or official OpenAI domains. For OpenRouter, use the model page, for example `https://openrouter.ai/openai/<model-id>`.
+
+Capture these facts before editing:
+
+- Provider-facing model ID.
+- Display name.
+- Context window and max output tokens.
+- Input and output price per 1M tokens.
+- Whether text, image input, functions/tools, streaming, JSON/structured outputs, and reasoning are supported.
+- Whether the model should become the provider default.
+
+## Edit Model Registries
+
+Provider model registries live under:
+
+```text
+src/services/llm/adapters/<provider>/<Provider>Models.ts
+```
+
+Common files:
+
+```text
+src/services/llm/adapters/openai/OpenAIModels.ts
+src/services/llm/adapters/openrouter/OpenRouterModels.ts
+src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
+src/services/llm/adapters/anthropic/AnthropicModels.ts
+src/services/llm/adapters/google/GoogleModels.ts
+```
+
+For each model, add or update a `ModelSpec` with:
+
+```ts
+{
+  provider: 'openai',
+  name: 'GPT-5.5',
+  apiName: 'gpt-5.5',
+  contextWindow: 1050000,
+  maxTokens: 128000,
+  inputCostPerMillion: 5.00,
+  outputCostPerMillion: 30.00,
+  capabilities: {
+    supportsJSON: true,
+    supportsImages: true,
+    supportsFunctions: true,
+    supportsStreaming: true,
+    supportsThinking: true
+  }
+}
+```
+
+If changing defaults, update the provider default export in the same file, and update any adapter constructor fallback that hard-codes a default model. Search with:
+
+```bash
+rg -n "gpt-|claude-|gemini-|DEFAULT_MODEL|super\\(" src/services/llm/adapters tests
+```
+
+OpenRouter model IDs usually include the upstream namespace, for example `openai/gpt-5.5`. The reusable smoke test accepts either `gpt-5.5` or `openai/gpt-5.5` for OpenRouter and normalizes un-namespaced IDs to `openai/<id>`.
+
+Codex OAuth models are defined in `OpenAICodexModels.ts`. Only add models that are available through the Codex/ChatGPT OAuth endpoint. Do not assume a Pro model is available in Codex just because it exists in ChatGPT or the OpenAI API.
+
+## Update Behavior
+
+Some models need code-path updates beyond registry entries:
+
+- OpenAI Pro or long-running Responses API models may need `DeepResearchHandler` routing if streaming chat is unsupported or background polling is recommended.
+- OAuth-backed Codex may reject some standard Responses API parameters. The generic live smoke test intentionally omits `maxTokens` for Codex because the endpoint has rejected `max_output_tokens`.
+- If a provider adapter has a stale fallback model in its constructor, update it with the same default as the registry.
+- If tests assert a previous default model, update those expectations.
+
+## Test Locally
+
+Run focused static tests after changing registries or defaults:
+
+```bash
+npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
+```
+
+Run the build before finishing:
+
+```bash
+npm run build
+```
+
+If `npm run build` only changes `src/utils/connectorContent.ts` generated timestamp, revert that generated churn unless connector source actually changed:
+
+```bash
+git restore -- src/utils/connectorContent.ts
+```
+
+## Live Smoke Test
+
+Use the reusable smoke test for arbitrary provider/model checks:
+
+```bash
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Run all provider defaults:
+
+```bash
+RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Provider-specific overrides when running all:
+
+```bash
+OPENAI_SMOKE_MODEL=gpt-5.5
+OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
+CODEX_SMOKE_MODEL=gpt-5.5
+```
+
+The live smoke suite is skipped unless `RUN_MODEL_SMOKE=1` is set. In Codex sandboxed sessions, live API calls may fail with DNS or network errors; rerun the same Jest command with escalated permissions when needed.
+
+The smoke test loads OpenAI/OpenRouter API keys from environment variables or repo `.env`, and Codex OAuth tokens from `data.json`. Never print or copy credentials into chat.
+
+## Final Checklist
+
+Before answering:
+
+- Cite or summarize the primary sources used for model facts.
+- Confirm which providers and model IDs were added.
+- State whether defaults changed.
+- Report static tests, live smoke tests, and build results.
+- Mention any skipped provider or known unsupported model variant.

--- a/.claude/skills/nexus-model-updates/agents/openai.yaml
+++ b/.claude/skills/nexus-model-updates/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nexus Model Updates"
+  short_description: "Add and test Nexus LLM models"
+  default_prompt: "Use $nexus-model-updates to add a new Nexus LLM model and verify it with the reusable live smoke test."

--- a/.cline/skills/nexus-model-updates/SKILL.md
+++ b/.cline/skills/nexus-model-updates/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: nexus-model-updates
+description: Add, update, or verify Nexus LLM provider model definitions. Use when adding newly released models, changing OpenAI/OpenRouter/Codex/GitHub Copilot/Anthropic/Google model metadata, updating provider defaults, or live-testing whether a model ID works through the reusable provider smoke test.
+---
+
+# Nexus Model Updates
+
+Use this skill whenever a task changes Nexus model availability, model prices, context windows, capabilities, defaults, or live provider compatibility.
+
+## Research First
+
+Verify new or changed cloud models against primary sources before editing. Prefer official provider docs, model pages, pricing pages, or API model listings. For OpenAI model work, use the `openai-docs` skill or official OpenAI domains. For OpenRouter, use the model page, for example `https://openrouter.ai/openai/<model-id>`.
+
+Capture these facts before editing:
+
+- Provider-facing model ID.
+- Display name.
+- Context window and max output tokens.
+- Input and output price per 1M tokens.
+- Whether text, image input, functions/tools, streaming, JSON/structured outputs, and reasoning are supported.
+- Whether the model should become the provider default.
+
+## Edit Model Registries
+
+Provider model registries live under:
+
+```text
+src/services/llm/adapters/<provider>/<Provider>Models.ts
+```
+
+Common files:
+
+```text
+src/services/llm/adapters/openai/OpenAIModels.ts
+src/services/llm/adapters/openrouter/OpenRouterModels.ts
+src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
+src/services/llm/adapters/anthropic/AnthropicModels.ts
+src/services/llm/adapters/google/GoogleModels.ts
+```
+
+For each model, add or update a `ModelSpec` with:
+
+```ts
+{
+  provider: 'openai',
+  name: 'GPT-5.5',
+  apiName: 'gpt-5.5',
+  contextWindow: 1050000,
+  maxTokens: 128000,
+  inputCostPerMillion: 5.00,
+  outputCostPerMillion: 30.00,
+  capabilities: {
+    supportsJSON: true,
+    supportsImages: true,
+    supportsFunctions: true,
+    supportsStreaming: true,
+    supportsThinking: true
+  }
+}
+```
+
+If changing defaults, update the provider default export in the same file, and update any adapter constructor fallback that hard-codes a default model. Search with:
+
+```bash
+rg -n "gpt-|claude-|gemini-|DEFAULT_MODEL|super\\(" src/services/llm/adapters tests
+```
+
+OpenRouter model IDs usually include the upstream namespace, for example `openai/gpt-5.5`. The reusable smoke test accepts either `gpt-5.5` or `openai/gpt-5.5` for OpenRouter and normalizes un-namespaced IDs to `openai/<id>`.
+
+Codex OAuth models are defined in `OpenAICodexModels.ts`. Only add models that are available through the Codex/ChatGPT OAuth endpoint. Do not assume a Pro model is available in Codex just because it exists in ChatGPT or the OpenAI API.
+
+## Update Behavior
+
+Some models need code-path updates beyond registry entries:
+
+- OpenAI Pro or long-running Responses API models may need `DeepResearchHandler` routing if streaming chat is unsupported or background polling is recommended.
+- OAuth-backed Codex may reject some standard Responses API parameters. The generic live smoke test intentionally omits `maxTokens` for Codex because the endpoint has rejected `max_output_tokens`.
+- If a provider adapter has a stale fallback model in its constructor, update it with the same default as the registry.
+- If tests assert a previous default model, update those expectations.
+
+## Test Locally
+
+Run focused static tests after changing registries or defaults:
+
+```bash
+npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
+```
+
+Run the build before finishing:
+
+```bash
+npm run build
+```
+
+If `npm run build` only changes `src/utils/connectorContent.ts` generated timestamp, revert that generated churn unless connector source actually changed:
+
+```bash
+git restore -- src/utils/connectorContent.ts
+```
+
+## Live Smoke Test
+
+Use the reusable smoke test for arbitrary provider/model checks:
+
+```bash
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Run all provider defaults:
+
+```bash
+RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Provider-specific overrides when running all:
+
+```bash
+OPENAI_SMOKE_MODEL=gpt-5.5
+OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
+CODEX_SMOKE_MODEL=gpt-5.5
+```
+
+The live smoke suite is skipped unless `RUN_MODEL_SMOKE=1` is set. In Codex sandboxed sessions, live API calls may fail with DNS or network errors; rerun the same Jest command with escalated permissions when needed.
+
+The smoke test loads OpenAI/OpenRouter API keys from environment variables or repo `.env`, and Codex OAuth tokens from `data.json`. Never print or copy credentials into chat.
+
+## Final Checklist
+
+Before answering:
+
+- Cite or summarize the primary sources used for model facts.
+- Confirm which providers and model IDs were added.
+- State whether defaults changed.
+- Report static tests, live smoke tests, and build results.
+- Mention any skipped provider or known unsupported model variant.

--- a/.cline/skills/nexus-model-updates/agents/openai.yaml
+++ b/.cline/skills/nexus-model-updates/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nexus Model Updates"
+  short_description: "Add and test Nexus LLM models"
+  default_prompt: "Use $nexus-model-updates to add a new Nexus LLM model and verify it with the reusable live smoke test."

--- a/.codex/skills/nexus-model-updates/SKILL.md
+++ b/.codex/skills/nexus-model-updates/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: nexus-model-updates
+description: Add, update, or verify Nexus LLM provider model definitions. Use when adding newly released models, changing OpenAI/OpenRouter/Codex/GitHub Copilot/Anthropic/Google model metadata, updating provider defaults, or live-testing whether a model ID works through the reusable provider smoke test.
+---
+
+# Nexus Model Updates
+
+Use this skill whenever a task changes Nexus model availability, model prices, context windows, capabilities, defaults, or live provider compatibility.
+
+## Research First
+
+Verify new or changed cloud models against primary sources before editing. Prefer official provider docs, model pages, pricing pages, or API model listings. For OpenAI model work, use the `openai-docs` skill or official OpenAI domains. For OpenRouter, use the model page, for example `https://openrouter.ai/openai/<model-id>`.
+
+Capture these facts before editing:
+
+- Provider-facing model ID.
+- Display name.
+- Context window and max output tokens.
+- Input and output price per 1M tokens.
+- Whether text, image input, functions/tools, streaming, JSON/structured outputs, and reasoning are supported.
+- Whether the model should become the provider default.
+
+## Edit Model Registries
+
+Provider model registries live under:
+
+```text
+src/services/llm/adapters/<provider>/<Provider>Models.ts
+```
+
+Common files:
+
+```text
+src/services/llm/adapters/openai/OpenAIModels.ts
+src/services/llm/adapters/openrouter/OpenRouterModels.ts
+src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
+src/services/llm/adapters/anthropic/AnthropicModels.ts
+src/services/llm/adapters/google/GoogleModels.ts
+```
+
+For each model, add or update a `ModelSpec` with:
+
+```ts
+{
+  provider: 'openai',
+  name: 'GPT-5.5',
+  apiName: 'gpt-5.5',
+  contextWindow: 1050000,
+  maxTokens: 128000,
+  inputCostPerMillion: 5.00,
+  outputCostPerMillion: 30.00,
+  capabilities: {
+    supportsJSON: true,
+    supportsImages: true,
+    supportsFunctions: true,
+    supportsStreaming: true,
+    supportsThinking: true
+  }
+}
+```
+
+If changing defaults, update the provider default export in the same file, and update any adapter constructor fallback that hard-codes a default model. Search with:
+
+```bash
+rg -n "gpt-|claude-|gemini-|DEFAULT_MODEL|super\\(" src/services/llm/adapters tests
+```
+
+OpenRouter model IDs usually include the upstream namespace, for example `openai/gpt-5.5`. The reusable smoke test accepts either `gpt-5.5` or `openai/gpt-5.5` for OpenRouter and normalizes un-namespaced IDs to `openai/<id>`.
+
+Codex OAuth models are defined in `OpenAICodexModels.ts`. Only add models that are available through the Codex/ChatGPT OAuth endpoint. Do not assume a Pro model is available in Codex just because it exists in ChatGPT or the OpenAI API.
+
+## Update Behavior
+
+Some models need code-path updates beyond registry entries:
+
+- OpenAI Pro or long-running Responses API models may need `DeepResearchHandler` routing if streaming chat is unsupported or background polling is recommended.
+- OAuth-backed Codex may reject some standard Responses API parameters. The generic live smoke test intentionally omits `maxTokens` for Codex because the endpoint has rejected `max_output_tokens`.
+- If a provider adapter has a stale fallback model in its constructor, update it with the same default as the registry.
+- If tests assert a previous default model, update those expectations.
+
+## Test Locally
+
+Run focused static tests after changing registries or defaults:
+
+```bash
+npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
+```
+
+Run the build before finishing:
+
+```bash
+npm run build
+```
+
+If `npm run build` only changes `src/utils/connectorContent.ts` generated timestamp, revert that generated churn unless connector source actually changed:
+
+```bash
+git restore -- src/utils/connectorContent.ts
+```
+
+## Live Smoke Test
+
+Use the reusable smoke test for arbitrary provider/model checks:
+
+```bash
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Run all provider defaults:
+
+```bash
+RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Provider-specific overrides when running all:
+
+```bash
+OPENAI_SMOKE_MODEL=gpt-5.5
+OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
+CODEX_SMOKE_MODEL=gpt-5.5
+```
+
+The live smoke suite is skipped unless `RUN_MODEL_SMOKE=1` is set. In Codex sandboxed sessions, live API calls may fail with DNS or network errors; rerun the same Jest command with escalated permissions when needed.
+
+The smoke test loads OpenAI/OpenRouter API keys from environment variables or repo `.env`, and Codex OAuth tokens from `data.json`. Never print or copy credentials into chat.
+
+## Final Checklist
+
+Before answering:
+
+- Cite or summarize the primary sources used for model facts.
+- Confirm which providers and model IDs were added.
+- State whether defaults changed.
+- Report static tests, live smoke tests, and build results.
+- Mention any skipped provider or known unsupported model variant.

--- a/.codex/skills/nexus-model-updates/agents/openai.yaml
+++ b/.codex/skills/nexus-model-updates/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nexus Model Updates"
+  short_description: "Add and test Nexus LLM models"
+  default_prompt: "Use $nexus-model-updates to add a new Nexus LLM model and verify it with the reusable live smoke test."

--- a/.skills/nexus-model-updates/SKILL.md
+++ b/.skills/nexus-model-updates/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: nexus-model-updates
+description: Add, update, or verify Nexus LLM provider model definitions. Use when adding newly released models, changing OpenAI/OpenRouter/Codex/GitHub Copilot/Anthropic/Google model metadata, updating provider defaults, or live-testing whether a model ID works through the reusable provider smoke test.
+---
+
+# Nexus Model Updates
+
+Use this skill whenever a task changes Nexus model availability, model prices, context windows, capabilities, defaults, or live provider compatibility.
+
+## Research First
+
+Verify new or changed cloud models against primary sources before editing. Prefer official provider docs, model pages, pricing pages, or API model listings. For OpenAI model work, use the `openai-docs` skill or official OpenAI domains. For OpenRouter, use the model page, for example `https://openrouter.ai/openai/<model-id>`.
+
+Capture these facts before editing:
+
+- Provider-facing model ID.
+- Display name.
+- Context window and max output tokens.
+- Input and output price per 1M tokens.
+- Whether text, image input, functions/tools, streaming, JSON/structured outputs, and reasoning are supported.
+- Whether the model should become the provider default.
+
+## Edit Model Registries
+
+Provider model registries live under:
+
+```text
+src/services/llm/adapters/<provider>/<Provider>Models.ts
+```
+
+Common files:
+
+```text
+src/services/llm/adapters/openai/OpenAIModels.ts
+src/services/llm/adapters/openrouter/OpenRouterModels.ts
+src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+src/services/llm/adapters/github-copilot/GithubCopilotModels.ts
+src/services/llm/adapters/anthropic/AnthropicModels.ts
+src/services/llm/adapters/google/GoogleModels.ts
+```
+
+For each model, add or update a `ModelSpec` with:
+
+```ts
+{
+  provider: 'openai',
+  name: 'GPT-5.5',
+  apiName: 'gpt-5.5',
+  contextWindow: 1050000,
+  maxTokens: 128000,
+  inputCostPerMillion: 5.00,
+  outputCostPerMillion: 30.00,
+  capabilities: {
+    supportsJSON: true,
+    supportsImages: true,
+    supportsFunctions: true,
+    supportsStreaming: true,
+    supportsThinking: true
+  }
+}
+```
+
+If changing defaults, update the provider default export in the same file, and update any adapter constructor fallback that hard-codes a default model. Search with:
+
+```bash
+rg -n "gpt-|claude-|gemini-|DEFAULT_MODEL|super\\(" src/services/llm/adapters tests
+```
+
+OpenRouter model IDs usually include the upstream namespace, for example `openai/gpt-5.5`. The reusable smoke test accepts either `gpt-5.5` or `openai/gpt-5.5` for OpenRouter and normalizes un-namespaced IDs to `openai/<id>`.
+
+Codex OAuth models are defined in `OpenAICodexModels.ts`. Only add models that are available through the Codex/ChatGPT OAuth endpoint. Do not assume a Pro model is available in Codex just because it exists in ChatGPT or the OpenAI API.
+
+## Update Behavior
+
+Some models need code-path updates beyond registry entries:
+
+- OpenAI Pro or long-running Responses API models may need `DeepResearchHandler` routing if streaming chat is unsupported or background polling is recommended.
+- OAuth-backed Codex may reject some standard Responses API parameters. The generic live smoke test intentionally omits `maxTokens` for Codex because the endpoint has rejected `max_output_tokens`.
+- If a provider adapter has a stale fallback model in its constructor, update it with the same default as the registry.
+- If tests assert a previous default model, update those expectations.
+
+## Test Locally
+
+Run focused static tests after changing registries or defaults:
+
+```bash
+npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
+```
+
+Run the build before finishing:
+
+```bash
+npm run build
+```
+
+If `npm run build` only changes `src/utils/connectorContent.ts` generated timestamp, revert that generated churn unless connector source actually changed:
+
+```bash
+git restore -- src/utils/connectorContent.ts
+```
+
+## Live Smoke Test
+
+Use the reusable smoke test for arbitrary provider/model checks:
+
+```bash
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Run all provider defaults:
+
+```bash
+RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+```
+
+Provider-specific overrides when running all:
+
+```bash
+OPENAI_SMOKE_MODEL=gpt-5.5
+OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
+CODEX_SMOKE_MODEL=gpt-5.5
+```
+
+The live smoke suite is skipped unless `RUN_MODEL_SMOKE=1` is set. In Codex sandboxed sessions, live API calls may fail with DNS or network errors; rerun the same Jest command with escalated permissions when needed.
+
+The smoke test loads OpenAI/OpenRouter API keys from environment variables or repo `.env`, and Codex OAuth tokens from `data.json`. Never print or copy credentials into chat.
+
+## Final Checklist
+
+Before answering:
+
+- Cite or summarize the primary sources used for model facts.
+- Confirm which providers and model IDs were added.
+- State whether defaults changed.
+- Report static tests, live smoke tests, and build results.
+- Mention any skipped provider or known unsupported model variant.

--- a/.skills/nexus-model-updates/agents/openai.yaml
+++ b/.skills/nexus-model-updates/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Nexus Model Updates"
+  short_description: "Add and test Nexus LLM models"
+  default_prompt: "Use $nexus-model-updates to add a new Nexus LLM model and verify it with the reusable live smoke test."

--- a/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
@@ -118,7 +118,7 @@ export class OpenAICodexAdapter extends BaseAdapter {
    */
   constructor(tokens: CodexOAuthTokens, onTokenRefresh?: TokenPersistCallback) {
     // Pass accessToken as apiKey for BaseAdapter compatibility; baseUrl is the Codex endpoint
-    super(tokens.accessToken, 'gpt-5.4', CODEX_API_ENDPOINT, false);
+    super(tokens.accessToken, 'gpt-5.5', CODEX_API_ENDPOINT, false);
     this.tokens = { ...tokens };
     this.onTokenRefresh = onTokenRefresh;
     this.initializeCache();

--- a/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
@@ -14,6 +14,22 @@ import { ModelSpec } from '../modelTypes';
 export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   {
     provider: 'openai-codex',
+    name: 'GPT-5.5',
+    apiName: 'gpt-5.5',
+    contextWindow: 400000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai-codex',
     name: 'GPT-5.4',
     apiName: 'gpt-5.4',
     contextWindow: 1050000,
@@ -126,4 +142,4 @@ export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   }
 ];
 
-export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.4';
+export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.5';

--- a/src/services/llm/adapters/openai/DeepResearchHandler.ts
+++ b/src/services/llm/adapters/openai/DeepResearchHandler.ts
@@ -83,7 +83,8 @@ export class DeepResearchHandler {
   isDeepResearchModel(model: string): boolean {
     return model.includes('deep-research')
       || model.includes('gpt-5.2-pro')
-      || model.includes('gpt-5.4-pro');
+      || model.includes('gpt-5.4-pro')
+      || model.includes('gpt-5.5-pro');
   }
 
   async generate(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
@@ -168,6 +169,7 @@ export class DeepResearchHandler {
       model.includes('o4-mini')
       || model.includes('gpt-5.2-pro')
       || model.includes('gpt-5.4-pro')
+      || model.includes('gpt-5.5-pro')
     ) ? 2000 : 5000;
 
     while (Date.now() - startTime < maxWaitTime) {

--- a/src/services/llm/adapters/openai/OpenAIAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAIAdapter.ts
@@ -137,7 +137,7 @@ export class OpenAIAdapter extends BaseAdapter {
   private deepResearch: DeepResearchHandler;
 
   constructor(apiKey: string) {
-    super(apiKey, 'gpt-5.4');
+    super(apiKey, 'gpt-5.5');
     this.deepResearch = new DeepResearchHandler(this.apiKey, this.baseUrl);
     this.initializeCache();
   }

--- a/src/services/llm/adapters/openai/OpenAIModels.ts
+++ b/src/services/llm/adapters/openai/OpenAIModels.ts
@@ -1,6 +1,6 @@
 /**
  * OpenAI Model Specifications
- * Updated March 2026 - Added GPT-5.4 family
+ * Updated April 2026 - Added GPT-5.5 family
  *
  * Pricing Notes:
  * - GPT-5 family supports 90% caching discount (cached tokens: $0.125/M vs $1.25/M fresh)
@@ -13,7 +13,41 @@
 import { ModelSpec } from '../modelTypes';
 
 export const OPENAI_MODELS: ModelSpec[] = [
-  // GPT-5.4 family (latest models)
+  // GPT-5.5 family (latest models)
+  {
+    provider: 'openai',
+    name: 'GPT-5.5',
+    apiName: 'gpt-5.5',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai',
+    name: 'GPT-5.5 Pro',
+    apiName: 'gpt-5.5-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 30.00,
+    outputCostPerMillion: 180.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: false,
+      supportsThinking: true
+    }
+  },
+
+  // GPT-5.4 family
   {
     provider: 'openai',
     name: 'GPT-5.4',
@@ -217,4 +251,4 @@ export const OPENAI_MODELS: ModelSpec[] = [
   // These models use a different parameter structure and would need special handling
 ];
 
-export const OPENAI_DEFAULT_MODEL = 'gpt-5.4';
+export const OPENAI_DEFAULT_MODEL = 'gpt-5.5';

--- a/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
@@ -157,7 +157,7 @@ export class OpenRouterAdapter extends BaseAdapter {
     apiKey: string,
     options?: { httpReferer?: string; xTitle?: string }
   ) {
-    super(apiKey, 'anthropic/claude-3.5-sonnet');
+    super(apiKey, 'openai/gpt-5.5');
     this.httpReferer = options?.httpReferer?.trim() || 'https://synapticlabs.ai';
     this.xTitle = options?.xTitle?.trim() || BRAND_NAME;
     this.initializeCache();

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -1,7 +1,7 @@
 /**
  * OpenRouter Model Specifications
  * OpenRouter provides access to multiple providers through a unified API
- * Updated April 2026 with GPT-5.4, Claude Sonnet 4.6, and Gemini 3.1 models
+ * Updated April 2026 with GPT-5.5, Claude Sonnet 4.6, and Gemini 3.1 models
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -475,6 +475,38 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'GPT-5.5',
+    apiName: 'openai/gpt-5.5',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.5 Pro',
+    apiName: 'openai/gpt-5.5-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 30.00,
+    outputCostPerMillion: 180.00,
+    capabilities: {
+      supportsJSON: false,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'MiMo-V2-Omni',
     apiName: 'xiaomi/mimo-v2-omni',
     contextWindow: 262144,
@@ -539,4 +571,4 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
 ];
 
-export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-5.4';
+export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-5.5';

--- a/tests/debug/provider-model-live-smoke.test.ts
+++ b/tests/debug/provider-model-live-smoke.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Generic live model smoke tests.
+ *
+ * These tests hit real provider APIs and are skipped unless explicitly enabled.
+ *
+ * Run all default smoke targets:
+ *   RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *
+ * Run one provider/model:
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *
+ * Provider-specific overrides when running all:
+ *   OPENAI_SMOKE_MODEL=gpt-5.5
+ *   OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
+ *   CODEX_SMOKE_MODEL=gpt-5.5
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { __setRequestUrlMock } from 'obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { DEFAULT_MODELS } from '../../src/services/llm/adapters/ModelRegistry';
+import { OpenAIAdapter } from '../../src/services/llm/adapters/openai/OpenAIAdapter';
+import { OpenRouterAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterAdapter';
+import { OpenAICodexAdapter, type CodexOAuthTokens } from '../../src/services/llm/adapters/openai-codex/OpenAICodexAdapter';
+import type { GenerateOptions, LLMResponse } from '../../src/services/llm/adapters/types';
+
+jest.setTimeout(240_000);
+
+type SmokeProvider = 'openai' | 'openrouter' | 'openai-codex';
+
+interface ProviderSettingsShape {
+  llmProviders?: {
+    providers?: Record<string, {
+      apiKey?: string;
+      enabled?: boolean;
+      oauth?: {
+        refreshToken?: string;
+        expiresAt?: number;
+        metadata?: {
+          accountId?: string;
+        };
+      };
+    }>;
+  };
+}
+
+interface SmokeTarget {
+  provider: SmokeProvider;
+  model: string;
+}
+
+const RUN_LIVE = process.env.RUN_MODEL_SMOKE === '1';
+const PROVIDERS: SmokeProvider[] = ['openai', 'openrouter', 'openai-codex'];
+
+function readDotEnv(): Map<string, string> {
+  const envPath = path.join(process.cwd(), '.env');
+  const values = new Map<string, string>();
+
+  if (!fs.existsSync(envPath)) {
+    return values;
+  }
+
+  const lines = fs.readFileSync(envPath, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    values.set(match[1], match[2].replace(/^['"]|['"]$/g, ''));
+  }
+
+  return values;
+}
+
+const DOT_ENV = readDotEnv();
+
+function getEnv(name: string): string | undefined {
+  return process.env[name] || DOT_ENV.get(name);
+}
+
+function loadCodexTokensFromLocalDataJson(): CodexOAuthTokens | null {
+  const dataPath = path.join(process.cwd(), 'data.json');
+  if (!fs.existsSync(dataPath)) {
+    return null;
+  }
+
+  const settings = JSON.parse(fs.readFileSync(dataPath, 'utf8')) as ProviderSettingsShape;
+  const config = settings.llmProviders?.providers?.['openai-codex'];
+  const accountId = config?.oauth?.metadata?.accountId;
+
+  if (!config?.enabled || !config.apiKey || !config.oauth?.refreshToken || !accountId) {
+    return null;
+  }
+
+  return {
+    accessToken: config.apiKey,
+    refreshToken: config.oauth.refreshToken,
+    expiresAt: config.oauth.expiresAt || 0,
+    accountId,
+  };
+}
+
+function normalizeModelForProvider(provider: SmokeProvider, model: string): string {
+  if (provider === 'openrouter' && !model.includes('/')) {
+    return `openai/${model}`;
+  }
+
+  if ((provider === 'openai' || provider === 'openai-codex') && model.startsWith('openai/')) {
+    return model.slice('openai/'.length);
+  }
+
+  return model;
+}
+
+function getProviderModel(provider: SmokeProvider): string {
+  const sharedOverride = getEnv('MODEL_SMOKE_MODEL');
+  const providerOverride = {
+    openai: getEnv('OPENAI_SMOKE_MODEL'),
+    openrouter: getEnv('OPENROUTER_SMOKE_MODEL'),
+    'openai-codex': getEnv('CODEX_SMOKE_MODEL'),
+  }[provider];
+
+  const model = providerOverride || sharedOverride || DEFAULT_MODELS[provider];
+  return normalizeModelForProvider(provider, model);
+}
+
+function getTargets(): SmokeTarget[] {
+  const providerFilter = getEnv('MODEL_SMOKE_PROVIDER');
+  if (!providerFilter) {
+    return PROVIDERS.map((provider) => ({ provider, model: getProviderModel(provider) }));
+  }
+
+  if (!PROVIDERS.includes(providerFilter as SmokeProvider)) {
+    throw new Error(`MODEL_SMOKE_PROVIDER must be one of: ${PROVIDERS.join(', ')}`);
+  }
+
+  const provider = providerFilter as SmokeProvider;
+  return [{ provider, model: getProviderModel(provider) }];
+}
+
+function setRequestUrlToRealFetch(): void {
+  __setRequestUrlMock(async (request) => {
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(request.headers || {})) {
+      headers[key] = String(value);
+    }
+
+    const response = await fetch(request.url ?? '', {
+      method: request.method || 'GET',
+      headers,
+      body: typeof request.body === 'string' ? request.body : undefined,
+    });
+    const arrayBuffer = await response.arrayBuffer();
+    const text = new TextDecoder().decode(arrayBuffer);
+
+    let json: unknown = {};
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // SSE responses are not JSON documents.
+    }
+
+    return {
+      status: response.status,
+      headers: Object.fromEntries(response.headers.entries()),
+      text,
+      json,
+      arrayBuffer,
+    };
+  });
+}
+
+function createAdapter(provider: SmokeProvider): OpenAIAdapter | OpenRouterAdapter | OpenAICodexAdapter {
+  if (provider === 'openai') {
+    const apiKey = getEnv('OPENAI_API_KEY');
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY is required for OpenAI smoke tests');
+    }
+    return new OpenAIAdapter(apiKey);
+  }
+
+  if (provider === 'openrouter') {
+    const apiKey = getEnv('OPENROUTER_API_KEY');
+    if (!apiKey) {
+      throw new Error('OPENROUTER_API_KEY is required for OpenRouter smoke tests');
+    }
+    return new OpenRouterAdapter(apiKey);
+  }
+
+  const tokens = loadCodexTokensFromLocalDataJson();
+  if (!tokens) {
+    throw new Error('Codex OAuth tokens are required in data.json for Codex smoke tests');
+  }
+  return new OpenAICodexAdapter(tokens);
+}
+
+async function callModel(target: SmokeTarget): Promise<LLMResponse> {
+  const adapter = createAdapter(target.provider);
+  const options: GenerateOptions = {
+    model: target.model,
+    systemPrompt: 'Follow the user instruction exactly.',
+  };
+
+  // Codex currently rejects max_output_tokens on the OAuth endpoint.
+  if (target.provider !== 'openai-codex') {
+    options.maxTokens = Number(getEnv('MODEL_SMOKE_MAX_TOKENS') || 16);
+  }
+
+  return adapter.generateUncached(
+    'Reply with exactly this token and no other words: OK',
+    options
+  );
+}
+
+const describeLive = RUN_LIVE ? describe : describe.skip;
+
+describeLive('generic provider model live smoke', () => {
+  beforeAll(() => {
+    setRequestUrlToRealFetch();
+  });
+
+  for (const target of getTargets()) {
+    it(`calls ${target.provider} model ${target.model}`, async () => {
+      const response = await callModel(target);
+
+      expect(response.provider).toBe(target.provider);
+      expect(response.model).toBe(target.model);
+      expect(response.text.trim().length).toBeGreaterThan(0);
+      expect(response.text.toUpperCase()).toContain('OK');
+    });
+  }
+});

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -1,0 +1,51 @@
+import { ModelRegistry, DEFAULT_MODELS } from '../../src/services/llm/adapters/ModelRegistry';
+
+describe('ModelRegistry GPT-5.5 models', () => {
+  it('registers GPT-5.5 and GPT-5.5 Pro for OpenAI', () => {
+    expect(ModelRegistry.findModel('openai', 'gpt-5.5')).toEqual(expect.objectContaining({
+      name: 'GPT-5.5',
+      contextWindow: 1050000,
+      maxTokens: 128000,
+      inputCostPerMillion: 5,
+      outputCostPerMillion: 30
+    }));
+
+    expect(ModelRegistry.findModel('openai', 'gpt-5.5-pro')).toEqual(expect.objectContaining({
+      name: 'GPT-5.5 Pro',
+      inputCostPerMillion: 30,
+      outputCostPerMillion: 180
+    }));
+  });
+
+  it('registers OpenRouter GPT-5.5 models with OpenRouter IDs', () => {
+    expect(ModelRegistry.findModel('openrouter', 'openai/gpt-5.5')).toEqual(expect.objectContaining({
+      name: 'GPT-5.5',
+      contextWindow: 1050000,
+      inputCostPerMillion: 5,
+      outputCostPerMillion: 30
+    }));
+
+    expect(ModelRegistry.findModel('openrouter', 'openai/gpt-5.5-pro')).toEqual(expect.objectContaining({
+      name: 'GPT-5.5 Pro',
+      inputCostPerMillion: 30,
+      outputCostPerMillion: 180
+    }));
+  });
+
+  it('registers GPT-5.5 but not GPT-5.5 Pro for Codex', () => {
+    expect(ModelRegistry.findModel('openai-codex', 'gpt-5.5')).toEqual(expect.objectContaining({
+      name: 'GPT-5.5',
+      contextWindow: 400000,
+      inputCostPerMillion: 0,
+      outputCostPerMillion: 0
+    }));
+
+    expect(ModelRegistry.findModel('openai-codex', 'gpt-5.5-pro')).toBeUndefined();
+  });
+
+  it('uses GPT-5.5 as the default for the updated OpenAI providers', () => {
+    expect(DEFAULT_MODELS.openai).toBe('gpt-5.5');
+    expect(DEFAULT_MODELS.openrouter).toBe('openai/gpt-5.5');
+    expect(DEFAULT_MODELS['openai-codex']).toBe('gpt-5.5');
+  });
+});

--- a/tests/unit/OpenAICodexAdapter.test.ts
+++ b/tests/unit/OpenAICodexAdapter.test.ts
@@ -112,7 +112,7 @@ describe('OpenAICodexAdapter', () => {
 
     expect(request.headers.Authorization).toBe('Bearer test-access-token');
     expect(request.headers['ChatGPT-Account-Id']).toBe('acct-test-123');
-    expect(body.model).toBe('gpt-5.4');
+    expect(body.model).toBe('gpt-5.5');
     expect(body.stream).toBe(true);
     expect(body.tool_choice).toBe('auto');
     expect(body.instructions).toContain('System message');


### PR DESCRIPTION
## Summary
- Add GPT-5.5 and GPT-5.5 Pro to OpenAI and OpenRouter model registries
- Add GPT-5.5 to Codex only, update defaults and adapter fallbacks
- Add reusable live provider/model smoke test and synced nexus-model-updates skill

## Validation
- npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
- npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose (skipped by default)
- RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose (live smoke: OpenAI, OpenRouter, Codex GPT-5.5)
- python3 /Users/jrosenbaum/.codex/skills/.system/skill-creator/scripts/quick_validate.py .skills/nexus-model-updates
- npm run build