### PR TITLE
[codex] Fix Claude Code Windows auth binary resolution

### DIFF
--- a/src/services/external/ClaudeHeadlessService.ts
+++ b/src/services/external/ClaudeHeadlessService.ts
@@ -3,6 +3,7 @@ import type { ChildProcessByStdio } from 'child_process';
 import type { Readable, Writable } from 'stream';
 import { getPrimaryServerKey } from '../../constants/branding';
 import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
+import { spawnDesktopProcess } from '../../utils/desktopProcess';
 
 const MAX_SAFE_WINDOWS_ARGV_CHARS = 24_000;
 
@@ -231,7 +232,7 @@ export class ClaudeHeadlessService {
             const stdio: ['pipe', 'pipe', 'pipe'] | ['ignore', 'pipe', 'pipe'] = stdinText !== undefined
                 ? ['pipe', 'pipe', 'pipe']
                 : ['ignore', 'pipe', 'pipe'];
-            const child = childProcess.spawn(command, args, {
+            const child = spawnDesktopProcess(childProcess, command, args, {
                 cwd,
                 env,
                 stdio

--- a/src/utils/binaryDiscovery.ts
+++ b/src/utils/binaryDiscovery.ts
@@ -16,7 +16,7 @@ const COMMON_UNIX_BIN_DIRS = [
     '/sbin'
 ];
 
-const COMMON_WINDOWS_BIN_DIRS = [
+const STATIC_COMMON_WINDOWS_BIN_DIRS = [
     'C:\\Program Files\\nodejs',
     'C:\\Program Files\\Claude',
     'C:\\Program Files\\Anthropic\\Claude'
@@ -73,9 +73,22 @@ function resolveFromCurrentPath(binaryName: string): string | null {
             env: { ...process.env }
         }).trim();
 
-        const firstLine = result.split(/\r?\n/)[0]?.trim();
-        if (firstLine && nodeFs.existsSync(firstLine)) {
-            return firstLine;
+        const lines = result
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+        const preferredLine = Platform.isWin
+            ? lines.find((line) => isWindowsCommandWrapperPath(line) && nodeFs.existsSync(line))
+            : null;
+
+        if (preferredLine) {
+            return preferredLine;
+        }
+
+        for (const line of lines) {
+            if (nodeFs.existsSync(line)) {
+                return line;
+            }
         }
     } catch {
         // Fall through to deterministic location checks.
@@ -92,8 +105,10 @@ function resolveFromCommonLocations(binaryName: string): string | null {
     try {
         const nodeFs = loadDesktopModule('fs');
         const pathMod = loadDesktopModule('path');
-        const binDirs = Platform.isWin ? COMMON_WINDOWS_BIN_DIRS : COMMON_UNIX_BIN_DIRS;
-        const candidateNames = Platform.isWin ? [binaryName, `${binaryName}.exe`, `${binaryName}.cmd`] : [binaryName];
+        const binDirs = Platform.isWin ? getCommonWindowsBinDirs() : COMMON_UNIX_BIN_DIRS;
+        const candidateNames = Platform.isWin
+            ? [`${binaryName}.cmd`, `${binaryName}.bat`, `${binaryName}.exe`, binaryName]
+            : [binaryName];
 
         for (const dir of binDirs) {
             for (const candidateName of candidateNames) {
@@ -108,6 +123,17 @@ function resolveFromCommonLocations(binaryName: string): string | null {
     }
 
     return null;
+}
+
+function isWindowsCommandWrapperPath(path: string): boolean {
+    return /\.(cmd|bat)$/i.test(path);
+}
+
+function getCommonWindowsBinDirs(): string[] {
+    return [
+        process.env.APPDATA ? `${process.env.APPDATA}\\npm` : null,
+        ...STATIC_COMMON_WINDOWS_BIN_DIRS
+    ].filter((dir): dir is string => typeof dir === 'string' && dir.length > 0);
 }
 
 function resolveFromLoginShell(binaryName: string): string | null {

--- a/tests/unit/binaryDiscovery.test.ts
+++ b/tests/unit/binaryDiscovery.test.ts
@@ -1,0 +1,64 @@
+import * as childProcess from 'child_process';
+import * as nodeFs from 'fs';
+import { Platform } from 'obsidian';
+import { resolveDesktopBinaryPath } from '../../src/utils/binaryDiscovery';
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+  execFileSync: jest.fn()
+}));
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn()
+}));
+
+describe('resolveDesktopBinaryPath', () => {
+  const originalAppData = process.env.APPDATA;
+  const execSyncMock = childProcess.execSync as jest.Mock;
+  const existsSyncMock = nodeFs.existsSync as jest.Mock;
+
+  beforeEach(() => {
+    Platform.isDesktop = true;
+    Platform.isWin = true;
+  });
+
+  afterEach(() => {
+    process.env.APPDATA = originalAppData;
+    jest.resetAllMocks();
+  });
+
+  it('prefers Windows command wrappers when where returns an extensionless npm shim first', () => {
+    execSyncMock.mockReturnValue(
+      'C:\\Users\\test\\AppData\\Roaming\\npm\\claude\r\nC:\\Users\\test\\AppData\\Roaming\\npm\\claude.cmd\r\n' as never
+    );
+    existsSyncMock.mockImplementation((path) => {
+      const candidate = String(path);
+      return candidate.endsWith('\\claude') || candidate.endsWith('\\claude.cmd');
+    });
+
+    expect(resolveDesktopBinaryPath('claude')).toBe('C:\\Users\\test\\AppData\\Roaming\\npm\\claude.cmd');
+  });
+
+  it('falls back to the first existing where result when no command wrapper exists', () => {
+    execSyncMock.mockReturnValue(
+      'C:\\Tools\\claude\r\nC:\\Tools\\claude.cmd\r\n' as never
+    );
+    existsSyncMock.mockImplementation((path) => String(path) === 'C:\\Tools\\claude');
+
+    expect(resolveDesktopBinaryPath('claude')).toBe('C:\\Tools\\claude');
+  });
+
+  it('checks the npm global bin directory from APPDATA with wrapper-first ordering', () => {
+    process.env.APPDATA = 'C:\\Users\\test\\AppData\\Roaming';
+    execSyncMock.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    existsSyncMock.mockImplementation((path) => (
+      String(path).replace(/\//g, '\\') === 'C:\\Users\\test\\AppData\\Roaming\\npm\\claude.cmd'
+    ));
+
+    expect(resolveDesktopBinaryPath('claude')?.replace(/\//g, '\\')).toBe(
+      'C:\\Users\\test\\AppData\\Roaming\\npm\\claude.cmd'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Prefer Windows .cmd/.bat wrappers when PATH lookup returns multiple CLI candidates.
- Add %APPDATA%\npm to Windows common CLI discovery with wrapper-first ordering.
- Route Claude headless process spawning through the shared Windows wrapper handling.
- Add regression tests for the reported npm shim ordering.

## Root cause
On Windows, npm global installs can expose both an extensionless Unix shim and a claude.cmd wrapper. `where claude` may return the extensionless shim first, and direct spawn without shell handling fails before Claude auth status can be read.

## Validation
- npx jest tests/unit/binaryDiscovery.test.ts tests/unit/ClaudeHeadlessService.test.ts tests/unit/cliProcessRunner.test.ts tests/unit/AnthropicClaudeCodeAdapter.test.ts --runInBand
- npm run build