### PR TITLE
[codex] Fix workspace state tool flows

### DIFF
--- a/src/agents/baseTool.ts
+++ b/src/agents/baseTool.ts
@@ -199,10 +199,11 @@ export abstract class BaseTool<T extends CommonParameters = CommonParameters, R 
    */
   protected getInheritedWorkspaceContext(params: CommonParameters): CommonResult['workspaceContext'] | null {
     // 1. Use explicitly provided context if available
-    if (params.workspaceContext) {
+    const contextParam = this.getContextWorkspaceIdParam(params);
+    if (params.workspaceContext || contextParam) {
       // Use the utility function to safely parse context
       const fallbackId = this.parentContext?.workspaceId || 'default-workspace';
-      return parseWorkspaceContext(params.workspaceContext, fallbackId);
+      return parseWorkspaceContext(params.workspaceContext, fallbackId, contextParam);
     }
 
     // 2. Fall back to parent context
@@ -211,6 +212,19 @@ export abstract class BaseTool<T extends CommonParameters = CommonParameters, R 
     }
 
     // 3. No context available
+    return null;
+  }
+
+  private getContextWorkspaceIdParam(params: CommonParameters): { workspaceId: string } | null {
+    const directWorkspaceId = (params as unknown as { workspaceId?: unknown }).workspaceId;
+    if (typeof directWorkspaceId === 'string' && directWorkspaceId.trim() !== '') {
+      return { workspaceId: directWorkspaceId };
+    }
+
+    if (params.context?.workspaceId) {
+      return { workspaceId: params.context.workspaceId };
+    }
+
     return null;
   }
 

--- a/src/agents/memoryManager/memoryManager.ts
+++ b/src/agents/memoryManager/memoryManager.ts
@@ -117,7 +117,7 @@ export class MemoryManagerAgent extends BaseAgent {
     });
     this.registerLazyTool({
       slug: 'loadState', name: 'Load State',
-      description: 'Load a saved state and optionally create a continuation session with restored context',
+      description: 'Load a saved workspace-scoped state with restored context',
       version: '2.0.0',
       factory: () => new LoadStateTool(this),
     });

--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -11,7 +11,7 @@ import {
   WorkspaceSession,
   WorkspaceState
 } from '../../../database/workspace-types';
-import { MemoryTraceData, SessionMetadata } from '../../../types/storage/HybridStorageTypes';
+import { MemoryTraceData, SessionMetadata, StateMetadata } from '../../../types/storage/HybridStorageTypes';
 import { PaginatedResult, PaginationParams, calculatePaginationMetadata } from '../../../types/pagination/PaginationTypes';
 import { normalizeLegacyTraceMetadata } from '../../../services/memory/LegacyTraceMetadataNormalizer';
 import { StorageAdapterOrGetter, resolveAdapter, withDualBackend, withReadableBackend } from '../../../services/helpers/DualBackendExecutor';
@@ -146,7 +146,7 @@ export class MemoryService {
    */
   async recordActivityTrace(trace: Omit<WorkspaceMemoryTrace, 'id'>): Promise<string> {
     const workspaceId = trace.workspaceId;
-    const sessionId = trace.sessionId || 'default-session';
+    const sessionId = trace.sessionId || this.createSessionId();
 
     const tracePayload = {
       timestamp: trace.timestamp || Date.now(),
@@ -168,7 +168,8 @@ export class MemoryService {
         } catch (error) {
           if ((error as Error).message?.includes('session')) {
             await adapter.createSession(workspaceId, {
-              name: 'Default Session',
+              id: sessionId,
+              name: `Session ${new Date().toLocaleString()}`,
               description: 'Auto-created session',
               startTime: Date.now(),
               isActive: true
@@ -187,7 +188,7 @@ export class MemoryService {
         if (!workspace.sessions[sessionId]) {
           await this.workspaceService.addSession(workspaceId, {
             id: sessionId,
-            name: 'Default Session',
+            name: `Session ${new Date().toLocaleString()}`,
             startTime: Date.now(),
             isActive: true,
             memoryTraces: {},
@@ -205,13 +206,16 @@ export class MemoryService {
    * Create memory trace
    */
   async createMemoryTrace(trace: Omit<WorkspaceMemoryTrace, 'id'>): Promise<WorkspaceMemoryTrace> {
-    const traceId = await this.recordActivityTrace(trace);
     const workspaceId = trace.workspaceId;
-    const sessionId = trace.sessionId || 'default-session';
+    const sessionId = trace.sessionId || this.createSessionId();
+    const traceId = await this.recordActivityTrace({
+      ...trace,
+      sessionId
+    });
 
     // Retrieve the created trace
-    const traces = await this.workspaceService.getMemoryTraces(workspaceId, sessionId);
-    const createdTrace = traces.find(t => t.id === traceId);
+    const traces = await this.getMemoryTraces(workspaceId, sessionId);
+    const createdTrace = traces.items.find((traceItem) => traceItem.id === traceId);
 
     if (!createdTrace) {
       throw new Error('Failed to retrieve created memory trace');
@@ -359,7 +363,9 @@ export class MemoryService {
     const state = await this.workspaceService.addState(workspaceId, sessionId, {
       id: stateData.id,  // Pass the ID to preserve it
       name: name || stateData.name || 'Unnamed State',
+      description: stateData.description,
       created: stateData.created || Date.now(),
+      tags: this.extractStateTags(stateData),
       state: stateData
     });
 
@@ -402,16 +408,6 @@ export class MemoryService {
   }
 
   /**
-   * State item type for getStates return
-   */
-  private static readonly StateItem = {} as {
-    id: string;
-    name: string;
-    created: number;
-    state: WorkspaceState;
-  };
-
-  /**
    * Get all states for a session (or all sessions in workspace if sessionId not provided)
    * @param workspaceId - Workspace ID
    * @param sessionId - Optional session ID to filter by
@@ -425,20 +421,41 @@ export class MemoryService {
   ): Promise<PaginatedResult<{
     id: string;
     name: string;
+    description?: string;
+    sessionId?: string;
+    workspaceId?: string;
     created: number;
+    tags?: string[];
     state: WorkspaceState;
   }>> {
-    type StateItem = { id: string; name: string; created: number; state: WorkspaceState };
+    type StateItem = {
+      id: string;
+      name: string;
+      description?: string;
+      sessionId?: string;
+      workspaceId?: string;
+      created: number;
+      tags?: string[];
+      state: WorkspaceState;
+    };
 
     return withReadableBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
         const result = await adapter.getStates(workspaceId, sessionId, options);
-        const convertedItems: StateItem[] = result.items.map(stateMeta => ({
-          id: stateMeta.id,
-          name: stateMeta.name,
-          created: stateMeta.created,
-          state: {} as WorkspaceState
+        const convertedItems: StateItem[] = await Promise.all(result.items.map(async stateMeta => {
+          const fullState = stateMeta.tags ? null : await adapter.getState(stateMeta.id);
+          const tags = stateMeta.tags || this.extractStateTagsFromContent(fullState?.content);
+          return {
+            id: stateMeta.id,
+            name: stateMeta.name,
+            description: stateMeta.description,
+            sessionId: stateMeta.sessionId,
+            workspaceId: stateMeta.workspaceId,
+            created: stateMeta.created,
+            tags,
+            state: this.stateMetadataToWorkspaceState(stateMeta, fullState?.content, tags)
+          };
         }));
         return {
           ...result,
@@ -464,6 +481,84 @@ export class MemoryService {
         return this.wrapInPaginatedResult(allStates, options);
       }
     );
+  }
+
+  private extractStateTags(state: WorkspaceState): string[] | undefined {
+    const tags = state.state?.metadata?.tags;
+    return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : undefined;
+  }
+
+  private extractStateTagsFromContent(content: unknown): string[] | undefined {
+    if (typeof content !== 'object' || content === null || Array.isArray(content)) {
+      return undefined;
+    }
+
+    const state = content as { state?: { metadata?: { tags?: unknown } } };
+    const tags = state.state?.metadata?.tags;
+    return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : undefined;
+  }
+
+  private stateMetadataToWorkspaceState(state: StateMetadata, content?: unknown, tags: string[] = state.tags || []): WorkspaceState {
+    if (typeof content === 'object' && content !== null && !Array.isArray(content)) {
+      const workspaceState = content as Partial<WorkspaceState>;
+      return {
+        ...workspaceState,
+        id: workspaceState.id || state.id,
+        name: workspaceState.name || state.name,
+        workspaceId: workspaceState.workspaceId || state.workspaceId,
+        sessionId: workspaceState.sessionId || state.sessionId,
+        description: workspaceState.description || state.description,
+        created: workspaceState.created || state.created,
+        context: workspaceState.context || {
+          workspaceContext: {
+            purpose: ''
+          },
+          conversationContext: '',
+          activeTask: state.description || '',
+          activeFiles: [],
+          nextSteps: []
+        },
+        state: {
+          workspace: workspaceState.state?.workspace ?? null,
+          recentTraces: workspaceState.state?.recentTraces ?? [],
+          contextFiles: workspaceState.state?.contextFiles ?? [],
+          metadata: {
+            ...workspaceState.state?.metadata,
+            tags
+          }
+        }
+      };
+    }
+
+    return {
+      id: state.id,
+      name: state.name,
+      workspaceId: state.workspaceId,
+      sessionId: state.sessionId,
+      description: state.description,
+      created: state.created,
+      context: {
+        workspaceContext: {
+          purpose: ''
+        },
+        conversationContext: '',
+        activeTask: state.description || '',
+        activeFiles: [],
+        nextSteps: []
+      },
+      state: {
+        workspace: null,
+        recentTraces: [],
+        contextFiles: [],
+        metadata: {
+          tags
+        }
+      }
+    };
+  }
+
+  private createSessionId(): string {
+    return `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 
   /**

--- a/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
+++ b/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
@@ -9,9 +9,8 @@
  * Integrates with: MemoryService for data access
  *
  * Responsibilities:
- * - Fetch workspace sessions with defensive validation and pagination
- * - Fetch workspace states with defensive validation and pagination
- * - Filter data to ensure workspace isolation
+ * - Fetch workspace sessions with pagination
+ * - Fetch workspace states with pagination
  */
 
 import { PaginatedResult, PaginationParams, createEmptyPaginatedResult } from '../../../types/pagination/PaginationTypes';
@@ -34,7 +33,7 @@ export interface StateSummary {
   id: string;
   name: string;
   description?: string;
-  sessionId: string;
+  sessionId?: string;
   created: number;
   tags?: string[];
   workspaceId?: string;
@@ -48,12 +47,13 @@ export class WorkspaceDataFetcher {
   private static isMemoryService(
     memoryService: unknown
   ): memoryService is {
-    getSessions(workspaceId: string): Promise<PaginatedResult<{ id: string; name: string; description?: string; startTime: number; workspaceId?: string }>>;
+    getSessions(workspaceId: string, options?: PaginationParams): Promise<PaginatedResult<{ id: string; name: string; description?: string; startTime?: number; created?: number; workspaceId?: string }>>;
     getStates(workspaceId: string, sessionId?: string, options?: PaginationParams): Promise<PaginatedResult<{
       id: string;
       name?: string;
       description?: string;
       sessionId?: string;
+      tags?: string[];
       created?: number;
       timestamp?: number;
       workspaceId?: string;
@@ -62,6 +62,9 @@ export class WorkspaceDataFetcher {
         sessionId?: string;
         workspaceId?: string;
         metadata?: { tags?: string[] };
+        state?: {
+          metadata?: { tags?: string[] };
+        };
       };
     }>>;
   } {
@@ -74,7 +77,7 @@ export class WorkspaceDataFetcher {
   }
 
   /**
-   * Fetch sessions for a workspace with defensive filtering and pagination
+   * Fetch sessions for a workspace with pagination
    * @param workspaceId The workspace ID
    * @param memoryService The memory service instance
    * @param options Optional pagination parameters
@@ -95,47 +98,29 @@ export class WorkspaceDataFetcher {
         return createEmptyPaginatedResult<SessionSummary>(0, options?.pageSize ?? 10);
       }
 
-      // getSessions returns PaginatedResult<WorkspaceSession>
-      const sessionsResult = await memoryService.getSessions(workspaceId);
+      // MemoryService delegates to workspace-scoped storage queries.
+      const sessionsResult = await memoryService.getSessions(workspaceId, options);
       const sessions = sessionsResult.items || [];
 
-      // Defensive validation: ensure all sessions belong to workspace
-      const validSessions = sessions.filter((session: { isActive?: boolean; workspaceId?: string }) =>
-        session.workspaceId === workspaceId
-      );
-
-      if (validSessions.length !== sessions.length) {
-        console.error(
-          `[WorkspaceDataFetcher] Database filtering failed! Retrieved ${sessions.length} sessions, ` +
-          `only ${validSessions.length} belong to workspace ${workspaceId}`
-        );
-      }
-
       // Map to session summaries
-      const sessionSummaries = validSessions.map((session: { id: string; name?: string; description?: string; isActive?: boolean; startTime?: number; workspaceId?: string }) => ({
-        id: session.id,
-        name: session.name || 'Untitled Session',
-        description: session.description,
-        created: session.startTime ?? 0,
-        workspaceId: session.workspaceId // Include for validation
-      }));
-
-      // Apply manual pagination since getSessions doesn't support it yet
-      const page = options?.page ?? 0;
-      const pageSize = options?.pageSize ?? sessionSummaries.length;
-      const start = page * pageSize;
-      const end = start + pageSize;
-      const paginatedItems = sessionSummaries.slice(start, end);
-      const totalPages = Math.ceil(sessionSummaries.length / pageSize);
+      const sessionSummaries = sessions
+        .filter((session: { id: string }) => session.id !== '_workspace')
+        .map((session: { id: string; name?: string; description?: string; startTime?: number; created?: number; workspaceId?: string }) => ({
+          id: session.id,
+          name: session.name || 'Untitled Session',
+          description: session.description,
+          created: session.startTime ?? session.created ?? 0,
+          workspaceId: session.workspaceId
+        }));
 
       return {
-        items: paginatedItems,
-        page,
-        pageSize,
-        totalItems: sessionSummaries.length,
-        totalPages,
-        hasNextPage: page < totalPages - 1,
-        hasPreviousPage: page > 0
+        items: sessionSummaries,
+        page: sessionsResult.page,
+        pageSize: sessionsResult.pageSize,
+        totalItems: sessionsResult.totalItems,
+        totalPages: sessionsResult.totalPages,
+        hasNextPage: sessionsResult.hasNextPage,
+        hasPreviousPage: sessionsResult.hasPreviousPage
       };
 
     } catch (error) {
@@ -145,7 +130,7 @@ export class WorkspaceDataFetcher {
   }
 
   /**
-   * Fetch states for a workspace with defensive filtering and pagination
+   * Fetch states for a workspace with pagination
    * @param workspaceId The workspace ID
    * @param memoryService The memory service instance
    * @param options Optional pagination parameters
@@ -169,27 +154,19 @@ export class WorkspaceDataFetcher {
       // getStates returns PaginatedResult - pass pagination options
       const statesResult = await memoryService.getStates(workspaceId, undefined, options);
 
-      // Extract items from paginated result
+      // Extract items from paginated result. MemoryService delegates to
+      // workspace-scoped storage queries, so an additional workspaceId filter
+      // here would reject adapter metadata rows that intentionally omit nested
+      // state.workspaceId content.
       const states = statesResult.items;
 
-      // Defensive validation: ensure all states belong to workspace
-      const validStates = states.filter((state: { isArchived?: boolean; workspaceId?: string; state?: { workspaceId?: string } }) =>
-        state.state?.workspaceId === workspaceId || state.workspaceId === workspaceId
-      );
-
-      if (validStates.length !== states.length) {
-        console.error(
-          `[WorkspaceDataFetcher] Filtered ${states.length - validStates.length} ` +
-          `cross-workspace states`
-        );
-      }
-
       // Map to state summaries
-      const stateSummaries = validStates.map((state: {
+      const stateSummaries = states.map((state: {
         id: string;
         name?: string;
         description?: string;
         sessionId?: string;
+        tags?: string[];
         isArchived?: boolean;
         created?: number;
         timestamp?: number;
@@ -198,15 +175,18 @@ export class WorkspaceDataFetcher {
           description?: string;
           sessionId?: string;
           workspaceId?: string;
-          metadata?: { tags?: string[] }
+          metadata?: { tags?: string[] };
+          state?: {
+            metadata?: { tags?: string[] };
+          };
         }
       }) => ({
         id: state.id,
         name: state.name || 'Untitled State',
         description: state.description || state.state?.description,
-        sessionId: state.sessionId || state.state?.sessionId || 'default-session',
+        sessionId: state.sessionId || state.state?.sessionId,
         created: state.created ?? state.timestamp ?? 0,
-        tags: state.state?.metadata?.tags || [],
+        tags: state.tags || state.state?.state?.metadata?.tags || state.state?.metadata?.tags || [],
         workspaceId: state.state?.workspaceId || state.workspaceId // Include for validation
       }));
 

--- a/src/agents/memoryManager/tools/states/createState.ts
+++ b/src/agents/memoryManager/tools/states/createState.ts
@@ -27,6 +27,8 @@ import { SchemaBuilder, SchemaType } from '../../../../utils/schemas/SchemaBuild
 import { WorkspaceContext } from '../../../../database/types/workspace/WorkspaceTypes';
 import { IndividualWorkspace } from '../../../../types/storage/StorageTypes';
 import { StateContext, WorkspaceState } from '../../../../database/types/session/SessionTypes';
+import { addRecommendations } from '../../../../utils/recommendationUtils';
+import { NudgeHelpers } from '../../../../utils/nudgeHelpers';
 
 interface WorkspaceResolutionData {
     workspaceId: string;
@@ -108,9 +110,11 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
                 return this.prepareResult(false, undefined, 'Workspace resolution failed - no workspace data returned', extractContextFromParams(params));
             }
 
-            // Phase 3.5: Check state name uniqueness (states are workspace-scoped using '_workspace' as sessionId)
+            const sessionId = this.resolveSessionId(params);
+
+            // Phase 3.5: Check state name uniqueness within the workspace
             const workspaceData = workspaceResult.data;
-            const existingStates = await memoryService.getStates(workspaceData.workspaceId, '_workspace');
+            const existingStates = await memoryService.getStates(workspaceData.workspaceId);
             const nameExists = existingStates.items.some(state => state.name === params.name);
             if (nameExists) {
                 return this.prepareResult(
@@ -125,7 +129,7 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
             const contextResult = this.buildStateContext(params, workspaceData, workspaceService);
 
             // Phase 5: Create and persist state (consolidated persistence logic)
-            const persistResult = await this.createAndPersistState(params, workspaceData, contextResult, memoryService);
+            const persistResult = await this.createAndPersistState(params, workspaceData, contextResult, memoryService, sessionId);
             if (!persistResult.success) {
                 return this.prepareResult(false, undefined, persistResult.error, extractContextFromParams(params));
             }
@@ -135,14 +139,13 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
                 return this.prepareResult(false, undefined, 'State creation failed - no state ID returned', extractContextFromParams(params));
             }
 
-            // Extract workspaceId for verification (use '_workspace' as sessionId)
             const workspaceId = workspaceData.workspaceId;
 
             // Phase 6: Verify persistence (data integrity check)
-            const verificationResult = await this.verifyStatePersistence(workspaceId, '_workspace', persistResult.stateId, memoryService);
+            const verificationResult = await this.verifyStatePersistence(workspaceId, sessionId, persistResult.stateId, memoryService);
             if (!verificationResult.success) {
                 // Rollback if verification fails
-                await this.rollbackState(workspaceId, '_workspace', persistResult.stateId, memoryService);
+                await this.rollbackState(workspaceId, sessionId, persistResult.stateId, memoryService);
                 return this.prepareResult(false, undefined, `State verification failed: ${verificationResult.error}`, extractContextFromParams(params));
             }
 
@@ -273,11 +276,43 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
                 return { success: false, error: `Workspace not found: ${workspaceId}` };
             }
 
-            return { success: true, data: { workspaceId, workspace } };
+            return { success: true, data: { workspaceId: workspace.id, workspace } };
 
         } catch (error) {
             return { success: false, error: createErrorMessage('Error resolving workspace: ', error) };
         }
+    }
+
+    private resolveSessionId(params: CreateStateParams): string {
+        const directSessionId = (params as unknown as { sessionId?: unknown }).sessionId;
+        if (typeof directSessionId === 'string' && directSessionId.trim() !== '') {
+            return directSessionId;
+        }
+
+        if (params.context?.sessionId) {
+            return params.context.sessionId;
+        }
+
+        const workspaceContext = params.workspaceContext;
+        if (workspaceContext && typeof workspaceContext === 'object' && !Array.isArray(workspaceContext)) {
+            const workspaceSessionId = (workspaceContext as { sessionId?: unknown }).sessionId;
+            if (typeof workspaceSessionId === 'string' && workspaceSessionId.trim() !== '') {
+                return workspaceSessionId;
+            }
+        }
+
+        if (typeof workspaceContext === 'string') {
+            try {
+                const parsed = JSON.parse(workspaceContext) as { sessionId?: unknown };
+                if (typeof parsed.sessionId === 'string' && parsed.sessionId.trim() !== '') {
+                    return parsed.sessionId;
+                }
+            } catch {
+                // Ignore malformed legacy workspaceContext and fall back to generated ID.
+            }
+        }
+
+        return `session_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
     }
 
     /**
@@ -322,16 +357,14 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
         params: CreateStateParams,
         workspaceData: WorkspaceResolutionData,
         contextResult: StateContextResult,
-        memoryService: MemoryService
+        memoryService: MemoryService,
+        sessionId: string
     ): Promise<{success: boolean; error?: string; stateId?: string; savedState?: PersistedWorkspaceState}> {
         try {
             const { workspaceId, workspace } = workspaceData;
             const { context } = contextResult;
             const now = Date.now();
 
-            // Build WorkspaceState for storage following the architecture design
-            // This matches the WorkspaceState interface which extends State
-            // Use '_workspace' as sessionId for workspace-scoped states
             const workspaceState: PersistedWorkspaceState = {
                 // Core State fields (required)
                 id: `state_${now}_${Math.random().toString(36).substring(2, 11)}`,
@@ -341,7 +374,7 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
                 context: context,  // The inner StateContext with activeTask, activeFiles, etc.
 
                 // Additional WorkspaceState fields
-                sessionId: '_workspace',  // All states are workspace-scoped
+                sessionId,
                 timestamp: now,
                 state: {
                     workspace,
@@ -356,10 +389,9 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
                 }
             };
 
-            // Persist to MemoryService - use '_workspace' as sessionId
             const stateId = await memoryService.saveState(
                 workspaceId,
-                '_workspace',
+                sessionId,
                 workspaceState,  // Pass the full object
                 workspaceState.name
             );
@@ -419,10 +451,12 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
         _contextResult: StateContextResult,
         _workspaceData: WorkspaceResolutionData,
         _startTime: number,
-        _params: CreateStateParams
+        params: CreateStateParams
     ): StateResult {
-        // Success - LLM already knows the state details it passed
-        return this.prepareResult(true);
+        return addRecommendations(
+            this.prepareResult(true),
+            [NudgeHelpers.suggestStateNameFollowup(params.name)]
+        );
     }
 
     getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {

--- a/src/agents/memoryManager/tools/states/listStates.ts
+++ b/src/agents/memoryManager/tools/states/listStates.ts
@@ -13,12 +13,17 @@ import { createErrorMessage } from '../../../../utils/errorUtils';
 import { WorkspaceService, GLOBAL_WORKSPACE_ID } from '../../../../services/WorkspaceService';
 
 interface StateLike {
+  id?: string;
   name: string;
   description?: string;
+  sessionId?: string;
+  tags?: string[];
   timestamp?: number;
   created?: number;
   workspaceId?: string;
   state?: {
+    sessionId?: string;
+    workspaceId?: string;
     context?: {
       activeFiles?: string[];
       activeTask?: string;
@@ -68,11 +73,14 @@ export class ListStatesTool extends BaseTool<ListStatesParams, StateResult> {
         return this.prepareResult(false, undefined, 'Memory service not available');
       }
 
-      // Get workspace ID from context
-      let workspaceId: string | undefined;
-      const inheritedContext = super.getInheritedWorkspaceContext(params);
-      if (inheritedContext?.workspaceId) {
-        workspaceId = inheritedContext.workspaceId;
+      const workspaceService = await this.agent.getWorkspaceServiceAsync();
+      if (!workspaceService) {
+        return this.prepareResult(false, undefined, 'Workspace service not available');
+      }
+
+      const workspaceResult = await this.resolveWorkspaceId(params, workspaceService);
+      if (!workspaceResult.success || !workspaceResult.workspaceId) {
+        return this.prepareResult(false, undefined, workspaceResult.error);
       }
 
       // Prepare pagination options for DB-level pagination
@@ -83,10 +91,10 @@ export class ListStatesTool extends BaseTool<ListStatesParams, StateResult> {
         pageSize: pageSize
       };
 
-      // Get states with true DB-level pagination (use '_workspace' as sessionId)
+      // Get states with true DB-level pagination across the workspace
       const statesResult = await memoryService.getStates(
-        workspaceId || GLOBAL_WORKSPACE_ID,
-        '_workspace',
+        workspaceResult.workspaceId,
+        undefined,
         paginationOptions
       );
 
@@ -111,7 +119,7 @@ export class ListStatesTool extends BaseTool<ListStatesParams, StateResult> {
           const stateData = state.state as unknown as Record<string, unknown> | undefined;
           const nestedState = stateData?.state as Record<string, unknown> | undefined;
           const metadata = nestedState?.metadata as Record<string, unknown> | undefined;
-          const stateTags = (metadata?.tags as string[]) || [];
+          const stateTags = state.tags || (metadata?.tags as string[]) || [];
           return tags.some(tag => stateTags.includes(tag));
         });
       }
@@ -119,13 +127,17 @@ export class ListStatesTool extends BaseTool<ListStatesParams, StateResult> {
       // Sort states (in-memory sorting for now - TODO: move to DB level)
       const sortedStates = this.sortStates(processedStates, params.order || 'desc');
 
-      // Simplify state data to just name and description
-      const simplifiedStates = sortedStates.map(state => ({
+      const listedStates = sortedStates.map(state => ({
+        id: state.id,
         name: state.name,
-        description: state.description || state.state?.context?.activeTask || 'No description'
+        description: state.description || state.state?.context?.activeTask || 'No description',
+        sessionId: state.sessionId || state.state?.sessionId,
+        workspaceId: state.workspaceId || state.state?.workspaceId,
+        created: state.created ?? state.timestamp ?? 0,
+        tags: state.tags || state.state?.state?.metadata?.tags || []
       }));
 
-      return this.prepareResult(true, simplifiedStates);
+      return this.prepareResult(true, listedStates);
 
     } catch (error) {
       return this.prepareResult(false, undefined, createErrorMessage('Error listing states: ', error));
@@ -141,6 +153,23 @@ export class ListStatesTool extends BaseTool<ListStatesParams, StateResult> {
       const timeB = b.timestamp || b.created || 0;
       return order === 'asc' ? timeA - timeB : timeB - timeA;
     });
+  }
+
+  private async resolveWorkspaceId(
+    params: ListStatesParams,
+    workspaceService: WorkspaceService
+  ): Promise<{ success: boolean; workspaceId?: string; error?: string }> {
+    const inheritedContext = super.getInheritedWorkspaceContext(params);
+    const workspaceIdentifier = inheritedContext?.workspaceId || GLOBAL_WORKSPACE_ID;
+    const workspace = await workspaceService.getWorkspaceByNameOrId(workspaceIdentifier);
+    if (!workspace) {
+      return {
+        success: false,
+        error: `Workspace not found: ${workspaceIdentifier}. Workspace names are accepted, but the name must match an existing workspace.`
+      };
+    }
+
+    return { success: true, workspaceId: workspace.id };
   }
 
   /**

--- a/src/agents/memoryManager/tools/states/loadState.ts
+++ b/src/agents/memoryManager/tools/states/loadState.ts
@@ -80,7 +80,7 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
         super(
             'loadState',
             'Load State',
-            'Load a saved state and optionally create a continuation session with restored context',
+            'Load a saved workspace-scoped state with restored context',
             '2.0.0'
         );
 
@@ -111,16 +111,22 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
                 return this.prepareResult(false, undefined, 'Memory service not available', extractContextFromParams(params));
             }
 
-            // Extract workspaceId from params (use '_workspace' as sessionId for workspace-scoped states)
-            const parsedContext = parseWorkspaceContext(params.workspaceContext);
-            const workspaceId = parsedContext?.workspaceId || GLOBAL_WORKSPACE_ID;
-
             // Use name (required) or fall back to deprecated stateId for backward compatibility
             const stateName = params.name ?? getLegacyStateId(params);
             if (!stateName) {
                 return this.prepareResult(false, undefined, 'State name is required. Use listStates to see available states.', extractContextFromParams(params));
             }
-            const stateResult = await this.loadStateData(workspaceId, '_workspace', stateName, memoryService);
+            if (!workspaceService) {
+                return this.prepareResult(false, undefined, 'Workspace service not available', extractContextFromParams(params));
+            }
+
+            // Extract and canonicalize workspace ID from tool context.
+            const workspaceResult = await this.resolveWorkspaceId(params, workspaceService);
+            if (!workspaceResult.success || !workspaceResult.workspaceId) {
+                return this.prepareResult(false, undefined, workspaceResult.error, extractContextFromParams(params));
+            }
+
+            const stateResult = await this.loadStateData(workspaceResult.workspaceId, stateName, memoryService);
             if (!stateResult.success) {
                 return this.prepareResult(false, undefined, stateResult.error, extractContextFromParams(params));
             }
@@ -129,9 +135,6 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
             }
 
             // Phase 3: Process and restore context (consolidated from FileCollector and TraceProcessor logic)
-            if (!workspaceService) {
-                return this.prepareResult(false, undefined, 'Workspace service not available', extractContextFromParams(params));
-            }
             const contextResult = await this.processAndRestoreContext(stateResult.data, workspaceService, memoryService);
 
             // Phase 4: Prepare simplified result (no session continuation, just return state data)
@@ -173,10 +176,18 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
      * Load state data (consolidated from StateRetriever logic)
      * Looks up state by name
      */
-    private async loadStateData(workspaceId: string, sessionId: string, stateName: string, memoryService: MemoryService): Promise<{success: boolean; error?: string; data?: LoadedStateResult}> {
+    private async loadStateData(workspaceId: string, stateName: string, memoryService: MemoryService): Promise<{success: boolean; error?: string; data?: LoadedStateResult}> {
         try {
-            // Get state from memory service by name
-            const loadedState = await memoryService.getStateByNameOrId(workspaceId, sessionId, stateName);
+            const statesResult = await memoryService.getStates(workspaceId, undefined, { pageSize: 100 });
+            const matchingState = statesResult.items.find(state =>
+                state.id === stateName || state.name?.toLowerCase() === stateName.toLowerCase()
+            );
+            if (!matchingState?.sessionId) {
+                return { success: false, error: `State "${stateName}" not found. Use listStates to see available states.` };
+            }
+
+            // Get full state from memory service by resolved ID/session.
+            const loadedState = await memoryService.getState(workspaceId, matchingState.sessionId, matchingState.id);
             if (!loadedState) {
                 return { success: false, error: `State "${stateName}" not found. Use listStates to see available states.` };
             }
@@ -184,7 +195,7 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
             // Get related traces if available using the actual state's session ID
             let relatedTraces: WorkspaceMemoryTrace[] = [];
             try {
-                const effectiveSessionId = loadedState.sessionId || sessionId;
+                const effectiveSessionId = loadedState.sessionId || matchingState.sessionId;
                 if (effectiveSessionId && effectiveSessionId !== 'current') {
                     const tracesResult = await memoryService.getMemoryTraces(workspaceId, effectiveSessionId);
                     relatedTraces = tracesResult.items;
@@ -204,6 +215,22 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
         } catch (error) {
             return { success: false, error: createErrorMessage('Error loading state data: ', error) };
         }
+    }
+
+    private async resolveWorkspaceId(
+        params: LoadStateParams,
+        workspaceService: WorkspaceService
+    ): Promise<{ success: boolean; workspaceId?: string; error?: string }> {
+        const workspaceIdentifier = resolveWorkspaceIdentifier(params);
+        const workspace = await workspaceService.getWorkspaceByNameOrId(workspaceIdentifier);
+        if (!workspace) {
+            return {
+                success: false,
+                error: `Workspace not found: ${workspaceIdentifier}. Workspace names are accepted, but the name must match an existing workspace.`
+            };
+        }
+
+        return { success: true, workspaceId: workspace.id };
     }
 
     /**
@@ -401,6 +428,20 @@ function parseWorkspaceContext(value: unknown): WorkspaceContextInput | null {
     }
 
     return isWorkspaceContextInput(value) ? value : null;
+}
+
+function resolveWorkspaceIdentifier(params: LoadStateParams): string {
+    const directWorkspaceId = (params as unknown as { workspaceId?: unknown }).workspaceId;
+    if (typeof directWorkspaceId === 'string' && directWorkspaceId.trim() !== '') {
+        return directWorkspaceId;
+    }
+
+    if (params.context?.workspaceId) {
+        return params.context.workspaceId;
+    }
+
+    const parsedContext = parseWorkspaceContext(params.workspaceContext);
+    return parsedContext?.workspaceId || GLOBAL_WORKSPACE_ID;
 }
 
 function isWorkspaceContextInput(value: unknown): value is WorkspaceContextInput {

--- a/src/agents/memoryManager/tools/workspaces/createWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/createWorkspace.ts
@@ -15,6 +15,8 @@ import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { createServiceIntegration } from '../../services/ValidationService';
 import type { IndividualWorkspace } from '../../../../types/storage/StorageTypes';
+import { addRecommendations, Recommendation } from '../../../../utils/recommendationUtils';
+import { NudgeHelpers } from '../../../../utils/nudgeHelpers';
 
 // Import types from existing workspace mode
 import { 
@@ -23,6 +25,10 @@ import {
 } from '../../../../database/types/workspace/ParameterTypes';
 import { WorkspaceContext } from '../../../../database/types/workspace/WorkspaceTypes';
 import { createErrorMessage } from '../../../../utils/errorUtils';
+
+type CreateWorkspaceResultWithRecommendations = CreateWorkspaceResult & {
+    recommendations: Recommendation[];
+};
 
 interface WorkspaceServiceLike {
     getWorkspaceByNameOrId(identifier: string): Promise<IndividualWorkspace | null>;
@@ -40,7 +46,7 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
         super(
             'createWorkspace',
             'Create Workspace',
-            'Create a new workspace with structured context data',
+            'Create a new workspace with structured context data. Follow-up workspace tools accept the workspace name.',
             '2.0.0'
         );
 
@@ -86,10 +92,6 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
                 // Ignore folder creation errors
             }
             
-            // Store dedicatedAgentId as-is (name or ID)
-            // Lookup will happen in WorkspacePromptResolver when loading (which runs in plugin context)
-            console.error('[CreateWorkspace] Storing dedicatedAgentId:', params.dedicatedAgentId);
-
             // Combine provided key files with auto-detected ones
             const providedKeyFiles = params.keyFiles || [];
             const autoDetectedKeyFiles = this.detectSimpleKeyFiles(params.rootFolder);
@@ -102,8 +104,6 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
                 keyFiles: allKeyFiles,
                 preferences: params.preferences || ''
             };
-
-            console.error('[CreateWorkspace] Creating workspace with dedicatedAgentId:', params.dedicatedAgentId);
 
             // Create workspace data
             const now = Date.now();
@@ -143,10 +143,12 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
             }
 
             // Save workspace
-            await workspaceService.createWorkspace(workspaceData);
+            const workspace = await workspaceService.createWorkspace(workspaceData);
 
-            // Success - LLM already knows the workspace details it passed
-            return this.prepareResult(true);
+            const result = this.prepareResult(true);
+            return addRecommendations(result, [
+                NudgeHelpers.suggestWorkspaceNameFollowup(workspace.name)
+            ]) as CreateWorkspaceResultWithRecommendations;
 
         } catch (error) {
             return this.prepareResult(false, undefined, createErrorMessage('Error creating workspace: ', error));
@@ -198,11 +200,11 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
         const toolSchema = {
             type: 'object',
             title: 'Create Workspace',
-            description: 'Create a new workspace with structured workflows and context.',
+            description: 'Create a new workspace with structured workflows and context. Follow-up workspace commands accept the workspace name; do not list workspaces solely to recover a UUID.',
             properties: {
                 name: {
                     type: 'string',
-                    description: 'Workspace name'
+                    description: 'Workspace name. This name can be used directly in follow-up workspace commands such as load-workspace and update-workspace; the UUID is not required unless you prefer it.'
                 },
                 description: {
                     type: 'string',
@@ -318,6 +320,18 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
                         workspaceId: { type: 'string' },
                         workspace: { type: 'object' },
                         validationPrompt: { type: 'string' }
+                    }
+                },
+                recommendations: {
+                    type: 'array',
+                    description: 'Agent-facing nudges and recommendations.',
+                    items: {
+                        type: 'object',
+                        properties: {
+                            type: { type: 'string' },
+                            message: { type: 'string' }
+                        },
+                        required: ['type', 'message']
                     }
                 }
             }

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -325,7 +325,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
       properties: {
         id: {
           type: 'string',
-          description: 'Workspace ID or name to load (REQUIRED). Accepts either the unique workspace ID or the workspace name.'
+          description: 'Workspace ID or name to load (REQUIRED). Accepts either the unique workspace ID or the workspace name. Using the name returned by create-workspace is fine; you do not need to call list-workspaces just to find the UUID.'
         },
         limit: {
           type: 'number',
@@ -494,7 +494,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
                     description: 'State tags'
                   }
                 },
-                required: ['id', 'name', 'sessionId', 'created']
+                required: ['id', 'name', 'created']
               },
               description: 'States in this workspace (paginated)'
             },

--- a/src/agents/memoryManager/tools/workspaces/updateWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/updateWorkspace.ts
@@ -21,7 +21,16 @@ import type { WorkspaceWorkflow } from '../../../../database/types/workspace/Wor
 
 // Define parameter and result types for workspace updates
 export interface UpdateWorkspaceParameters extends CommonParameters {
-    workspaceId: string;
+    /**
+     * Workspace ID or name to update. This is the explicit tool argument used
+     * by the CLI because `workspaceId` is reserved for ToolManager context.
+     */
+    id?: string;
+    /**
+     * Legacy/internal fallback. ToolManager strips this from CLI metadata
+     * because it is a top-level context key, so new callers should use `id`.
+     */
+    workspaceId?: string;
     // Top-level fields (all optional)
     name?: string;
     description?: string;
@@ -72,11 +81,15 @@ export class UpdateWorkspaceTool extends BaseTool<UpdateWorkspaceParameters, Upd
             }
 
             const workspaceService = serviceResult.service;
+            const workspaceIdentifier = this.resolveWorkspaceIdentifier(params);
+            if (!workspaceIdentifier) {
+                return this.prepareResult(false, undefined, 'Workspace identifier is required. Pass the workspace ID or name as the first argument. Example: memory update-workspace "Project Workspace" --description "Updated description".');
+            }
 
             // Validate workspace exists using unified lookup (ID or name)
-            const existingWorkspace = await workspaceService.getWorkspaceByNameOrId(params.workspaceId);
+            const existingWorkspace = await workspaceService.getWorkspaceByNameOrId(workspaceIdentifier);
             if (!existingWorkspace) {
-                return this.prepareResult(false, undefined, `Workspace "${params.workspaceId}" not found. Use listWorkspaces to see available workspaces.`);
+                return this.prepareResult(false, undefined, `Workspace "${workspaceIdentifier}" not found. Use listWorkspaces to see available workspaces.`);
             }
 
             // Check that at least one field is being updated
@@ -92,10 +105,6 @@ export class UpdateWorkspaceTool extends BaseTool<UpdateWorkspaceParameters, Upd
             if (!hasTopLevelUpdates && !hasContextUpdates) {
                 return this.prepareResult(false, undefined, 'No updates provided. Pass at least one field to update (name, description, rootFolder, purpose, workflows, keyFiles, preferences, or dedicatedAgentId).');
             }
-
-            // Store dedicatedAgentId as-is (name or ID)
-            // Lookup will happen in WorkspacePromptResolver when loading
-            console.error('[UpdateWorkspace] Updating dedicatedAgentId to:', params.dedicatedAgentId);
 
             // Create a deep copy for updating
             const workspaceCopy: IndividualWorkspace = {
@@ -166,22 +175,32 @@ export class UpdateWorkspaceTool extends BaseTool<UpdateWorkspaceParameters, Upd
         }
     }
 
+    private resolveWorkspaceIdentifier(params: UpdateWorkspaceParameters): string | null {
+        const explicitId = params.id?.trim();
+        if (explicitId) {
+            return explicitId;
+        }
+
+        const legacyWorkspaceId = params.workspaceId?.trim();
+        return legacyWorkspaceId || null;
+    }
+
     getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
-        return labelWithId(verbs('Updating workspace', 'Updated workspace', 'Failed to update workspace'), params, tense, { keys: ['workspaceId'], fallback: 'workspace' });
+        return labelWithId(verbs('Updating workspace', 'Updated workspace', 'Failed to update workspace'), params, tense, { keys: ['id', 'workspaceId'], fallback: 'workspace' });
     }
 
     getParameterSchema(): Record<string, unknown> {
         const toolSchema = {
             type: 'object',
             properties: {
-                workspaceId: {
+                id: {
                     type: 'string',
-                    description: 'ID or name of the workspace to update (REQUIRED)'
+                    description: 'Workspace ID or name to update (REQUIRED). This selects the target workspace; using the workspace name is fine and the UUID is not required.'
                 },
                 // Top-level optional fields
                 name: {
                     type: 'string',
-                    description: 'New workspace name (optional)'
+                    description: 'New workspace name (optional). This renames the workspace; it is not the target identifier.'
                 },
                 description: {
                     type: 'string',
@@ -241,7 +260,7 @@ export class UpdateWorkspaceTool extends BaseTool<UpdateWorkspaceParameters, Upd
                     description: 'ID of custom agent to set as workspace dedicated agent (optional, updates context.dedicatedAgent). Pass empty string to remove dedicated agent.'
                 }
             },
-            required: ['workspaceId']
+            required: ['id']
         };
 
         return this.getMergedSchema(toolSchema);

--- a/src/agents/searchManager/tools/searchMemory.ts
+++ b/src/agents/searchManager/tools/searchMemory.ts
@@ -239,7 +239,7 @@ export class SearchMemoryTool extends BaseTool<SearchMemoryParams, SearchMemoryR
         },
         sessionId: {
           type: 'string',
-          description: 'Provide a session ID to switch to Scoped mode: search is limited to this session and returns surrounding messages around each match. Use MemoryManager listSessions to find session IDs.'
+          description: 'Provide a known session ID to switch to Scoped mode: search is limited to this session and returns surrounding messages around each match.'
         },
         windowSize: {
           type: 'number',

--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -213,7 +213,7 @@ export class ToolBatchExecutionService {
     }
 
     if (!context.sessionId || typeof context.sessionId !== 'string') {
-      errors.push('context.sessionId is required (any descriptive name, e.g. "blog_writing_session")');
+      errors.push('context.sessionId is required. Use the current chat session ID assigned by the runtime; do not generate a new one per tool call.');
     }
 
     if (!context.memory || typeof context.memory !== 'string') {
@@ -370,7 +370,8 @@ export class ToolBatchExecutionService {
   ): Record<string, unknown> {
     const defaulted: Record<string, unknown> = {
       ...params,
-      workspaceId: params.workspaceId || context.workspaceId
+      workspaceId: params.workspaceId || context.workspaceId,
+      sessionId: params.sessionId || context.sessionId
     };
 
     if (agentName === 'promptManager' && toolSlug === 'generateImage') {
@@ -402,22 +403,20 @@ export class ToolBatchExecutionService {
             agent: result.agent,
             tool: result.tool,
             success: true,
-            ...(result.params ? { params: result.params } : {}),
             ...(result.data as Record<string, unknown>)
           };
         }
 
         if (result.data !== undefined) {
-          return { agent: result.agent, tool: result.tool, ...(result.params ? { params: result.params } : {}), success: true, data: result.data };
+          return { agent: result.agent, tool: result.tool, success: true, data: result.data };
         }
 
-        return { agent: result.agent, tool: result.tool, ...(result.params ? { params: result.params } : {}), success: true };
+        return { agent: result.agent, tool: result.tool, success: true };
       }
 
       return {
         agent: result.agent,
         tool: result.tool,
-        ...(result.params ? { params: result.params } : {}),
         success: false,
         error: result.error || 'Unknown error'
       };

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -39,6 +39,7 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
       'REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.',
       'This returns CLI-oriented command metadata for the tools you need next.',
       'Send workspaceId, sessionId, memory, goal, and constraints at the top level.',
+      'The chat runtime assigns one sessionId for the conversation. Reuse that same sessionId for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state.',
       'Do not send a nested "context" object or legacy "request" array.',
       '',
       'Workflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands',
@@ -141,7 +142,7 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
         },
         sessionId: {
           type: 'string',
-          description: 'Session identifier for traces. Optional; auto-generated if omitted.'
+          description: 'Current chat session ID. Required. The chat runtime assigns this once per conversation; reuse the same value for every getTools/useTools call so traces and saved states attach to the current session.'
         },
         memory: {
           type: 'string',

--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -15,7 +15,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   ) {
     this.slug = 'useTools';
     this.name = 'Use Tools';
-    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"session_123","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
+    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"session_123","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. The chat runtime assigns one sessionId for the conversation; reuse that same sessionId for every useTools call so traces and saved states attach to the current session. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
     this.version = '1.0.0';
   }
 
@@ -38,7 +38,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
         },
         sessionId: {
           type: 'string',
-          description: 'Session identifier for traces. Optional; auto-generated if omitted.'
+          description: 'Current chat session ID. Required. The chat runtime assigns this once per conversation; reuse the same value for every useTools call so traces and saved states attach to the current session.'
         },
         memory: {
           type: 'string',

--- a/src/agents/toolManager/types.ts
+++ b/src/agents/toolManager/types.ts
@@ -121,7 +121,7 @@ export function getTopLevelToolContextSchema(): Record<string, unknown> {
     },
     sessionId: {
       type: 'string',
-      description: 'Session identifier for trace continuity. Reuse the provided value for subsequent calls.'
+      description: 'Current chat session ID assigned by the runtime. Reuse the same value for every tool call in the conversation so traces and saved states attach to the current session.'
     },
     memory: {
       type: 'string',

--- a/src/components/workspace/WorkspaceListRenderer.ts
+++ b/src/components/workspace/WorkspaceListRenderer.ts
@@ -3,7 +3,6 @@
  * Extracted from WorkspacesTab to keep the tab under 600 lines.
  */
 
-import { Notice } from 'obsidian';
 import { CardItem } from '../CardManager';
 import { SearchableCardManager } from '../SearchableCardManager';
 import { ProjectWorkspace } from '../../database/workspace-types';
@@ -17,8 +16,6 @@ export interface WorkspaceListCallbacks {
 
 export class WorkspaceListRenderer {
     private cardManager?: SearchableCardManager<CardItem>;
-    private pendingDeleteWorkspaceId: string | null = null;
-    private pendingDeleteTimer: number | null = null;
 
     render(
         container: HTMLElement,
@@ -71,7 +68,7 @@ export class WorkspaceListRenderer {
                     callbacks.onEdit(item.id);
                 },
                 onDelete: (item) => {
-                    this.requestDelete(item, callbacks);
+                    void callbacks.onDelete(item.id, item.name);
                 }
             },
             items: cardItems,
@@ -97,39 +94,6 @@ export class WorkspaceListRenderer {
             skeleton.createDiv('nexus-skeleton-title');
             skeleton.createDiv('nexus-skeleton-description');
             skeleton.createDiv('nexus-skeleton-actions');
-        }
-    }
-
-    private requestDelete(item: CardItem, callbacks: WorkspaceListCallbacks): void {
-        if (this.pendingDeleteWorkspaceId === item.id) {
-            this.clearPendingDelete();
-            void callbacks.onDelete(item.id, item.name)
-                .then(() => {
-                    new Notice('Workspace deleted');
-                })
-                .catch((error: unknown) => {
-                    console.error('[WorkspaceListRenderer] Failed to delete workspace:', error);
-                    new Notice('Failed to delete workspace');
-                });
-            return;
-        }
-
-        this.pendingDeleteWorkspaceId = item.id;
-        if (this.pendingDeleteTimer !== null) {
-            window.clearTimeout(this.pendingDeleteTimer);
-        }
-        this.pendingDeleteTimer = window.setTimeout(() => {
-            this.clearPendingDelete();
-        }, 5000);
-
-        new Notice(`Click delete again to remove workspace "${item.name}".`, 4000);
-    }
-
-    private clearPendingDelete(): void {
-        this.pendingDeleteWorkspaceId = null;
-        if (this.pendingDeleteTimer !== null) {
-            window.clearTimeout(this.pendingDeleteTimer);
-            this.pendingDeleteTimer = null;
         }
     }
 }

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -1041,7 +1041,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.sessionRepo.getByWorkspaceId(workspaceId, options);
   };
 
-  createSession = async (workspaceId: string, session: Omit<SessionMetadata, 'id' | 'workspaceId'>): Promise<string> => {
+  createSession = async (workspaceId: string, session: Omit<SessionMetadata, 'id' | 'workspaceId'> & { id?: string }): Promise<string> => {
     await this.ensureInitialized();
     return this.sessionRepo.create({ ...session, workspaceId });
   };

--- a/src/database/interfaces/IStorageAdapter.ts
+++ b/src/database/interfaces/IStorageAdapter.ts
@@ -234,7 +234,7 @@ export interface IStorageAdapter {
    */
   createSession(
     workspaceId: string,
-    session: Omit<SessionMetadata, 'id' | 'workspaceId'>
+    session: Omit<SessionMetadata, 'id' | 'workspaceId'> & { id?: string }
   ): Promise<string>;
 
   /**

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -92,7 +92,7 @@ export class SessionRepository
   }
 
   async create(data: CreateSessionData & { workspaceId: string }): Promise<string> {
-    const id = this.generateId();
+    const id = data.id || this.generateId();
     const now = Date.now();
 
     try {

--- a/src/database/repositories/interfaces/ISessionRepository.ts
+++ b/src/database/repositories/interfaces/ISessionRepository.ts
@@ -19,6 +19,7 @@ import { PaginatedResult, PaginationParams } from '../../../types/pagination/Pag
  * Data required to create a new session
  */
 export interface CreateSessionData {
+  id?: string;
   name: string;
   description?: string;
   startTime?: number;

--- a/src/database/types/workspace/ParameterTypes.ts
+++ b/src/database/types/workspace/ParameterTypes.ts
@@ -5,7 +5,6 @@
 
 import { CommonParameters, CommonResult } from '../../../types/mcp';
 import {
-  ProjectWorkspace,
   WorkspaceWorkflow
 } from './WorkspaceTypes';
 
@@ -76,10 +75,7 @@ export interface CreateWorkspaceParameters extends CommonParameters {
  * Create workspace result
  */
 export interface CreateWorkspaceResult extends CommonResult {
-  data: {
-    workspaceId: string;
-    workspace: ProjectWorkspace;
-  };
+  data?: never;
 }
 
 /**
@@ -113,7 +109,7 @@ export interface LoadWorkspaceResult extends CommonResult {
       id: string;
       name: string;
       description?: string;
-      sessionId: string;
+      sessionId?: string;
       created: number;
       tags?: string[];
     }>;

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -5,7 +5,7 @@
 // Dependencies: FileSystemService, IndexManager for data access (legacy)
 //               IStorageAdapter for new hybrid storage backend
 
-import { Plugin } from 'obsidian';
+import { EventRef, Events, Plugin } from 'obsidian';
 import { FileSystemService } from './storage/FileSystemService';
 import { IndexManager } from './storage/IndexManager';
 import { IndividualWorkspace, WorkspaceMetadata, SessionData, MemoryTrace, StateData } from '../types/storage/StorageTypes';
@@ -33,11 +33,20 @@ interface WorkspaceServiceOptions {
   getSettings?: () => Pick<MCPSettings, 'storage'> | undefined;
 }
 
+export type WorkspaceChangeAction = 'created' | 'updated' | 'deleted';
+
+export interface WorkspaceChangeEvent {
+  workspaceId: string;
+  action: WorkspaceChangeAction;
+  workspace?: IndividualWorkspace;
+}
+
 export class WorkspaceService {
   private storageAdapterOrGetter: StorageAdapterOrGetter;
   private sessionService: WorkspaceSessionService;
   private stateService: WorkspaceStateService;
   private systemGuidesProvider: SystemGuidesWorkspaceProvider | null;
+  private readonly workspaceEvents = new Events();
 
   constructor(
     private plugin: Plugin,
@@ -140,6 +149,20 @@ export class WorkspaceService {
     if (this.isSystemWorkspaceId(id)) {
       throw new Error('The system-managed guides workspace cannot be modified.');
     }
+  }
+
+  onWorkspaceChange(callback: (event: WorkspaceChangeEvent) => void): EventRef {
+    return this.workspaceEvents.on('workspace-change', (...data: unknown[]) => {
+      callback(data[0] as WorkspaceChangeEvent);
+    });
+  }
+
+  offWorkspaceChange(ref: EventRef): void {
+    this.workspaceEvents.offref(ref);
+  }
+
+  private notifyWorkspaceChange(event: WorkspaceChangeEvent): void {
+    this.workspaceEvents.trigger('workspace-change', event);
   }
 
   // ============================================================================
@@ -340,8 +363,7 @@ export class WorkspaceService {
 
       try {
         const id = await adapterForCreate.createWorkspace(hybridData);
-
-        return {
+        const workspace: IndividualWorkspace = {
           id,
           name: hybridData.name,
           description: hybridData.description,
@@ -353,6 +375,8 @@ export class WorkspaceService {
           context: data.context,
           sessions: {}
         };
+        this.notifyWorkspaceChange({ workspaceId: id, action: 'created', workspace });
+        return workspace;
       } catch (error) {
         const isDefaultWorkspace =
           hybridData.id === GLOBAL_WORKSPACE_ID || hybridData.name === DEFAULT_WORKSPACE_NAME;
@@ -389,6 +413,7 @@ export class WorkspaceService {
     // Update index
     await this.indexManager.updateWorkspaceInIndex(workspace);
 
+    this.notifyWorkspaceChange({ workspaceId: id, action: 'created', workspace });
     return workspace;
   }
 
@@ -397,7 +422,7 @@ export class WorkspaceService {
    */
   async updateWorkspace(id: string, updates: Partial<IndividualWorkspace>): Promise<void> {
     this.ensureSystemWorkspaceMutable(id);
-    return withDualBackend(
+    await withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
         const hybridUpdates: Partial<HybridTypes.WorkspaceMetadata> = {};
@@ -444,6 +469,12 @@ export class WorkspaceService {
         await this.indexManager.updateWorkspaceInIndex(updatedWorkspace);
       }
     );
+    const workspace = await this.getWorkspace(id);
+    this.notifyWorkspaceChange({
+      workspaceId: id,
+      action: 'updated',
+      workspace: workspace ?? undefined
+    });
   }
 
   /**
@@ -473,7 +504,7 @@ export class WorkspaceService {
    */
   async deleteWorkspace(id: string): Promise<void> {
     this.ensureSystemWorkspaceMutable(id);
-    return withDualBackend(
+    await withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
         await adapter.deleteWorkspace(id);
@@ -483,6 +514,7 @@ export class WorkspaceService {
         await this.indexManager.removeWorkspaceFromIndex(id);
       }
     );
+    this.notifyWorkspaceChange({ workspaceId: id, action: 'deleted' });
   }
 
   // ============================================================================
@@ -643,15 +675,16 @@ export class WorkspaceService {
       return byId;
     }
 
+    const lookupName = identifier === GLOBAL_WORKSPACE_ID ? DEFAULT_WORKSPACE_NAME : identifier;
     const matchId = await withReadableBackend<string | null>(
       this.storageAdapterOrGetter,
       async (adapter) => {
         const result = await adapter.getWorkspaces({
-          search: identifier,
+          search: lookupName,
           pageSize: 100
         });
         const match = result.items.find(
-          ws => ws.name.toLowerCase() === identifier.toLowerCase()
+          ws => ws.name.toLowerCase() === lookupName.toLowerCase()
         );
         return match?.id ?? null;
       },
@@ -659,7 +692,7 @@ export class WorkspaceService {
         const index = await this.indexManager.loadWorkspaceIndex();
         const workspaces = Object.values(index.workspaces);
         const match = workspaces.find(
-          ws => ws.name.toLowerCase() === identifier.toLowerCase()
+          ws => ws.name.toLowerCase() === lookupName.toLowerCase()
         );
         return match?.id ?? null;
       }

--- a/src/services/workspace/WorkspaceSessionService.ts
+++ b/src/services/workspace/WorkspaceSessionService.ts
@@ -63,7 +63,8 @@ export class WorkspaceSessionService {
         }
       }
 
-      const hybridSession: Omit<HybridTypes.SessionMetadata, 'id' | 'workspaceId'> = {
+      const hybridSession: Omit<HybridTypes.SessionMetadata, 'id' | 'workspaceId'> & { id?: string } = {
+        id: sessionData.id,
         name: sessionData.name || 'Untitled Session',
         description: sessionData.description,
         startTime: sessionData.startTime || Date.now(),

--- a/src/services/workspace/WorkspaceStateService.ts
+++ b/src/services/workspace/WorkspaceStateService.ts
@@ -138,36 +138,44 @@ export class WorkspaceStateService {
     if (adapter) {
       // Ensure session exists before saving state (referential integrity)
       const existingSession = await this.sessionDeps.getSession(workspaceId, sessionId);
+      let effectiveSessionId = sessionId;
       if (!existingSession) {
-        await this.sessionDeps.addSession(workspaceId, {
-          id: sessionId,
+        const sessionIdToCreate = this.isReservedSessionId(sessionId) ? this.createSessionId() : sessionId;
+        const createdSession = await this.sessionDeps.addSession(workspaceId, {
+          id: sessionIdToCreate,
           name: `Session ${new Date().toLocaleString()}`,
           description: `Auto-created session for state storage`,
           startTime: Date.now(),
           isActive: true
         });
+        effectiveSessionId = createdSession.id;
       }
 
       // Support both new 'state' property and legacy 'snapshot' property
       const stateContent = stateData.state ||
         (stateData as Partial<StateData> & { snapshot?: WorkspaceState }).snapshot ||
         {};
+      const tags = this.extractTags(stateData, stateContent);
 
       const hybridState: Omit<HybridTypes.StateData, 'id' | 'workspaceId' | 'sessionId'> = {
         name: stateData.name || 'Untitled State',
         created: stateData.created || Date.now(),
-        description: undefined,
-        tags: undefined,
+        description: stateData.description,
+        tags,
         content: stateContent
       };
 
-      const stateId = await adapter.saveState(workspaceId, sessionId, hybridState);
+      const stateId = await adapter.saveState(workspaceId, effectiveSessionId, hybridState);
       await adapter.updateWorkspace(workspaceId, { lastAccessed: Date.now() });
 
       return {
         id: stateId,
+        workspaceId,
+        sessionId: effectiveSessionId,
         name: hybridState.name,
+        description: hybridState.description,
         created: hybridState.created,
+        tags,
         state: this.coerceWorkspaceState(hybridState.content)
       };
     }
@@ -193,8 +201,12 @@ export class WorkspaceStateService {
 
     const state: StateData = {
       id: stateId,
+      workspaceId,
+      sessionId,
       name: stateData.name || 'Untitled State',
+      description: stateData.description,
       created: stateData.created || Date.now(),
+      tags: this.extractTags(stateData, stateContent),
       state: stateContent
     };
 
@@ -219,8 +231,12 @@ export class WorkspaceStateService {
         }
         return {
           id: state.id,
+          workspaceId: state.workspaceId,
+          sessionId: state.sessionId,
           name: state.name,
+          description: state.description,
           created: state.created,
+          tags: state.tags,
           state: this.coerceWorkspaceState(state.content)
         };
       },
@@ -275,5 +291,27 @@ export class WorkspaceStateService {
 
   private coerceWorkspaceState(state: unknown): WorkspaceState {
     return state as WorkspaceState;
+  }
+
+  private extractTags(stateData: Partial<StateData>, stateContent: unknown): string[] | undefined {
+    if (Array.isArray(stateData.tags)) {
+      return stateData.tags;
+    }
+
+    if (typeof stateContent !== 'object' || stateContent === null || Array.isArray(stateContent)) {
+      return undefined;
+    }
+
+    const workspaceState = stateContent as { state?: { metadata?: { tags?: unknown } } };
+    const tags = workspaceState.state?.metadata?.tags;
+    return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : undefined;
+  }
+
+  private isReservedSessionId(sessionId: string): boolean {
+    return sessionId === 'default-session' || sessionId === '_workspace';
+  }
+
+  private createSessionId(): string {
+    return `session_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
   }
 }

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -18,7 +18,7 @@ import { WorkspaceListRenderer } from '../../components/workspace/WorkspaceListR
 import { WorkspaceDetailRenderer, DetailCallbacks } from '../../components/workspace/WorkspaceDetailRenderer';
 import { ProjectsManagerView } from '../../components/workspace/ProjectsManagerView';
 import { ProjectWorkspace } from '../../database/workspace-types';
-import { WorkspaceService } from '../../services/WorkspaceService';
+import { WorkspaceService, type WorkspaceChangeEvent } from '../../services/WorkspaceService';
 import { CustomPromptStorageService } from '../../agents/promptManager/services/CustomPromptStorageService';
 import { CustomPrompt } from '../../types/mcp/CustomPromptTypes';
 import { v4 as uuidv4 } from '../../utils/uuid';
@@ -44,9 +44,11 @@ export class WorkspacesTab {
     private services: WorkspacesTabServices;
     private workspaces: ProjectWorkspace[] = [];
     private currentWorkspace: Partial<ProjectWorkspace> | null = null;
+    private isDraftWorkspace = false;
     private currentWorkflowIndex = -1;
     private currentFileIndex = -1;
     private currentView: WorkspacesView = 'list';
+    private workspaceChangeService?: WorkspaceService;
 
     // Renderers
     private listRenderer: WorkspaceListRenderer;
@@ -98,6 +100,7 @@ export class WorkspacesTab {
         // Refresh the list / active detail when Obsidian Sync lands remote
         // workspace or task JSONL changes from another device.
         this.subscribeToExternalSync();
+        this.subscribeToWorkspaceChanges(this.services.workspaceService);
     }
 
     /**
@@ -125,6 +128,19 @@ export class WorkspacesTab {
             void this.handleExternalSync(event);
         });
         component.registerEvent(ref);
+    }
+
+    private subscribeToWorkspaceChanges(workspaceService?: WorkspaceService): void {
+        const component = this.services.component;
+        if (!component || !workspaceService || this.workspaceChangeService === workspaceService) {
+            return;
+        }
+
+        const ref = workspaceService.onWorkspaceChange((event) => {
+            void this.handleWorkspaceChange(event);
+        });
+        component.registerEvent(ref);
+        this.workspaceChangeService = workspaceService;
     }
 
     /**
@@ -182,25 +198,65 @@ export class WorkspacesTab {
         }
     }
 
+    private async handleWorkspaceChange(event: WorkspaceChangeEvent): Promise<void> {
+        try {
+            await this.loadWorkspaces();
+
+            if (
+                event.action === 'deleted' &&
+                this.currentWorkspace?.id === event.workspaceId
+            ) {
+                this.currentWorkspace = null;
+                this.isDraftWorkspace = false;
+                this.currentView = 'list';
+                this.router.back();
+                return;
+            }
+
+            if (
+                this.currentView === 'detail' &&
+                !this.isDraftWorkspace &&
+                this.currentWorkspace?.id === event.workspaceId
+            ) {
+                const updatedWorkspace = this.workspaces.find(w => w.id === event.workspaceId);
+                if (updatedWorkspace) {
+                    this.currentWorkspace = { ...updatedWorkspace };
+                    this.render();
+                }
+                return;
+            }
+
+            if (this.currentView === 'list') {
+                this.render();
+            }
+        } catch (error) {
+            console.error('[WorkspacesTab] Failed to refresh workspaces on workspace-change:', error);
+        }
+    }
+
     private async loadWorkspaces(): Promise<void> {
         let workspaceService = this.services.workspaceService;
 
         if (this.services.serviceManager) {
             const timeout = <T>(ms: number) => new Promise<T | undefined>(r => setTimeout(() => r(undefined), ms));
             try {
-                const [service] = await Promise.all([
+                const [service, adapter] = await Promise.all([
                     Promise.race([
                         this.services.serviceManager.getService<WorkspaceService>('workspaceService'),
                         timeout<WorkspaceService>(10000)
                     ]),
                     Promise.race([
-                        this.services.serviceManager.getService('hybridStorageAdapter'),
-                        timeout(10000)
+                        this.services.serviceManager.getService<HybridStorageAdapter>('hybridStorageAdapter'),
+                        timeout<HybridStorageAdapter>(10000)
                     ])
                 ]);
                 if (service) {
                     workspaceService = service;
                     this.services.workspaceService = workspaceService;
+                    this.subscribeToWorkspaceChanges(workspaceService);
+                }
+                if (adapter && typeof adapter.waitForQueryReady === 'function') {
+                    await adapter.waitForQueryReady();
                 }
             } catch {
                 // Service unavailable
@@ -251,6 +307,7 @@ export class WorkspacesTab {
             this.currentView = 'detail';
             const workspace = this.workspaces.find(w => w.id === state.detailId);
             if (workspace) {
+                this.isDraftWorkspace = false;
                 this.currentWorkspace = { ...workspace };
                 this.detailRenderer.renderDetail(
                     this.container,
@@ -260,6 +317,16 @@ export class WorkspacesTab {
                 );
                 return;
             }
+        }
+
+        if (this.currentView === 'detail' && this.currentWorkspace && this.isDraftWorkspace) {
+            this.detailRenderer.renderDetail(
+                this.container,
+                this.currentWorkspace,
+                this.workspaces,
+                this.buildDetailCallbacks()
+            );
+            return;
         }
 
         // Default to list view
@@ -281,11 +348,21 @@ export class WorkspacesTab {
                         workspace.isActive = enabled;
                     }
                 },
-                onDelete: async (id) => {
-                    if (this.services.workspaceService) {
+                onDelete: async (id, name) => {
+                    if (!this.services.workspaceService) return;
+
+                    const confirmed = await this.confirmDeleteWorkspace(name);
+                    if (!confirmed) return;
+
+                    try {
                         await this.services.workspaceService.deleteWorkspace(id);
                         this.workspaces = this.workspaces.filter(w => w.id !== id);
+                        await this.loadWorkspaces();
                         this.listRenderer.updateItems(this.workspaces);
+                        new Notice('Workspace deleted');
+                    } catch (error) {
+                        console.error('[WorkspacesTab] Failed to delete workspace:', error);
+                        new Notice('Failed to delete workspace');
                     }
                 }
             }
@@ -346,6 +423,7 @@ export class WorkspacesTab {
             created: Date.now(),
             lastAccessed: Date.now()
         };
+        this.isDraftWorkspace = true;
         this.currentView = 'detail';
         this.render();
     }
@@ -366,11 +444,13 @@ export class WorkspacesTab {
                     this.currentWorkspace
                 );
                 this.workspaces[existingIndex] = this.currentWorkspace as ProjectWorkspace;
+                this.isDraftWorkspace = false;
                 return this.currentWorkspace as ProjectWorkspace;
             } else {
                 const created = await this.services.workspaceService.createWorkspace(this.currentWorkspace);
                 this.workspaces.push(created);
                 this.currentWorkspace = created;
+                this.isDraftWorkspace = false;
                 return created;
             }
         } catch (error) {
@@ -388,8 +468,9 @@ export class WorkspacesTab {
 
         try {
             await this.services.workspaceService.deleteWorkspace(this.currentWorkspace.id);
-            this.workspaces = this.workspaces.filter(w => w.id !== this.currentWorkspace?.id);
+            await this.loadWorkspaces();
             this.currentWorkspace = null;
+            this.isDraftWorkspace = false;
             this.router.back();
             new Notice('Workspace deleted');
         } catch (error) {
@@ -398,11 +479,11 @@ export class WorkspacesTab {
         }
     }
 
-    private async confirmDeleteWorkspace(): Promise<boolean> {
+    private async confirmDeleteWorkspace(workspaceName = this.currentWorkspace?.name || 'Workspace'): Promise<boolean> {
         return new Promise<boolean>((resolve) => {
             const modal = new WorkspaceDeleteConfirmModal(
                 this.services.app,
-                this.currentWorkspace?.name || 'Workspace',
+                workspaceName,
                 resolve
             );
             modal.open();
@@ -721,7 +802,7 @@ class WorkspaceDeleteConfirmModal extends Modal {
 
         new ButtonComponent(buttonRow)
             .setButtonText('Delete')
-            .setCta()
+            .setWarning()
             .onClick(() => {
                 this.resolve(true);
                 this.close();

--- a/src/types/mcp/AgentTypes.ts
+++ b/src/types/mcp/AgentTypes.ts
@@ -60,7 +60,7 @@ export interface ToolContext {
   /** Workspace scope identifier */
   workspaceId: string;
 
-  /** Session identifier for tracking */
+  /** Current chat session ID assigned once by the runtime and reused for every tool call */
   sessionId: string;
 
   /** Compressed essence of conversation so far (1-3 sentences) */

--- a/src/types/storage/StorageTypes.ts
+++ b/src/types/storage/StorageTypes.ts
@@ -208,9 +208,12 @@ export interface MemoryTrace {
  */
 export interface StateData {
   id: string;
+  workspaceId?: string;
+  sessionId?: string;
   name: string;
   description?: string;
   created: number;
+  tags?: string[];
   state: WorkspaceState;
 }
 

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-04-28T12:03:54.006Z
+ * Generated: 2026-04-28T20:10:00.059Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/src/utils/nudgeHelpers.ts
+++ b/src/utils/nudgeHelpers.ts
@@ -168,6 +168,16 @@ export class NudgeHelpers {
   }
 
   /**
+   * Remind agents that workspace names are valid handles for follow-up workspace commands.
+   */
+  static suggestWorkspaceNameFollowup(workspaceName: string): Recommendation {
+    return {
+      type: "workspace_reference",
+      message: `Workspace created as "${workspaceName}". You can use this workspace name in follow-up workspace commands; do not call list-workspaces solely to recover a workspace ID.`
+    };
+  }
+
+  /**
    * Check for large workspace (>20 files) to suggest exploration tools
    */
   static checkLargeWorkspace(fileCount: number): Recommendation | null {
@@ -187,6 +197,16 @@ export class NudgeHelpers {
     return {
       type: "next_steps",
       message: "Progress saved. Consider what you'd like to work on next, or use promptManager if you want to automate similar future workflows."
+    };
+  }
+
+  /**
+   * Remind agents that saved states can be loaded by name.
+   */
+  static suggestStateNameFollowup(stateName: string): Recommendation {
+    return {
+      type: "state_reference",
+      message: `State saved as "${stateName}". You can load this state later by name with MemoryManager loadState; do not call list-states solely to recover a state ID.`
     };
   }
 

--- a/src/utils/recommendationUtils.ts
+++ b/src/utils/recommendationUtils.ts
@@ -14,7 +14,7 @@ export interface Recommendation {
  * @param recommendations - Array of recommendations to inject
  * @returns Enhanced result with recommendations field
  */
-export function addRecommendations<T extends Record<string, unknown>>(
+export function addRecommendations<T extends object>(
 	result: T,
 	recommendations: Recommendation[]
 ): T & { recommendations: Recommendation[] } {

--- a/src/utils/schemaUtils.ts
+++ b/src/utils/schemaUtils.ts
@@ -68,7 +68,7 @@ export function getContextSchema(): ValidationSchema {
           },
           sessionId: {
             type: 'string',
-            description: 'Session identifier for tracking'
+            description: 'Current chat session ID assigned once by the runtime and reused for every tool call'
           },
           memory: {
             type: 'string',
@@ -84,7 +84,7 @@ export function getContextSchema(): ValidationSchema {
           }
         },
         required: ['workspaceId', 'sessionId', 'memory', 'goal'],
-        description: 'Context for this tool call. Use toolManager_useTool for automatic context handling.'
+        description: 'Context for this tool call. sessionId is the current chat session ID and must stay stable across all tool calls in the conversation.'
       }
     }
   });

--- a/tests/mocks/obsidian/core.ts
+++ b/tests/mocks/obsidian/core.ts
@@ -189,8 +189,35 @@ export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
 
-// EventRef mock
-export type EventRef = Record<string, never>;
+// Events / EventRef mocks
+export interface EventRef {
+  name?: string;
+  callback?: (...data: unknown[]) => unknown;
+}
+
+export class Events {
+  private listeners = new Map<string, Set<(...data: unknown[]) => unknown>>();
+
+  on(name: string, callback: (...data: unknown[]) => unknown): EventRef {
+    const callbacks = this.listeners.get(name) ?? new Set<(...data: unknown[]) => unknown>();
+    callbacks.add(callback);
+    this.listeners.set(name, callbacks);
+    return { name, callback };
+  }
+
+  offref(ref: EventRef): void {
+    if (!ref.name || !ref.callback) {
+      return;
+    }
+    this.listeners.get(ref.name)?.delete(ref.callback);
+  }
+
+  trigger(name: string, ...data: unknown[]): void {
+    this.listeners.get(name)?.forEach(callback => {
+      callback(...data);
+    });
+  }
+}
 
 // MarkdownFileInfo mock (used in editorCallback context)
 export interface MarkdownFileInfo {

--- a/tests/mocks/obsidian/index.ts
+++ b/tests/mocks/obsidian/index.ts
@@ -21,6 +21,7 @@ export {
   requestUrl,
   __setRequestUrlMock,
   normalizePath,
+  Events,
   EventRef,
   MarkdownFileInfo,
   createMockElement,

--- a/tests/unit/BaseToolWorkspaceContext.test.ts
+++ b/tests/unit/BaseToolWorkspaceContext.test.ts
@@ -1,0 +1,54 @@
+import { BaseTool } from '../../src/agents/baseTool';
+import { CommonParameters, CommonResult } from '../../src/types';
+import { JSONSchema } from '../../src/types/schema/JSONSchemaTypes';
+
+class WorkspaceContextTestTool extends BaseTool<CommonParameters, CommonResult> {
+  constructor() {
+    super('workspaceContextTest', 'Workspace context test', 'Tests workspace context resolution', '1.0.0');
+  }
+
+  async execute(_params: CommonParameters): Promise<CommonResult> {
+    return { success: true };
+  }
+
+  getParameterSchema(): JSONSchema {
+    return { type: 'object' };
+  }
+
+  resolve(params: CommonParameters): CommonResult['workspaceContext'] | null {
+    return this.getInheritedWorkspaceContext(params);
+  }
+}
+
+function buildParams(workspaceId: string): CommonParameters {
+  return {
+    context: {
+      workspaceId,
+      sessionId: 'session-1',
+      memory: 'Testing workspace context resolution.',
+      goal: 'Ensure canonical tool context scopes state tools.'
+    }
+  };
+}
+
+describe('BaseTool workspace context resolution', () => {
+  it('uses the canonical tool context workspaceId when workspaceContext is absent', () => {
+    const tool = new WorkspaceContextTestTool();
+
+    expect(tool.resolve(buildParams('workspace-uuid'))).toEqual({
+      workspaceId: 'workspace-uuid',
+      workspacePath: [],
+      activeWorkspace: true
+    });
+  });
+
+  it('uses a direct workspaceId param injected by tool batch execution', () => {
+    const tool = new WorkspaceContextTestTool();
+    const params: CommonParameters & { workspaceId: string } = {
+      ...buildParams('context-workspace'),
+      workspaceId: 'direct-workspace'
+    };
+
+    expect(tool.resolve(params)?.workspaceId).toBe('direct-workspace');
+  });
+});

--- a/tests/unit/CreateStateWorkspaceContext.test.ts
+++ b/tests/unit/CreateStateWorkspaceContext.test.ts
@@ -1,0 +1,148 @@
+import { CreateStateTool } from '../../src/agents/memoryManager/tools/states/createState';
+import { CreateStateParams } from '../../src/agents/memoryManager/types';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import { createServiceIntegration } from '../../src/agents/memoryManager/services/ValidationService';
+
+jest.mock('../../src/agents/memoryManager/services/ValidationService', () => ({
+  createServiceIntegration: jest.fn()
+}));
+
+describe('CreateStateTool workspace context', () => {
+  const createServiceIntegrationMock = createServiceIntegration as jest.MockedFunction<typeof createServiceIntegration>;
+
+  beforeEach(() => {
+    createServiceIntegrationMock.mockReset();
+  });
+
+  it('honors the workspaceId injected into tool params instead of falling back to default', async () => {
+    const memoryService = {
+      getStates: jest.fn().mockResolvedValue({ items: [] }),
+      saveState: jest.fn().mockResolvedValue('state-1'),
+      getState: jest.fn().mockResolvedValue({
+        workspaceId: 'workspace-uuid',
+        name: 'diagnostic-state',
+        context: { activeTask: 'Diagnostic' }
+      }),
+      deleteState: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Diagnostic workspace',
+        description: 'Workspace used by the create-state diagnostic.',
+        rootFolder: '/',
+        created: 1,
+        lastAccessed: 1,
+        isActive: true,
+        sessions: {}
+      })
+    };
+
+    createServiceIntegrationMock.mockReturnValue({
+      getMemoryService: jest.fn().mockResolvedValue({ success: true, service: memoryService }),
+      getWorkspaceService: jest.fn().mockResolvedValue({ success: true, service: workspaceService })
+    } as unknown as ReturnType<typeof createServiceIntegration>);
+
+    const agent = {
+      getApp: () => ({})
+    } as unknown as MemoryManagerAgent;
+    const tool = new CreateStateTool(agent);
+    const params: CreateStateParams & { workspaceId: string } = {
+      context: {
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1',
+        memory: 'Testing create-state workspace scoping.',
+        goal: 'Create a state in the requested workspace.'
+      },
+      workspaceId: 'workspace-uuid',
+      name: 'diagnostic-state',
+      conversationContext: '## Original Request\nDiagnostic test',
+      activeTask: 'Diagnostic',
+      activeFiles: ['none'],
+      nextSteps: ['Check result'],
+      tags: ['diagnostic']
+    };
+
+    const result = await tool.execute(params);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+    expect(result).toHaveProperty('recommendations', [
+      {
+        type: 'state_reference',
+        message: expect.stringContaining('State saved as "diagnostic-state"')
+      }
+    ]);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('workspace-uuid');
+    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-uuid');
+    expect(memoryService.saveState).toHaveBeenCalledWith(
+      'workspace-uuid',
+      'session-1',
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1',
+        name: 'diagnostic-state'
+      }),
+      'diagnostic-state'
+    );
+  });
+
+  it('uses the top-level sessionId injected by useTools instead of creating a new session', async () => {
+    const memoryService = {
+      getStates: jest.fn().mockResolvedValue({ items: [] }),
+      saveState: jest.fn().mockResolvedValue('state-1'),
+      getState: jest.fn().mockResolvedValue({
+        workspaceId: 'workspace-uuid',
+        name: 'diagnostic-state',
+        context: { activeTask: 'Diagnostic' }
+      }),
+      deleteState: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Diagnostic workspace',
+        description: 'Workspace used by the create-state diagnostic.',
+        rootFolder: '/',
+        created: 1,
+        lastAccessed: 1,
+        isActive: true,
+        sessions: {}
+      })
+    };
+
+    createServiceIntegrationMock.mockReturnValue({
+      getMemoryService: jest.fn().mockResolvedValue({ success: true, service: memoryService }),
+      getWorkspaceService: jest.fn().mockResolvedValue({ success: true, service: workspaceService })
+    } as unknown as ReturnType<typeof createServiceIntegration>);
+
+    const agent = {
+      getApp: () => ({})
+    } as unknown as MemoryManagerAgent;
+    const tool = new CreateStateTool(agent);
+    const params = {
+      workspaceId: 'workspace-uuid',
+      sessionId: 'current-session',
+      name: 'diagnostic-state',
+      conversationContext: '## Original Request\nDiagnostic test',
+      activeTask: 'Diagnostic',
+      activeFiles: ['none'],
+      nextSteps: ['Check result'],
+      tags: ['diagnostic']
+    } as unknown as CreateStateParams;
+
+    const result = await tool.execute(params);
+
+    expect(result.success).toBe(true);
+    expect(memoryService.saveState).toHaveBeenCalledWith(
+      'workspace-uuid',
+      'current-session',
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'current-session',
+        name: 'diagnostic-state'
+      }),
+      'diagnostic-state'
+    );
+  });
+});

--- a/tests/unit/CreateWorkspaceTool.test.ts
+++ b/tests/unit/CreateWorkspaceTool.test.ts
@@ -1,0 +1,71 @@
+import { CreateWorkspaceTool } from '../../src/agents/memoryManager/tools/workspaces/createWorkspace';
+import { CreateWorkspaceParameters } from '../../src/database/types/workspace/ParameterTypes';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import { createServiceIntegration } from '../../src/agents/memoryManager/services/ValidationService';
+
+jest.mock('../../src/agents/memoryManager/services/ValidationService', () => ({
+  createServiceIntegration: jest.fn()
+}));
+
+describe('CreateWorkspaceTool', () => {
+  const createServiceIntegrationMock = createServiceIntegration as jest.MockedFunction<typeof createServiceIntegration>;
+
+  beforeEach(() => {
+    createServiceIntegrationMock.mockReset();
+  });
+
+  it('returns success and nudges agents that the workspace name is valid for follow-up commands', async () => {
+    const workspace = {
+      id: 'workspace-uuid',
+      name: 'E2E Workspace State Test',
+      description: 'End-to-end test workspace.',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true,
+      sessions: {}
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(null),
+      createWorkspace: jest.fn().mockResolvedValue(workspace)
+    };
+
+    createServiceIntegrationMock.mockReturnValue({
+      getWorkspaceService: jest.fn().mockResolvedValue({ success: true, service: workspaceService })
+    } as unknown as ReturnType<typeof createServiceIntegration>);
+
+    const agent = {
+      getApp: () => ({
+        vault: {
+          getAbstractFileByPath: jest.fn().mockReturnValue({ path: '/' }),
+          createFolder: jest.fn()
+        }
+      })
+    } as unknown as MemoryManagerAgent;
+    const tool = new CreateWorkspaceTool(agent);
+    const params = {
+      context: {
+        workspaceId: 'default',
+        sessionId: 'current-session',
+        memory: 'Testing create workspace.',
+        goal: 'Create a test workspace.'
+      },
+      name: 'E2E Workspace State Test',
+      description: 'End-to-end test workspace.',
+      rootFolder: '/',
+      purpose: 'End-to-end test workspace.'
+    } as CreateWorkspaceParameters;
+
+    const result = await tool.execute(params);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toBeUndefined();
+    expect(result.recommendations).toEqual([
+      {
+        type: 'workspace_reference',
+        message: expect.stringContaining('Workspace created as "E2E Workspace State Test"')
+      }
+    ]);
+    expect(result.recommendations[0].message).not.toContain('workspace-uuid');
+  });
+});

--- a/tests/unit/ListStatesTool.test.ts
+++ b/tests/unit/ListStatesTool.test.ts
@@ -1,0 +1,119 @@
+import { ListStatesTool } from '../../src/agents/memoryManager/tools/states/listStates';
+import { ListStatesParams } from '../../src/agents/memoryManager/types';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+
+describe('ListStatesTool', () => {
+  it('returns metadata needed to verify tag filtering and session linkage', async () => {
+    const memoryService = {
+      getStates: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: 'state-1',
+            name: 'Verification checkpoint',
+            description: 'Checkpoint description',
+            sessionId: 'session-1',
+            workspaceId: 'workspace-1',
+            created: 123,
+            tags: ['test', 'verification'],
+            state: {
+              state: {
+                metadata: {
+                  tags: ['test', 'verification']
+                }
+              }
+            }
+          },
+          {
+            id: 'state-2',
+            name: 'Other checkpoint',
+            description: 'Other description',
+            sessionId: 'session-2',
+            workspaceId: 'workspace-1',
+            created: 100,
+            tags: ['other'],
+            state: {
+              state: {
+                metadata: {
+                  tags: ['other']
+                }
+              }
+            }
+          }
+        ],
+        page: 0,
+        pageSize: 10,
+        totalItems: 2,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      })
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-1',
+        name: 'Workspace Name'
+      })
+    };
+    const agent = {
+      getMemoryServiceAsync: jest.fn().mockResolvedValue(memoryService),
+      getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService)
+    } as unknown as MemoryManagerAgent;
+    const tool = new ListStatesTool(agent);
+    const params: ListStatesParams = {
+      context: {
+        workspaceId: 'Workspace Name',
+        sessionId: 'session-1',
+        memory: 'Testing list states.',
+        goal: 'Verify metadata is visible.'
+      },
+      tags: ['test']
+    };
+
+    const result = await tool.execute(params);
+
+    expect(result.success).toBe(true);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Workspace Name');
+    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-1', undefined, {
+      page: 0,
+      pageSize: undefined
+    });
+    expect(result.data).toEqual([
+      {
+        id: 'state-1',
+        name: 'Verification checkpoint',
+        description: 'Checkpoint description',
+        sessionId: 'session-1',
+        workspaceId: 'workspace-1',
+        created: 123,
+        tags: ['test', 'verification']
+      }
+    ]);
+  });
+
+  it('returns a clear error when the scoped workspace name cannot be resolved', async () => {
+    const memoryService = {
+      getStates: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(null)
+    };
+    const agent = {
+      getMemoryServiceAsync: jest.fn().mockResolvedValue(memoryService),
+      getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService)
+    } as unknown as MemoryManagerAgent;
+    const tool = new ListStatesTool(agent);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'Missing Workspace',
+        sessionId: 'session-1',
+        memory: 'Testing list states.',
+        goal: 'Verify workspace name resolution.'
+      }
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Workspace not found: Missing Workspace/);
+    expect(memoryService.getStates).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/LoadStateTool.test.ts
+++ b/tests/unit/LoadStateTool.test.ts
@@ -1,0 +1,129 @@
+import { LoadStateTool } from '../../src/agents/memoryManager/tools/states/loadState';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import { createServiceIntegration } from '../../src/agents/memoryManager/services/ValidationService';
+
+jest.mock('../../src/agents/memoryManager/services/ValidationService', () => ({
+  createServiceIntegration: jest.fn()
+}));
+
+describe('LoadStateTool', () => {
+  const createServiceIntegrationMock = createServiceIntegration as jest.MockedFunction<typeof createServiceIntegration>;
+
+  beforeEach(() => {
+    createServiceIntegrationMock.mockReset();
+  });
+
+  function createTool(memoryService: Record<string, unknown>, workspaceService: Record<string, unknown>): LoadStateTool {
+    createServiceIntegrationMock.mockReturnValue({
+      getMemoryService: jest.fn().mockResolvedValue({ success: true, service: memoryService }),
+      getWorkspaceService: jest.fn().mockResolvedValue({ success: true, service: workspaceService })
+    } as unknown as ReturnType<typeof createServiceIntegration>);
+
+    const agent = {
+      getApp: () => ({})
+    } as unknown as MemoryManagerAgent;
+
+    return new LoadStateTool(agent);
+  }
+
+  it('resolves workspace names before loading states', async () => {
+    const matchingState = {
+      id: 'state-1',
+      name: 'Checkpoint',
+      sessionId: 'session-1',
+      workspaceId: 'workspace-uuid'
+    };
+    const loadedState = {
+      id: 'state-1',
+      name: 'Checkpoint',
+      description: 'Checkpoint description',
+      sessionId: 'session-1',
+      workspaceId: 'workspace-uuid',
+      created: Date.now(),
+      context: {
+        conversationContext: 'Conversation context',
+        activeTask: 'Active task',
+        activeFiles: ['note.md'],
+        nextSteps: ['Continue testing']
+      },
+      state: {
+        metadata: {
+          tags: ['test']
+        }
+      }
+    };
+    const memoryService = {
+      getStates: jest.fn().mockResolvedValue({
+        items: [matchingState],
+        page: 0,
+        pageSize: 100,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }),
+      getState: jest.fn().mockResolvedValue(loadedState),
+      getMemoryTraces: jest.fn().mockResolvedValue({ items: [] })
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      }),
+      getWorkspace: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      })
+    };
+    const tool = createTool(memoryService, workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'Workspace Name',
+        sessionId: 'session-1',
+        memory: 'Testing load state.',
+        goal: 'Verify workspace name resolution.'
+      },
+      name: 'Checkpoint'
+    });
+
+    expect(result.success).toBe(true);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Workspace Name');
+    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-uuid', undefined, { pageSize: 100 });
+    expect(memoryService.getState).toHaveBeenCalledWith('workspace-uuid', 'session-1', 'state-1');
+    expect(result.data).toMatchObject({
+      name: 'Checkpoint',
+      conversationContext: 'Conversation context',
+      activeTask: 'Active task',
+      activeFiles: ['note.md'],
+      nextSteps: ['Continue testing'],
+      description: 'Checkpoint description',
+      tags: ['test']
+    });
+  });
+
+  it('returns a clear error when the scoped workspace name cannot be resolved', async () => {
+    const memoryService = {
+      getStates: jest.fn(),
+      getState: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(null)
+    };
+    const tool = createTool(memoryService, workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'Missing Workspace',
+        sessionId: 'session-1',
+        memory: 'Testing load state.',
+        goal: 'Verify workspace name resolution.'
+      },
+      name: 'Checkpoint'
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Workspace not found: Missing Workspace/);
+    expect(memoryService.getStates).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/LoadWorkspaceSystemGuides.test.ts
+++ b/tests/unit/LoadWorkspaceSystemGuides.test.ts
@@ -2,6 +2,16 @@ import { LoadWorkspaceTool } from '../../src/agents/memoryManager/tools/workspac
 import { SYSTEM_GUIDES_WORKSPACE_ID } from '../../src/services/workspace/SystemGuidesWorkspaceProvider';
 
 describe('LoadWorkspaceTool system guides workspace', () => {
+  const emptyPage = {
+    items: [],
+    page: 0,
+    pageSize: 5,
+    totalItems: 0,
+    totalPages: 0,
+    hasNextPage: false,
+    hasPreviousPage: false
+  };
+
   it('returns a bounded docs payload for the reserved guides workspace', async () => {
     const tool = new LoadWorkspaceTool({
       getWorkspaceServiceAsync: jest.fn().mockResolvedValue({
@@ -40,5 +50,64 @@ describe('LoadWorkspaceTool system guides workspace', () => {
     expect(result.data.keyFiles['Assistant data/guides/index.md']).toContain('# Assistant guides');
     expect(result.pagination?.sessions.totalItems).toBe(0);
     expect(result.pagination?.states.totalItems).toBe(0);
+  });
+
+  it('loads a regular workspace by case-insensitive name and uses the resolved workspace ID downstream', async () => {
+    const workspace = {
+      id: 'ws-actual-id',
+      name: 'My Workspace',
+      description: 'Workspace loaded by name',
+      rootFolder: 'Projects/My Workspace',
+      created: 1000,
+      lastAccessed: 2000,
+      isActive: true,
+      context: {
+        purpose: 'Verify name lookup',
+        keyFiles: ['Projects/My Workspace/README.md'],
+        preferences: 'Use exact workspace names when possible.'
+      },
+      sessions: {}
+    };
+    const workspaceService = {
+      isSystemWorkspaceId: jest.fn().mockReturnValue(false),
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(workspace),
+      updateLastAccessed: jest.fn().mockResolvedValue(undefined)
+    };
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue(emptyPage),
+      getSessions: jest.fn().mockResolvedValue(emptyPage),
+      getStates: jest.fn().mockResolvedValue(emptyPage)
+    };
+    const app = {
+      vault: {
+        getAbstractFileByPath: jest.fn().mockReturnValue(null)
+      }
+    };
+    const tool = new LoadWorkspaceTool({
+      getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService),
+      getMemoryService: jest.fn().mockReturnValue(memoryService),
+      getCacheManager: jest.fn().mockReturnValue(null),
+      getTaskService: jest.fn().mockReturnValue(null),
+      getApp: jest.fn().mockReturnValue(app),
+      plugin: {},
+      customPromptStorage: undefined
+    } as never);
+
+    const result = await tool.execute({ id: 'my workspace', limit: 5 });
+
+    expect(result.success).toBe(true);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('my workspace');
+    expect(workspaceService.updateLastAccessed).toHaveBeenCalledWith('ws-actual-id');
+    expect(memoryService.getMemoryTraces).toHaveBeenCalledWith('ws-actual-id');
+    expect(memoryService.getSessions).toHaveBeenCalledWith('ws-actual-id', {
+      page: 0,
+      pageSize: 5
+    });
+    expect(memoryService.getStates).toHaveBeenCalledWith('ws-actual-id', undefined, {
+      page: 0,
+      pageSize: 5
+    });
+    expect(result.workspaceContext?.workspaceId).toBe('ws-actual-id');
+    expect(result.data.context.name).toBe('My Workspace');
   });
 });

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -440,6 +440,54 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
     });
   });
 
+  describe('workspace command targets', () => {
+    it('keeps update-workspace target separate from --name rename value', () => {
+      const updateWorkspaceTool = makeStubTool('updateWorkspace', {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Workspace ID or name to update'
+          },
+          workspaceId: {
+            type: 'string',
+            description: 'Context workspace ID, not a CLI tool argument'
+          },
+          name: {
+            type: 'string',
+            description: 'New workspace name'
+          },
+          description: {
+            type: 'string',
+            description: 'New workspace description'
+          }
+        },
+        required: ['id']
+      });
+      const normalizer = new ToolCliNormalizer(new Map<string, IAgent>([
+        ['memoryManager', makeStubAgent('memoryManager', [updateWorkspaceTool])]
+      ]));
+
+      const schema = normalizer.buildCliSchema('memoryManager', updateWorkspaceTool);
+      expect(schema.usage).toContain('memory update-workspace <id>');
+      expect(schema.arguments.find(arg => arg.name === 'id')?.positional).toBe(true);
+      expect(schema.arguments.find(arg => arg.name === 'name')?.flag).toBe('--name');
+      expect(schema.arguments.some(arg => arg.name === 'workspaceId')).toBe(false);
+
+      const [call] = normalizer.normalizeExecutionCalls({
+        tool: 'memory update-workspace "E2E Workspace Name Handle Test" --name "Renamed Workspace"'
+      });
+      expect(call).toMatchObject({
+        agent: 'memoryManager',
+        tool: 'updateWorkspace',
+        params: {
+          id: 'E2E Workspace Name Handle Test',
+          name: 'Renamed Workspace'
+        }
+      });
+    });
+  });
+
   // -------------------------------------------------------------------------
   // Value coercion — coerceValue branches
   // -------------------------------------------------------------------------

--- a/tests/unit/ToolManagerDynamicRegistry.test.ts
+++ b/tests/unit/ToolManagerDynamicRegistry.test.ts
@@ -7,7 +7,10 @@ class StubAgent extends BaseAgent {
   constructor() {
     super('webTools', 'Web tools test agent', '1.0.0');
 
-    const tool: ITool<{ url: string }, { success: boolean; data?: { opened: string } }> = {
+    const tool: ITool<
+      { url: string; workspaceId?: string; sessionId?: string },
+      { success: boolean; data?: { opened: string; workspaceId?: string; sessionId?: string } }
+    > = {
       slug: 'openWebpage',
       name: 'Open Webpage',
       description: 'Open a webpage',
@@ -15,7 +18,11 @@ class StubAgent extends BaseAgent {
       async execute(params) {
         return {
           success: true,
-          data: { opened: params.url }
+          data: {
+            opened: params.url,
+            workspaceId: params.workspaceId,
+            sessionId: params.sessionId
+          }
         };
       },
       getParameterSchema() {
@@ -95,8 +102,11 @@ describe('ToolManagerAgent dynamic registry updates', () => {
       agent: 'webTools',
       tool: 'openWebpage',
       success: true,
-      opened: 'https://example.com'
+      opened: 'https://example.com',
+      workspaceId: 'default',
+      sessionId: 'session_test'
     });
+    expect(execution).not.toHaveProperty('params');
   });
 
   it('removes dynamically unregistered agents from discovery', async () => {

--- a/tests/unit/UpdateWorkspaceTool.test.ts
+++ b/tests/unit/UpdateWorkspaceTool.test.ts
@@ -1,0 +1,130 @@
+import { UpdateWorkspaceTool } from '../../src/agents/memoryManager/tools/workspaces/updateWorkspace';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import { createServiceIntegration } from '../../src/agents/memoryManager/services/ValidationService';
+
+jest.mock('../../src/agents/memoryManager/services/ValidationService', () => ({
+  createServiceIntegration: jest.fn()
+}));
+
+describe('UpdateWorkspaceTool', () => {
+  const createServiceIntegrationMock = createServiceIntegration as jest.MockedFunction<typeof createServiceIntegration>;
+
+  beforeEach(() => {
+    createServiceIntegrationMock.mockReset();
+  });
+
+  function createTool(workspaceService: Record<string, unknown>): UpdateWorkspaceTool {
+    createServiceIntegrationMock.mockReturnValue({
+      getWorkspaceService: jest.fn().mockResolvedValue({ success: true, service: workspaceService })
+    } as unknown as ReturnType<typeof createServiceIntegration>);
+
+    const agent = {
+      getApp: () => ({
+        vault: {
+          getAbstractFileByPath: jest.fn().mockReturnValue({ path: '/' }),
+          createFolder: jest.fn()
+        }
+      })
+    } as unknown as MemoryManagerAgent;
+
+    return new UpdateWorkspaceTool(agent);
+  }
+
+  it('uses the explicit id argument as a workspace ID or name and applies name as the rename value', async () => {
+    const workspace = {
+      id: 'workspace-uuid',
+      name: 'E2E Workspace Name Handle Test',
+      description: 'Original description.',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true,
+      sessions: {},
+      context: {
+        purpose: 'Original purpose.'
+      }
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(workspace),
+      updateWorkspace: jest.fn().mockResolvedValue(undefined)
+    };
+    const tool = createTool(workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'default',
+        sessionId: 'current-session',
+        memory: 'Testing update workspace.',
+        goal: 'Rename a workspace by name.'
+      },
+      id: 'E2E Workspace Name Handle Test',
+      name: 'Renamed Workspace',
+      description: 'Updated description.'
+    });
+
+    expect(result.success).toBe(true);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('E2E Workspace Name Handle Test');
+    expect(workspaceService.updateWorkspace).toHaveBeenCalledWith(
+      'workspace-uuid',
+      expect.objectContaining({
+        id: 'workspace-uuid',
+        name: 'Renamed Workspace',
+        description: 'Updated description.'
+      })
+    );
+  });
+
+  it('keeps legacy direct workspaceId calls working as an internal fallback', async () => {
+    const workspace = {
+      id: 'workspace-uuid',
+      name: 'Workspace',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true,
+      sessions: {}
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue(workspace),
+      updateWorkspace: jest.fn().mockResolvedValue(undefined)
+    };
+    const tool = createTool(workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'default',
+        sessionId: 'current-session',
+        memory: 'Testing legacy update.',
+        goal: 'Update a workspace by legacy workspaceId.'
+      },
+      workspaceId: 'workspace-uuid',
+      description: 'Updated description.'
+    });
+
+    expect(result.success).toBe(true);
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('workspace-uuid');
+  });
+
+  it('fails with clear guidance when no target workspace identifier is provided', async () => {
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn(),
+      updateWorkspace: jest.fn()
+    };
+    const tool = createTool(workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'default',
+        sessionId: 'current-session',
+        memory: 'Testing missing target.',
+        goal: 'Update should require a target.'
+      },
+      description: 'Updated description.'
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/Workspace identifier is required/);
+    expect(workspaceService.getWorkspaceByNameOrId).not.toHaveBeenCalled();
+    expect(workspaceService.updateWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/WorkspaceDataFetcher.test.ts
+++ b/tests/unit/WorkspaceDataFetcher.test.ts
@@ -1,0 +1,190 @@
+import { WorkspaceDataFetcher } from '../../src/agents/memoryManager/services/WorkspaceDataFetcher';
+
+describe('WorkspaceDataFetcher', () => {
+  it('returns adapter-backed states even when mapped state payloads do not include workspaceId', async () => {
+    const fetcher = new WorkspaceDataFetcher();
+    const memoryService = {
+      getSessions: jest.fn(),
+      getStates: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: 'state-1',
+            name: 'Planning checkpoint',
+            description: 'Checkpoint description',
+            sessionId: 'session-1',
+            created: 123,
+            state: {}
+          }
+        ],
+        page: 0,
+        pageSize: 5,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      })
+    };
+
+    const result = await fetcher.fetchWorkspaceStates('workspace-1', memoryService, {
+      page: 0,
+      pageSize: 5
+    });
+
+    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-1', undefined, {
+      page: 0,
+      pageSize: 5
+    });
+    expect(result.items).toEqual([
+      {
+        id: 'state-1',
+        name: 'Planning checkpoint',
+        description: 'Checkpoint description',
+        sessionId: 'session-1',
+        created: 123,
+        tags: [],
+        workspaceId: undefined
+      }
+    ]);
+    expect(result.totalItems).toBe(1);
+  });
+
+  it('preserves session pagination metadata from MemoryService', async () => {
+    const fetcher = new WorkspaceDataFetcher();
+    const memoryService = {
+      getSessions: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: 'session-1',
+            name: 'Session one',
+            description: 'First session',
+            workspaceId: 'workspace-1',
+            created: 456
+          }
+        ],
+        page: 1,
+        pageSize: 1,
+        totalItems: 3,
+        totalPages: 3,
+        hasNextPage: true,
+        hasPreviousPage: true
+      }),
+      getStates: jest.fn()
+    };
+
+    const result = await fetcher.fetchWorkspaceSessions('workspace-1', memoryService, {
+      page: 1,
+      pageSize: 1
+    });
+
+    expect(memoryService.getSessions).toHaveBeenCalledWith('workspace-1', {
+      page: 1,
+      pageSize: 1
+    });
+    expect(result).toEqual({
+      items: [
+        {
+          id: 'session-1',
+          name: 'Session one',
+          description: 'First session',
+          created: 456,
+          workspaceId: 'workspace-1'
+        }
+      ],
+      page: 1,
+      pageSize: 1,
+      totalItems: 3,
+      totalPages: 3,
+      hasNextPage: true,
+      hasPreviousPage: true
+    });
+  });
+
+  it('surfaces state metadata tags and real session IDs from adapter-backed state lists', async () => {
+    const fetcher = new WorkspaceDataFetcher();
+    const memoryService = {
+      getSessions: jest.fn(),
+      getStates: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: 'state-1',
+            name: 'Verification checkpoint',
+            description: 'Checkpoint description',
+            sessionId: 'session-1',
+            workspaceId: 'workspace-1',
+            created: 789,
+            tags: ['test', 'verification'],
+            state: {
+              state: {
+                metadata: {
+                  tags: ['test', 'verification']
+                }
+              }
+            }
+          }
+        ],
+        page: 0,
+        pageSize: 5,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      })
+    };
+
+    const result = await fetcher.fetchWorkspaceStates('workspace-1', memoryService, {
+      page: 0,
+      pageSize: 5
+    });
+
+    expect(result.items[0]).toEqual({
+      id: 'state-1',
+      name: 'Verification checkpoint',
+      description: 'Checkpoint description',
+      sessionId: 'session-1',
+      created: 789,
+      tags: ['test', 'verification'],
+      workspaceId: 'workspace-1'
+    });
+  });
+
+  it('hides the internal workspace-state session from workspace session summaries', async () => {
+    const fetcher = new WorkspaceDataFetcher();
+    const memoryService = {
+      getSessions: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: '_workspace',
+            name: 'Workspace states',
+            workspaceId: 'workspace-1',
+            created: 100
+          },
+          {
+            id: 'session-1',
+            name: 'Session one',
+            workspaceId: 'workspace-1',
+            created: 200
+          }
+        ],
+        page: 0,
+        pageSize: 10,
+        totalItems: 2,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }),
+      getStates: jest.fn()
+    };
+
+    const result = await fetcher.fetchWorkspaceSessions('workspace-1', memoryService);
+
+    expect(result.items).toEqual([
+      {
+        id: 'session-1',
+        name: 'Session one',
+        description: undefined,
+        created: 200,
+        workspaceId: 'workspace-1'
+      }
+    ]);
+  });
+});

--- a/tests/unit/WorkspacesTab.test.ts
+++ b/tests/unit/WorkspacesTab.test.ts
@@ -1,9 +1,9 @@
-import { App } from 'obsidian';
+import { App, Component, createMockElement } from 'obsidian';
 import { WorkspacesTab } from '../../src/settings/tabs/WorkspacesTab';
 import { WorkspaceDetailRenderer } from '../../src/components/workspace/WorkspaceDetailRenderer';
 import { SettingsRouter } from '../../src/settings/SettingsRouter';
 import { TaskService } from '../../src/agents/taskManager/services/TaskService';
-import { createMockElement } from '../helpers/mockFactories';
+import { ProjectWorkspace } from '../../src/database/workspace-types';
 
 /**
  * Test-only interface exposing private WorkspacesTab members needed for testing.
@@ -12,6 +12,7 @@ import { createMockElement } from '../helpers/mockFactories';
 interface TestableWorkspacesTab {
   currentWorkspace: { id: string; name: string } | null;
   currentView: string;
+  isDraftWorkspace: boolean;
   projectsManager: {
     taskService: jest.Mocked<TaskService>;
     getCurrentProject(): { name: string };
@@ -21,6 +22,10 @@ interface TestableWorkspacesTab {
     currentProject: Record<string, unknown> | null;
   };
   render: jest.Mock;
+  workspaces: ProjectWorkspace[];
+  createNewWorkspace(): void;
+  deleteCurrentWorkspace(): Promise<void>;
+  confirmDeleteWorkspace(workspaceName?: string): Promise<boolean>;
   openProjectsPage(): Promise<void>;
   openProjectDetailAndRender(project: Record<string, unknown>): Promise<void>;
 }
@@ -63,7 +68,7 @@ function createMockTaskService(): jest.Mocked<TaskService> {
 
 describe('WorkspacesTab task management', () => {
   function createTab(): TestableWorkspacesTab {
-    const container = createMockElement();
+    const container = createMockElement('div');
     const router = new SettingsRouter();
     const tab = new WorkspacesTab(container, router, {
       app: new App(),
@@ -104,6 +109,85 @@ describe('WorkspacesTab task management', () => {
 
     expect(taskService.listProjects).toHaveBeenCalledWith('ws-1', { pageSize: 1000 });
     expect(tab.currentView).toBe('projects');
+    expect(tab.render).toHaveBeenCalled();
+  });
+
+  it('keeps a new workspace draft in detail view after rendering', () => {
+    const tab = createTab();
+
+    tab.createNewWorkspace();
+
+    expect(tab.currentView).toBe('detail');
+    expect(tab.isDraftWorkspace).toBe(true);
+    expect(tab.currentWorkspace?.id).toBeTruthy();
+  });
+
+  it('confirms before deleting the current workspace', async () => {
+    const container = createMockElement('div');
+    const router = new SettingsRouter();
+    const workspace: ProjectWorkspace = {
+      id: 'ws-delete',
+      name: 'Delete me',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true,
+      sessions: {}
+    };
+    const workspaceService = {
+      deleteWorkspace: jest.fn().mockResolvedValue(undefined),
+      getAllWorkspaces: jest.fn().mockResolvedValue([])
+    };
+    const tab = new WorkspacesTab(container, router, {
+      app: new App(),
+      prefetchedWorkspaces: [workspace],
+      workspaceService: workspaceService as never
+    }) as unknown as TestableWorkspacesTab;
+
+    tab.currentWorkspace = workspace;
+    tab.confirmDeleteWorkspace = jest.fn().mockResolvedValue(true);
+
+    await tab.deleteCurrentWorkspace();
+
+    expect(tab.confirmDeleteWorkspace).toHaveBeenCalled();
+    expect(workspaceService.deleteWorkspace).toHaveBeenCalledWith('ws-delete');
+    expect(workspaceService.getAllWorkspaces).toHaveBeenCalled();
+    expect(tab.currentWorkspace).toBeNull();
+  });
+
+  it('refreshes the workspace list when the workspace service emits a change', async () => {
+    const container = createMockElement('div');
+    const router = new SettingsRouter();
+    const workspace: ProjectWorkspace = {
+      id: 'ws-agent',
+      name: 'Agent workspace',
+      rootFolder: '/',
+      created: 1,
+      lastAccessed: 1,
+      isActive: true,
+      sessions: {}
+    };
+    let emitChange: ((event: { workspaceId: string; action: 'created' }) => void) | undefined;
+    const workspaceService = {
+      getAllWorkspaces: jest.fn().mockResolvedValue([workspace]),
+      onWorkspaceChange: jest.fn((callback: (event: { workspaceId: string; action: 'created' }) => void) => {
+        emitChange = callback;
+        return { id: 'workspace-change-ref' };
+      })
+    };
+    const tab = new WorkspacesTab(container, router, {
+      app: new App(),
+      prefetchedWorkspaces: [],
+      workspaceService: workspaceService as never,
+      component: new Component()
+    }) as unknown as TestableWorkspacesTab;
+    tab.render = jest.fn();
+
+    emitChange?.({ workspaceId: 'ws-agent', action: 'created' });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(workspaceService.getAllWorkspaces).toHaveBeenCalled();
     expect(tab.render).toHaveBeenCalled();
   });
 

--- a/tests/unit/dual-backend-characterization.test.ts
+++ b/tests/unit/dual-backend-characterization.test.ts
@@ -14,6 +14,7 @@
 import { WorkspaceService } from '../../src/services/WorkspaceService';
 import { ConversationService } from '../../src/services/ConversationService';
 import { MemoryService } from '../../src/agents/memoryManager/services/MemoryService';
+import { WorkspaceStateService } from '../../src/services/workspace/WorkspaceStateService';
 import { createMockPlugin, createMockFileSystem, createMockIndexManager, createMockAdapter } from '../helpers/mockFactories';
 
 // ============================================================================
@@ -381,6 +382,8 @@ describe('MemoryService dual-backend characterization', () => {
   type WorkspaceServiceLike = {
     getWorkspace: jest.Mock;
     getMemoryTraces: jest.Mock;
+    addSession?: jest.Mock;
+    addMemoryTrace?: jest.Mock;
   };
 
   describe('when adapter IS ready (adapter path)', () => {
@@ -402,6 +405,165 @@ describe('MemoryService dual-backend characterization', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].id).toBe('t1');
     });
+
+    it('getStates preserves adapter metadata needed for tags and session display', async () => {
+      const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
+      const adapter = createMockAdapter(true);
+      adapter.getStates.mockResolvedValue({
+        items: [
+          {
+            id: 'state-1',
+            workspaceId: 'ws1',
+            sessionId: 'session-1',
+            name: 'Verification checkpoint',
+            description: 'Checkpoint description',
+            created: 1000,
+            tags: ['test', 'verification']
+          }
+        ],
+        page: 0,
+        pageSize: 100,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      });
+
+      const service = new MemoryService(plugin, ws, adapter);
+      const result = await service.getStates('ws1', 'session-1');
+
+      expect(result.items[0]).toEqual(expect.objectContaining({
+        id: 'state-1',
+        name: 'Verification checkpoint',
+        description: 'Checkpoint description',
+        sessionId: 'session-1',
+        workspaceId: 'ws1',
+        tags: ['test', 'verification']
+      }));
+      expect(result.items[0].state.state?.metadata.tags).toEqual(['test', 'verification']);
+    });
+
+    it('getStates backfills missing tag metadata from full state content', async () => {
+      const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
+      const adapter = createMockAdapter(true);
+      adapter.getStates.mockResolvedValue({
+        items: [
+          {
+            id: 'state-1',
+            workspaceId: 'ws1',
+            sessionId: 'session-1',
+            name: 'Verification checkpoint',
+            created: 1000
+          }
+        ],
+        page: 0,
+        pageSize: 100,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      });
+      adapter.getState.mockResolvedValue({
+        id: 'state-1',
+        workspaceId: 'ws1',
+        sessionId: 'session-1',
+        name: 'Verification checkpoint',
+        created: 1000,
+        content: {
+          id: 'state-1',
+          name: 'Verification checkpoint',
+          workspaceId: 'ws1',
+          sessionId: 'session-1',
+          created: 1000,
+          context: {
+            workspaceContext: { purpose: 'Testing' },
+            conversationContext: 'Diagnostic context',
+            activeTask: 'Verify state metadata',
+            activeFiles: [],
+            nextSteps: []
+          },
+          state: {
+            workspace: null,
+            recentTraces: [],
+            contextFiles: [],
+            metadata: {
+              tags: ['test', 'verification']
+            }
+          }
+        }
+      });
+
+      const service = new MemoryService(plugin, ws, adapter);
+      const result = await service.getStates('ws1');
+
+      expect(adapter.getState).toHaveBeenCalledWith('state-1');
+      expect(result.items[0].tags).toEqual(['test', 'verification']);
+      expect(result.items[0].state.state?.metadata.tags).toEqual(['test', 'verification']);
+    });
+
+    it('recordActivityTrace creates the missing adapter session with the same generated ID', async () => {
+      const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
+      const adapter = createMockAdapter(true);
+      adapter.addTrace
+        .mockRejectedValueOnce(new Error('session not found'))
+        .mockResolvedValueOnce('trace-1');
+
+      const service = new MemoryService(plugin, ws, adapter);
+      const result = await service.recordActivityTrace({
+        workspaceId: 'ws1',
+        timestamp: 1000,
+        type: 'action',
+        content: 'created from diagnostic'
+      });
+
+      const createdSessionId = adapter.createSession.mock.calls[0][1].id;
+      expect(createdSessionId).toMatch(/^session_/);
+      expect(adapter.createSession).toHaveBeenCalledWith('ws1', expect.objectContaining({
+        id: createdSessionId
+      }));
+      expect(adapter.addTrace).toHaveBeenNthCalledWith(2, 'ws1', createdSessionId, expect.objectContaining({
+        content: 'created from diagnostic'
+      }));
+      expect(result).toBe('trace-1');
+    });
+
+    it('createMemoryTrace reuses one generated session ID for save and reload', async () => {
+      const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
+      const adapter = createMockAdapter(true);
+      adapter.addTrace.mockResolvedValue('trace-1');
+      adapter.getTraces.mockImplementation((_workspaceId, sessionId) => Promise.resolve({
+        items: [
+          {
+            id: 'trace-1',
+            workspaceId: 'ws1',
+            sessionId,
+            timestamp: 1000,
+            type: 'action',
+            content: 'created from diagnostic'
+          }
+        ],
+        page: 0,
+        pageSize: 100,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }));
+
+      const service = new MemoryService(plugin, ws, adapter);
+      const result = await service.createMemoryTrace({
+        workspaceId: 'ws1',
+        timestamp: 1000,
+        type: 'action',
+        content: 'created from diagnostic'
+      });
+
+      const savedSessionId = adapter.addTrace.mock.calls[0][1];
+      expect(savedSessionId).toMatch(/^session_/);
+      expect(adapter.getTraces).toHaveBeenCalledWith('ws1', savedSessionId, undefined);
+      expect(result.sessionId).toBe(savedSessionId);
+      expect(result.id).toBe('trace-1');
+    });
   });
 
   describe('when adapter is NOT ready (legacy path)', () => {
@@ -422,5 +584,97 @@ describe('MemoryService dual-backend characterization', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0].content).toBe('legacy trace');
     });
+  });
+});
+
+describe('WorkspaceStateService adapter path', () => {
+  it('persists state tags and preserves the provided unique session ID', async () => {
+    const adapter = createMockAdapter(true);
+    const sessionDeps = {
+      getSession: jest.fn().mockResolvedValue(null),
+      addSession: jest.fn().mockResolvedValue({ id: 'session-1' })
+    };
+    const service = new WorkspaceStateService(
+      createMockFileSystem(),
+      createMockIndexManager(),
+      adapter,
+      sessionDeps
+    );
+
+    await service.addState('ws1', 'session-1', {
+      id: 'state-1',
+      name: 'Verification checkpoint',
+      created: 1000,
+      state: {
+        id: 'state-1',
+        name: 'Verification checkpoint',
+        workspaceId: 'ws1',
+        sessionId: 'session-1',
+        created: 1000,
+        context: {
+          workspaceContext: { purpose: 'Testing' },
+          conversationContext: 'Diagnostic context',
+          activeTask: 'Verify state metadata',
+          activeFiles: [],
+          nextSteps: []
+        },
+        state: {
+          workspace: null,
+          recentTraces: [],
+          contextFiles: [],
+          metadata: {
+            tags: ['test', 'verification']
+          }
+        }
+      }
+    });
+
+    expect(sessionDeps.addSession).toHaveBeenCalledWith('ws1', expect.objectContaining({
+      id: 'session-1'
+    }));
+    expect(adapter.saveState).toHaveBeenCalledWith('ws1', 'session-1', expect.objectContaining({
+      tags: ['test', 'verification']
+    }));
+  });
+
+  it('replaces reserved fallback session IDs with generated unique IDs before saving', async () => {
+    const adapter = createMockAdapter(true);
+    const sessionDeps = {
+      getSession: jest.fn().mockResolvedValue(null),
+      addSession: jest.fn().mockResolvedValue({ id: 'session-generated' })
+    };
+    const service = new WorkspaceStateService(
+      createMockFileSystem(),
+      createMockIndexManager(),
+      adapter,
+      sessionDeps
+    );
+
+    await service.addState('ws1', 'default-session', {
+      id: 'state-1',
+      name: 'Verification checkpoint',
+      created: 1000,
+      state: {
+        id: 'state-1',
+        name: 'Verification checkpoint',
+        workspaceId: 'ws1',
+        sessionId: 'default-session',
+        created: 1000,
+        context: {
+          workspaceContext: { purpose: 'Testing' },
+          conversationContext: 'Diagnostic context',
+          activeTask: 'Verify state metadata',
+          activeFiles: [],
+          nextSteps: []
+        }
+      }
+    });
+
+    expect(sessionDeps.addSession).toHaveBeenCalledWith('ws1', expect.objectContaining({
+      id: expect.stringMatching(/^session_/)
+    }));
+    expect(adapter.saveState).toHaveBeenCalledWith('ws1', 'session-generated', expect.objectContaining({
+      name: 'Verification checkpoint'
+    }));
   });
 });

--- a/tests/unit/find-by-name-or-id-characterization.test.ts
+++ b/tests/unit/find-by-name-or-id-characterization.test.ts
@@ -76,6 +76,37 @@ describe('getWorkspaceByNameOrId characterization', () => {
     expect(expectDefined(result).id).toBe('ws-actual-id');
   });
 
+  it('treats default as an alias for Default Workspace when no literal default ID exists', async () => {
+    const fs = createMockFileSystem();
+    const idx = createMockIndexManager();
+    const adapter = createMockAdapter(true);
+
+    adapter.getWorkspace
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: 'default-workspace-uuid', name: 'Default Workspace', description: 'desc',
+        rootFolder: '/', created: 1000, lastAccessed: 2000, isActive: true,
+      });
+
+    adapter.getWorkspaces.mockResolvedValue({
+      items: [
+        { id: 'default-workspace-uuid', name: 'Default Workspace', description: 'desc',
+          rootFolder: '/', created: 1000, lastAccessed: 2000, isActive: true },
+      ],
+      page: 0, pageSize: 100, totalItems: 1, totalPages: 1, hasNextPage: false,
+    });
+
+    const service = new WorkspaceService(plugin, fs, idx, adapter);
+    const result = await service.getWorkspaceByNameOrId('default');
+
+    expect(result).not.toBeNull();
+    expect(expectDefined(result).id).toBe('default-workspace-uuid');
+    expect(adapter.getWorkspaces).toHaveBeenCalledWith({
+      search: 'Default Workspace',
+      pageSize: 100
+    });
+  });
+
   it('returns null when neither ID nor name matches (legacy path)', async () => {
     const fs = createMockFileSystem();
     const idx = createMockIndexManager();


### PR DESCRIPTION
## Summary
- Fix workspace create/update/delete/settings refresh behavior, including an Obsidian-style delete confirmation modal and workspace settings auto-refresh.
- Make workspace/state memory tools consistently resolve workspace names as handles, not just UUIDs.
- Ensure state saves use the current runtime session ID, remove default-session behavior, improve state listing/loading metadata, and keep create responses thin with name-handle nudges.
- Remove public session CRUD tooling language and update ToolManager context/session guidance and response formatting.

## Root Cause
Several memory tools treated the ToolManager envelope workspaceId differently from tool-specific identifiers. Some paths persisted with canonical workspace UUIDs while read/update paths queried with raw names or reserved context keys. State creation also fell back to reserved session placeholders in some storage paths, and ToolManager echoed normalized params into responses.

## Validation
- npm test -- --runTestsByPath tests/unit/BaseToolWorkspaceContext.test.ts tests/unit/CreateStateWorkspaceContext.test.ts tests/unit/CreateWorkspaceTool.test.ts tests/unit/ListStatesTool.test.ts tests/unit/LoadStateTool.test.ts tests/unit/LoadWorkspaceSystemGuides.test.ts tests/unit/ToolManagerCliSyntax.test.ts tests/unit/ToolManagerDynamicRegistry.test.ts tests/unit/UpdateWorkspaceTool.test.ts tests/unit/WorkspaceDataFetcher.test.ts tests/unit/WorkspacesTab.test.ts tests/unit/dual-backend-characterization.test.ts tests/unit/find-by-name-or-id-characterization.test.ts --runInBand
- npm run build