### PR TITLE
feat(workspace): folder watcher + context builder expansion + recordActivityTrace dedup

### DIFF
--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -4,7 +4,7 @@
 // Dependencies: WorkspaceService (legacy) or IStorageAdapter (new) for all data access
 
 import { Plugin } from 'obsidian';
-import { WorkspaceService } from '../../../services/WorkspaceService';
+import { GLOBAL_WORKSPACE_ID, WorkspaceService } from '../../../services/WorkspaceService';
 import { IStorageAdapter } from '../../../database/interfaces/IStorageAdapter';
 import {
   WorkspaceMemoryTrace,
@@ -145,7 +145,7 @@ export class MemoryService {
    * Record activity trace in a session
    */
   async recordActivityTrace(trace: Omit<WorkspaceMemoryTrace, 'id'>): Promise<string> {
-    const workspaceId = trace.workspaceId;
+    const workspaceId = await this.resolveTraceWorkspaceId(trace);
     const sessionId = trace.sessionId || this.createSessionId();
 
     const tracePayload = {
@@ -163,21 +163,25 @@ export class MemoryService {
     return withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
-        try {
-          return await adapter.addTrace(workspaceId, sessionId, tracePayload);
-        } catch (error) {
-          if ((error as Error).message?.includes('session')) {
-            await adapter.createSession(workspaceId, {
-              id: sessionId,
-              name: `Session ${new Date().toLocaleString()}`,
-              description: 'Auto-created session',
-              startTime: Date.now(),
-              isActive: true
-            });
-            return await adapter.addTrace(workspaceId, sessionId, tracePayload);
-          }
-          throw error;
+        const existingSession = await adapter.getSession(sessionId);
+        if (!existingSession) {
+          await adapter.createSession(workspaceId, {
+            id: sessionId,
+            name: this.buildSessionName({ ...trace, sessionId }),
+            description: this.buildSessionDescription(trace),
+            startTime: Date.now(),
+            isActive: true
+          });
+        } else if (existingSession.workspaceId !== workspaceId && adapter.moveSessionToWorkspace) {
+          await adapter.moveSessionToWorkspace(sessionId, workspaceId);
+          await adapter.updateSession(workspaceId, sessionId, {
+            name: existingSession.name,
+            description: existingSession.description,
+            endTime: existingSession.endTime,
+            isActive: existingSession.isActive
+          });
         }
+        return await adapter.addTrace(workspaceId, sessionId, tracePayload);
       },
       async () => {
         const workspace = await this.workspaceService.getWorkspace(workspaceId);
@@ -188,7 +192,8 @@ export class MemoryService {
         if (!workspace.sessions[sessionId]) {
           await this.workspaceService.addSession(workspaceId, {
             id: sessionId,
-            name: `Session ${new Date().toLocaleString()}`,
+            name: this.buildSessionName({ ...trace, sessionId }),
+            description: this.buildSessionDescription(trace),
             startTime: Date.now(),
             isActive: true,
             memoryTraces: {},
@@ -200,6 +205,71 @@ export class MemoryService {
         return createdTrace.id;
       }
     );
+  }
+
+  private async resolveTraceWorkspaceId(trace: Omit<WorkspaceMemoryTrace, 'id'>): Promise<string> {
+    const context = this.extractTraceContext(trace.metadata);
+    const contextWorkspaceId = typeof context.workspaceId === 'string' ? context.workspaceId.trim() : '';
+    const preferredWorkspaceId =
+      contextWorkspaceId && trace.workspaceId === GLOBAL_WORKSPACE_ID
+        ? contextWorkspaceId
+        : trace.workspaceId;
+
+    if (!preferredWorkspaceId) {
+      return trace.workspaceId;
+    }
+
+    try {
+      const workspace = await this.workspaceService.getWorkspaceByNameOrId(preferredWorkspaceId);
+      return workspace?.id || preferredWorkspaceId;
+    } catch {
+      return preferredWorkspaceId;
+    }
+  }
+
+  private buildSessionName(trace: Omit<WorkspaceMemoryTrace, 'id'>): string {
+    const context = this.extractTraceContext(trace.metadata);
+    const sessionName = typeof context.sessionName === 'string' ? context.sessionName.trim() : '';
+    if (sessionName) {
+      return this.truncateSessionText(sessionName, 80);
+    }
+
+    const displaySessionId = typeof context.displaySessionId === 'string' ? context.displaySessionId.trim() : '';
+    if (displaySessionId) {
+      return this.truncateSessionText(displaySessionId, 80);
+    }
+
+    if (trace.sessionId) {
+      return `Session ${trace.sessionId}`;
+    }
+
+    return 'Auto-created session';
+  }
+
+  private buildSessionDescription(trace: Omit<WorkspaceMemoryTrace, 'id'>): string {
+    const context = this.extractTraceContext(trace.metadata);
+    const memory = typeof context.memory === 'string' ? context.memory.trim() : '';
+    if (memory) {
+      return this.truncateSessionText(memory, 180);
+    }
+
+    return 'Auto-created session';
+  }
+
+  private extractTraceContext(metadata: unknown): Record<string, unknown> {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return {};
+    }
+
+    const metadataRecord = metadata as Record<string, unknown>;
+    const context = metadataRecord.context;
+    return context && typeof context === 'object' && !Array.isArray(context)
+      ? context as Record<string, unknown>
+      : {};
+  }
+
+  private truncateSessionText(value: string, maxLength: number): string {
+    return value.length > maxLength ? `${value.slice(0, maxLength - 3)}...` : value;
   }
 
   /**
@@ -360,6 +430,14 @@ export class MemoryService {
     stateData: WorkspaceState,
     name?: string
   ): Promise<string> {
+    await this.workspaceService.addSession(workspaceId, {
+      id: sessionId,
+      name: this.buildStateSessionName(stateData, name),
+      description: this.buildStateSessionDescription(stateData),
+      startTime: Date.now(),
+      isActive: true
+    });
+
     const state = await this.workspaceService.addState(workspaceId, sessionId, {
       id: stateData.id,  // Pass the ID to preserve it
       name: name || stateData.name || 'Unnamed State',
@@ -370,6 +448,28 @@ export class MemoryService {
     });
 
     return state.id;
+  }
+
+  private buildStateSessionName(stateData: WorkspaceState, name?: string): string {
+    const activeTask = typeof stateData.context?.activeTask === 'string'
+      ? stateData.context.activeTask.trim()
+      : '';
+    if (activeTask) {
+      return this.truncateSessionText(activeTask, 80);
+    }
+
+    return this.truncateSessionText(name || stateData.name || `Session ${new Date().toLocaleString()}`, 80);
+  }
+
+  private buildStateSessionDescription(stateData: WorkspaceState): string {
+    const conversationContext = typeof stateData.context?.conversationContext === 'string'
+      ? stateData.context.conversationContext.trim()
+      : '';
+    if (conversationContext) {
+      return this.truncateSessionText(conversationContext, 180);
+    }
+
+    return stateData.description || 'Auto-created session for state storage';
   }
 
   /**

--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -163,6 +163,14 @@ export class MemoryService {
     return withDualBackend(
       this.storageAdapterOrGetter,
       async (adapter) => {
+        // Pre-check session existence (replaces the prior catch-and-retry pattern
+        // around addTrace). Dedup is now explicit: getSession + create-if-missing,
+        // so concurrent first-traces for the same new sessionId may both pass the
+        // existence check and the second adapter.createSession will surface a
+        // duplicate-key error from the storage layer rather than racing through
+        // the implicit retry. Acceptable here because the adapter is the
+        // authoritative dedup point and the SQLite UNIQUE constraint is the
+        // backstop.
         const existingSession = await adapter.getSession(sessionId);
         if (!existingSession) {
           await adapter.createSession(workspaceId, {

--- a/src/agents/memoryManager/services/WorkspaceContextBuilder.ts
+++ b/src/agents/memoryManager/services/WorkspaceContextBuilder.ts
@@ -17,11 +17,13 @@
 
 import { ProjectWorkspace } from '../../../database/types/workspace/WorkspaceTypes';
 import { formatWorkflowScheduleSummary } from '../../../services/workflows/types';
+import { splitTopLevelSegments, tokenizeWithMeta } from '../../toolManager/services/ToolCliNormalizer';
 
 /** Trace item shape for context building */
 interface TraceItem {
   timestamp?: number;
   content?: string;
+  metadata?: unknown;
 }
 
 /**
@@ -188,9 +190,13 @@ export class WorkspaceContextBuilder {
 
       // Use trace content directly - it contains the activity description
       const activities: string[] = [];
-      for (let i = 0; i < Math.min(limit, traces.length); i++) {
-        const trace = traces[i];
-        activities.push(trace.content || 'Unknown activity');
+      for (const trace of traces) {
+        for (const activity of this.formatTraceActivities(trace)) {
+          activities.push(activity);
+          if (activities.length >= limit) {
+            return activities;
+          }
+        }
       }
 
       return activities.length > 0 ? activities : ['No recent activity'];
@@ -199,4 +205,410 @@ export class WorkspaceContextBuilder {
       return ['Recent activity unavailable'];
     }
   }
+
+  private formatTraceActivities(trace: TraceItem): string[] {
+    const metadata = asRecord(trace.metadata);
+    const tool = asRecord(metadata.tool);
+    const agent = getString(tool.agent);
+    const mode = getString(tool.mode);
+
+    if (mode === 'getTools') {
+      return [];
+    }
+
+    if (mode === 'useTools' || mode === 'useTool') {
+      const toolString = this.extractUseToolsCommand(metadata);
+      if (toolString) {
+        const executedActivities = this.formatExecutedUseToolsActivities(metadata, toolString);
+        if (executedActivities.length > 0) {
+          return [...executedActivities].reverse();
+        }
+
+        const activities = this.formatUseToolsActivities(toolString);
+        if (activities.length > 0) {
+          return [...activities].reverse();
+        }
+      }
+    }
+
+    const args = this.extractTraceArguments(metadata);
+    const formatted = mode ? this.formatSingleToolActivity(agent, mode, args) : null;
+    return [formatted || trace.content || 'Unknown activity'];
+  }
+
+  private extractUseToolsCommand(metadata: Record<string, unknown>): string | undefined {
+    const args = this.extractTraceArguments(metadata);
+    return getString(args.tool);
+  }
+
+  private extractTraceArguments(metadata: Record<string, unknown>): Record<string, unknown> {
+    const input = asRecord(metadata.input);
+    const inputArgs = asRecord(input.arguments);
+    if (Object.keys(inputArgs).length > 0) {
+      return inputArgs;
+    }
+
+    const legacy = asRecord(metadata.legacy);
+    return asRecord(legacy.params);
+  }
+
+  private formatUseToolsActivities(toolString: string): string[] {
+    return splitTopLevelSegments(toolString)
+      .map(segment => this.formatCliSegmentActivity(segment))
+      .filter((activity): activity is string => Boolean(activity));
+  }
+
+  private formatExecutedUseToolsActivities(metadata: Record<string, unknown>, toolString: string): string[] {
+    const results = this.extractUseToolsResults(metadata);
+    if (results.length === 0) {
+      return [];
+    }
+
+    const segments = splitTopLevelSegments(toolString);
+    return results
+      .map((result, index) => this.formatExecutedUseToolsResult(result, segments[index]))
+      .filter((activity): activity is string => Boolean(activity));
+  }
+
+  private extractUseToolsResults(metadata: Record<string, unknown>): Record<string, unknown>[] {
+    const legacy = asRecord(metadata.legacy);
+    const result = asRecord(legacy.result);
+    const data = asRecord(result.data);
+    const results = data.results;
+    if (!Array.isArray(results)) {
+      return Object.keys(result).length > 0 && result.agent && result.tool ? [result] : [];
+    }
+
+    return results.filter((item): item is Record<string, unknown> =>
+      typeof item === 'object' && item !== null && !Array.isArray(item)
+    );
+  }
+
+  private formatExecutedUseToolsResult(result: Record<string, unknown>, segment: string | undefined): string | null {
+    const agent = getString(result.agent);
+    const tool = getString(result.tool);
+    if (!tool) {
+      return null;
+    }
+
+    const args = segment ? this.extractSegmentArgs(segment) : {};
+    const base = this.formatSingleToolActivity(agent, tool, args);
+    if (!base) {
+      return null;
+    }
+
+    return result.success === false ? `Failed: ${base}` : base;
+  }
+
+  private formatCliSegmentActivity(segment: string): string | null {
+    const parsed = this.parseCliSegment(segment);
+    if (!parsed) {
+      return null;
+    }
+
+    return this.formatSingleToolActivity(parsed.agent, parsed.tool, parsed.args);
+  }
+
+  private extractSegmentArgs(segment: string): Record<string, unknown> {
+    const parsed = this.parseCliSegment(segment);
+    return parsed?.args || {};
+  }
+
+  private parseCliSegment(segment: string): { agent: string; tool: string; args: Record<string, unknown> } | null {
+    const tokens = tokenizeWithMeta(segment);
+    if (tokens.length < 2) {
+      return null;
+    }
+
+    const agent = tokens[0].value;
+    const tool = tokens[1].value;
+    const args = parseDisplayArgs(tokens.slice(2));
+    return { agent, tool, args };
+  }
+
+  private formatSingleToolActivity(agent: string | undefined, tool: string, args: Record<string, unknown>): string | null {
+    const normalizedAgent = normalizeToken(agent || '');
+    const normalizedTool = normalizeToken(tool);
+    const target = getTarget(args);
+    const query = getString(args.query) || getString(args._positional0);
+
+    if (normalizedAgent === 'content' || normalizedAgent === 'contentmanager') {
+      switch (normalizedTool) {
+        case 'read':
+          return target ? `Read ${target}` : 'Read file';
+        case 'write':
+          return target ? `Wrote ${target}` : 'Wrote file';
+        case 'replace':
+        case 'insert':
+        case 'setproperty':
+          return target ? `Updated ${target}` : 'Updated file';
+        default:
+          return null;
+      }
+    }
+
+    if (normalizedAgent === 'search' || normalizedAgent === 'searchmanager') {
+      switch (normalizedTool) {
+        case 'searchcontent':
+        case 'searchmemory':
+          return query ? `Searched for "${truncate(query)}"` : 'Searched';
+        case 'searchdirectory':
+          return query ? `Searched directory for "${truncate(query)}"` : 'Searched directory';
+        default:
+          return null;
+      }
+    }
+
+    if (normalizedAgent === 'memory' || normalizedAgent === 'memorymanager') {
+      return this.formatMemoryActivity(normalizedTool, args, target);
+    }
+
+    if (normalizedAgent === 'storage' || normalizedAgent === 'storagemanager') {
+      return this.formatStorageActivity(normalizedTool, args, target);
+    }
+
+    if (normalizedAgent === 'task' || normalizedAgent === 'taskmanager') {
+      return this.formatTaskActivity(normalizedTool, args, target);
+    }
+
+    if (normalizedAgent === 'prompt' || normalizedAgent === 'promptmanager') {
+      return this.formatPromptActivity(normalizedTool, args, target);
+    }
+
+    if (normalizedAgent === 'canvas' || normalizedAgent === 'canvasmanager') {
+      switch (normalizedTool) {
+        case 'read':
+          return target ? `Read canvas ${target}` : 'Read canvas';
+        case 'write':
+        case 'update':
+          return target ? `Updated canvas ${target}` : 'Updated canvas';
+        case 'list':
+          return 'Listed canvases';
+        default:
+          return null;
+      }
+    }
+
+    switch (normalizedTool) {
+      case 'read':
+        return target ? `Read ${target}` : 'Read file';
+      case 'write':
+        return target ? `Wrote ${target}` : 'Wrote file';
+      case 'replace':
+      case 'insert':
+      case 'setproperty':
+      case 'update':
+        return target ? `Updated ${target}` : 'Updated file';
+      case 'searchcontent':
+      case 'searchmemory':
+        return query ? `Searched for "${truncate(query)}"` : 'Searched';
+      case 'searchdirectory':
+        return query ? `Searched directory for "${truncate(query)}"` : 'Searched directory';
+      default:
+        return this.formatGenericActivity(tool, target);
+    }
+  }
+
+  private formatMemoryActivity(tool: string, args: Record<string, unknown>, target: string | undefined): string | null {
+    const workspaceTarget = getString(args.workspaceId) || target;
+    const stateTarget = getString(args.name) || getString(args.id) || target;
+
+    switch (tool) {
+      case 'createworkspace':
+        return workspaceTarget ? `Created workspace ${workspaceTarget}` : 'Created workspace';
+      case 'loadworkspace':
+        return workspaceTarget ? `Loaded workspace ${workspaceTarget}` : 'Loaded workspace';
+      case 'updateworkspace':
+        return workspaceTarget ? `Updated workspace ${workspaceTarget}` : 'Updated workspace';
+      case 'archiveworkspace':
+        return workspaceTarget ? `Archived workspace ${workspaceTarget}` : 'Archived workspace';
+      case 'listworkspaces':
+        return 'Listed workspaces';
+      case 'createstate':
+        return stateTarget ? `Saved state ${stateTarget}` : 'Saved state';
+      case 'loadstate':
+        return stateTarget ? `Loaded state ${stateTarget}` : 'Loaded state';
+      case 'liststates':
+        return 'Listed states';
+      case 'runworkflow':
+        return target ? `Ran workflow ${target}` : 'Ran workflow';
+      default:
+        return null;
+    }
+  }
+
+  private formatStorageActivity(tool: string, args: Record<string, unknown>, target: string | undefined): string | null {
+    const destination = getString(args.newPath) || getString(args.destinationPath) || getString(args.to) || getString(args._positional1);
+
+    switch (tool) {
+      case 'list':
+        return target ? `Listed ${target}` : 'Listed vault';
+      case 'createfolder':
+        return target ? `Created folder ${target}` : 'Created folder';
+      case 'move':
+        return target && destination ? `Moved ${target} to ${destination}` : target ? `Moved ${target}` : 'Moved item';
+      case 'copy':
+        return target && destination ? `Copied ${target} to ${destination}` : target ? `Copied ${target}` : 'Copied item';
+      case 'archive':
+        return target ? `Archived ${target}` : 'Archived item';
+      case 'open':
+        return target ? `Opened ${target}` : 'Opened item';
+      default:
+        return null;
+    }
+  }
+
+  private formatTaskActivity(tool: string, args: Record<string, unknown>, target: string | undefined): string | null {
+    const taskTarget = getString(args.title) ||
+      getString(args.taskId) ||
+      (tool === 'createtask' ? getString(args._positional1) : undefined) ||
+      target;
+    const projectTarget = getString(args.name) ||
+      getString(args.projectId) ||
+      (tool === 'createproject' ? getString(args._positional1) : undefined) ||
+      target;
+
+    switch (tool) {
+      case 'createproject':
+        return projectTarget ? `Created project ${projectTarget}` : 'Created project';
+      case 'listprojects':
+        return 'Listed projects';
+      case 'updateproject':
+        return projectTarget ? `Updated project ${projectTarget}` : 'Updated project';
+      case 'archiveproject':
+        return projectTarget ? `Archived project ${projectTarget}` : 'Archived project';
+      case 'createtask':
+        return taskTarget ? `Created task ${taskTarget}` : 'Created task';
+      case 'listtasks':
+        return projectTarget ? `Listed tasks for ${projectTarget}` : 'Listed tasks';
+      case 'opentasks':
+        return 'Opened tasks';
+      case 'updatetask':
+        return taskTarget ? `Updated task ${taskTarget}` : 'Updated task';
+      case 'movetask':
+        return taskTarget ? `Moved task ${taskTarget}` : 'Moved task';
+      case 'querytasks':
+        return 'Queried tasks';
+      case 'linknote':
+        return target ? `Linked note ${target}` : 'Linked note';
+      default:
+        return null;
+    }
+  }
+
+  private formatPromptActivity(tool: string, args: Record<string, unknown>, target: string | undefined): string | null {
+    const promptTarget = getString(args.promptName) || target;
+
+    switch (tool) {
+      case 'createprompt':
+        return promptTarget ? `Created prompt ${promptTarget}` : 'Created prompt';
+      case 'getprompt':
+        return promptTarget ? `Loaded prompt ${promptTarget}` : 'Loaded prompt';
+      case 'listprompts':
+        return 'Listed prompts';
+      case 'updateprompt':
+        return promptTarget ? `Updated prompt ${promptTarget}` : 'Updated prompt';
+      case 'archiveprompt':
+        return promptTarget ? `Archived prompt ${promptTarget}` : 'Archived prompt';
+      case 'executeprompts':
+        return promptTarget ? `Executed prompt ${promptTarget}` : 'Executed prompt';
+      case 'generateimage':
+        return promptTarget ? `Generated image for ${promptTarget}` : 'Generated image';
+      case 'listmodels':
+        return 'Listed models';
+      case 'subagent':
+        return promptTarget ? `Ran subagent ${promptTarget}` : 'Ran subagent';
+      default:
+        return null;
+    }
+  }
+
+  private formatGenericActivity(tool: string, target: string | undefined): string {
+    const label = humanizeToken(tool);
+    return target ? `${label} ${target}` : label;
+  }
+}
+
+function parseDisplayArgs(tokens: ReturnType<typeof tokenizeWithMeta>): Record<string, unknown> {
+  const args: Record<string, unknown> = {};
+  const positionals: string[] = [];
+  const looksLikeFlag = (token: (typeof tokens)[number]): boolean =>
+    !token.wasQuoted && token.value.startsWith('--');
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (!looksLikeFlag(token)) {
+      positionals.push(token.value);
+      continue;
+    }
+
+    let key = toCamelCase(token.value.slice(2));
+    let inlineValue: string | undefined;
+    const equalsIdx = key.indexOf('=');
+    if (equalsIdx >= 0) {
+      inlineValue = key.slice(equalsIdx + 1);
+      key = key.slice(0, equalsIdx);
+    }
+
+    if (inlineValue !== undefined) {
+      args[key] = inlineValue;
+      continue;
+    }
+
+    const next = tokens[i + 1];
+    if (!next || looksLikeFlag(next)) {
+      args[key] = true;
+      continue;
+    }
+
+    args[key] = next.value;
+    i += 1;
+  }
+
+  positionals.forEach((value, index) => {
+    args[`_positional${index}`] = value;
+  });
+
+  return args;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getTarget(args: Record<string, unknown>): string | undefined {
+  return getString(args.path) ||
+    getString(args.filePath) ||
+    getString(args.sourcePath) ||
+    getString(args.id) ||
+    getString(args.name) ||
+    getString(args.title) ||
+    getString(args._positional0);
+}
+
+function normalizeToken(value: string): string {
+  return value.replace(/[-_\s]/g, '').toLowerCase();
+}
+
+function humanizeToken(value: string): string {
+  const words = value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .trim();
+  if (!words) {
+    return 'Ran tool';
+  }
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+function toCamelCase(value: string): string {
+  return value.replace(/-([a-z])/g, (_match, char: string) => char.toUpperCase());
+}
+
+function truncate(value: string): string {
+  return value.length > 60 ? `${value.slice(0, 60)}...` : value;
 }

--- a/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
+++ b/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
@@ -30,13 +30,8 @@ export interface SessionSummary {
  * State summary returned from fetch operations
  */
 export interface StateSummary {
-  id: string;
   name: string;
-  description?: string;
-  sessionId?: string;
-  created: number;
   tags?: string[];
-  workspaceId?: string;
 }
 
 /**
@@ -181,13 +176,8 @@ export class WorkspaceDataFetcher {
           };
         }
       }) => ({
-        id: state.id,
         name: state.name || 'Untitled State',
-        description: state.description || state.state?.description,
-        sessionId: state.sessionId || state.state?.sessionId,
-        created: state.created ?? state.timestamp ?? 0,
-        tags: state.tags || state.state?.state?.metadata?.tags || state.state?.metadata?.tags || [],
-        workspaceId: state.state?.workspaceId || state.workspaceId // Include for validation
+        tags: state.tags || state.state?.state?.metadata?.tags || state.state?.metadata?.tags || []
       }));
 
       // Return with pagination metadata from the original result

--- a/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
+++ b/src/agents/memoryManager/services/WorkspaceDataFetcher.ts
@@ -27,7 +27,17 @@ export interface SessionSummary {
 }
 
 /**
- * State summary returned from fetch operations
+ * State summary returned from fetch operations.
+ *
+ * Schema is intentionally narrowed to {name, tags} — id, description, sessionId,
+ * created, and workspaceId were dropped. State *names* are valid handles for
+ * load-state while scoped to the workspace, so internal storage ids are not
+ * exposed to the model. The only consumer is `loadWorkspace` (see its `states`
+ * schema in tools/workspaces/loadWorkspace.ts), which mirrors this shape.
+ *
+ * If a future caller needs id/sessionId, fetch them via the workspace state
+ * service rather than widening this surface — keeping the LLM-visible payload
+ * minimal is deliberate.
  */
 export interface StateSummary {
   name: string;

--- a/src/agents/memoryManager/services/WorkspaceFileCollector.ts
+++ b/src/agents/memoryManager/services/WorkspaceFileCollector.ts
@@ -14,13 +14,17 @@
  * - Get recently modified files in workspace
  */
 
-import { App, TFolder } from 'obsidian';
+import { App, TFile, TFolder } from 'obsidian';
 
 /**
  * Interface for workspace data
  */
 interface IWorkspaceData {
   rootFolder: string;
+}
+
+interface IVaultLike {
+  getFiles(): TFile[];
 }
 
 /**
@@ -157,27 +161,58 @@ export class WorkspaceFileCollector {
    */
   getRecentFilesInWorkspace(
     workspace: IWorkspaceData,
-    cacheManager: ICacheManager | null
+    cacheManager: ICacheManager | null,
+    app?: App
   ): RecentFileInfo[] {
     try {
-      if (!cacheManager) {
-        return [];
+      const recentFiles = cacheManager?.getRecentFiles(5, workspace.rootFolder) || [];
+
+      if (recentFiles.length > 0) {
+        // Map IndexedFile[] to simple {path, modified} objects
+        return recentFiles.map((file) => ({
+          path: file.path,
+          modified: file.modified
+        }));
       }
 
-      const recentFiles = cacheManager.getRecentFiles(5, workspace.rootFolder);
-
-      if (!recentFiles || recentFiles.length === 0) {
-        return [];
-      }
-
-      // Map IndexedFile[] to simple {path, modified} objects
-      return recentFiles.map((file) => ({
-        path: file.path,
-        modified: file.modified
-      }));
+      return app ? this.getRecentFilesFromVault(workspace, app.vault) : [];
 
     } catch {
-      return [];
+      try {
+        return app ? this.getRecentFilesFromVault(workspace, app.vault) : [];
+      } catch {
+        return [];
+      }
     }
   }
+
+  private getRecentFilesFromVault(workspace: IWorkspaceData, vault: IVaultLike): RecentFileInfo[] {
+    const rootFolder = normalizeRootFolder(workspace.rootFolder);
+    return vault.getFiles()
+      .filter(file => isWorkspaceFile(file, rootFolder))
+      .filter(file => file.extension === 'md' || file.extension === 'canvas')
+      .sort((a, b) => b.stat.mtime - a.stat.mtime)
+      .slice(0, 5)
+      .map(file => ({
+        path: file.path,
+        modified: file.stat.mtime
+      }));
+  }
+}
+
+function normalizeRootFolder(rootFolder: string): string {
+  const trimmed = rootFolder.trim();
+  if (!trimmed || trimmed === '/') {
+    return '';
+  }
+
+  return trimmed.replace(/^\/+|\/+$/g, '');
+}
+
+function isWorkspaceFile(file: TFile, rootFolder: string): boolean {
+  if (!rootFolder) {
+    return true;
+  }
+
+  return file.path === rootFolder || file.path.startsWith(`${rootFolder}/`);
 }

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -205,7 +205,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
 
       // Collect files using file collector
       const cacheManager = this.agent.getCacheManager();
-      const recentFiles = this.fileCollector.getRecentFilesInWorkspace(workspace, cacheManager);
+      const recentFiles = this.fileCollector.getRecentFilesInWorkspace(workspace, cacheManager, app);
 
       // Build workspace structure using file collector
       // recursive defaults to false (top-level only)
@@ -468,25 +468,9 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
               items: {
                 type: 'object',
                 properties: {
-                  id: {
-                    type: 'string',
-                    description: 'State ID'
-                  },
                   name: {
                     type: 'string',
-                    description: 'State name'
-                  },
-                  description: {
-                    type: 'string',
-                    description: 'State description'
-                  },
-                  sessionId: {
-                    type: 'string',
-                    description: 'Session ID this state belongs to'
-                  },
-                  created: {
-                    type: 'number',
-                    description: 'State creation timestamp'
+                    description: 'State name. Use this name with load-state while scoped to the same workspace.'
                   },
                   tags: {
                     type: 'array',
@@ -494,9 +478,9 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
                     description: 'State tags'
                   }
                 },
-                required: ['id', 'name', 'created']
+                required: ['name']
               },
-              description: 'States in this workspace (paginated)'
+              description: 'Saved states in this workspace (paginated). State names are valid handles for load-state; IDs and session IDs are intentionally omitted.'
             },
             prompt: {
               type: 'object',

--- a/src/core/services/ServiceDefinitions.ts
+++ b/src/core/services/ServiceDefinitions.ts
@@ -93,6 +93,20 @@ export const CORE_SERVICE_DEFINITIONS: ServiceDefinition[] = [
         })
     },
 
+    // Workspace folder watcher (keeps workspace root paths synced after folder moves/renames)
+    {
+        name: 'workspaceFolderWatcher',
+        dependencies: ['workspaceService'],
+        create: defineService(async (context) => {
+            const { WorkspaceFolderWatcher } = await import('../../services/workspace/WorkspaceFolderWatcher');
+            const workspaceService = await context.serviceManager.getService<WorkspaceService>('workspaceService');
+
+            const watcher = new WorkspaceFolderWatcher(context.app, workspaceService);
+            watcher.startWhenReady();
+            return watcher;
+        })
+    },
+
     // Default workspace manager (ensures default workspace exists)
     {
         name: 'defaultWorkspaceManager',

--- a/src/core/services/ServiceRegistrar.ts
+++ b/src/core/services/ServiceRegistrar.ts
@@ -169,6 +169,7 @@ export class ServiceRegistrar {
             await this.context.serviceManager.getService('memoryService');
             await this.context.serviceManager.getService('sessionService');
             await this.context.serviceManager.getService('sessionContextManager');
+            await this.context.serviceManager.getService('workspaceFolderWatcher');
 
             // Now initialize business services
             await this.context.serviceManager.getService('defaultWorkspaceManager');

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -1053,6 +1053,11 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.sessionRepo.update(sessionId, { name, description, endTime, isActive, workspaceId });
   };
 
+  moveSessionToWorkspace = async (sessionId: string, workspaceId: string): Promise<void> => {
+    await this.ensureInitialized();
+    return this.sessionRepo.moveToWorkspace(sessionId, workspaceId);
+  };
+
   deleteSession = async (sessionId: string): Promise<void> => {
     await this.ensureInitialized();
     return this.sessionRepo.delete(sessionId);

--- a/src/database/interfaces/IStorageAdapter.ts
+++ b/src/database/interfaces/IStorageAdapter.ts
@@ -251,6 +251,15 @@ export interface IStorageAdapter {
   ): Promise<void>;
 
   /**
+   * Move an existing session to another workspace. Implementations should also
+   * rehome dependent state and trace rows for that session.
+   */
+  moveSessionToWorkspace?(
+    sessionId: string,
+    workspaceId: string
+  ): Promise<void>;
+
+  /**
    * Delete a session
    *
    * @param sessionId - Session ID

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -158,6 +158,7 @@ export interface SessionUpdatedEvent extends BaseStorageEvent {
     description: string;
     endTime: number;
     isActive: boolean;
+    workspaceId: string;
   }>;
 }
 

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -177,6 +177,10 @@ export class SessionRepository
           setClauses.push('isActive = ?');
           params.push(data.isActive ? 1 : 0);
         }
+        if (data.workspaceId !== undefined) {
+          setClauses.push('workspaceId = ?');
+          params.push(data.workspaceId);
+        }
 
         if (setClauses.length > 0) {
           params.push(id);
@@ -286,6 +290,70 @@ export class SessionRepository
 
   async countByWorkspace(workspaceId: string): Promise<number> {
     return this.count({ workspaceId });
+  }
+
+  async moveToWorkspace(id: string, workspaceId: string): Promise<void> {
+    const session = await this.getById(id);
+    if (!session) {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    if (session.workspaceId === workspaceId) {
+      return;
+    }
+
+    try {
+      await this.transaction(async () => {
+        await this.writeEvent<SessionUpdatedEvent>(
+          this.jsonlPath(session.workspaceId),
+          {
+            type: 'session_updated',
+            workspaceId: session.workspaceId,
+            sessionId: id,
+            data: {
+              workspaceId
+            }
+          }
+        );
+
+        await this.writeEvent<SessionCreatedEvent>(
+          this.jsonlPath(workspaceId),
+          {
+            type: 'session_created',
+            workspaceId,
+            data: {
+              id,
+              name: session.name,
+              description: session.description,
+              startTime: session.startTime
+            }
+          }
+        );
+
+        await this.sqliteCache.run(
+          'UPDATE sessions SET workspaceId = ? WHERE id = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE states SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE memory_traces SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE trace_embedding_metadata SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+      });
+
+      this.invalidateCache(id);
+      this.log('moveToWorkspace', { id, workspaceId });
+    } catch (error) {
+      this.logError('moveToWorkspace', error);
+      throw error;
+    }
   }
 
   // ============================================================================

--- a/src/database/repositories/TraceRepository.ts
+++ b/src/database/repositories/TraceRepository.ts
@@ -233,14 +233,15 @@ export class TraceRepository
       let baseQuery = `
         SELECT mt.* FROM memory_traces mt
         WHERE mt.workspaceId = ?
-        AND mt.content LIKE ?
+        AND (mt.content LIKE ? OR mt.metadataJson LIKE ?)
       `;
       let countQuery = `
         SELECT COUNT(*) as count FROM memory_traces mt
         WHERE mt.workspaceId = ?
-        AND mt.content LIKE ?
+        AND (mt.content LIKE ? OR mt.metadataJson LIKE ?)
       `;
-    const params: QueryParams = [workspaceId, `%${query}%`];
+    const queryPattern = `%${query}%`;
+    const params: QueryParams = [workspaceId, queryPattern, queryPattern];
 
       if (sessionId) {
         baseQuery += ' AND mt.sessionId = ?';

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -295,9 +295,15 @@ export class WorkspaceRepository
 
     let whereClause = '';
     const params: SqliteValue[] = [];
+    const filters: string[] = [];
+
+    if (options?.search && options.search.trim()) {
+      const searchTerm = `%${options.search.trim().toLowerCase()}%`;
+      filters.push('(LOWER(name) LIKE ? OR LOWER(COALESCE(description, \'\')) LIKE ? OR LOWER(rootFolder) LIKE ?)');
+      params.push(searchTerm, searchTerm, searchTerm);
+    }
 
     if (options?.filter) {
-      const filters: string[] = [];
       if (options.filter.isActive !== undefined) {
         filters.push('isActive = ?');
         params.push(options.filter.isActive ? 1 : 0);
@@ -306,9 +312,14 @@ export class WorkspaceRepository
         filters.push('isArchived = ?');
         params.push(options.filter.isArchived ? 1 : 0);
       }
-      if (filters.length > 0) {
-        whereClause = `WHERE ${filters.join(' AND ')}`;
+      if (typeof options.filter.rootFolder === 'string') {
+        filters.push('rootFolder = ?');
+        params.push(options.filter.rootFolder);
       }
+    }
+
+    if (filters.length > 0) {
+      whereClause = `WHERE ${filters.join(' AND ')}`;
     }
 
     const baseQuery = `SELECT * FROM workspaces ${whereClause} ORDER BY ${sortBy} ${sortOrder}`;

--- a/src/database/repositories/interfaces/ISessionRepository.ts
+++ b/src/database/repositories/interfaces/ISessionRepository.ts
@@ -34,6 +34,7 @@ export interface UpdateSessionData {
   description?: string;
   endTime?: number;
   isActive?: boolean;
+  workspaceId?: string;
 }
 
 /**
@@ -74,4 +75,12 @@ export interface ISessionRepository extends IRepository<SessionMetadata> {
    * @returns Number of sessions
    */
   countByWorkspace(workspaceId: string): Promise<number>;
+
+  /**
+   * Move a session and its dependent state/trace rows to another workspace.
+   *
+   * @param id - Session ID
+   * @param workspaceId - Target workspace ID
+   */
+  moveToWorkspace(id: string, workspaceId: string): Promise<void>;
 }

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -157,6 +157,7 @@ export class WorkspaceEventApplier {
     if (event.data.description !== undefined) { updates.push('description = ?'); values.push(event.data.description); }
     if (event.data.endTime !== undefined) { updates.push('endTime = ?'); values.push(event.data.endTime); }
     if (event.data.isActive !== undefined) { updates.push('isActive = ?'); values.push(event.data.isActive ? 1 : 0); }
+    if (event.data.workspaceId !== undefined) { updates.push('workspaceId = ?'); values.push(event.data.workspaceId); }
 
     if (updates.length > 0) {
       values.push(event.sessionId);

--- a/src/database/types/workspace/ParameterTypes.ts
+++ b/src/database/types/workspace/ParameterTypes.ts
@@ -106,11 +106,7 @@ export interface LoadWorkspaceResult extends CommonResult {
       created: number;
     }>;
     states: Array<{
-      id: string;
       name: string;
-      description?: string;
-      sessionId?: string;
-      created: number;
       tags?: string[];
     }>;
     prompt?: {

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -23,7 +23,10 @@ interface SessionServiceLike {
     id: string;
   }): Promise<unknown> | void;
   updateSession(sessionData: SessionData): Promise<unknown> | void;
+  registerOnSessionDeleted?(listener: SessionDeletedListener): () => void;
 }
+
+export type SessionDeletedListener = (sessionId: string, workspaceId: string) => void;
 
 export interface SessionValidationResult {
   id: string;
@@ -47,7 +50,17 @@ export class SessionContextManager {
   private sessionContextMap: Map<string, WorkspaceContext> = new Map();
 
   // Map of model-facing session handles to internal unique session IDs.
-  private sessionHandleMap: Map<string, { id: string; displaySessionId: string }> = new Map();
+  // Keyed by `${workspaceId}::${handle}` so the same friendly handle ("research")
+  // in different workspaces resolves to distinct internal sessions instead of
+  // aliasing — workspaces are UX scoping, and reusing names across them is
+  // expected. The map stores the originating workspaceId so eviction on session
+  // delete (registerOnSessionDeleted) can purge both the input handle entry and
+  // the display-name entry without scanning the whole map.
+  private sessionHandleMap: Map<string, { id: string; displaySessionId: string; workspaceId: string }> = new Map();
+
+  // Disposer for the session-deleted subscription so re-wiring or teardown can
+  // unregister cleanly.
+  private sessionDeletedUnsubscribe: (() => void) | null = null;
   
   // Default workspace context for new sessions (global)
   private defaultWorkspaceContext: WorkspaceContext | null = null;
@@ -60,7 +73,39 @@ export class SessionContextManager {
    * This is called during plugin initialization
    */
   setSessionService(sessionService: SessionServiceLike): void {
+    if (this.sessionDeletedUnsubscribe) {
+      this.sessionDeletedUnsubscribe();
+      this.sessionDeletedUnsubscribe = null;
+    }
     this.sessionService = sessionService;
+    if (sessionService.registerOnSessionDeleted) {
+      this.sessionDeletedUnsubscribe = sessionService.registerOnSessionDeleted(
+        (sessionId, workspaceId) => this.evictSessionHandles(sessionId, workspaceId)
+      );
+    }
+  }
+
+  /**
+   * Build the partition key used for sessionHandleMap lookups.
+   * Friendly handles are unique only within a workspace; the same string in two
+   * workspaces must map to two distinct sessions.
+   */
+  private handleKey(workspaceId: string, handle: string): string {
+    return `${workspaceId}::${handle}`;
+  }
+
+  /**
+   * Remove sessionHandleMap entries for a deleted session in a given workspace.
+   * Called from the session-deleted listener registered on SessionService.
+   */
+  evictSessionHandles(sessionId: string, workspaceId = 'default'): void {
+    for (const [key, entry] of this.sessionHandleMap.entries()) {
+      if (entry.id === sessionId && entry.workspaceId === workspaceId) {
+        this.sessionHandleMap.delete(key);
+      }
+    }
+    this.sessionContextMap.delete(sessionId);
+    this.instructedSessions.delete(sessionId);
   }
   
   /**
@@ -186,7 +231,21 @@ export class SessionContextManager {
   clearAll(): void {
     this.sessionContextMap.clear();
     this.sessionHandleMap.clear();
+    this.instructedSessions.clear();
     this.defaultWorkspaceContext = null;
+  }
+
+  /**
+   * ServiceContainer-detected cleanup hook. Runs on plugin teardown
+   * (ServiceContainer.clear) so the in-memory handle map and session-deleted
+   * subscription do not survive a plugin reload.
+   */
+  cleanup(): void {
+    if (this.sessionDeletedUnsubscribe) {
+      this.sessionDeletedUnsubscribe();
+      this.sessionDeletedUnsubscribe = null;
+    }
+    this.clearAll();
   }
   
   /**
@@ -227,7 +286,7 @@ export class SessionContextManager {
     
     // If the session ID doesn't match our standard format, it's a friendly name - create session
     if (!isStandardSessionId(sessionId)) {
-      const existingHandle = this.sessionHandleMap.get(sessionId);
+      const existingHandle = this.sessionHandleMap.get(this.handleKey(workspaceId, sessionId));
       if (existingHandle) {
         return {
           id: existingHandle.id,
@@ -239,8 +298,9 @@ export class SessionContextManager {
 
       const newId = generateSessionId();
       const displaySessionId = await this.createUniqueSessionDisplayName(sessionId, workspaceId);
-      this.sessionHandleMap.set(sessionId, { id: newId, displaySessionId });
-      this.sessionHandleMap.set(displaySessionId, { id: newId, displaySessionId });
+      const handleEntry = { id: newId, displaySessionId, workspaceId };
+      this.sessionHandleMap.set(this.handleKey(workspaceId, sessionId), handleEntry);
+      this.sessionHandleMap.set(this.handleKey(workspaceId, displaySessionId), handleEntry);
       await this.createAutoSession(newId, displaySessionId, sessionDescription, workspaceId);
       return {
         id: newId,
@@ -321,7 +381,11 @@ export class SessionContextManager {
   private async createUniqueSessionDisplayName(baseName: string, workspaceId: string): Promise<string> {
     const usedNames = new Set<string>();
     for (const entry of this.sessionHandleMap.values()) {
-      usedNames.add(entry.displaySessionId.toLowerCase());
+      // Only collide names within the same workspace — same handle in two
+      // workspaces is allowed (workspaces are UX scoping).
+      if (entry.workspaceId === workspaceId) {
+        usedNames.add(entry.displaySessionId.toLowerCase());
+      }
     }
 
     if (this.sessionService?.getAllSessions) {

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -15,6 +15,7 @@ export interface WorkspaceContext {
 
 interface SessionServiceLike {
   getSession(sessionId: string): Promise<SessionData | null> | SessionData | null;
+  getAllSessions?(workspaceId?: string): Promise<SessionData[]> | SessionData[];
   createSession(sessionData: {
     name: string;
     description: string;
@@ -22,6 +23,13 @@ interface SessionServiceLike {
     id: string;
   }): Promise<unknown> | void;
   updateSession(sessionData: SessionData): Promise<unknown> | void;
+}
+
+export interface SessionValidationResult {
+  id: string;
+  created: boolean;
+  displaySessionId: string;
+  displaySessionIdChanged: boolean;
 }
 
 /**
@@ -37,6 +45,9 @@ export class SessionContextManager {
   
   // Map of sessionId -> workspace context
   private sessionContextMap: Map<string, WorkspaceContext> = new Map();
+
+  // Map of model-facing session handles to internal unique session IDs.
+  private sessionHandleMap: Map<string, { id: string; displaySessionId: string }> = new Map();
   
   // Default workspace context for new sessions (global)
   private defaultWorkspaceContext: WorkspaceContext | null = null;
@@ -174,6 +185,7 @@ export class SessionContextManager {
    */
   clearAll(): void {
     this.sessionContextMap.clear();
+    this.sessionHandleMap.clear();
     this.defaultWorkspaceContext = null;
   }
   
@@ -194,21 +206,48 @@ export class SessionContextManager {
    * @param sessionDescription Optional session description for auto-creation
    * @returns Object with validated session ID and creation status
    */
-  async validateSessionId(sessionId: string, sessionDescription?: string): Promise<{id: string, created: boolean}> {
+  async validateSessionId(
+    sessionId: string,
+    sessionDescription?: string,
+    workspaceId = 'default'
+  ): Promise<SessionValidationResult> {
     
     // If no session ID is provided, generate a new one in our standard format
     if (!sessionId) {
       logger.systemWarn('Empty sessionId provided for validation, generating a new one');
       const newId = generateSessionId();
       await this.createAutoSession(newId, 'Default Session', sessionDescription);
-      return {id: newId, created: true};
+      return {
+        id: newId,
+        created: true,
+        displaySessionId: 'Default Session',
+        displaySessionIdChanged: true
+      };
     }
     
     // If the session ID doesn't match our standard format, it's a friendly name - create session
     if (!isStandardSessionId(sessionId)) {
+      const existingHandle = this.sessionHandleMap.get(sessionId);
+      if (existingHandle) {
+        return {
+          id: existingHandle.id,
+          created: false,
+          displaySessionId: existingHandle.displaySessionId,
+          displaySessionIdChanged: existingHandle.displaySessionId !== sessionId
+        };
+      }
+
       const newId = generateSessionId();
-      await this.createAutoSession(newId, sessionId, sessionDescription);
-      return {id: newId, created: true};
+      const displaySessionId = await this.createUniqueSessionDisplayName(sessionId, workspaceId);
+      this.sessionHandleMap.set(sessionId, { id: newId, displaySessionId });
+      this.sessionHandleMap.set(displaySessionId, { id: newId, displaySessionId });
+      await this.createAutoSession(newId, displaySessionId, sessionDescription, workspaceId);
+      return {
+        id: newId,
+        created: true,
+        displaySessionId,
+        displaySessionIdChanged: displaySessionId !== sessionId
+      };
     }
     
     // Session ID is in standard format - check if it exists in our context map first
@@ -216,7 +255,7 @@ export class SessionContextManager {
     // it means the session was already bound - no need to check database
     if (this.sessionContextMap.has(sessionId)) {
       logger.systemLog(`Session ${sessionId} found in context map - already bound to workspace`);
-      return {id: sessionId, created: false};
+      return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
     }
 
     // Check database if not in context map
@@ -228,15 +267,15 @@ export class SessionContextManager {
     try {
       const existingSession = await this.sessionService.getSession(sessionId);
       if (existingSession) {
-        return {id: sessionId, created: false};
+        return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
       } else {
         await this.createAutoSession(sessionId, `Session ${sessionId}`, sessionDescription);
-        return {id: sessionId, created: true};
+        return {id: sessionId, created: true, displaySessionId: sessionId, displaySessionIdChanged: false};
       }
     } catch (error) {
       logger.systemWarn(`Error checking session existence: ${error instanceof Error ? error.message : String(error)}`);
       // Fallback to returning the session ID without verification
-      return {id: sessionId, created: false};
+      return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
     }
   }
 
@@ -247,10 +286,15 @@ export class SessionContextManager {
    * @param sessionName Friendly name provided by LLM
    * @param sessionDescription Optional session description
    */
-  private async createAutoSession(sessionId: string, sessionName: string, sessionDescription?: string): Promise<void> {
+  private async createAutoSession(
+    sessionId: string,
+    sessionName: string,
+    sessionDescription?: string,
+    explicitWorkspaceId?: string
+  ): Promise<void> {
     // ✅ CRITICAL FIX: Use workspace from sessionContextMap if available
     const context = this.sessionContextMap.get(sessionId);
-    const workspaceId = context?.workspaceId || 'default';
+    const workspaceId = explicitWorkspaceId || context?.workspaceId || 'default';
 
     logger.systemLog(`Auto-created session: ${sessionId} with name "${sessionName}", workspace "${workspaceId}", and description "${sessionDescription || 'No description'}"`);
 
@@ -272,6 +316,37 @@ export class SessionContextManager {
     } else {
       logger.systemWarn(`SessionService not available - session ${sessionId} not saved to database`);
     }
+  }
+
+  private async createUniqueSessionDisplayName(baseName: string, workspaceId: string): Promise<string> {
+    const usedNames = new Set<string>();
+    for (const entry of this.sessionHandleMap.values()) {
+      usedNames.add(entry.displaySessionId.toLowerCase());
+    }
+
+    if (this.sessionService?.getAllSessions) {
+      try {
+        const sessions = await this.sessionService.getAllSessions(workspaceId);
+        for (const session of sessions) {
+          if (session.name) {
+            usedNames.add(session.name.toLowerCase());
+          }
+        }
+      } catch {
+        // Best effort only; storage-level uniqueness is not required for the
+        // internal ID, but unique display handles prevent ambiguous future use.
+      }
+    }
+
+    const normalizedBaseName = baseName.trim() || 'Session';
+    let candidate = normalizedBaseName;
+    let suffix = 2;
+    while (usedNames.has(candidate.toLowerCase())) {
+      candidate = `${normalizedBaseName}-${suffix}`;
+      suffix += 1;
+    }
+
+    return candidate;
   }
   
   /**

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -34,11 +34,14 @@ export class SessionService {
     // Use provided ID if available, otherwise generate one
     const id = ('id' in sessionData && sessionData.id) ? sessionData.id : this.generateSessionId();
     const workspaceId = sessionData.workspaceId || 'default';
+    const existingSession = this.sessions.get(id);
 
     const session: SessionData = {
+      ...existingSession,
       ...sessionData,
       id,
-      workspaceId
+      workspaceId,
+      name: existingSession?.name || sessionData.name
     };
 
     // Store in memory cache

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -18,13 +18,30 @@ export interface IMemoryService {
 }
 
 /**
+ * Listener fired after a session is deleted. Receives the deleted sessionId
+ * and the workspace it was scoped to. Used by SessionContextManager to evict
+ * cached friendly-handle entries.
+ */
+export type SessionDeletedListener = (sessionId: string, workspaceId: string) => void;
+
+/**
  * Session management service that delegates to MemoryService/WorkspaceService
  * Provides session tracking across workspaces with proper persistence
  */
 export class SessionService {
   private sessions = new Map<string, SessionData>();
+  private sessionDeletedListeners = new Set<SessionDeletedListener>();
 
   constructor(private memoryService: IMemoryService) {
+  }
+
+  /**
+   * Register a callback to be notified after a session is deleted.
+   * Returns an unsubscribe function.
+   */
+  registerOnSessionDeleted(listener: SessionDeletedListener): () => void {
+    this.sessionDeletedListeners.add(listener);
+    return () => this.sessionDeletedListeners.delete(listener);
   }
 
   /**
@@ -151,6 +168,16 @@ export class SessionService {
       await this.memoryService.deleteSession(workspaceId, sessionId);
     } catch (error) {
       console.error(`[SessionService] Failed to delete session ${sessionId}:`, error);
+    }
+
+    // Notify listeners (e.g. SessionContextManager) so friendly-handle caches
+    // do not retain stale references to the deleted session.
+    for (const listener of this.sessionDeletedListeners) {
+      try {
+        listener(sessionId, workspaceId);
+      } catch (error) {
+        console.error('[SessionService] sessionDeleted listener threw:', error);
+      }
     }
   }
   

--- a/src/services/trace/ToolCallTraceService.ts
+++ b/src/services/trace/ToolCallTraceService.ts
@@ -10,6 +10,7 @@ import { WorkspaceService } from '../WorkspaceService';
 import { TraceMetadataBuilder } from '../memory/TraceMetadataBuilder';
 import { TraceContextMetadata, TraceOutcomeMetadata } from '../../database/workspace-types';
 import { formatTraceContent } from './TraceContentFormatter';
+import { splitTopLevelSegments, tokenizeWithMeta } from '../../agents/toolManager/services/ToolCliNormalizer';
 
 type ToolCallParams = unknown;
 type ToolCallResponse = unknown;
@@ -79,16 +80,12 @@ export class ToolCallTraceService {
         return;
       }
 
-      // 3. Get workspace context from SessionContextManager
-      const workspaceContext = this.sessionContextManager.getWorkspaceContext(sessionId);
-      const workspaceId = workspaceContext?.workspaceId ||
-                         getString(isRecord(paramsRecord.workspaceContext) ? paramsRecord.workspaceContext.workspaceId : undefined) ||
-                         getString(isRecord(paramsRecord.context) ? paramsRecord.context.workspaceId : undefined) ||
-                         'default';
-
+      // 3. Resolve workspace context from the session or explicit tool envelope
+      const workspaceId = await this.resolveWorkspaceId(paramsRecord, sessionId);
       if (!workspaceId) {
         return;
       }
+      this.sessionContextManager.setWorkspaceContext(sessionId, { workspaceId });
 
       // 4. Build trace content (human-readable description)
       const traceContent = formatTraceContent({ agent, mode, params: paramsRecord, success });
@@ -162,6 +159,56 @@ export class ToolCallTraceService {
     return null;
   }
 
+  private async resolveWorkspaceId(params: ToolCallParams, sessionId: string): Promise<string | null> {
+    const paramsRecord = asRecord(params);
+    const workspaceContext = this.sessionContextManager.getWorkspaceContext(sessionId);
+    const explicitCandidate =
+      getString(paramsRecord.workspaceId) ||
+      getString(isRecord(paramsRecord.workspaceContext) ? paramsRecord.workspaceContext.workspaceId : undefined) ||
+      getString(isRecord(paramsRecord.context) ? paramsRecord.context.workspaceId : undefined);
+    const commandWorkspaceCandidate = this.extractWorkspaceHandleFromUseTools(paramsRecord);
+    const candidate =
+      (explicitCandidate && explicitCandidate !== 'default' ? explicitCandidate : undefined) ||
+      commandWorkspaceCandidate ||
+      explicitCandidate ||
+      workspaceContext?.workspaceId ||
+      'default';
+
+    if (!candidate) {
+      return null;
+    }
+
+    try {
+      const workspace = await this.workspaceService.getWorkspaceByNameOrId(candidate);
+      return workspace?.id || candidate;
+    } catch {
+      return candidate;
+    }
+  }
+
+  private extractWorkspaceHandleFromUseTools(params: Record<string, unknown>): string | undefined {
+    const toolString = getString(params.tool);
+    if (!toolString) {
+      return undefined;
+    }
+
+    for (const segment of splitTopLevelSegments(toolString)) {
+      const tokens = tokenizeWithMeta(segment);
+      if (tokens.length < 3) {
+        continue;
+      }
+
+      const agent = tokens[0].value.replace(/[-_\s]/g, '').toLowerCase();
+      const tool = tokens[1].value.replace(/[-_\s]/g, '').toLowerCase();
+      if ((agent === 'memory' || agent === 'memorymanager') &&
+          (tool === 'loadworkspace' || tool === 'createworkspace')) {
+        return tokens[2].value;
+      }
+    }
+
+    return undefined;
+  }
+
   private buildCanonicalMetadata(options: {
     toolName: string;
     agent: string;
@@ -215,9 +262,14 @@ export class ToolCallTraceService {
     return {
       workspaceId,
       sessionId,
-      memory: getString(contextSource.memory) || '',
-      goal: getString(contextSource.goal) || '',
-      constraints: getString(contextSource.constraints)
+      memory: getString(contextSource.memory) || getString(paramsRecord.memory) || '',
+      goal: getString(contextSource.goal) || getString(paramsRecord.goal) || '',
+      sessionName:
+        getString(contextSource.sessionName) ||
+        getString(contextSource.displaySessionId) ||
+        getString(paramsRecord.sessionName) ||
+        getString(paramsRecord._displaySessionId),
+      constraints: getString(contextSource.constraints) || getString(paramsRecord.constraints)
     };
   }
 
@@ -229,6 +281,7 @@ export class ToolCallTraceService {
     const sanitized = { ...params };
     delete sanitized.context;
     delete sanitized.workspaceContext;
+    delete sanitized._displaySessionId;
     return Object.keys(sanitized).length > 0 ? sanitized : undefined;
   }
 

--- a/src/services/workspace/WorkspaceFolderWatcher.ts
+++ b/src/services/workspace/WorkspaceFolderWatcher.ts
@@ -1,0 +1,149 @@
+/**
+ * Watches Obsidian folder rename/move events and keeps workspace root paths in sync.
+ */
+
+import { TFolder, normalizePath } from 'obsidian';
+import type { App, EventRef, TAbstractFile } from 'obsidian';
+import type { IndividualWorkspace } from '../../types/storage/StorageTypes';
+import type { WorkspaceService } from '../WorkspaceService';
+
+export interface WorkspaceRootMove {
+  workspaceId: string;
+  oldRootFolder: string;
+  newRootFolder: string;
+}
+
+export class WorkspaceFolderWatcher {
+  private eventRefs: EventRef[] = [];
+  private started = false;
+  private disposed = false;
+
+  constructor(
+    private readonly app: App,
+    private readonly workspaceService: WorkspaceService
+  ) {}
+
+  startWhenReady(): void {
+    if (this.disposed || this.started) {
+      return;
+    }
+
+    if (this.app.workspace.layoutReady) {
+      this.start();
+      return;
+    }
+
+    this.app.workspace.onLayoutReady(() => {
+      if (!this.disposed) {
+        this.start();
+      }
+    });
+  }
+
+  start(): void {
+    if (this.disposed || this.started) {
+      return;
+    }
+
+    this.started = true;
+    this.eventRefs.push(
+      this.app.vault.on('rename', (file, oldPath) => {
+        void this.handleRename(file, oldPath).catch((error) => {
+          console.error('[WorkspaceFolderWatcher] Failed to sync workspace folder rename:', error);
+        });
+      })
+    );
+  }
+
+  cleanup(): void {
+    this.disposed = true;
+    this.stop();
+  }
+
+  stop(): void {
+    if (!this.started) {
+      return;
+    }
+
+    for (const ref of this.eventRefs) {
+      this.app.vault.offref(ref);
+    }
+
+    this.eventRefs = [];
+    this.started = false;
+  }
+
+  async handleRename(file: TAbstractFile, oldPath: string): Promise<WorkspaceRootMove[]> {
+    if (!(file instanceof TFolder)) {
+      return [];
+    }
+
+    const oldFolder = normalizeWorkspacePath(oldPath);
+    const newFolder = normalizeWorkspacePath(file.path);
+    if (oldFolder === '/' || newFolder === '/' || oldFolder === newFolder) {
+      return [];
+    }
+
+    const workspaces = await this.workspaceService.getAllWorkspaces();
+    const moves = findWorkspaceRootMoves(workspaces, oldFolder, newFolder);
+
+    for (const move of moves) {
+      await this.workspaceService.updateWorkspace(move.workspaceId, {
+        rootFolder: move.newRootFolder
+      });
+    }
+
+    return moves;
+  }
+}
+
+export function findWorkspaceRootMoves(
+  workspaces: Pick<IndividualWorkspace, 'id' | 'rootFolder'>[],
+  oldFolder: string,
+  newFolder: string
+): WorkspaceRootMove[] {
+  const normalizedOld = normalizeWorkspacePath(oldFolder);
+  const normalizedNew = normalizeWorkspacePath(newFolder);
+
+  if (normalizedOld === '/' || normalizedNew === '/' || normalizedOld === normalizedNew) {
+    return [];
+  }
+
+  return workspaces
+    .map((workspace) => {
+      const oldRootFolder = normalizeWorkspacePath(workspace.rootFolder);
+      const newRootFolder = rewriteWorkspaceRoot(oldRootFolder, normalizedOld, normalizedNew);
+      if (!newRootFolder || newRootFolder === oldRootFolder) {
+        return null;
+      }
+
+      return {
+        workspaceId: workspace.id,
+        oldRootFolder,
+        newRootFolder
+      };
+    })
+    .filter((move): move is WorkspaceRootMove => move !== null);
+}
+
+function rewriteWorkspaceRoot(rootFolder: string, oldFolder: string, newFolder: string): string | null {
+  if (rootFolder === '/') {
+    return null;
+  }
+
+  if (rootFolder === oldFolder) {
+    return newFolder;
+  }
+
+  const oldPrefix = `${oldFolder}/`;
+  if (!rootFolder.startsWith(oldPrefix)) {
+    return null;
+  }
+
+  return `${newFolder}/${rootFolder.slice(oldPrefix.length)}`;
+}
+
+function normalizeWorkspacePath(path: string): string {
+  const normalized = normalizePath(path).trim().replace(/^\/+|\/+$/g, '');
+  return normalized === '' ? '/' : normalized;
+}

--- a/src/services/workspace/WorkspaceSessionService.ts
+++ b/src/services/workspace/WorkspaceSessionService.ts
@@ -45,6 +45,13 @@ export class WorkspaceSessionService {
       // Ensure workspace exists before creating session (referential integrity)
       let existingWorkspace = await this.workspaceDeps.getWorkspace(workspaceId);
       if (!existingWorkspace) {
+        existingWorkspace = await this.workspaceDeps.getWorkspaceByNameOrId(workspaceId);
+        if (existingWorkspace) {
+          workspaceId = existingWorkspace.id;
+        }
+      }
+
+      if (!existingWorkspace) {
         if (workspaceId === GLOBAL_WORKSPACE_ID) {
           existingWorkspace = await this.workspaceDeps.getWorkspaceByNameOrId(DEFAULT_WORKSPACE_NAME);
           if (existingWorkspace) {
@@ -71,6 +78,34 @@ export class WorkspaceSessionService {
         endTime: sessionData.endTime,
         isActive: sessionData.isActive ?? true
       };
+
+      if (hybridSession.id) {
+        const existingSession = await adapter.getSession(hybridSession.id);
+        if (existingSession) {
+          if (existingSession.workspaceId !== workspaceId) {
+            if (!adapter.moveSessionToWorkspace) {
+              throw new Error(`Session ${hybridSession.id} already belongs to workspace ${existingSession.workspaceId}`);
+            }
+            await adapter.moveSessionToWorkspace(hybridSession.id, workspaceId);
+          }
+          await adapter.updateSession(workspaceId, hybridSession.id, {
+            description: hybridSession.description,
+            endTime: hybridSession.endTime,
+            isActive: hybridSession.isActive
+          });
+          await adapter.updateWorkspace(workspaceId, { lastAccessed: Date.now() });
+          return {
+            id: hybridSession.id,
+            name: existingSession.name,
+            description: hybridSession.description,
+            startTime: existingSession.startTime,
+            endTime: hybridSession.endTime,
+            isActive: hybridSession.isActive,
+            memoryTraces: {},
+            states: {}
+          };
+        }
+      }
 
       const sessionId = await adapter.createSession(workspaceId, hybridSession);
       await adapter.updateWorkspace(workspaceId, { lastAccessed: Date.now() });
@@ -181,6 +216,9 @@ export class WorkspaceSessionService {
       async (adapter) => {
         const session = await adapter.getSession(sessionId);
         if (!session) {
+          return null;
+        }
+        if (session.workspaceId !== workspaceId) {
           return null;
         }
         return {

--- a/tests/helpers/mockFactories.ts
+++ b/tests/helpers/mockFactories.ts
@@ -46,6 +46,7 @@ interface MockStorageAdapter {
   getSession: MockFn<[], Promise<unknown>>;
   getSessions: MockFn<[], Promise<Record<string, unknown>>>;
   updateSession: MockFn;
+  moveSessionToWorkspace?: MockFn;
   deleteSession: MockFn;
   addTrace: MockFn<[], Promise<string>>;
   getTraces: MockFn<[], Promise<Record<string, unknown>>>;
@@ -168,6 +169,7 @@ export function createMockAdapter(ready: boolean): MockStorageAdapter {
     getSession: jest.fn().mockResolvedValue(null),
     getSessions: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
     updateSession: jest.fn(),
+    moveSessionToWorkspace: jest.fn(),
     deleteSession: jest.fn(),
     addTrace: jest.fn().mockResolvedValue('trace-new'),
     getTraces: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),

--- a/tests/unit/SessionContextManager.test.ts
+++ b/tests/unit/SessionContextManager.test.ts
@@ -1,0 +1,68 @@
+import { SessionContextManager } from '../../src/services/SessionContextManager';
+
+describe('SessionContextManager', () => {
+  it('keeps a friendly session handle model-facing while storing an internal ID', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = {
+      getSession: jest.fn().mockResolvedValue(null),
+      getAllSessions: jest.fn().mockResolvedValue([]),
+      createSession: jest.fn(),
+      updateSession: jest.fn()
+    };
+    manager.setSessionService(sessionService);
+
+    const result = await manager.validateSessionId('workspace setup', 'Testing session handles', 'default');
+
+    expect(result.id).toMatch(/^s-/);
+    expect(result.displaySessionId).toBe('workspace setup');
+    expect(result.displaySessionIdChanged).toBe(false);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: result.id,
+        name: 'workspace setup',
+        description: 'Testing session handles',
+        workspaceId: 'default'
+      })
+    );
+
+    await expect(manager.validateSessionId('workspace setup', undefined, 'default')).resolves.toEqual(
+      expect.objectContaining({
+        id: result.id,
+        created: false,
+        displaySessionId: 'workspace setup',
+        displaySessionIdChanged: false
+      })
+    );
+  });
+
+  it('suffixes duplicate friendly session handles and reports the display handle', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = {
+      getSession: jest.fn().mockResolvedValue(null),
+      getAllSessions: jest.fn().mockResolvedValue([
+        { id: 's-existing', workspaceId: 'default', name: 'session' }
+      ]),
+      createSession: jest.fn(),
+      updateSession: jest.fn()
+    };
+    manager.setSessionService(sessionService);
+
+    const result = await manager.validateSessionId('session', undefined, 'default');
+
+    expect(result.displaySessionId).toBe('session-2');
+    expect(result.displaySessionIdChanged).toBe(true);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'session-2'
+      })
+    );
+
+    await expect(manager.validateSessionId('session-2', undefined, 'default')).resolves.toEqual(
+      expect.objectContaining({
+        id: result.id,
+        created: false,
+        displaySessionId: 'session-2'
+      })
+    );
+  });
+});

--- a/tests/unit/SessionRepository.moveToWorkspace.test.ts
+++ b/tests/unit/SessionRepository.moveToWorkspace.test.ts
@@ -1,0 +1,242 @@
+/**
+ * SessionRepository.moveToWorkspace — direct unit coverage of the
+ * load-bearing dual-write + 4-table SQLite cascade introduced in
+ * commit 799ed540 (B1 of review/workspace-memory-batch).
+ *
+ * Project pinned norm prefers real DB over mocks. The repository layer
+ * runs on top of `SQLiteCacheManager`, which is a sql.js WASM bridge —
+ * a real-DB harness would require WASM init and is not currently set
+ * up in jest. Existing repository tests (WorkspaceRepository,
+ * TaskRepository, ProjectRepository) all use the mocked
+ * RepositoryDependencies pattern; this test follows that convention.
+ *
+ * The test is structured to make cascade regressions visible: it
+ * pins the exact SQL fragments + the JSONL event order so that
+ * dropping a table from the cascade or reversing the dual-write
+ * fails loudly here rather than silently leaving traces in the
+ * wrong workspace.
+ */
+
+import { SessionRepository } from '../../src/database/repositories/SessionRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+
+interface MockSqliteCache {
+  queryOne: jest.Mock;
+  query: jest.Mock;
+  run: jest.Mock;
+  transaction: jest.Mock;
+}
+
+interface MockJsonlWriter {
+  appendEvent: jest.Mock;
+}
+
+interface MockQueryCache {
+  cachedQuery: jest.Mock;
+  invalidateByType: jest.Mock;
+  invalidateById: jest.Mock;
+  invalidate: jest.Mock;
+}
+
+interface MockDeps {
+  sqliteCache: MockSqliteCache;
+  jsonlWriter: MockJsonlWriter;
+  queryCache: MockQueryCache;
+}
+
+function createMockDeps(): MockDeps {
+  return {
+    sqliteCache: {
+      queryOne: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      run: jest.fn().mockResolvedValue(undefined),
+      transaction: jest.fn(async (fn: () => Promise<unknown>) => fn())
+    },
+    jsonlWriter: {
+      appendEvent: jest.fn().mockImplementation(async (_path: string, event: Record<string, unknown>) => ({
+        id: 'evt-mock',
+        timestamp: 1,
+        deviceId: 'dev-1',
+        ...event
+      }))
+    },
+    queryCache: {
+      cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+      invalidateByType: jest.fn(),
+      invalidateById: jest.fn(),
+      invalidate: jest.fn()
+    }
+  };
+}
+
+const SOURCE_WORKSPACE = 'ws-source';
+const TARGET_WORKSPACE = 'ws-target';
+const SESSION_ID = 'session-abc';
+
+const SESSION_ROW = {
+  id: SESSION_ID,
+  workspaceId: SOURCE_WORKSPACE,
+  name: 'Working session',
+  description: 'Original description',
+  startTime: 1700000000,
+  endTime: null,
+  isActive: 1
+};
+
+describe('SessionRepository.moveToWorkspace', () => {
+  let deps: MockDeps;
+  let repo: SessionRepository;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    repo = new SessionRepository(deps as unknown as RepositoryDependencies);
+  });
+
+  it('cascades the SQLite update across all four workspace-scoped tables', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    const runCalls = deps.sqliteCache.run.mock.calls;
+    expect(runCalls).toHaveLength(4);
+
+    const tablesUpdated = runCalls.map(([sql]: [string]) => {
+      const match = /UPDATE\s+(\w+)\s+SET/i.exec(sql);
+      return match ? match[1] : null;
+    });
+
+    expect(tablesUpdated).toEqual([
+      'sessions',
+      'states',
+      'memory_traces',
+      'trace_embedding_metadata'
+    ]);
+
+    for (const [, params] of runCalls) {
+      expect(params).toEqual([TARGET_WORKSPACE, SESSION_ID]);
+    }
+
+    const sessionsUpdate = runCalls[0][0] as string;
+    expect(sessionsUpdate).toMatch(/WHERE\s+id\s*=\s*\?/i);
+    for (const cascadeSql of runCalls.slice(1).map((c: [string]) => c[0])) {
+      expect(cascadeSql).toMatch(/WHERE\s+sessionId\s*=\s*\?/i);
+    }
+  });
+
+  it('writes session_updated to the source workspace JSONL and session_created to the destination, in that order', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    const events = deps.jsonlWriter.appendEvent.mock.calls;
+    expect(events).toHaveLength(2);
+
+    const [firstPath, firstEvent] = events[0];
+    expect(firstPath).toBe(`workspaces/ws_${SOURCE_WORKSPACE}.jsonl`);
+    expect(firstEvent).toMatchObject({
+      type: 'session_updated',
+      workspaceId: SOURCE_WORKSPACE,
+      sessionId: SESSION_ID,
+      data: { workspaceId: TARGET_WORKSPACE }
+    });
+
+    const [secondPath, secondEvent] = events[1];
+    expect(secondPath).toBe(`workspaces/ws_${TARGET_WORKSPACE}.jsonl`);
+    expect(secondEvent).toMatchObject({
+      type: 'session_created',
+      workspaceId: TARGET_WORKSPACE,
+      data: {
+        id: SESSION_ID,
+        name: SESSION_ROW.name,
+        description: SESSION_ROW.description,
+        startTime: SESSION_ROW.startTime
+      }
+    });
+  });
+
+  it('runs JSONL writes before SQLite updates within the transaction', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const order: string[] = [];
+    deps.jsonlWriter.appendEvent.mockImplementation(async (_path: string, event: Record<string, unknown>) => {
+      order.push(`jsonl:${event.type as string}`);
+      return { id: 'evt', timestamp: 1, deviceId: 'd', ...event };
+    });
+    deps.sqliteCache.run.mockImplementation(async (sql: string) => {
+      const table = /UPDATE\s+(\w+)/i.exec(sql)?.[1] ?? 'unknown';
+      order.push(`sqlite:${table}`);
+    });
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(order).toEqual([
+      'jsonl:session_updated',
+      'jsonl:session_created',
+      'sqlite:sessions',
+      'sqlite:states',
+      'sqlite:memory_traces',
+      'sqlite:trace_embedding_metadata'
+    ]);
+  });
+
+  it('wraps the entire move in a single transaction so a failed cascade rolls back', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const cascadeFailure = new Error('SQLITE_CONSTRAINT: trace_embedding_metadata.sessionId');
+    deps.sqliteCache.run
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(cascadeFailure);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE)).rejects.toBe(cascadeFailure);
+
+    expect(deps.sqliteCache.transaction).toHaveBeenCalledTimes(1);
+    expect(deps.sqliteCache.run).toHaveBeenCalledTimes(4);
+    expect(deps.jsonlWriter.appendEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('also rolls back when the destination JSONL write fails after the source write', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const jsonlFailure = new Error('disk full writing destination JSONL');
+    deps.jsonlWriter.appendEvent
+      .mockResolvedValueOnce({ id: 'evt-1', timestamp: 1, deviceId: 'd', type: 'session_updated' })
+      .mockRejectedValueOnce(jsonlFailure);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE)).rejects.toBe(jsonlFailure);
+
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+  });
+
+  it('throws and does not write anything when the session does not exist', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(null);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE))
+      .rejects.toThrow(`Session not found: ${SESSION_ID}`);
+
+    expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the session is already in the destination workspace', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce({
+      ...SESSION_ROW,
+      workspaceId: TARGET_WORKSPACE
+    });
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.transaction).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the per-id cache entry after a successful move', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(deps.queryCache.invalidateById).toHaveBeenCalledWith('session', SESSION_ID);
+  });
+});

--- a/tests/unit/ToolCallTraceService.test.ts
+++ b/tests/unit/ToolCallTraceService.test.ts
@@ -1,0 +1,147 @@
+import { ToolCallTraceService } from '../../src/services/trace/ToolCallTraceService';
+
+describe('ToolCallTraceService', () => {
+  it('resolves top-level workspace names before recording useTools traces', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue(null),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'Workspace Name',
+        sessionId: 'session-1',
+        _displaySessionId: 'Focused trace session',
+        memory: 'Testing recent activity.',
+        goal: 'Record a file read.',
+        tool: 'content read "Projects/A.md"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Workspace Name');
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1',
+        type: 'tool_call',
+        metadata: expect.objectContaining({
+          context: expect.objectContaining({
+            workspaceId: 'workspace-uuid',
+            sessionId: 'session-1',
+            sessionName: 'Focused trace session',
+            memory: 'Testing recent activity.',
+            goal: 'Record a file read.'
+          })
+        })
+      })
+    );
+  });
+
+  it('prefers an explicit workspace over stale session workspace context', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue({
+        workspaceId: 'session-workspace'
+      }),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'envelope-workspace-uuid',
+        name: 'Envelope workspace'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'Envelope workspace',
+        sessionId: 'session-1',
+        tool: 'content read "Projects/A.md"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Envelope workspace');
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'envelope-workspace-uuid',
+        sessionId: 'session-1'
+      })
+    );
+  });
+
+  it('uses a load-workspace command handle when the envelope is still default', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue({ workspaceId: 'default' }),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Human Workspace'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'default',
+        sessionId: 'session-1',
+        tool: 'memory load-workspace "Human Workspace"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Human Workspace');
+    expect(sessionContextManager.setWorkspaceContext).toHaveBeenCalledWith('session-1', {
+      workspaceId: 'workspace-uuid'
+    });
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1'
+      })
+    );
+  });
+});

--- a/tests/unit/WorkspaceContextBuilder.test.ts
+++ b/tests/unit/WorkspaceContextBuilder.test.ts
@@ -1,0 +1,254 @@
+import { WorkspaceContextBuilder } from '../../src/agents/memoryManager/services/WorkspaceContextBuilder';
+
+describe('WorkspaceContextBuilder', () => {
+  it('expands useTools traces into recent tool and file activity', async () => {
+    const builder = new WorkspaceContextBuilder();
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue({
+        items: [
+          {
+            timestamp: 300,
+            content: 'Used tool',
+            metadata: {
+              tool: {
+                agent: 'toolManager',
+                mode: 'useTools'
+              },
+              input: {
+                arguments: {
+                  tool: 'search search-content "workspace state", content read "Projects/A.md", content replace "Projects/A.md" "old" "new"'
+                }
+              }
+            }
+          }
+        ]
+      })
+    };
+
+    const result = await builder.buildContextBriefing(
+      {
+        id: 'workspace-uuid',
+        name: 'Workspace',
+        rootFolder: '/',
+        context: {}
+      } as never,
+      memoryService as never,
+      5
+    );
+
+    expect(memoryService.getMemoryTraces).toHaveBeenCalledWith('workspace-uuid');
+    expect(result.recentActivity).toEqual([
+      'Updated Projects/A.md',
+      'Read Projects/A.md',
+      'Searched for "workspace state"'
+    ]);
+  });
+
+  it('surfaces memory, storage, and task manager actions from useTools traces', async () => {
+    const builder = new WorkspaceContextBuilder();
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue({
+        items: [
+          {
+            timestamp: 300,
+            content: 'Used tool',
+            metadata: {
+              tool: {
+                agent: 'toolManager',
+                mode: 'useTools'
+              },
+              input: {
+                arguments: {
+                  tool: 'memory create-state "checkpoint" "context" "task" --active-files "Projects/A.md" --next-steps "Continue", memory load-workspace "Product Workspace", storage move "Projects/A.md" "Archive/A.md", task create-task "proj-1" "Write tests"'
+                }
+              }
+            }
+          }
+        ]
+      })
+    };
+
+    const result = await builder.buildContextBriefing(
+      {
+        id: 'workspace-uuid',
+        name: 'Workspace',
+        rootFolder: '/',
+        context: {}
+      } as never,
+      memoryService as never,
+      10
+    );
+
+    expect(result.recentActivity).toEqual([
+      'Created task Write tests',
+      'Moved Projects/A.md to Archive/A.md',
+      'Loaded workspace Product Workspace',
+      'Saved state checkpoint'
+    ]);
+  });
+
+  it('uses executed batch results for serial and parallel useTools activity', async () => {
+    const builder = new WorkspaceContextBuilder();
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue({
+        items: [
+          {
+            timestamp: 300,
+            content: 'Used tool',
+            metadata: {
+              tool: {
+                agent: 'toolManager',
+                mode: 'useTools'
+              },
+              input: {
+                arguments: {
+                  strategy: 'serial',
+                  tool: 'content write "Projects/A.md" "new content", content read "Projects/A.md"'
+                }
+              },
+              legacy: {
+                result: {
+                  success: true,
+                  data: {
+                    results: [
+                      { agent: 'contentManager', tool: 'write', success: true },
+                      { agent: 'contentManager', tool: 'read', success: true }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      })
+    };
+
+    const result = await builder.buildContextBriefing(
+      {
+        id: 'workspace-uuid',
+        name: 'Workspace',
+        rootFolder: '/',
+        context: {}
+      } as never,
+      memoryService as never,
+      10
+    );
+
+    expect(result.recentActivity).toEqual([
+      'Read Projects/A.md',
+      'Wrote Projects/A.md'
+    ]);
+  });
+
+  it('orders newer traces and newer batch operations before older activity', async () => {
+    const builder = new WorkspaceContextBuilder();
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue({
+        items: [
+          {
+            timestamp: 100,
+            content: 'Updated Projects/old.md'
+          },
+          {
+            timestamp: 300,
+            content: 'Used tool',
+            metadata: {
+              tool: {
+                agent: 'toolManager',
+                mode: 'useTools'
+              },
+              input: {
+                arguments: {
+                  tool: 'storage create-folder "Projects/probes", content write "Projects/probes/new-file.md" "body", content replace "Projects/activity-probe.md" "old" "new", memory create-state "E2E Activity Probe State 2" "context" "task" --active-files "Projects/activity-probe.md" --next-steps "Continue"'
+                }
+              },
+              legacy: {
+                result: {
+                  success: true,
+                  data: {
+                    results: [
+                      { agent: 'storageManager', tool: 'createFolder', success: true },
+                      { agent: 'contentManager', tool: 'write', success: true },
+                      { agent: 'contentManager', tool: 'replace', success: true },
+                      { agent: 'memoryManager', tool: 'createState', success: true }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      })
+    };
+
+    const result = await builder.buildContextBriefing(
+      {
+        id: 'workspace-uuid',
+        name: 'Workspace',
+        rootFolder: '/',
+        context: {}
+      } as never,
+      memoryService as never,
+      5
+    );
+
+    expect(result.recentActivity).toEqual([
+      'Saved state E2E Activity Probe State 2',
+      'Updated Projects/activity-probe.md',
+      'Wrote Projects/probes/new-file.md',
+      'Created folder Projects/probes',
+      'Updated Projects/old.md'
+    ]);
+  });
+
+  it('does not show unexecuted later commands when a serial batch stops early', async () => {
+    const builder = new WorkspaceContextBuilder();
+    const memoryService = {
+      getMemoryTraces: jest.fn().mockResolvedValue({
+        items: [
+          {
+            timestamp: 300,
+            content: 'Tool execution failed',
+            metadata: {
+              tool: {
+                agent: 'toolManager',
+                mode: 'useTools'
+              },
+              input: {
+                arguments: {
+                  strategy: 'serial',
+                  tool: 'content write "Projects/A.md" "new content", content read "Projects/A.md"'
+                }
+              },
+              legacy: {
+                result: {
+                  success: false,
+                  data: {
+                    results: [
+                      { agent: 'contentManager', tool: 'write', success: false }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        ]
+      })
+    };
+
+    const result = await builder.buildContextBriefing(
+      {
+        id: 'workspace-uuid',
+        name: 'Workspace',
+        rootFolder: '/',
+        context: {}
+      } as never,
+      memoryService as never,
+      10
+    );
+
+    expect(result.recentActivity).toEqual([
+      'Failed: Wrote Projects/A.md'
+    ]);
+  });
+});

--- a/tests/unit/WorkspaceDataFetcher.test.ts
+++ b/tests/unit/WorkspaceDataFetcher.test.ts
@@ -36,13 +36,8 @@ describe('WorkspaceDataFetcher', () => {
     });
     expect(result.items).toEqual([
       {
-        id: 'state-1',
         name: 'Planning checkpoint',
-        description: 'Checkpoint description',
-        sessionId: 'session-1',
-        created: 123,
-        tags: [],
-        workspaceId: undefined
+        tags: []
       }
     ]);
     expect(result.totalItems).toBe(1);
@@ -99,7 +94,7 @@ describe('WorkspaceDataFetcher', () => {
     });
   });
 
-  it('surfaces state metadata tags and real session IDs from adapter-backed state lists', async () => {
+  it('surfaces only state names and tags in workspace load summaries', async () => {
     const fetcher = new WorkspaceDataFetcher();
     const memoryService = {
       getSessions: jest.fn(),
@@ -137,13 +132,8 @@ describe('WorkspaceDataFetcher', () => {
     });
 
     expect(result.items[0]).toEqual({
-      id: 'state-1',
       name: 'Verification checkpoint',
-      description: 'Checkpoint description',
-      sessionId: 'session-1',
-      created: 789,
-      tags: ['test', 'verification'],
-      workspaceId: 'workspace-1'
+      tags: ['test', 'verification']
     });
   });
 

--- a/tests/unit/WorkspaceFileCollector.test.ts
+++ b/tests/unit/WorkspaceFileCollector.test.ts
@@ -1,0 +1,86 @@
+import { WorkspaceFileCollector } from '../../src/agents/memoryManager/services/WorkspaceFileCollector';
+
+describe('WorkspaceFileCollector', () => {
+  it('falls back to vault files when the cache manager is unavailable', () => {
+    const collector = new WorkspaceFileCollector();
+    const result = collector.getRecentFilesInWorkspace(
+      { rootFolder: 'Projects' },
+      null,
+      {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([
+            makeFile('Projects/old.md', 100),
+            makeFile('Projects/new.md', 300),
+            makeFile('Other/newer.md', 500),
+            makeFile('Projects/image.png', 600, 'png')
+          ])
+        }
+      } as never
+    );
+
+    expect(result).toEqual([
+      { path: 'Projects/new.md', modified: 300 },
+      { path: 'Projects/old.md', modified: 100 }
+    ]);
+  });
+
+  it('treats slash root workspaces as the full vault', () => {
+    const collector = new WorkspaceFileCollector();
+    const result = collector.getRecentFilesInWorkspace(
+      { rootFolder: '/' },
+      { getRecentFiles: jest.fn().mockReturnValue([]) },
+      {
+        vault: {
+          getFiles: jest.fn().mockReturnValue([
+            makeFile('Root.md', 200),
+            makeFile('Projects/new.md', 300)
+          ])
+        }
+      } as never
+    );
+
+    expect(result).toEqual([
+      { path: 'Projects/new.md', modified: 300 },
+      { path: 'Root.md', modified: 200 }
+    ]);
+  });
+
+  it('prefers cache results when available', () => {
+    const collector = new WorkspaceFileCollector();
+    const cacheManager = {
+      getRecentFiles: jest.fn().mockReturnValue([
+        { path: 'Projects/cache.md', modified: 700 }
+      ])
+    };
+    const app = {
+      vault: {
+        getFiles: jest.fn()
+      }
+    };
+
+    const result = collector.getRecentFilesInWorkspace(
+      { rootFolder: 'Projects' },
+      cacheManager,
+      app as never
+    );
+
+    expect(result).toEqual([
+      { path: 'Projects/cache.md', modified: 700 }
+    ]);
+    expect(app.vault.getFiles).not.toHaveBeenCalled();
+  });
+});
+
+function makeFile(path: string, mtime: number, extension = 'md') {
+  const name = path.split('/').pop() || path;
+  return {
+    path,
+    name,
+    extension,
+    stat: {
+      mtime,
+      ctime: 1,
+      size: 10
+    }
+  };
+}

--- a/tests/unit/WorkspaceFolderWatcher.test.ts
+++ b/tests/unit/WorkspaceFolderWatcher.test.ts
@@ -1,0 +1,166 @@
+import { TFile, TFolder } from 'obsidian';
+import type { App, EventRef } from 'obsidian';
+import {
+  WorkspaceFolderWatcher,
+  findWorkspaceRootMoves
+} from '../../src/services/workspace/WorkspaceFolderWatcher';
+import type { IndividualWorkspace } from '../../src/types/storage/StorageTypes';
+import type { WorkspaceService } from '../../src/services/WorkspaceService';
+
+type VaultRenameHandler = (file: TFile | TFolder, oldPath: string) => void;
+
+function workspace(id: string, rootFolder: string): IndividualWorkspace {
+  return {
+    id,
+    name: id,
+    rootFolder,
+    created: 1,
+    lastAccessed: 1,
+    isActive: true,
+    sessions: {}
+  };
+}
+
+function createMockApp(layoutReady = true) {
+  let renameHandler: VaultRenameHandler | null = null;
+  const ref: EventRef = {};
+  const onLayoutReadyCallbacks: Array<() => void> = [];
+
+  const app = {
+    vault: {
+      on: jest.fn((_event: string, handler: VaultRenameHandler) => {
+        renameHandler = handler;
+        return ref;
+      }),
+      offref: jest.fn()
+    },
+    workspace: {
+      layoutReady,
+      onLayoutReady: jest.fn((callback: () => void) => {
+        onLayoutReadyCallbacks.push(callback);
+      })
+    }
+  } as unknown as App;
+
+  return {
+    app,
+    ref,
+    fireRename: (file: TFile | TFolder, oldPath: string) => {
+      renameHandler?.(file, oldPath);
+    },
+    flushLayoutReady: () => {
+      for (const callback of onLayoutReadyCallbacks) {
+        callback();
+      }
+    }
+  };
+}
+
+describe('findWorkspaceRootMoves', () => {
+  it('rewrites an exact workspace root folder move', () => {
+    expect(findWorkspaceRootMoves(
+      [workspace('ws-1', 'Subfolder A/Project')],
+      'Subfolder A/Project',
+      'Subfolder B/Project'
+    )).toEqual([
+      {
+        workspaceId: 'ws-1',
+        oldRootFolder: 'Subfolder A/Project',
+        newRootFolder: 'Subfolder B/Project'
+      }
+    ]);
+  });
+
+  it('rewrites workspace roots under a moved parent folder', () => {
+    expect(findWorkspaceRootMoves(
+      [
+        workspace('ws-1', 'Subfolder A/Project One'),
+        workspace('ws-2', 'Subfolder A/Nested/Project Two'),
+        workspace('ws-3', 'Other/Project Three')
+      ],
+      'Subfolder A',
+      'Subfolder B'
+    )).toEqual([
+      {
+        workspaceId: 'ws-1',
+        oldRootFolder: 'Subfolder A/Project One',
+        newRootFolder: 'Subfolder B/Project One'
+      },
+      {
+        workspaceId: 'ws-2',
+        oldRootFolder: 'Subfolder A/Nested/Project Two',
+        newRootFolder: 'Subfolder B/Nested/Project Two'
+      }
+    ]);
+  });
+
+  it('does not rewrite root or sibling prefixes', () => {
+    expect(findWorkspaceRootMoves(
+      [
+        workspace('default', '/'),
+        workspace('ws-1', 'Projects/Application')
+      ],
+      'Projects/App',
+      'Archive/App'
+    )).toEqual([]);
+  });
+});
+
+describe('WorkspaceFolderWatcher', () => {
+  it('updates matching workspace root folders when Obsidian renames a folder', async () => {
+    const workspaceService = {
+      getAllWorkspaces: jest.fn().mockResolvedValue([
+        workspace('ws-1', 'Subfolder A/Project'),
+        workspace('ws-2', 'Unrelated/Project')
+      ]),
+      updateWorkspace: jest.fn().mockResolvedValue(undefined)
+    } as unknown as WorkspaceService;
+    const { app } = createMockApp();
+    const watcher = new WorkspaceFolderWatcher(app, workspaceService);
+
+    const moves = await watcher.handleRename(new TFolder('Subfolder B/Project'), 'Subfolder A/Project');
+
+    expect(moves).toEqual([
+      {
+        workspaceId: 'ws-1',
+        oldRootFolder: 'Subfolder A/Project',
+        newRootFolder: 'Subfolder B/Project'
+      }
+    ]);
+    expect(workspaceService.updateWorkspace).toHaveBeenCalledWith('ws-1', {
+      rootFolder: 'Subfolder B/Project'
+    });
+  });
+
+  it('ignores file renames', async () => {
+    const workspaceService = {
+      getAllWorkspaces: jest.fn(),
+      updateWorkspace: jest.fn()
+    } as unknown as WorkspaceService;
+    const { app } = createMockApp();
+    const watcher = new WorkspaceFolderWatcher(app, workspaceService);
+
+    const moves = await watcher.handleRename(new TFile('Note.md', 'Subfolder B/Note.md'), 'Subfolder A/Note.md');
+
+    expect(moves).toEqual([]);
+    expect(workspaceService.getAllWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('waits for layout ready before registering the vault listener', () => {
+    const workspaceService = {
+      getAllWorkspaces: jest.fn(),
+      updateWorkspace: jest.fn()
+    } as unknown as WorkspaceService;
+    const { app, flushLayoutReady } = createMockApp(false);
+    const watcher = new WorkspaceFolderWatcher(app, workspaceService);
+
+    watcher.startWhenReady();
+    expect(app.vault.on).not.toHaveBeenCalled();
+
+    flushLayoutReady();
+    expect(app.vault.on).toHaveBeenCalledWith('rename', expect.any(Function));
+
+    watcher.cleanup();
+    expect(app.vault.offref).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/WorkspaceRepository.test.ts
+++ b/tests/unit/WorkspaceRepository.test.ts
@@ -106,4 +106,26 @@ describe('WorkspaceRepository', () => {
       [1]
     );
   });
+
+  it('supports filtering by rootFolder', async () => {
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({ count: 0 });
+
+    await repo.getWorkspaces({ filter: { rootFolder: 'Subfolder B/Project' } });
+
+    expect(deps.sqliteCache.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('rootFolder = ?'),
+      ['Subfolder B/Project']
+    );
+  });
+
+  it('applies search to workspace name lookups', async () => {
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({ count: 0 });
+
+    await repo.getWorkspaces({ search: 'Default Workspace', pageSize: 100 });
+
+    expect(deps.sqliteCache.queryOne).toHaveBeenCalledWith(
+      expect.stringContaining('LOWER(name) LIKE ?'),
+      ['%default workspace%', '%default workspace%', '%default workspace%']
+    );
+  });
 });

--- a/tests/unit/WorkspaceSessionService.test.ts
+++ b/tests/unit/WorkspaceSessionService.test.ts
@@ -1,0 +1,128 @@
+import { WorkspaceSessionService } from '../../src/services/workspace/WorkspaceSessionService';
+import { createMockAdapter, createMockFileSystem, createMockIndexManager } from '../helpers/mockFactories';
+
+describe('WorkspaceSessionService', () => {
+  it('resolves missing workspace identifiers by name before creating a session', async () => {
+    const adapter = createMockAdapter(true);
+    const deps = {
+      getWorkspace: jest.fn().mockResolvedValue(null),
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid'
+      }),
+      createWorkspace: jest.fn()
+    };
+    const service = new WorkspaceSessionService(
+      createMockFileSystem() as never,
+      createMockIndexManager() as never,
+      adapter as never,
+      deps
+    );
+
+    await service.addSession('Human Workspace Name', {
+      id: 'session-1',
+      name: 'Human session'
+    });
+
+    expect(deps.getWorkspaceByNameOrId).toHaveBeenCalledWith('Human Workspace Name');
+    expect(deps.createWorkspace).not.toHaveBeenCalled();
+    expect(adapter.createSession).toHaveBeenCalledWith(
+      'workspace-uuid',
+      expect.objectContaining({
+        id: 'session-1',
+        name: 'Human session'
+      })
+    );
+  });
+
+  it('reuses an existing Default Workspace row before attempting default creation', async () => {
+    const adapter = createMockAdapter(true);
+    const deps = {
+      getWorkspace: jest.fn().mockResolvedValue(null),
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'existing-default-workspace'
+      }),
+      createWorkspace: jest.fn()
+    };
+    const service = new WorkspaceSessionService(
+      createMockFileSystem() as never,
+      createMockIndexManager() as never,
+      adapter as never,
+      deps
+    );
+
+    await service.addSession('default', {
+      id: 'session-1',
+      name: 'Default session'
+    });
+
+    expect(deps.getWorkspaceByNameOrId).toHaveBeenCalledWith('default');
+    expect(deps.createWorkspace).not.toHaveBeenCalled();
+    expect(adapter.createSession).toHaveBeenCalledWith(
+      'existing-default-workspace',
+      expect.objectContaining({
+        id: 'session-1',
+        name: 'Default session'
+      })
+    );
+  });
+
+  it('moves an existing default session into the selected workspace without overwriting its name', async () => {
+    const adapter = createMockAdapter(true);
+    adapter.getSession.mockResolvedValue({
+      id: 'session-1',
+      workspaceId: 'default',
+      name: 'Original session',
+      startTime: 123,
+      isActive: true
+    });
+    const deps = {
+      getWorkspace: jest.fn().mockResolvedValue({ id: 'workspace-uuid' }),
+      getWorkspaceByNameOrId: jest.fn(),
+      createWorkspace: jest.fn()
+    };
+    const service = new WorkspaceSessionService(
+      createMockFileSystem() as never,
+      createMockIndexManager() as never,
+      adapter as never,
+      deps
+    );
+
+    const session = await service.addSession('workspace-uuid', {
+      id: 'session-1',
+      name: 'Human session'
+    });
+
+    expect(adapter.moveSessionToWorkspace).toHaveBeenCalledWith('session-1', 'workspace-uuid');
+    expect(adapter.createSession).not.toHaveBeenCalled();
+    expect(adapter.updateSession).toHaveBeenCalledWith(
+      'workspace-uuid',
+      'session-1',
+      expect.not.objectContaining({ name: 'Human session' })
+    );
+    expect(session).toEqual(expect.objectContaining({
+      id: 'session-1',
+      name: 'Original session'
+    }));
+  });
+
+  it('treats getSession as workspace-scoped when the adapter returns another workspace', async () => {
+    const adapter = createMockAdapter(true);
+    adapter.getSession.mockResolvedValue({
+      id: 'session-1',
+      workspaceId: 'default',
+      name: 'Original session'
+    });
+    const service = new WorkspaceSessionService(
+      createMockFileSystem() as never,
+      createMockIndexManager() as never,
+      adapter as never,
+      {
+        getWorkspace: jest.fn(),
+        getWorkspaceByNameOrId: jest.fn(),
+        createWorkspace: jest.fn()
+      }
+    );
+
+    await expect(service.getSession('workspace-uuid', 'session-1')).resolves.toBeNull();
+  });
+});

--- a/tests/unit/dual-backend-characterization.test.ts
+++ b/tests/unit/dual-backend-characterization.test.ts
@@ -501,30 +501,108 @@ describe('MemoryService dual-backend characterization', () => {
       expect(result.items[0].state.state?.metadata.tags).toEqual(['test', 'verification']);
     });
 
-    it('recordActivityTrace creates the missing adapter session with the same generated ID', async () => {
+    it('recordActivityTrace creates the missing adapter session before writing the trace', async () => {
       const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
       const adapter = createMockAdapter(true);
-      adapter.addTrace
-        .mockRejectedValueOnce(new Error('session not found'))
-        .mockResolvedValueOnce('trace-1');
+      adapter.getSession.mockResolvedValue(null);
+      adapter.addTrace.mockResolvedValue('trace-1');
 
       const service = new MemoryService(plugin, ws, adapter);
       const result = await service.recordActivityTrace({
         workspaceId: 'ws1',
         timestamp: 1000,
         type: 'action',
-        content: 'created from diagnostic'
+        content: 'created from diagnostic',
+        metadata: {
+          context: {
+            workspaceId: 'ws1',
+            sessionId: 'ignored-here',
+            memory: 'Need to verify recent session listing.',
+            goal: 'Investigate workspace session population'
+          }
+        }
       });
 
       const createdSessionId = adapter.createSession.mock.calls[0][1].id;
       expect(createdSessionId).toMatch(/^session_/);
       expect(adapter.createSession).toHaveBeenCalledWith('ws1', expect.objectContaining({
-        id: createdSessionId
+        id: createdSessionId,
+        name: `Session ${createdSessionId}`,
+        description: 'Need to verify recent session listing.'
       }));
-      expect(adapter.addTrace).toHaveBeenNthCalledWith(2, 'ws1', createdSessionId, expect.objectContaining({
+      expect(adapter.addTrace).toHaveBeenCalledWith('ws1', createdSessionId, expect.objectContaining({
         content: 'created from diagnostic'
       }));
       expect(result).toBe('trace-1');
+    });
+
+    it('recordActivityTrace uses explicit sessionName instead of goal when auto-creating a missing session', async () => {
+      const ws = { getWorkspace: jest.fn(), getMemoryTraces: jest.fn() } as WorkspaceServiceLike;
+      const adapter = createMockAdapter(true);
+      adapter.getSession.mockResolvedValue(null);
+      adapter.addTrace.mockResolvedValue('trace-1');
+
+      const service = new MemoryService(plugin, ws, adapter);
+      await service.recordActivityTrace({
+        workspaceId: 'ws1',
+        sessionId: 's-20260429111500',
+        timestamp: 1000,
+        type: 'action',
+        content: 'created from diagnostic',
+        metadata: {
+          context: {
+            workspaceId: 'ws1',
+            sessionId: 's-20260429111500',
+            sessionName: 'focused trace session',
+            memory: 'Need to verify recent session listing.',
+            goal: 'Inspect memory, content, storage, and search agent commands'
+          }
+        }
+      });
+
+      expect(adapter.createSession).toHaveBeenCalledWith('ws1', expect.objectContaining({
+        id: 's-20260429111500',
+        name: 'focused trace session',
+        description: 'Need to verify recent session listing.'
+      }));
+    });
+
+    it('recordActivityTrace stores default-routed traces under the explicit context workspace', async () => {
+      const ws = {
+        getWorkspace: jest.fn(),
+        getMemoryTraces: jest.fn(),
+        getWorkspaceByNameOrId: jest.fn().mockResolvedValue({ id: 'ws-target' })
+      } as WorkspaceServiceLike & { getWorkspaceByNameOrId: jest.Mock };
+      const adapter = createMockAdapter(true);
+      adapter.getSession.mockResolvedValue(null);
+      adapter.addTrace.mockResolvedValue('trace-1');
+
+      const service = new MemoryService(plugin, ws, adapter);
+      await service.recordActivityTrace({
+        workspaceId: 'default',
+        sessionId: 's-20260429113826',
+        timestamp: 1000,
+        type: 'tool_call',
+        content: 'Used tool',
+        metadata: {
+          context: {
+            workspaceId: 'E2E Focused Trace Search Test 2',
+            sessionId: 's-20260429113826',
+            sessionName: 'focused trace session',
+            memory: 'Testing trace routing.',
+            goal: 'Write a probe file.'
+          }
+        }
+      });
+
+      expect(ws.getWorkspaceByNameOrId).toHaveBeenCalledWith('E2E Focused Trace Search Test 2');
+      expect(adapter.createSession).toHaveBeenCalledWith('ws-target', expect.objectContaining({
+        id: 's-20260429113826',
+        name: 'focused trace session'
+      }));
+      expect(adapter.addTrace).toHaveBeenCalledWith('ws-target', 's-20260429113826', expect.objectContaining({
+        content: 'Used tool'
+      }));
     });
 
     it('createMemoryTrace reuses one generated session ID for save and reload', async () => {

--- a/tests/unit/find-by-name-or-id-characterization.test.ts
+++ b/tests/unit/find-by-name-or-id-characterization.test.ts
@@ -135,7 +135,7 @@ describe('getSessionByNameOrId characterization', () => {
     const adapter = createMockAdapter(true);
 
     adapter.getSession.mockResolvedValue({
-      id: 'session-1', name: 'My Session', description: 'desc',
+      id: 'session-1', workspaceId: 'ws1', name: 'My Session', description: 'desc',
       startTime: 1000, isActive: true,
     });
 


### PR DESCRIPTION
## Summary

Adds the workspace folder watcher and expands the WorkspaceContextBuilder, with dedup and create-if-missing handling on `recordActivityTrace`.

**3 new commits (stacks on #192):**
- `faad5d3d` feat(workspace): folder watcher + workspace context builder expansion
- `0b975a49` test(workspace): cover recordActivityTrace explicit getSession + create-if-missing path
- `a5a9f508` fix(workspace): document StateSummary narrowing + recordActivityTrace dedup

> **Stacks on #192** — base will rebase cleanly once #192 merges. Branch currently includes the 3 commits from #192 (a9264fe4 / ae6993af / 8b94421b) for standalone test pass.

## Why

Slice 2/5 of the workspace/memory/search batch refactor. The dual-backend characterization tests (B2's `0b975a49`) cover behavior whose implementation lives in this slice's `cfc23a0f`/`faad5d3d` — they were moved here from #192 during the split so each branch is independently green.

## Test plan
- [x] `npm test` green standalone against main with #192 commits in tree (2503 pass / 1 pre-existing ModelAgentManager fail / 12 skip)
- [ ] Smoke: open a workspace, add a file to its rootFolder, verify watcher picks up the change
- [ ] Smoke: trigger an activity trace twice in quick succession, verify dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)