### PR TITLE
feat(tools): displaySessionId/sessionName plumbing through tool batch + handlers + connector

### DIFF
--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -368,10 +368,15 @@ export class ToolBatchExecutionService {
     toolSlug: string | undefined,
     params: Record<string, unknown>
   ): Record<string, unknown> {
+    const shouldInjectSessionId =
+      !(agentName === 'searchManager' &&
+        toolSlug === 'searchMemory' &&
+        params.sessionId === undefined &&
+        params.sessionName === undefined);
     const defaulted: Record<string, unknown> = {
       ...params,
       workspaceId: params.workspaceId || context.workspaceId,
-      sessionId: params.sessionId || context.sessionId
+      ...(shouldInjectSessionId ? { sessionId: params.sessionId || context.sessionId } : {})
     };
 
     if (agentName === 'promptManager' && toolSlug === 'generateImage') {

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -39,11 +39,11 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
       'REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.',
       'This returns CLI-oriented command metadata for the tools you need next.',
       'Send workspaceId, sessionId, memory, goal, and constraints at the top level.',
-      'The chat runtime assigns one sessionId for the conversation. Reuse that same sessionId for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state.',
+      'Use one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.',
       'Do not send a nested "context" object or legacy "request" array.',
       '',
       'Workflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands',
-      'Known-good example: {"workspaceId":"default","sessionId":"session_123","memory":"Summarize work so far.","goal":"Inspect available storage tools.","tool":"storage move, content read"}',
+      'Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available storage tools.","tool":"storage move, content read"}',
       'Example selectors: tool="--help", tool="storage", tool="storage move", tool="storage move, content read"',
       '',
       'Agents:'
@@ -142,7 +142,7 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
         },
         sessionId: {
           type: 'string',
-          description: 'Current chat session ID. Required. The chat runtime assigns this once per conversation; reuse the same value for every getTools/useTools call so traces and saved states attach to the current session.'
+          description: 'Stable human-readable session name for this chat. Required. Reuse the same value for every getTools/useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently.'
         },
         memory: {
           type: 'string',

--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -15,7 +15,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   ) {
     this.slug = 'useTools';
     this.name = 'Use Tools';
-    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"session_123","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. The chat runtime assigns one sessionId for the conversation; reuse that same sessionId for every useTools call so traces and saved states attach to the current session. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
+    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
     this.version = '1.0.0';
   }
 
@@ -38,7 +38,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
         },
         sessionId: {
           type: 'string',
-          description: 'Current chat session ID. Required. The chat runtime assigns this once per conversation; reuse the same value for every useTools call so traces and saved states attach to the current session.'
+          description: 'Stable human-readable session name for this chat. Required. Reuse the same value for every useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently.'
         },
         memory: {
           type: 'string',

--- a/src/agents/toolManager/types.ts
+++ b/src/agents/toolManager/types.ts
@@ -121,7 +121,7 @@ export function getTopLevelToolContextSchema(): Record<string, unknown> {
     },
     sessionId: {
       type: 'string',
-      description: 'Current chat session ID assigned by the runtime. Reuse the same value for every tool call in the conversation so traces and saved states attach to the current session.'
+      description: 'Stable human-readable session name for this chat. Reuse the same value for every tool call in the conversation so traces and saved states attach to the current session; Nexus stores the internal UUID silently.'
     },
     memory: {
       type: 'string',

--- a/src/connector.ts
+++ b/src/connector.ts
@@ -5,7 +5,6 @@ import type { ServiceManager } from './core/ServiceManager';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from './utils/logger';
 import { CustomPromptStorageService } from "./agents/promptManager/services/CustomPromptStorageService";
-import { generateSessionId, isStandardSessionId } from './utils/sessionUtils';
 // ToolCallCaptureService removed in simplified architecture
 
 // Extracted services
@@ -522,29 +521,31 @@ Keep workspaceId and sessionId values EXACTLY as shown above throughout the conv
 
             const toolManagerMetaTool = isToolManagerMetaTool(agent, tool);
 
-            // 1. SESSION ID VALIDATION: Extract and validate/generate sessionId first
-            const providedSessionId = (toolManagerMetaTool ? typedParams.sessionId : (typedParams.context?.sessionId || typedParams.sessionId)) as string | undefined;
-            let validatedSessionId: string;
+            const sessionContextManager = this.getSessionContextManagerFromService();
 
-            if (!providedSessionId || !isStandardSessionId(providedSessionId)) {
-                // No sessionId or non-standard format - generate a new one
-                validatedSessionId = generateSessionId();
-            } else {
-                // Valid standard sessionId - use it
-                validatedSessionId = providedSessionId;
-            }
+            // 1. SESSION HANDLE VALIDATION: Extract and resolve the model-facing
+            // session name to an internal ID. The internal ID is not surfaced to
+            // the model; callers should keep sending the same readable handle.
+            const providedSessionId = (toolManagerMetaTool ? typedParams.sessionId : (typedParams.context?.sessionId || typedParams.sessionId)) as string | undefined;
+            const validationResult = await sessionContextManager.validateSessionId(
+                providedSessionId || 'Default Session',
+                typeof typedParams.memory === 'string' ? typedParams.memory : undefined,
+                typeof typedParams.workspaceId === 'string' ? typedParams.workspaceId : undefined
+            );
+            const validatedSessionId = validationResult.id;
 
             // 2. INJECT VALIDATED SESSION ID into all relevant locations
             typedParams.sessionId = validatedSessionId;
+            typedParams._displaySessionId = validationResult.displaySessionId;
             if (!toolManagerMetaTool) {
                 if (!typedParams.context) {
                     typedParams.context = {};
                 }
                 typedParams.context.sessionId = validatedSessionId;
+                typedParams.context.sessionName = validationResult.displaySessionId;
             }
 
             // 3. WORKSPACE CONTEXT LOOKUP FROM SESSION
-            const sessionContextManager = this.getSessionContextManagerFromService();
             const workspaceContext = sessionContextManager.getWorkspaceContext(validatedSessionId);
 
             if (workspaceContext) {

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -1053,6 +1053,11 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.sessionRepo.update(sessionId, { name, description, endTime, isActive, workspaceId });
   };
 
+  moveSessionToWorkspace = async (sessionId: string, workspaceId: string): Promise<void> => {
+    await this.ensureInitialized();
+    return this.sessionRepo.moveToWorkspace(sessionId, workspaceId);
+  };
+
   deleteSession = async (sessionId: string): Promise<void> => {
     await this.ensureInitialized();
     return this.sessionRepo.delete(sessionId);

--- a/src/database/interfaces/IStorageAdapter.ts
+++ b/src/database/interfaces/IStorageAdapter.ts
@@ -251,6 +251,15 @@ export interface IStorageAdapter {
   ): Promise<void>;
 
   /**
+   * Move an existing session to another workspace. Implementations should also
+   * rehome dependent state and trace rows for that session.
+   */
+  moveSessionToWorkspace?(
+    sessionId: string,
+    workspaceId: string
+  ): Promise<void>;
+
+  /**
    * Delete a session
    *
    * @param sessionId - Session ID

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -158,6 +158,7 @@ export interface SessionUpdatedEvent extends BaseStorageEvent {
     description: string;
     endTime: number;
     isActive: boolean;
+    workspaceId: string;
   }>;
 }
 

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -177,6 +177,10 @@ export class SessionRepository
           setClauses.push('isActive = ?');
           params.push(data.isActive ? 1 : 0);
         }
+        if (data.workspaceId !== undefined) {
+          setClauses.push('workspaceId = ?');
+          params.push(data.workspaceId);
+        }
 
         if (setClauses.length > 0) {
           params.push(id);
@@ -286,6 +290,70 @@ export class SessionRepository
 
   async countByWorkspace(workspaceId: string): Promise<number> {
     return this.count({ workspaceId });
+  }
+
+  async moveToWorkspace(id: string, workspaceId: string): Promise<void> {
+    const session = await this.getById(id);
+    if (!session) {
+      throw new Error(`Session not found: ${id}`);
+    }
+
+    if (session.workspaceId === workspaceId) {
+      return;
+    }
+
+    try {
+      await this.transaction(async () => {
+        await this.writeEvent<SessionUpdatedEvent>(
+          this.jsonlPath(session.workspaceId),
+          {
+            type: 'session_updated',
+            workspaceId: session.workspaceId,
+            sessionId: id,
+            data: {
+              workspaceId
+            }
+          }
+        );
+
+        await this.writeEvent<SessionCreatedEvent>(
+          this.jsonlPath(workspaceId),
+          {
+            type: 'session_created',
+            workspaceId,
+            data: {
+              id,
+              name: session.name,
+              description: session.description,
+              startTime: session.startTime
+            }
+          }
+        );
+
+        await this.sqliteCache.run(
+          'UPDATE sessions SET workspaceId = ? WHERE id = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE states SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE memory_traces SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+        await this.sqliteCache.run(
+          'UPDATE trace_embedding_metadata SET workspaceId = ? WHERE sessionId = ?',
+          [workspaceId, id]
+        );
+      });
+
+      this.invalidateCache(id);
+      this.log('moveToWorkspace', { id, workspaceId });
+    } catch (error) {
+      this.logError('moveToWorkspace', error);
+      throw error;
+    }
   }
 
   // ============================================================================

--- a/src/database/repositories/TraceRepository.ts
+++ b/src/database/repositories/TraceRepository.ts
@@ -233,14 +233,15 @@ export class TraceRepository
       let baseQuery = `
         SELECT mt.* FROM memory_traces mt
         WHERE mt.workspaceId = ?
-        AND mt.content LIKE ?
+        AND (mt.content LIKE ? OR mt.metadataJson LIKE ?)
       `;
       let countQuery = `
         SELECT COUNT(*) as count FROM memory_traces mt
         WHERE mt.workspaceId = ?
-        AND mt.content LIKE ?
+        AND (mt.content LIKE ? OR mt.metadataJson LIKE ?)
       `;
-    const params: QueryParams = [workspaceId, `%${query}%`];
+    const queryPattern = `%${query}%`;
+    const params: QueryParams = [workspaceId, queryPattern, queryPattern];
 
       if (sessionId) {
         baseQuery += ' AND mt.sessionId = ?';

--- a/src/database/repositories/interfaces/ISessionRepository.ts
+++ b/src/database/repositories/interfaces/ISessionRepository.ts
@@ -34,6 +34,7 @@ export interface UpdateSessionData {
   description?: string;
   endTime?: number;
   isActive?: boolean;
+  workspaceId?: string;
 }
 
 /**
@@ -74,4 +75,12 @@ export interface ISessionRepository extends IRepository<SessionMetadata> {
    * @returns Number of sessions
    */
   countByWorkspace(workspaceId: string): Promise<number>;
+
+  /**
+   * Move a session and its dependent state/trace rows to another workspace.
+   *
+   * @param id - Session ID
+   * @param workspaceId - Target workspace ID
+   */
+  moveToWorkspace(id: string, workspaceId: string): Promise<void>;
 }

--- a/src/handlers/interfaces/IRequestHandlerServices.ts
+++ b/src/handlers/interfaces/IRequestHandlerServices.ts
@@ -11,6 +11,8 @@ export interface SessionInfo {
     isNewSession: boolean;
     isNonStandardId: boolean;
     originalSessionId?: string;
+    displaySessionId?: string;
+    displaySessionIdChanged?: boolean;
     shouldInjectInstructions?: boolean;
 }
 

--- a/src/handlers/services/ResponseFormatter.ts
+++ b/src/handlers/services/ResponseFormatter.ts
@@ -86,6 +86,11 @@ export class ResponseFormatter implements IResponseFormatter {
     }
 
     private formatWithSessionInstructions(result: ToolExecutionResult, sessionInfo: SessionInfo): MCPContentResponse {
+        // The pre-B4 implementation called this.formatSessionInstructions(sessionInfo.sessionId, result)
+        // here, which stamped the *internal* validated sessionId onto the result envelope
+        // for the model to echo back. That contradicted the B1/B4 contract where the
+        // internal UUID must stay hidden — the model is told to keep using its
+        // friendly handle (displaySessionId) instead. The call is intentionally omitted.
         let responseText = "";
 
         // Compact session handle notice when a duplicate readable name was adjusted.

--- a/src/handlers/services/ResponseFormatter.ts
+++ b/src/handlers/services/ResponseFormatter.ts
@@ -9,8 +9,8 @@ export class ResponseFormatter implements IResponseFormatter {
             return this.formatDetailedError(result, sessionInfo);
         }
 
-        // Only show session ID message when Claude's ID was REPLACED (non-standard format)
-        // If Claude provided a valid format ID, no need to announce - just use it silently
+        // Only show a session handle message when the requested human-readable
+        // handle had to be changed to avoid ambiguity. Internal UUIDs stay hidden.
         if (sessionInfo && sessionInfo.isNonStandardId) {
             return this.formatWithSessionInstructions(result, sessionInfo);
         }
@@ -44,9 +44,9 @@ export class ResponseFormatter implements IResponseFormatter {
     private formatDetailedError(result: ToolExecutionResult, sessionInfo?: SessionInfo): MCPContentResponse {
         let errorText = "";
         
-        // Compact session ID notice when replaced
+        // Compact session handle notice when a duplicate readable name was adjusted.
         if (sessionInfo?.isNonStandardId && sessionInfo.originalSessionId) {
-            errorText += `[Session ID changed: Use "${sessionInfo.sessionId}" for all future requests]\n\n`;
+            errorText += `[Session name changed: "${sessionInfo.originalSessionId}" already exists. Use "${sessionInfo.displaySessionId || sessionInfo.originalSessionId}" for this chat moving forward]\n\n`;
         }
         
         errorText += `❌ Error: ${result.error}\n\n`;
@@ -86,13 +86,11 @@ export class ResponseFormatter implements IResponseFormatter {
     }
 
     private formatWithSessionInstructions(result: ToolExecutionResult, sessionInfo: SessionInfo): MCPContentResponse {
-        this.formatSessionInstructions(sessionInfo.sessionId, result);
-
         let responseText = "";
 
-        // Compact session ID notice when replaced
+        // Compact session handle notice when a duplicate readable name was adjusted.
         if (sessionInfo.originalSessionId) {
-            responseText += `[Session ID changed: Use "${sessionInfo.sessionId}" for all future requests]\n\n`;
+            responseText += `[Session name changed: "${sessionInfo.originalSessionId}" already exists. Use "${sessionInfo.displaySessionId || sessionInfo.originalSessionId}" for this chat moving forward]\n\n`;
         }
 
         responseText += safeStringify(result);

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -221,21 +221,31 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         let sessionInfo: SessionInfo;
         if (this.sessionContextManager && sessionId) {
             try {
-                const validationResult = await this.sessionContextManager.validateSessionId(sessionId);
-                const isNonStandardId = validationResult.id !== sessionId;
+                const validationResult = await this.sessionContextManager.validateSessionId(
+                    sessionId,
+                    typeof params.memory === 'string' ? params.memory : undefined,
+                    typeof params.workspaceId === 'string'
+                        ? params.workspaceId
+                        : params.context?.workspaceId
+                );
+                const isNonStandardId = validationResult.displaySessionIdChanged;
                 
                 sessionInfo = {
                     sessionId: validationResult.id,
                     isNewSession: validationResult.created,
                     isNonStandardId: isNonStandardId,
-                    originalSessionId: isNonStandardId ? sessionId : undefined
+                    originalSessionId: isNonStandardId ? sessionId : undefined,
+                    displaySessionId: validationResult.displaySessionId,
+                    displaySessionIdChanged: validationResult.displaySessionIdChanged
                 };
                 
                 // Update params with validated session ID (both locations for compatibility)
                 if (params.context) {
                     params.context.sessionId = validationResult.id;
+                    params.context.sessionName = validationResult.displaySessionId;
                 }
                 params.sessionId = validationResult.id;
+                params._displaySessionId = validationResult.displaySessionId;
             } catch (error) {
                 logger.systemWarn(`SessionContextManager validation failed: ${getErrorMessage(error)}. Falling back to SessionService`);
                 // Fallback to original SessionService if SessionContextManager fails
@@ -294,11 +304,11 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         );
         const enhancedParams = validatedParams as EnhancedToolParams;
 
-        // Session validation is now handled in buildRequestContext() to avoid duplication
-        // Session description updates: support both new format (goal) and legacy (sessionDescription)
-        // Note: In new format, 'goal' is the current objective. We update session description
-        // to keep track of what the session is working on.
-        const sessionGoal = enhancedParams.context?.goal || enhancedParams.context?.sessionDescription;
+        // Session validation is now handled in buildRequestContext() to avoid duplication.
+        // Keep the session *name* stable; only update the description with explicit
+        // long-lived session memory. The current goal changes every tool call and
+        // should not overwrite the human-readable session title.
+        const sessionGoal = enhancedParams.context?.sessionDescription;
         if (this.sessionContextManager &&
             enhancedParams.context?.sessionId &&
             sessionGoal) {

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -305,9 +305,16 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         const enhancedParams = validatedParams as EnhancedToolParams;
 
         // Session validation is now handled in buildRequestContext() to avoid duplication.
-        // Keep the session *name* stable; only update the description with explicit
-        // long-lived session memory. The current goal changes every tool call and
-        // should not overwrite the human-readable session title.
+        //
+        // BEHAVIOR CHANGE (B4): the session description is no longer derived from
+        // `context.goal`. Pre-B4 this branch read `context.goal || context.sessionDescription`;
+        // that conflated the per-call objective with the long-lived session label and
+        // caused the description to churn on every tool call. Under the B1/B4 contract
+        // `goal` is request-scoped (workspaceId/sessionId/memory/goal/constraints are
+        // top-level CLI fields) and is preserved on `params.context.goal` for
+        // downstream tooling — it just does not overwrite the persistent session
+        // description any more. Callers that previously sent only `goal` to update
+        // the description must now send `sessionDescription` explicitly.
         const sessionGoal = enhancedParams.context?.sessionDescription;
         if (this.sessionContextManager &&
             enhancedParams.context?.sessionId &&

--- a/src/server/execution/AgentExecutionManager.ts
+++ b/src/server/execution/AgentExecutionManager.ts
@@ -126,8 +126,14 @@ export class AgentExecutionManager {
 
         try {
             // Validate session ID - destructure the result to get the actual ID
-            const { id: validatedSessionId } = await this.sessionContextManager.validateSessionId(sessionId);
+            const validationResult = await this.sessionContextManager.validateSessionId(
+                sessionId,
+                typeof params.memory === 'string' ? params.memory : undefined,
+                typeof params.workspaceId === 'string' ? params.workspaceId : undefined
+            );
+            const validatedSessionId = validationResult.id;
             params.sessionId = validatedSessionId;
+            params._displaySessionId = validationResult.displaySessionId;
 
             // Apply workspace context
             params = this.sessionContextManager.applyWorkspaceContext(validatedSessionId, params);
@@ -183,13 +189,12 @@ export class AgentExecutionManager {
         if (params._isNonStandardId && originalSessionId) {
             resultObj.sessionIdCorrection = {
                 originalId: originalSessionId,
-                correctedId: sessionId,
-                message: "Your session ID has been standardized. Please use this corrected session ID for all future requests in this conversation."
+                correctedId: originalSessionId,
+                message: "Keep using the same human-readable session name for future requests in this conversation."
             };
         } else if (params._isNewSession && !originalSessionId) {
             resultObj.newSessionInfo = {
-                sessionId: sessionId,
-                message: "A new session has been created. This ID must be used for all future requests in this conversation."
+                message: "A new session has been created. Keep using the same human-readable session name for future requests in this conversation."
             };
         }
 
@@ -207,11 +212,9 @@ export class AgentExecutionManager {
             return result;
         }
 
-        result.newSessionId = params.sessionId;
         result.validSessionInfo = {
             originalId: null,
-            newId: params.sessionId,
-            message: "No session ID was provided. A new session has been created. Please use this session ID for future requests."
+            message: "No session name was provided. A new internal session has been created."
         };
 
         return result;

--- a/src/server/execution/AgentExecutionManager.ts
+++ b/src/server/execution/AgentExecutionManager.ts
@@ -187,6 +187,11 @@ export class AgentExecutionManager {
         // Add session instructions
         const originalSessionId = typeof params._originalSessionId === 'string' ? params._originalSessionId : undefined;
         if (params._isNonStandardId && originalSessionId) {
+            // correctedId mirrors the model-facing handle (originalSessionId), not the
+            // internal UUID. Under the B1 contract the friendly name is the stable
+            // model-facing id and the internal UUID stays hidden — so the model
+            // should keep emitting `originalSessionId` on every call. Returning the
+            // UUID here would defeat that and re-leak storage ids to the LLM.
             resultObj.sessionIdCorrection = {
                 originalId: originalSessionId,
                 correctedId: originalSessionId,

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -23,7 +23,10 @@ interface SessionServiceLike {
     id: string;
   }): Promise<unknown> | void;
   updateSession(sessionData: SessionData): Promise<unknown> | void;
+  registerOnSessionDeleted?(listener: SessionDeletedListener): () => void;
 }
+
+export type SessionDeletedListener = (sessionId: string, workspaceId: string) => void;
 
 export interface SessionValidationResult {
   id: string;
@@ -47,7 +50,17 @@ export class SessionContextManager {
   private sessionContextMap: Map<string, WorkspaceContext> = new Map();
 
   // Map of model-facing session handles to internal unique session IDs.
-  private sessionHandleMap: Map<string, { id: string; displaySessionId: string }> = new Map();
+  // Keyed by `${workspaceId}::${handle}` so the same friendly handle ("research")
+  // in different workspaces resolves to distinct internal sessions instead of
+  // aliasing — workspaces are UX scoping, and reusing names across them is
+  // expected. The map stores the originating workspaceId so eviction on session
+  // delete (registerOnSessionDeleted) can purge both the input handle entry and
+  // the display-name entry without scanning the whole map.
+  private sessionHandleMap: Map<string, { id: string; displaySessionId: string; workspaceId: string }> = new Map();
+
+  // Disposer for the session-deleted subscription so re-wiring or teardown can
+  // unregister cleanly.
+  private sessionDeletedUnsubscribe: (() => void) | null = null;
   
   // Default workspace context for new sessions (global)
   private defaultWorkspaceContext: WorkspaceContext | null = null;
@@ -60,7 +73,39 @@ export class SessionContextManager {
    * This is called during plugin initialization
    */
   setSessionService(sessionService: SessionServiceLike): void {
+    if (this.sessionDeletedUnsubscribe) {
+      this.sessionDeletedUnsubscribe();
+      this.sessionDeletedUnsubscribe = null;
+    }
     this.sessionService = sessionService;
+    if (sessionService.registerOnSessionDeleted) {
+      this.sessionDeletedUnsubscribe = sessionService.registerOnSessionDeleted(
+        (sessionId, workspaceId) => this.evictSessionHandles(sessionId, workspaceId)
+      );
+    }
+  }
+
+  /**
+   * Build the partition key used for sessionHandleMap lookups.
+   * Friendly handles are unique only within a workspace; the same string in two
+   * workspaces must map to two distinct sessions.
+   */
+  private handleKey(workspaceId: string, handle: string): string {
+    return `${workspaceId}::${handle}`;
+  }
+
+  /**
+   * Remove sessionHandleMap entries for a deleted session in a given workspace.
+   * Called from the session-deleted listener registered on SessionService.
+   */
+  evictSessionHandles(sessionId: string, workspaceId = 'default'): void {
+    for (const [key, entry] of this.sessionHandleMap.entries()) {
+      if (entry.id === sessionId && entry.workspaceId === workspaceId) {
+        this.sessionHandleMap.delete(key);
+      }
+    }
+    this.sessionContextMap.delete(sessionId);
+    this.instructedSessions.delete(sessionId);
   }
   
   /**
@@ -186,7 +231,21 @@ export class SessionContextManager {
   clearAll(): void {
     this.sessionContextMap.clear();
     this.sessionHandleMap.clear();
+    this.instructedSessions.clear();
     this.defaultWorkspaceContext = null;
+  }
+
+  /**
+   * ServiceContainer-detected cleanup hook. Runs on plugin teardown
+   * (ServiceContainer.clear) so the in-memory handle map and session-deleted
+   * subscription do not survive a plugin reload.
+   */
+  cleanup(): void {
+    if (this.sessionDeletedUnsubscribe) {
+      this.sessionDeletedUnsubscribe();
+      this.sessionDeletedUnsubscribe = null;
+    }
+    this.clearAll();
   }
   
   /**
@@ -227,7 +286,7 @@ export class SessionContextManager {
     
     // If the session ID doesn't match our standard format, it's a friendly name - create session
     if (!isStandardSessionId(sessionId)) {
-      const existingHandle = this.sessionHandleMap.get(sessionId);
+      const existingHandle = this.sessionHandleMap.get(this.handleKey(workspaceId, sessionId));
       if (existingHandle) {
         return {
           id: existingHandle.id,
@@ -239,8 +298,9 @@ export class SessionContextManager {
 
       const newId = generateSessionId();
       const displaySessionId = await this.createUniqueSessionDisplayName(sessionId, workspaceId);
-      this.sessionHandleMap.set(sessionId, { id: newId, displaySessionId });
-      this.sessionHandleMap.set(displaySessionId, { id: newId, displaySessionId });
+      const handleEntry = { id: newId, displaySessionId, workspaceId };
+      this.sessionHandleMap.set(this.handleKey(workspaceId, sessionId), handleEntry);
+      this.sessionHandleMap.set(this.handleKey(workspaceId, displaySessionId), handleEntry);
       await this.createAutoSession(newId, displaySessionId, sessionDescription, workspaceId);
       return {
         id: newId,
@@ -321,7 +381,11 @@ export class SessionContextManager {
   private async createUniqueSessionDisplayName(baseName: string, workspaceId: string): Promise<string> {
     const usedNames = new Set<string>();
     for (const entry of this.sessionHandleMap.values()) {
-      usedNames.add(entry.displaySessionId.toLowerCase());
+      // Only collide names within the same workspace — same handle in two
+      // workspaces is allowed (workspaces are UX scoping).
+      if (entry.workspaceId === workspaceId) {
+        usedNames.add(entry.displaySessionId.toLowerCase());
+      }
     }
 
     if (this.sessionService?.getAllSessions) {

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -15,6 +15,7 @@ export interface WorkspaceContext {
 
 interface SessionServiceLike {
   getSession(sessionId: string): Promise<SessionData | null> | SessionData | null;
+  getAllSessions?(workspaceId?: string): Promise<SessionData[]> | SessionData[];
   createSession(sessionData: {
     name: string;
     description: string;
@@ -22,6 +23,13 @@ interface SessionServiceLike {
     id: string;
   }): Promise<unknown> | void;
   updateSession(sessionData: SessionData): Promise<unknown> | void;
+}
+
+export interface SessionValidationResult {
+  id: string;
+  created: boolean;
+  displaySessionId: string;
+  displaySessionIdChanged: boolean;
 }
 
 /**
@@ -37,6 +45,9 @@ export class SessionContextManager {
   
   // Map of sessionId -> workspace context
   private sessionContextMap: Map<string, WorkspaceContext> = new Map();
+
+  // Map of model-facing session handles to internal unique session IDs.
+  private sessionHandleMap: Map<string, { id: string; displaySessionId: string }> = new Map();
   
   // Default workspace context for new sessions (global)
   private defaultWorkspaceContext: WorkspaceContext | null = null;
@@ -174,6 +185,7 @@ export class SessionContextManager {
    */
   clearAll(): void {
     this.sessionContextMap.clear();
+    this.sessionHandleMap.clear();
     this.defaultWorkspaceContext = null;
   }
   
@@ -194,21 +206,48 @@ export class SessionContextManager {
    * @param sessionDescription Optional session description for auto-creation
    * @returns Object with validated session ID and creation status
    */
-  async validateSessionId(sessionId: string, sessionDescription?: string): Promise<{id: string, created: boolean}> {
+  async validateSessionId(
+    sessionId: string,
+    sessionDescription?: string,
+    workspaceId = 'default'
+  ): Promise<SessionValidationResult> {
     
     // If no session ID is provided, generate a new one in our standard format
     if (!sessionId) {
       logger.systemWarn('Empty sessionId provided for validation, generating a new one');
       const newId = generateSessionId();
       await this.createAutoSession(newId, 'Default Session', sessionDescription);
-      return {id: newId, created: true};
+      return {
+        id: newId,
+        created: true,
+        displaySessionId: 'Default Session',
+        displaySessionIdChanged: true
+      };
     }
     
     // If the session ID doesn't match our standard format, it's a friendly name - create session
     if (!isStandardSessionId(sessionId)) {
+      const existingHandle = this.sessionHandleMap.get(sessionId);
+      if (existingHandle) {
+        return {
+          id: existingHandle.id,
+          created: false,
+          displaySessionId: existingHandle.displaySessionId,
+          displaySessionIdChanged: existingHandle.displaySessionId !== sessionId
+        };
+      }
+
       const newId = generateSessionId();
-      await this.createAutoSession(newId, sessionId, sessionDescription);
-      return {id: newId, created: true};
+      const displaySessionId = await this.createUniqueSessionDisplayName(sessionId, workspaceId);
+      this.sessionHandleMap.set(sessionId, { id: newId, displaySessionId });
+      this.sessionHandleMap.set(displaySessionId, { id: newId, displaySessionId });
+      await this.createAutoSession(newId, displaySessionId, sessionDescription, workspaceId);
+      return {
+        id: newId,
+        created: true,
+        displaySessionId,
+        displaySessionIdChanged: displaySessionId !== sessionId
+      };
     }
     
     // Session ID is in standard format - check if it exists in our context map first
@@ -216,7 +255,7 @@ export class SessionContextManager {
     // it means the session was already bound - no need to check database
     if (this.sessionContextMap.has(sessionId)) {
       logger.systemLog(`Session ${sessionId} found in context map - already bound to workspace`);
-      return {id: sessionId, created: false};
+      return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
     }
 
     // Check database if not in context map
@@ -228,15 +267,15 @@ export class SessionContextManager {
     try {
       const existingSession = await this.sessionService.getSession(sessionId);
       if (existingSession) {
-        return {id: sessionId, created: false};
+        return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
       } else {
         await this.createAutoSession(sessionId, `Session ${sessionId}`, sessionDescription);
-        return {id: sessionId, created: true};
+        return {id: sessionId, created: true, displaySessionId: sessionId, displaySessionIdChanged: false};
       }
     } catch (error) {
       logger.systemWarn(`Error checking session existence: ${error instanceof Error ? error.message : String(error)}`);
       // Fallback to returning the session ID without verification
-      return {id: sessionId, created: false};
+      return {id: sessionId, created: false, displaySessionId: sessionId, displaySessionIdChanged: false};
     }
   }
 
@@ -247,10 +286,15 @@ export class SessionContextManager {
    * @param sessionName Friendly name provided by LLM
    * @param sessionDescription Optional session description
    */
-  private async createAutoSession(sessionId: string, sessionName: string, sessionDescription?: string): Promise<void> {
+  private async createAutoSession(
+    sessionId: string,
+    sessionName: string,
+    sessionDescription?: string,
+    explicitWorkspaceId?: string
+  ): Promise<void> {
     // ✅ CRITICAL FIX: Use workspace from sessionContextMap if available
     const context = this.sessionContextMap.get(sessionId);
-    const workspaceId = context?.workspaceId || 'default';
+    const workspaceId = explicitWorkspaceId || context?.workspaceId || 'default';
 
     logger.systemLog(`Auto-created session: ${sessionId} with name "${sessionName}", workspace "${workspaceId}", and description "${sessionDescription || 'No description'}"`);
 
@@ -272,6 +316,37 @@ export class SessionContextManager {
     } else {
       logger.systemWarn(`SessionService not available - session ${sessionId} not saved to database`);
     }
+  }
+
+  private async createUniqueSessionDisplayName(baseName: string, workspaceId: string): Promise<string> {
+    const usedNames = new Set<string>();
+    for (const entry of this.sessionHandleMap.values()) {
+      usedNames.add(entry.displaySessionId.toLowerCase());
+    }
+
+    if (this.sessionService?.getAllSessions) {
+      try {
+        const sessions = await this.sessionService.getAllSessions(workspaceId);
+        for (const session of sessions) {
+          if (session.name) {
+            usedNames.add(session.name.toLowerCase());
+          }
+        }
+      } catch {
+        // Best effort only; storage-level uniqueness is not required for the
+        // internal ID, but unique display handles prevent ambiguous future use.
+      }
+    }
+
+    const normalizedBaseName = baseName.trim() || 'Session';
+    let candidate = normalizedBaseName;
+    let suffix = 2;
+    while (usedNames.has(candidate.toLowerCase())) {
+      candidate = `${normalizedBaseName}-${suffix}`;
+      suffix += 1;
+    }
+
+    return candidate;
   }
   
   /**

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -34,11 +34,14 @@ export class SessionService {
     // Use provided ID if available, otherwise generate one
     const id = ('id' in sessionData && sessionData.id) ? sessionData.id : this.generateSessionId();
     const workspaceId = sessionData.workspaceId || 'default';
+    const existingSession = this.sessions.get(id);
 
     const session: SessionData = {
+      ...existingSession,
       ...sessionData,
       id,
-      workspaceId
+      workspaceId,
+      name: existingSession?.name || sessionData.name
     };
 
     // Store in memory cache

--- a/src/services/session/SessionService.ts
+++ b/src/services/session/SessionService.ts
@@ -18,13 +18,30 @@ export interface IMemoryService {
 }
 
 /**
+ * Listener fired after a session is deleted. Receives the deleted sessionId
+ * and the workspace it was scoped to. Used by SessionContextManager to evict
+ * cached friendly-handle entries.
+ */
+export type SessionDeletedListener = (sessionId: string, workspaceId: string) => void;
+
+/**
  * Session management service that delegates to MemoryService/WorkspaceService
  * Provides session tracking across workspaces with proper persistence
  */
 export class SessionService {
   private sessions = new Map<string, SessionData>();
+  private sessionDeletedListeners = new Set<SessionDeletedListener>();
 
   constructor(private memoryService: IMemoryService) {
+  }
+
+  /**
+   * Register a callback to be notified after a session is deleted.
+   * Returns an unsubscribe function.
+   */
+  registerOnSessionDeleted(listener: SessionDeletedListener): () => void {
+    this.sessionDeletedListeners.add(listener);
+    return () => this.sessionDeletedListeners.delete(listener);
   }
 
   /**
@@ -151,6 +168,16 @@ export class SessionService {
       await this.memoryService.deleteSession(workspaceId, sessionId);
     } catch (error) {
       console.error(`[SessionService] Failed to delete session ${sessionId}:`, error);
+    }
+
+    // Notify listeners (e.g. SessionContextManager) so friendly-handle caches
+    // do not retain stale references to the deleted session.
+    for (const listener of this.sessionDeletedListeners) {
+      try {
+        listener(sessionId, workspaceId);
+      } catch (error) {
+        console.error('[SessionService] sessionDeleted listener threw:', error);
+      }
     }
   }
   

--- a/src/services/trace/ToolCallTraceService.ts
+++ b/src/services/trace/ToolCallTraceService.ts
@@ -10,6 +10,7 @@ import { WorkspaceService } from '../WorkspaceService';
 import { TraceMetadataBuilder } from '../memory/TraceMetadataBuilder';
 import { TraceContextMetadata, TraceOutcomeMetadata } from '../../database/workspace-types';
 import { formatTraceContent } from './TraceContentFormatter';
+import { splitTopLevelSegments, tokenizeWithMeta } from '../../agents/toolManager/services/ToolCliNormalizer';
 
 type ToolCallParams = unknown;
 type ToolCallResponse = unknown;
@@ -79,16 +80,12 @@ export class ToolCallTraceService {
         return;
       }
 
-      // 3. Get workspace context from SessionContextManager
-      const workspaceContext = this.sessionContextManager.getWorkspaceContext(sessionId);
-      const workspaceId = workspaceContext?.workspaceId ||
-                         getString(isRecord(paramsRecord.workspaceContext) ? paramsRecord.workspaceContext.workspaceId : undefined) ||
-                         getString(isRecord(paramsRecord.context) ? paramsRecord.context.workspaceId : undefined) ||
-                         'default';
-
+      // 3. Resolve workspace context from the session or explicit tool envelope
+      const workspaceId = await this.resolveWorkspaceId(paramsRecord, sessionId);
       if (!workspaceId) {
         return;
       }
+      this.sessionContextManager.setWorkspaceContext(sessionId, { workspaceId });
 
       // 4. Build trace content (human-readable description)
       const traceContent = formatTraceContent({ agent, mode, params: paramsRecord, success });
@@ -162,6 +159,56 @@ export class ToolCallTraceService {
     return null;
   }
 
+  private async resolveWorkspaceId(params: ToolCallParams, sessionId: string): Promise<string | null> {
+    const paramsRecord = asRecord(params);
+    const workspaceContext = this.sessionContextManager.getWorkspaceContext(sessionId);
+    const explicitCandidate =
+      getString(paramsRecord.workspaceId) ||
+      getString(isRecord(paramsRecord.workspaceContext) ? paramsRecord.workspaceContext.workspaceId : undefined) ||
+      getString(isRecord(paramsRecord.context) ? paramsRecord.context.workspaceId : undefined);
+    const commandWorkspaceCandidate = this.extractWorkspaceHandleFromUseTools(paramsRecord);
+    const candidate =
+      (explicitCandidate && explicitCandidate !== 'default' ? explicitCandidate : undefined) ||
+      commandWorkspaceCandidate ||
+      explicitCandidate ||
+      workspaceContext?.workspaceId ||
+      'default';
+
+    if (!candidate) {
+      return null;
+    }
+
+    try {
+      const workspace = await this.workspaceService.getWorkspaceByNameOrId(candidate);
+      return workspace?.id || candidate;
+    } catch {
+      return candidate;
+    }
+  }
+
+  private extractWorkspaceHandleFromUseTools(params: Record<string, unknown>): string | undefined {
+    const toolString = getString(params.tool);
+    if (!toolString) {
+      return undefined;
+    }
+
+    for (const segment of splitTopLevelSegments(toolString)) {
+      const tokens = tokenizeWithMeta(segment);
+      if (tokens.length < 3) {
+        continue;
+      }
+
+      const agent = tokens[0].value.replace(/[-_\s]/g, '').toLowerCase();
+      const tool = tokens[1].value.replace(/[-_\s]/g, '').toLowerCase();
+      if ((agent === 'memory' || agent === 'memorymanager') &&
+          (tool === 'loadworkspace' || tool === 'createworkspace')) {
+        return tokens[2].value;
+      }
+    }
+
+    return undefined;
+  }
+
   private buildCanonicalMetadata(options: {
     toolName: string;
     agent: string;
@@ -215,9 +262,14 @@ export class ToolCallTraceService {
     return {
       workspaceId,
       sessionId,
-      memory: getString(contextSource.memory) || '',
-      goal: getString(contextSource.goal) || '',
-      constraints: getString(contextSource.constraints)
+      memory: getString(contextSource.memory) || getString(paramsRecord.memory) || '',
+      goal: getString(contextSource.goal) || getString(paramsRecord.goal) || '',
+      sessionName:
+        getString(contextSource.sessionName) ||
+        getString(contextSource.displaySessionId) ||
+        getString(paramsRecord.sessionName) ||
+        getString(paramsRecord._displaySessionId),
+      constraints: getString(contextSource.constraints) || getString(paramsRecord.constraints)
     };
   }
 
@@ -229,6 +281,7 @@ export class ToolCallTraceService {
     const sanitized = { ...params };
     delete sanitized.context;
     delete sanitized.workspaceContext;
+    delete sanitized._displaySessionId;
     return Object.keys(sanitized).length > 0 ? sanitized : undefined;
   }
 

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-04-28T20:13:47.630Z
+ * Generated: 2026-04-29T12:26:13.167Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/helpers/mockFactories.ts
+++ b/tests/helpers/mockFactories.ts
@@ -46,6 +46,7 @@ interface MockStorageAdapter {
   getSession: MockFn<[], Promise<unknown>>;
   getSessions: MockFn<[], Promise<Record<string, unknown>>>;
   updateSession: MockFn;
+  moveSessionToWorkspace?: MockFn;
   deleteSession: MockFn;
   addTrace: MockFn<[], Promise<string>>;
   getTraces: MockFn<[], Promise<Record<string, unknown>>>;
@@ -168,6 +169,7 @@ export function createMockAdapter(ready: boolean): MockStorageAdapter {
     getSession: jest.fn().mockResolvedValue(null),
     getSessions: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
     updateSession: jest.fn(),
+    moveSessionToWorkspace: jest.fn(),
     deleteSession: jest.fn(),
     addTrace: jest.fn().mockResolvedValue('trace-new'),
     getTraces: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),

--- a/tests/unit/AgentExecutionManager.processResponse.test.ts
+++ b/tests/unit/AgentExecutionManager.processResponse.test.ts
@@ -1,6 +1,7 @@
 /**
  * AgentExecutionManager — coverage of the user-visible message + correctedId
- * semantic introduced in commit b90ce865 (B4 of review/workspace-memory-batch).
+ * semantic introduced in commit b90ce865 and pinned by 4f07aaf1
+ * (B4 of review/workspace-memory-batch).
  *
  * Surface tested: `executeAgentTool` end-to-end, focusing on
  * `addSessionInstructions` (private). The flow:
@@ -9,17 +10,11 @@
  *   3. The agent returns a CommonResult; AEM enriches it with
  *      `sessionIdCorrection: { originalId, correctedId, message }`.
  *
- * Pre-b90ce865, `correctedId` was the standardized internal session ID.
- * Post-b90ce865, `correctedId === originalSessionId` (the human-readable
- * handle the model originally sent). External consumers that read
- * `sessionIdCorrection.correctedId` to update their session pointer
- * will get the friendly handle, not the internal UUID.
- *
- * NOTE: this test asserts the **current post-b90ce865 behavior**.
- * If the coder reverts that semantic flip ("revert" decision), the
- * assertion in the first test below should change to assert
- * `correctedId === <internal validated id>` instead of `originalHandle`.
- * TODO: confirm with coder decision (flip|revert) before merge.
+ * Contract (locked in by 4f07aaf1): correctedId === originalSessionId —
+ * the human-readable handle the model sent, NOT the internal UUID.
+ * The internal UUID stays hidden from the model. External consumers
+ * that read sessionIdCorrection.correctedId to update their session
+ * pointer keep using the friendly handle.
  */
 
 import { AgentExecutionManager } from '../../src/server/execution/AgentExecutionManager';
@@ -65,7 +60,7 @@ function makeRegistry(agent: IAgent): AgentRegistry {
 }
 
 describe('AgentExecutionManager.executeAgentTool — sessionIdCorrection semantic', () => {
-  it('sets correctedId to the original human-readable handle (post-b90ce865) and surfaces the new message', async () => {
+  it('sets correctedId to the original human-readable handle and surfaces the keep-using-handle message', async () => {
     const agent = makeAgent('runStub', () => ({
       success: true,
       data: { ok: true },
@@ -107,10 +102,12 @@ describe('AgentExecutionManager.executeAgentTool — sessionIdCorrection semanti
     expect(result.sessionIdCorrection).toBeDefined();
     expect(result.sessionIdCorrection!.originalId).toBe('planning chat');
 
-    // Current b90ce865 semantic: correctedId === originalSessionId (the friendly handle).
+    // Contract (4f07aaf1): correctedId mirrors originalSessionId — the friendly
+    // handle the model sent. The internal UUID 's-internal-uuid' must NOT leak.
     expect(result.sessionIdCorrection!.correctedId).toBe('planning chat');
+    expect(result.sessionIdCorrection!.correctedId).not.toBe('s-internal-uuid');
 
-    // New user-facing message guides the model to keep using the friendly name.
+    // User-facing message guides the model to keep using the friendly handle.
     expect(result.sessionIdCorrection!.message).toMatch(/human-readable session name/i);
     expect(result.sessionIdCorrection!.message).not.toMatch(/standardized/i);
   });

--- a/tests/unit/AgentExecutionManager.processResponse.test.ts
+++ b/tests/unit/AgentExecutionManager.processResponse.test.ts
@@ -1,0 +1,175 @@
+/**
+ * AgentExecutionManager — coverage of the user-visible message + correctedId
+ * semantic introduced in commit b90ce865 (B4 of review/workspace-memory-batch).
+ *
+ * Surface tested: `executeAgentTool` end-to-end, focusing on
+ * `addSessionInstructions` (private). The flow:
+ *   1. params._isNonStandardId === true and params._originalSessionId is set.
+ *   2. SessionContextManager has not yet recorded instructions for this session.
+ *   3. The agent returns a CommonResult; AEM enriches it with
+ *      `sessionIdCorrection: { originalId, correctedId, message }`.
+ *
+ * Pre-b90ce865, `correctedId` was the standardized internal session ID.
+ * Post-b90ce865, `correctedId === originalSessionId` (the human-readable
+ * handle the model originally sent). External consumers that read
+ * `sessionIdCorrection.correctedId` to update their session pointer
+ * will get the friendly handle, not the internal UUID.
+ *
+ * NOTE: this test asserts the **current post-b90ce865 behavior**.
+ * If the coder reverts that semantic flip ("revert" decision), the
+ * assertion in the first test below should change to assert
+ * `correctedId === <internal validated id>` instead of `originalHandle`.
+ * TODO: confirm with coder decision (flip|revert) before merge.
+ */
+
+import { AgentExecutionManager } from '../../src/server/execution/AgentExecutionManager';
+import { AgentRegistry } from '../../src/server/services/AgentRegistry';
+import { SessionContextManager } from '../../src/services/SessionContextManager';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+
+function makeAgent(toolSlug: string, executeReturnFactory: () => unknown): IAgent {
+  const tool = {
+    slug: toolSlug,
+    name: 'Stub tool',
+    description: '',
+    version: '1.0.0',
+    execute: jest.fn(async () => executeReturnFactory()),
+    getParameterSchema: jest.fn(),
+    getResultSchema: jest.fn()
+  } as unknown as ITool;
+
+  return {
+    name: 'stubAgent',
+    description: 'stub',
+    version: '1.0.0',
+    getTools: () => [tool],
+    getTool: (slug: string) => (slug === toolSlug ? tool : undefined),
+    initialize: jest.fn().mockResolvedValue(undefined),
+    executeTool: jest.fn(async (slug: string) => {
+      if (slug !== toolSlug) {
+        throw new Error(`unknown tool ${slug}`);
+      }
+      return executeReturnFactory();
+    }),
+    setAgentManager: jest.fn()
+  };
+}
+
+function makeRegistry(agent: IAgent): AgentRegistry {
+  const registry = new AgentRegistry();
+  // The registry exposes registerAgent in src; relying on the public method
+  // keeps this test resilient to internal map shape changes.
+  (registry as unknown as { registerAgent: (a: IAgent) => void }).registerAgent(agent);
+  return registry;
+}
+
+describe('AgentExecutionManager.executeAgentTool — sessionIdCorrection semantic', () => {
+  it('sets correctedId to the original human-readable handle (post-b90ce865) and surfaces the new message', async () => {
+    const agent = makeAgent('runStub', () => ({
+      success: true,
+      data: { ok: true },
+      workspaceContext: { workspaceId: 'default' }
+    }));
+    const registry = makeRegistry(agent);
+    const sessionContextManager = new SessionContextManager();
+
+    // The instructions-injection path is gated by hasReceivedInstructions
+    // returning false; force that without exercising the rest of the
+    // SessionContextManager state machine.
+    sessionContextManager.hasReceivedInstructions = jest.fn().mockReturnValue(false);
+    sessionContextManager.markInstructionsReceived = jest.fn();
+
+    // processSessionContext also calls validateSessionId; stub it to
+    // pass through so addSessionInstructions sees the params we pass in.
+    sessionContextManager.validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'planning chat-2',
+      displaySessionIdChanged: true
+    });
+    sessionContextManager.applyWorkspaceContext = jest.fn((_id, p) => p);
+    sessionContextManager.updateFromResult = jest.fn();
+
+    const aem = new AgentExecutionManager(registry, sessionContextManager);
+
+    const params: Record<string, unknown> = {
+      sessionId: 's-internal-uuid',
+      _isNonStandardId: true,
+      _originalSessionId: 'planning chat',
+      memory: 'short memory'
+    };
+
+    const result = await aem.executeAgentTool('stubAgent', 'runStub', params) as {
+      sessionIdCorrection?: { originalId: string; correctedId: string; message: string };
+    };
+
+    expect(result.sessionIdCorrection).toBeDefined();
+    expect(result.sessionIdCorrection!.originalId).toBe('planning chat');
+
+    // Current b90ce865 semantic: correctedId === originalSessionId (the friendly handle).
+    expect(result.sessionIdCorrection!.correctedId).toBe('planning chat');
+
+    // New user-facing message guides the model to keep using the friendly name.
+    expect(result.sessionIdCorrection!.message).toMatch(/human-readable session name/i);
+    expect(result.sessionIdCorrection!.message).not.toMatch(/standardized/i);
+  });
+
+  it('does NOT add sessionIdCorrection when isNonStandardId is false', async () => {
+    const agent = makeAgent('runStub', () => ({ success: true, data: { ok: true } }));
+    const registry = makeRegistry(agent);
+    const sessionContextManager = new SessionContextManager();
+    sessionContextManager.hasReceivedInstructions = jest.fn().mockReturnValue(false);
+    sessionContextManager.markInstructionsReceived = jest.fn();
+    sessionContextManager.validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'standard handle',
+      displaySessionIdChanged: false
+    });
+    sessionContextManager.applyWorkspaceContext = jest.fn((_id, p) => p);
+    sessionContextManager.updateFromResult = jest.fn();
+
+    const aem = new AgentExecutionManager(registry, sessionContextManager);
+
+    const result = await aem.executeAgentTool('stubAgent', 'runStub', {
+      sessionId: 's-internal-uuid'
+    }) as Record<string, unknown>;
+
+    expect(result.sessionIdCorrection).toBeUndefined();
+  });
+
+  it('does NOT re-emit sessionIdCorrection on a follow-up call once instructions have been received', async () => {
+    const agent = makeAgent('runStub', () => ({ success: true, data: { ok: true } }));
+    const registry = makeRegistry(agent);
+    const sessionContextManager = new SessionContextManager();
+
+    // First call: not yet received → emit. Second call: already received → silent.
+    sessionContextManager.hasReceivedInstructions = jest.fn()
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    sessionContextManager.markInstructionsReceived = jest.fn();
+    sessionContextManager.validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'planning chat-2',
+      displaySessionIdChanged: true
+    });
+    sessionContextManager.applyWorkspaceContext = jest.fn((_id, p) => p);
+    sessionContextManager.updateFromResult = jest.fn();
+
+    const aem = new AgentExecutionManager(registry, sessionContextManager);
+
+    const baseParams: Record<string, unknown> = {
+      sessionId: 's-internal-uuid',
+      _isNonStandardId: true,
+      _originalSessionId: 'planning chat'
+    };
+
+    const first = await aem.executeAgentTool('stubAgent', 'runStub', { ...baseParams }) as Record<string, unknown>;
+    const second = await aem.executeAgentTool('stubAgent', 'runStub', { ...baseParams }) as Record<string, unknown>;
+
+    expect(first.sessionIdCorrection).toBeDefined();
+    expect(second.sessionIdCorrection).toBeUndefined();
+  });
+});

--- a/tests/unit/ResponseFormatter.test.ts
+++ b/tests/unit/ResponseFormatter.test.ts
@@ -1,0 +1,131 @@
+/**
+ * ResponseFormatter — coverage of the user-visible "Session name changed"
+ * prose surfaced when a friendly session handle had to be suffixed to
+ * keep it unique within a workspace (B4 of review/workspace-memory-batch).
+ *
+ * The string is embedded in the MCP response body and is the only
+ * channel through which the user discovers the renamed handle, so a
+ * regression that drops the prose, renders `undefined`, or stops
+ * gating it behind the right flag is user-visible immediately.
+ */
+
+import { ResponseFormatter } from '../../src/handlers/services/ResponseFormatter';
+import type { SessionInfo, ToolExecutionResult } from '../../src/handlers/interfaces/IRequestHandlerServices';
+
+function getResponseText(response: { content: Array<{ text: string }> }): string {
+  return response.content.map((c) => c.text).join('');
+}
+
+describe('ResponseFormatter — Session name changed prose', () => {
+  let formatter: ResponseFormatter;
+
+  beforeEach(() => {
+    formatter = new ResponseFormatter();
+  });
+
+  describe('success path (formatWithSessionInstructions)', () => {
+    it('emits the prose when isNonStandardId is true and a displaySessionId differs from originalSessionId', () => {
+      const result: ToolExecutionResult = { success: true, data: { value: 1 } };
+      const sessionInfo: SessionInfo = {
+        sessionId: 's-internal-1',
+        isNewSession: false,
+        isNonStandardId: true,
+        originalSessionId: 'planning chat',
+        displaySessionId: 'planning chat-2',
+        displaySessionIdChanged: true
+      };
+
+      const response = formatter.formatToolExecutionResponse(result, sessionInfo);
+      const text = getResponseText(response);
+
+      expect(text).toContain('Session name changed');
+      expect(text).toContain('"planning chat"');
+      expect(text).toContain('"planning chat-2"');
+      expect(text).toContain('already exists');
+    });
+
+    it('does NOT emit the prose when isNonStandardId is false (handle was unique)', () => {
+      const result: ToolExecutionResult = { success: true, data: { value: 1 } };
+      const sessionInfo: SessionInfo = {
+        sessionId: 's-internal-1',
+        isNewSession: false,
+        isNonStandardId: false,
+        displaySessionId: 'planning chat',
+        displaySessionIdChanged: false
+      };
+
+      const response = formatter.formatToolExecutionResponse(result, sessionInfo);
+      const text = getResponseText(response);
+
+      expect(text).not.toContain('Session name changed');
+    });
+
+    it('falls back to originalSessionId when displaySessionId is missing rather than rendering undefined', () => {
+      const result: ToolExecutionResult = { success: true, data: {} };
+      const sessionInfo: SessionInfo = {
+        sessionId: 's-internal-1',
+        isNewSession: true,
+        isNonStandardId: true,
+        originalSessionId: 'orphan handle',
+        displaySessionIdChanged: true
+      };
+
+      const response = formatter.formatToolExecutionResponse(result, sessionInfo);
+      const text = getResponseText(response);
+
+      expect(text).toContain('Session name changed');
+      expect(text).toContain('"orphan handle"');
+      expect(text).not.toContain('undefined');
+    });
+
+    it('omits the prose when there is no sessionInfo at all', () => {
+      const result: ToolExecutionResult = { success: true, data: {} };
+      const response = formatter.formatToolExecutionResponse(result);
+      const text = getResponseText(response);
+
+      expect(text).not.toContain('Session name changed');
+    });
+  });
+
+  describe('error path (formatDetailedError)', () => {
+    it('prepends the prose to the error body when isNonStandardId + originalSessionId are set', () => {
+      const result: ToolExecutionResult = {
+        success: false,
+        error: 'Tool execution failed: invalid path'
+      };
+      const sessionInfo: SessionInfo = {
+        sessionId: 's-internal-2',
+        isNewSession: false,
+        isNonStandardId: true,
+        originalSessionId: 'debug chat',
+        displaySessionId: 'debug chat-3',
+        displaySessionIdChanged: true
+      };
+
+      const response = formatter.formatToolExecutionResponse(result, sessionInfo);
+      const text = getResponseText(response);
+
+      const noticeIndex = text.indexOf('Session name changed');
+      const errorIndex = text.indexOf('Tool execution failed');
+      expect(noticeIndex).toBeGreaterThanOrEqual(0);
+      expect(errorIndex).toBeGreaterThan(noticeIndex);
+      expect(text).toContain('"debug chat"');
+      expect(text).toContain('"debug chat-3"');
+    });
+
+    it('omits the prose on errors when originalSessionId is absent', () => {
+      const result: ToolExecutionResult = { success: false, error: 'boom' };
+      const sessionInfo: SessionInfo = {
+        sessionId: 's-internal-3',
+        isNewSession: false,
+        isNonStandardId: true
+      };
+
+      const response = formatter.formatToolExecutionResponse(result, sessionInfo);
+      const text = getResponseText(response);
+
+      expect(text).not.toContain('Session name changed');
+      expect(text).toContain('boom');
+    });
+  });
+});

--- a/tests/unit/SessionContextManager.test.ts
+++ b/tests/unit/SessionContextManager.test.ts
@@ -1,0 +1,68 @@
+import { SessionContextManager } from '../../src/services/SessionContextManager';
+
+describe('SessionContextManager', () => {
+  it('keeps a friendly session handle model-facing while storing an internal ID', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = {
+      getSession: jest.fn().mockResolvedValue(null),
+      getAllSessions: jest.fn().mockResolvedValue([]),
+      createSession: jest.fn(),
+      updateSession: jest.fn()
+    };
+    manager.setSessionService(sessionService);
+
+    const result = await manager.validateSessionId('workspace setup', 'Testing session handles', 'default');
+
+    expect(result.id).toMatch(/^s-/);
+    expect(result.displaySessionId).toBe('workspace setup');
+    expect(result.displaySessionIdChanged).toBe(false);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: result.id,
+        name: 'workspace setup',
+        description: 'Testing session handles',
+        workspaceId: 'default'
+      })
+    );
+
+    await expect(manager.validateSessionId('workspace setup', undefined, 'default')).resolves.toEqual(
+      expect.objectContaining({
+        id: result.id,
+        created: false,
+        displaySessionId: 'workspace setup',
+        displaySessionIdChanged: false
+      })
+    );
+  });
+
+  it('suffixes duplicate friendly session handles and reports the display handle', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = {
+      getSession: jest.fn().mockResolvedValue(null),
+      getAllSessions: jest.fn().mockResolvedValue([
+        { id: 's-existing', workspaceId: 'default', name: 'session' }
+      ]),
+      createSession: jest.fn(),
+      updateSession: jest.fn()
+    };
+    manager.setSessionService(sessionService);
+
+    const result = await manager.validateSessionId('session', undefined, 'default');
+
+    expect(result.displaySessionId).toBe('session-2');
+    expect(result.displaySessionIdChanged).toBe(true);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'session-2'
+      })
+    );
+
+    await expect(manager.validateSessionId('session-2', undefined, 'default')).resolves.toEqual(
+      expect.objectContaining({
+        id: result.id,
+        created: false,
+        displaySessionId: 'session-2'
+      })
+    );
+  });
+});

--- a/tests/unit/SessionRepository.moveToWorkspace.test.ts
+++ b/tests/unit/SessionRepository.moveToWorkspace.test.ts
@@ -1,0 +1,242 @@
+/**
+ * SessionRepository.moveToWorkspace — direct unit coverage of the
+ * load-bearing dual-write + 4-table SQLite cascade introduced in
+ * commit 799ed540 (B1 of review/workspace-memory-batch).
+ *
+ * Project pinned norm prefers real DB over mocks. The repository layer
+ * runs on top of `SQLiteCacheManager`, which is a sql.js WASM bridge —
+ * a real-DB harness would require WASM init and is not currently set
+ * up in jest. Existing repository tests (WorkspaceRepository,
+ * TaskRepository, ProjectRepository) all use the mocked
+ * RepositoryDependencies pattern; this test follows that convention.
+ *
+ * The test is structured to make cascade regressions visible: it
+ * pins the exact SQL fragments + the JSONL event order so that
+ * dropping a table from the cascade or reversing the dual-write
+ * fails loudly here rather than silently leaving traces in the
+ * wrong workspace.
+ */
+
+import { SessionRepository } from '../../src/database/repositories/SessionRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+
+interface MockSqliteCache {
+  queryOne: jest.Mock;
+  query: jest.Mock;
+  run: jest.Mock;
+  transaction: jest.Mock;
+}
+
+interface MockJsonlWriter {
+  appendEvent: jest.Mock;
+}
+
+interface MockQueryCache {
+  cachedQuery: jest.Mock;
+  invalidateByType: jest.Mock;
+  invalidateById: jest.Mock;
+  invalidate: jest.Mock;
+}
+
+interface MockDeps {
+  sqliteCache: MockSqliteCache;
+  jsonlWriter: MockJsonlWriter;
+  queryCache: MockQueryCache;
+}
+
+function createMockDeps(): MockDeps {
+  return {
+    sqliteCache: {
+      queryOne: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      run: jest.fn().mockResolvedValue(undefined),
+      transaction: jest.fn(async (fn: () => Promise<unknown>) => fn())
+    },
+    jsonlWriter: {
+      appendEvent: jest.fn().mockImplementation(async (_path: string, event: Record<string, unknown>) => ({
+        id: 'evt-mock',
+        timestamp: 1,
+        deviceId: 'dev-1',
+        ...event
+      }))
+    },
+    queryCache: {
+      cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+      invalidateByType: jest.fn(),
+      invalidateById: jest.fn(),
+      invalidate: jest.fn()
+    }
+  };
+}
+
+const SOURCE_WORKSPACE = 'ws-source';
+const TARGET_WORKSPACE = 'ws-target';
+const SESSION_ID = 'session-abc';
+
+const SESSION_ROW = {
+  id: SESSION_ID,
+  workspaceId: SOURCE_WORKSPACE,
+  name: 'Working session',
+  description: 'Original description',
+  startTime: 1700000000,
+  endTime: null,
+  isActive: 1
+};
+
+describe('SessionRepository.moveToWorkspace', () => {
+  let deps: MockDeps;
+  let repo: SessionRepository;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    repo = new SessionRepository(deps as unknown as RepositoryDependencies);
+  });
+
+  it('cascades the SQLite update across all four workspace-scoped tables', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    const runCalls = deps.sqliteCache.run.mock.calls;
+    expect(runCalls).toHaveLength(4);
+
+    const tablesUpdated = runCalls.map(([sql]: [string]) => {
+      const match = /UPDATE\s+(\w+)\s+SET/i.exec(sql);
+      return match ? match[1] : null;
+    });
+
+    expect(tablesUpdated).toEqual([
+      'sessions',
+      'states',
+      'memory_traces',
+      'trace_embedding_metadata'
+    ]);
+
+    for (const [, params] of runCalls) {
+      expect(params).toEqual([TARGET_WORKSPACE, SESSION_ID]);
+    }
+
+    const sessionsUpdate = runCalls[0][0] as string;
+    expect(sessionsUpdate).toMatch(/WHERE\s+id\s*=\s*\?/i);
+    for (const cascadeSql of runCalls.slice(1).map((c: [string]) => c[0])) {
+      expect(cascadeSql).toMatch(/WHERE\s+sessionId\s*=\s*\?/i);
+    }
+  });
+
+  it('writes session_updated to the source workspace JSONL and session_created to the destination, in that order', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    const events = deps.jsonlWriter.appendEvent.mock.calls;
+    expect(events).toHaveLength(2);
+
+    const [firstPath, firstEvent] = events[0];
+    expect(firstPath).toBe(`workspaces/ws_${SOURCE_WORKSPACE}.jsonl`);
+    expect(firstEvent).toMatchObject({
+      type: 'session_updated',
+      workspaceId: SOURCE_WORKSPACE,
+      sessionId: SESSION_ID,
+      data: { workspaceId: TARGET_WORKSPACE }
+    });
+
+    const [secondPath, secondEvent] = events[1];
+    expect(secondPath).toBe(`workspaces/ws_${TARGET_WORKSPACE}.jsonl`);
+    expect(secondEvent).toMatchObject({
+      type: 'session_created',
+      workspaceId: TARGET_WORKSPACE,
+      data: {
+        id: SESSION_ID,
+        name: SESSION_ROW.name,
+        description: SESSION_ROW.description,
+        startTime: SESSION_ROW.startTime
+      }
+    });
+  });
+
+  it('runs JSONL writes before SQLite updates within the transaction', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const order: string[] = [];
+    deps.jsonlWriter.appendEvent.mockImplementation(async (_path: string, event: Record<string, unknown>) => {
+      order.push(`jsonl:${event.type as string}`);
+      return { id: 'evt', timestamp: 1, deviceId: 'd', ...event };
+    });
+    deps.sqliteCache.run.mockImplementation(async (sql: string) => {
+      const table = /UPDATE\s+(\w+)/i.exec(sql)?.[1] ?? 'unknown';
+      order.push(`sqlite:${table}`);
+    });
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(order).toEqual([
+      'jsonl:session_updated',
+      'jsonl:session_created',
+      'sqlite:sessions',
+      'sqlite:states',
+      'sqlite:memory_traces',
+      'sqlite:trace_embedding_metadata'
+    ]);
+  });
+
+  it('wraps the entire move in a single transaction so a failed cascade rolls back', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const cascadeFailure = new Error('SQLITE_CONSTRAINT: trace_embedding_metadata.sessionId');
+    deps.sqliteCache.run
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(cascadeFailure);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE)).rejects.toBe(cascadeFailure);
+
+    expect(deps.sqliteCache.transaction).toHaveBeenCalledTimes(1);
+    expect(deps.sqliteCache.run).toHaveBeenCalledTimes(4);
+    expect(deps.jsonlWriter.appendEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it('also rolls back when the destination JSONL write fails after the source write', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    const jsonlFailure = new Error('disk full writing destination JSONL');
+    deps.jsonlWriter.appendEvent
+      .mockResolvedValueOnce({ id: 'evt-1', timestamp: 1, deviceId: 'd', type: 'session_updated' })
+      .mockRejectedValueOnce(jsonlFailure);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE)).rejects.toBe(jsonlFailure);
+
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+  });
+
+  it('throws and does not write anything when the session does not exist', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(null);
+
+    await expect(repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE))
+      .rejects.toThrow(`Session not found: ${SESSION_ID}`);
+
+    expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the session is already in the destination workspace', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce({
+      ...SESSION_ROW,
+      workspaceId: TARGET_WORKSPACE
+    });
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+    expect(deps.sqliteCache.transaction).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the per-id cache entry after a successful move', async () => {
+    deps.sqliteCache.queryOne.mockResolvedValueOnce(SESSION_ROW);
+
+    await repo.moveToWorkspace(SESSION_ID, TARGET_WORKSPACE);
+
+    expect(deps.queryCache.invalidateById).toHaveBeenCalledWith('session', SESSION_ID);
+  });
+});

--- a/tests/unit/ToolBatchExecutionService.test.ts
+++ b/tests/unit/ToolBatchExecutionService.test.ts
@@ -1,0 +1,96 @@
+import { ToolBatchExecutionService } from '../../src/agents/toolManager/services/ToolBatchExecutionService';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+
+function createAgent(tool: ITool): IAgent {
+  return {
+    name: 'searchManager',
+    description: 'Search manager',
+    version: '1.0.0',
+    getTools: () => [tool],
+    getTool: (slug: string) => slug === tool.slug ? tool : undefined,
+    initialize: jest.fn().mockResolvedValue(undefined),
+    executeTool: jest.fn(),
+    setAgentManager: jest.fn()
+  };
+}
+
+describe('ToolBatchExecutionService', () => {
+  it('does not inject the ambient chat sessionId into unscoped searchMemory calls', async () => {
+    const execute = jest.fn().mockResolvedValue({ success: true, results: [] });
+    const tool = {
+      slug: 'searchMemory',
+      name: 'Search memory',
+      description: '',
+      version: '1.0.0',
+      execute,
+      getParameterSchema: jest.fn(),
+      getResultSchema: jest.fn()
+    } as unknown as ITool;
+    const agentRegistry = new Map<string, IAgent>([
+      ['searchManager', createAgent(tool)]
+    ]);
+    const service = new ToolBatchExecutionService({} as never, agentRegistry);
+
+    await service.execute({
+      context: {
+        workspaceId: 'default',
+        sessionId: 'focused trace session',
+        memory: 'Memory summary',
+        goal: 'Search workspace traces'
+      },
+      calls: [
+        {
+          agent: 'searchManager',
+          tool: 'searchMemory',
+          params: { query: 'replaced.md', memoryTypes: ['traces'] }
+        }
+      ]
+    });
+
+    expect(execute).toHaveBeenCalledWith(expect.not.objectContaining({
+      sessionId: 'focused trace session'
+    }));
+  });
+
+  it('preserves an explicit searchMemory session filter', async () => {
+    const execute = jest.fn().mockResolvedValue({ success: true, results: [] });
+    const tool = {
+      slug: 'searchMemory',
+      name: 'Search memory',
+      description: '',
+      version: '1.0.0',
+      execute,
+      getParameterSchema: jest.fn(),
+      getResultSchema: jest.fn()
+    } as unknown as ITool;
+    const agentRegistry = new Map<string, IAgent>([
+      ['searchManager', createAgent(tool)]
+    ]);
+    const service = new ToolBatchExecutionService({} as never, agentRegistry);
+
+    await service.execute({
+      context: {
+        workspaceId: 'default',
+        sessionId: 'ambient chat session',
+        memory: 'Memory summary',
+        goal: 'Search one named session'
+      },
+      calls: [
+        {
+          agent: 'searchManager',
+          tool: 'searchMemory',
+          params: {
+            query: 'replaced.md',
+            memoryTypes: ['traces'],
+            sessionName: 'focused trace session'
+          }
+        }
+      ]
+    });
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      sessionName: 'focused trace session'
+    }));
+  });
+});

--- a/tests/unit/ToolCallTraceService.test.ts
+++ b/tests/unit/ToolCallTraceService.test.ts
@@ -1,0 +1,147 @@
+import { ToolCallTraceService } from '../../src/services/trace/ToolCallTraceService';
+
+describe('ToolCallTraceService', () => {
+  it('resolves top-level workspace names before recording useTools traces', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue(null),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'Workspace Name',
+        sessionId: 'session-1',
+        _displaySessionId: 'Focused trace session',
+        memory: 'Testing recent activity.',
+        goal: 'Record a file read.',
+        tool: 'content read "Projects/A.md"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Workspace Name');
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1',
+        type: 'tool_call',
+        metadata: expect.objectContaining({
+          context: expect.objectContaining({
+            workspaceId: 'workspace-uuid',
+            sessionId: 'session-1',
+            sessionName: 'Focused trace session',
+            memory: 'Testing recent activity.',
+            goal: 'Record a file read.'
+          })
+        })
+      })
+    );
+  });
+
+  it('prefers an explicit workspace over stale session workspace context', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue({
+        workspaceId: 'session-workspace'
+      }),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'envelope-workspace-uuid',
+        name: 'Envelope workspace'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'Envelope workspace',
+        sessionId: 'session-1',
+        tool: 'content read "Projects/A.md"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Envelope workspace');
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'envelope-workspace-uuid',
+        sessionId: 'session-1'
+      })
+    );
+  });
+
+  it('uses a load-workspace command handle when the envelope is still default', async () => {
+    const memoryService = {
+      recordActivityTrace: jest.fn().mockResolvedValue('trace-1')
+    };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue({ workspaceId: 'default' }),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Human Workspace'
+      })
+    };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+
+    await service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'default',
+        sessionId: 'session-1',
+        tool: 'memory load-workspace "Human Workspace"'
+      },
+      { success: true },
+      true,
+      12
+    );
+
+    expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Human Workspace');
+    expect(sessionContextManager.setWorkspaceContext).toHaveBeenCalledWith('session-1', {
+      workspaceId: 'workspace-uuid'
+    });
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'workspace-uuid',
+        sessionId: 'session-1'
+      })
+    );
+  });
+});

--- a/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
+++ b/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
@@ -1,0 +1,337 @@
+/**
+ * ToolExecutionStrategy — coverage of the request-boundary plumbing
+ * introduced in commit b90ce865 (B4 of review/workspace-memory-batch).
+ *
+ * `buildRequestContext` is private; we exercise it through `handle()`,
+ * which is the public entry point for every MCP tool call. Each test
+ * pins one signal at a time:
+ *   - 3-arg `validateSessionId(sessionId, memory, workspaceId)` shape
+ *   - displaySessionId / sessionName threading into params.context
+ *     and params._displaySessionId
+ *   - displaySessionIdChanged → isNonStandardId + originalSessionId
+ *   - validation throw → fallback to legacy SessionService
+ *   - missing params.context → safely defaults
+ *
+ * The fallback branch is the riskiest seam: a thrown validation error
+ * silently downgrades to legacy session handling, and there is no
+ * explicit assertion in production code that the downgrade preserves
+ * the displaySessionId thread.
+ */
+
+import { ToolExecutionStrategy } from '../../src/handlers/strategies/ToolExecutionStrategy';
+import type {
+  IRequestHandlerDependencies,
+  ToolExecutionResult,
+  SessionInfo
+} from '../../src/handlers/interfaces/IRequestHandlerServices';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+import type { SessionContextManager } from '../../src/services/SessionContextManager';
+
+interface CapturedExecution {
+  sessionInfo?: SessionInfo;
+  toolParams?: Record<string, unknown>;
+}
+
+function makeStubTool(): ITool {
+  return {
+    slug: 'stubTool',
+    name: 'Stub tool',
+    description: '',
+    version: '1.0.0',
+    execute: jest.fn(),
+    getParameterSchema: jest.fn().mockReturnValue({}),
+    getResultSchema: jest.fn().mockReturnValue({})
+  } as unknown as ITool;
+}
+
+function makeStubAgent(tool: ITool, name = 'stubAgent'): IAgent {
+  return {
+    name,
+    description: '',
+    version: '1.0.0',
+    getTools: () => [tool],
+    getTool: (slug: string) => (slug === tool.slug ? tool : undefined),
+    initialize: jest.fn(),
+    executeTool: jest.fn(),
+    setAgentManager: jest.fn()
+  };
+}
+
+function makeDeps(captured: CapturedExecution): IRequestHandlerDependencies {
+  return {
+    validationService: {
+      validateToolParams: jest.fn(async (params: Record<string, unknown>) => params),
+      validateSessionId: jest.fn(),
+      validateBatchOperations: jest.fn(),
+      validateBatchPaths: jest.fn()
+    },
+    sessionService: {
+      processSessionId: jest.fn(async (sessionId: string | undefined) => ({
+        sessionId: sessionId ?? 's-fallback',
+        isNewSession: false,
+        isNonStandardId: false
+      })),
+      generateSessionId: jest.fn(),
+      isStandardSessionId: jest.fn(),
+      shouldInjectInstructions: jest.fn().mockReturnValue(false)
+    },
+    toolExecutionService: {
+      executeAgent: jest.fn(async (_agent, _tool, params: Record<string, unknown>) => {
+        captured.toolParams = params;
+        const successResult: ToolExecutionResult = { success: true, data: { ok: true } };
+        return successResult;
+      })
+    },
+    responseFormatter: {
+      formatToolExecutionResponse: jest.fn((_result, sessionInfo) => {
+        captured.sessionInfo = sessionInfo;
+        return { content: [{ type: 'text', text: 'ok' }] };
+      }),
+      formatSessionInstructions: jest.fn((_id, r) => r),
+      formatErrorResponse: jest.fn((err) => ({ content: [{ type: 'text', text: err.message }] }))
+    },
+    toolListService: {} as never,
+    resourceListService: {} as never,
+    resourceReadService: {} as never,
+    promptsListService: {} as never,
+    toolHelpService: {} as never,
+    schemaEnhancementService: {} as never
+  };
+}
+
+function makeContextManager(overrides: Partial<SessionContextManager> = {}): SessionContextManager {
+  return {
+    validateSessionId: jest.fn(),
+    applyWorkspaceContext: jest.fn((_id: string, p: Record<string, unknown>) => p),
+    updateFromResult: jest.fn(),
+    updateSessionDescription: jest.fn(),
+    hasReceivedInstructions: jest.fn().mockReturnValue(false),
+    markInstructionsReceived: jest.fn(),
+    ...overrides
+  } as unknown as SessionContextManager;
+}
+
+function makeRequest(
+  toolName: string,
+  args: Record<string, unknown>
+): { params: { name: string; arguments: Record<string, unknown> } } {
+  return { params: { name: toolName, arguments: args } };
+}
+
+describe('ToolExecutionStrategy.buildRequestContext', () => {
+  it('calls validateSessionId with the 3-arg (sessionId, memory, workspaceId) shape', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'planning chat',
+      displaySessionIdChanged: false
+    });
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'planning chat',
+      memory: 'short memory snapshot',
+      workspaceId: 'ws-target',
+      context: {
+        sessionId: 'planning chat',
+        workspaceId: 'ws-target'
+      }
+    }));
+
+    expect(validateSessionId).toHaveBeenCalledTimes(1);
+    expect(validateSessionId).toHaveBeenCalledWith(
+      'planning chat',
+      'short memory snapshot',
+      'ws-target'
+    );
+  });
+
+  it('falls back to context.workspaceId when params.workspaceId is not a string', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-1',
+      created: false,
+      displaySessionId: 'chat',
+      displaySessionIdChanged: false
+    });
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'chat',
+      memory: 'm',
+      context: {
+        sessionId: 'chat',
+        workspaceId: 'ws-from-context'
+      }
+    }));
+
+    expect(validateSessionId).toHaveBeenCalledWith('chat', 'm', 'ws-from-context');
+  });
+
+  it('threads displaySessionId into params.context.sessionName and params._displaySessionId', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'planning chat-2',
+      displaySessionIdChanged: true
+    });
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'planning chat',
+      memory: 'memory',
+      context: {
+        sessionId: 'planning chat',
+        workspaceId: 'default'
+      }
+    }));
+
+    expect(captured.toolParams).toBeDefined();
+    expect(captured.toolParams!._displaySessionId).toBe('planning chat-2');
+    const ctx = captured.toolParams!.context as Record<string, unknown>;
+    expect(ctx.sessionId).toBe('s-internal-uuid');
+    expect(ctx.sessionName).toBe('planning chat-2');
+    expect(captured.toolParams!.sessionId).toBe('s-internal-uuid');
+  });
+
+  it('produces isNonStandardId + originalSessionId when displaySessionIdChanged is true', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'planning chat-2',
+      displaySessionIdChanged: true
+    });
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'planning chat',
+      memory: 'memory',
+      context: { sessionId: 'planning chat', workspaceId: 'default' }
+    }));
+
+    expect(captured.sessionInfo).toBeDefined();
+    expect(captured.sessionInfo!.isNonStandardId).toBe(true);
+    expect(captured.sessionInfo!.originalSessionId).toBe('planning chat');
+    expect(captured.sessionInfo!.displaySessionId).toBe('planning chat-2');
+    expect(captured.sessionInfo!.displaySessionIdChanged).toBe(true);
+  });
+
+  it('does NOT mark isNonStandardId when displaySessionIdChanged is false', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockResolvedValue({
+      id: 's-internal-uuid',
+      created: false,
+      displaySessionId: 'unique handle',
+      displaySessionIdChanged: false
+    });
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'unique handle',
+      context: { sessionId: 'unique handle' }
+    }));
+
+    expect(captured.sessionInfo!.isNonStandardId).toBe(false);
+    expect(captured.sessionInfo!.originalSessionId).toBeUndefined();
+  });
+
+  it('falls back to SessionService.processSessionId when validateSessionId throws', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const validateSessionId = jest.fn().mockRejectedValue(
+      new Error('SessionService not initialized - cannot validate session')
+    );
+    const sessionContextManager = makeContextManager({
+      validateSessionId
+    } as Partial<SessionContextManager>);
+    const deps = makeDeps(captured);
+    const processSessionId = deps.sessionService.processSessionId as jest.Mock;
+    processSessionId.mockResolvedValue({
+      sessionId: 's-fallback-uuid',
+      isNewSession: false,
+      isNonStandardId: false
+    });
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, sessionContextManager);
+
+    const response = await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'planning chat',
+      memory: 'm',
+      context: { sessionId: 'planning chat', workspaceId: 'ws-target' }
+    }));
+
+    expect(processSessionId).toHaveBeenCalledWith('planning chat');
+    expect(captured.toolParams!.sessionId).toBe('s-fallback-uuid');
+    expect(response.content[0].text).toBe('ok');
+  });
+
+  it('routes through SessionService when no SessionContextManager is provided', async () => {
+    const tool = makeStubTool();
+    const agent = makeStubAgent(tool);
+    const captured: CapturedExecution = {};
+    const deps = makeDeps(captured);
+    const processSessionId = deps.sessionService.processSessionId as jest.Mock;
+    processSessionId.mockResolvedValue({
+      sessionId: 's-legacy-uuid',
+      isNewSession: true,
+      isNonStandardId: false
+    });
+
+    const strategy = new ToolExecutionStrategy(deps, () => agent, /* no SCM */ undefined);
+
+    await strategy.handle(makeRequest('stubAgent_stubTool', {
+      tool: 'stubTool',
+      sessionId: 'whatever',
+      context: { sessionId: 'whatever' }
+    }));
+
+    expect(processSessionId).toHaveBeenCalledWith('whatever');
+    expect(captured.toolParams!.sessionId).toBe('s-legacy-uuid');
+  });
+});

--- a/tests/unit/connector.session.test.ts
+++ b/tests/unit/connector.session.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Connector session-handle resolution — coverage of the
+ * 'Default Session' defaulting + 3-arg validateSessionId path
+ * introduced in commit b90ce865 (B4 of review/workspace-memory-batch).
+ *
+ * The MCPConnector's `callTool` (src/connector.ts:529-534) computes:
+ *
+ *   const providedSessionId = (toolManagerMetaTool ? typedParams.sessionId
+ *     : (typedParams.context?.sessionId || typedParams.sessionId));
+ *   const validationResult = await sessionContextManager.validateSessionId(
+ *     providedSessionId || 'Default Session',
+ *     typeof typedParams.memory === 'string' ? typedParams.memory : undefined,
+ *     typeof typedParams.workspaceId === 'string' ? typedParams.workspaceId : undefined
+ *   );
+ *
+ * Building a full MCPConnector requires plugin + agentManager + service
+ * container wiring, all far beyond the surface this test cares about.
+ * Instead, this test exercises the contract the connector relies on:
+ * `SessionContextManager.validateSessionId` is the seam the connector
+ * calls into, and these tests pin its behavior under exactly the inputs
+ * the connector synthesizes.
+ *
+ * Backend-reviewer flag (preserved verbatim): the friendly-name
+ * workspaceId is passed straight through to the validator, so a model
+ * that sends `workspaceId: "Engineering"` will get a session bound to
+ * the literal name "Engineering" rather than its resolved UUID. The
+ * test below documents the current behavior; it is not asserted to
+ * be desired or undesired.
+ */
+
+import { SessionContextManager } from '../../src/services/SessionContextManager';
+
+interface SessionServiceStub {
+  getSession: jest.Mock;
+  getAllSessions: jest.Mock;
+  createSession: jest.Mock;
+  updateSession: jest.Mock;
+}
+
+function makeSessionService(): SessionServiceStub {
+  return {
+    getSession: jest.fn().mockResolvedValue(null),
+    getAllSessions: jest.fn().mockResolvedValue([]),
+    createSession: jest.fn().mockResolvedValue(undefined),
+    updateSession: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe("connector session resolution — 'Default Session' default + 3-arg validateSessionId", () => {
+  it("creates a fresh session keyed to the literal display 'Default Session' when no sessionId is provided", async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    // Connector default: providedSessionId is undefined so falls through
+    // to the literal 'Default Session' string.
+    const providedSessionId: string | undefined = undefined;
+    const result = await manager.validateSessionId(
+      providedSessionId || 'Default Session',
+      'short memory',
+      'default'
+    );
+
+    expect(result.id).toMatch(/^s-/);
+    expect(result.created).toBe(true);
+    expect(result.displaySessionId).toBe('Default Session');
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: result.id,
+        name: 'Default Session',
+        description: 'short memory',
+        workspaceId: 'default'
+      })
+    );
+  });
+
+  it("returns the same internal id on the second call with 'Default Session' (handle reuse)", async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    const first = await manager.validateSessionId('Default Session', 'memory', 'default');
+    const second = await manager.validateSessionId('Default Session', undefined, 'default');
+
+    expect(second.id).toBe(first.id);
+    expect(second.created).toBe(false);
+    expect(second.displaySessionId).toBe('Default Session');
+    expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes memory through as the session description on auto-create', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    await manager.validateSessionId('Default Session', 'pivotal memory text', 'default');
+
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'pivotal memory text' })
+    );
+  });
+
+  it('routes Default Session into the supplied workspaceId, not the global default', async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    await manager.validateSessionId('Default Session', undefined, 'ws-engineering');
+
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'ws-engineering' })
+    );
+  });
+
+  it("explicit sessionId provided by the caller wins over 'Default Session' fallback", async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    const providedSessionId: string | undefined = 'planning chat';
+    const result = await manager.validateSessionId(
+      providedSessionId || 'Default Session',
+      'mem',
+      'default'
+    );
+
+    expect(result.displaySessionId).toBe('planning chat');
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'planning chat' })
+    );
+  });
+
+  it('documents current behavior: friendly-name workspaceId is passed straight through to createSession', async () => {
+    // Backend-reviewer flag: the connector does not resolve a friendly
+    // workspace handle (e.g., "Engineering") to its UUID before calling
+    // validateSessionId. As a result, the resulting session is bound
+    // to the literal name as its workspaceId. This test pins that
+    // behavior; whether it is desired is a product decision, not a
+    // test concern.
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    manager.setSessionService(sessionService);
+
+    await manager.validateSessionId('Default Session', undefined, 'Engineering');
+
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'Engineering' })
+    );
+  });
+
+  it("guards against the 'Default Session' display being suffixed when an existing real session already uses that name", async () => {
+    const manager = new SessionContextManager();
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValue([
+      { id: 's-existing', workspaceId: 'default', name: 'Default Session' }
+    ]);
+    manager.setSessionService(sessionService);
+
+    const result = await manager.validateSessionId('Default Session', undefined, 'default');
+
+    // When a workspace already has a "Default Session", the validator
+    // emits a unique-suffixed display handle and flags the change.
+    expect(result.displaySessionId).toBe('Default Session-2');
+    expect(result.displaySessionIdChanged).toBe(true);
+  });
+});

--- a/tests/unit/find-by-name-or-id-characterization.test.ts
+++ b/tests/unit/find-by-name-or-id-characterization.test.ts
@@ -135,7 +135,7 @@ describe('getSessionByNameOrId characterization', () => {
     const adapter = createMockAdapter(true);
 
     adapter.getSession.mockResolvedValue({
-      id: 'session-1', name: 'My Session', description: 'desc',
+      id: 'session-1', workspaceId: 'ws1', name: 'My Session', description: 'desc',
       startTime: 1000, isActive: true,
     });
 


### PR DESCRIPTION
## Summary

Threads `displaySessionId` and `sessionName` through the tool batch execution path, request handlers, and connector so the user-visible session label survives the boundary without leaking the internal UUID.

**6 new commits (stacks on #192):**
- `dfcd1800` feat(tools): displaySessionId/sessionName plumbing through tool batch + handlers + connector
- `2b557cd2` fix(execution): keep correctedId=originalSessionId — internal UUID must stay hidden
- `a1750cbf` fix(handler): document goal/sessionDescription split in session description update
- `48617db4` fix(handler): document formatSessionInstructions removal contract
- `cbbd301e` test(tools): cover B4 request-boundary plumbing
- `48287e13` test: drop stale TODO from correctedId test header

> **Stacks on #192** — base will rebase cleanly once #192 merges. Branch currently includes the 3 commits from #192 (a9264fe4 / ae6993af / 8b94421b) for standalone test pass.

## Why

Slice 4/5 of the workspace/memory/search batch refactor. The internal UUID (`correctedId === originalSessionId`) must NOT leak to the model — only `displaySessionId`/`sessionName` cross the wire. This was previously handled inconsistently across the request handler / connector seam.

## Test plan
- [x] `npm test` green standalone against main with #192 commits in tree (2506 pass / 1 pre-existing ModelAgentManager fail / 12 skip)
- [ ] Smoke: invoke a tool batch, verify `displaySessionId` is the human-readable name in the response, internal UUID is not echoed
- [ ] Smoke: update a session description, verify goal vs sessionDescription split holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)