### PR TITLE
feat(eval): expand harness with retry, structured config, scenario coverage + nexus-eval-harness skill

### DIFF
--- a/.codex/skills/nexus-eval-harness/SKILL.md
+++ b/.codex/skills/nexus-eval-harness/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: nexus-eval-harness
+description: Run or update the Nexus LLM eval harness for arbitrary provider/model matrices. Use when comparing models in the real vault-like tool environment, changing eval configs, adding eval scenarios, or debugging eval reports.
+---
+
+# Nexus Eval Harness
+
+Use this skill for full Nexus model-behavior evals, not simple provider availability checks.
+
+## Core Rule
+
+Use the shared harness in `tests/eval/eval.test.ts`. Do not create one-off runners unless the harness itself is broken and you are actively fixing it.
+
+The harness should run provider/model/scenario jobs in parallel. Avoid sequential loops for model comparisons.
+
+## Production-Like Vault Runs
+
+For the native vault environment, run live mode against the two-tool surface:
+
+```bash
+RUN_EVAL=1 EVAL_MODE=live EVAL_TOOL_SET=meta EVAL_TARGETS='openrouter=deepseek/deepseek-v4-pro,openrouter=deepseek/deepseek-v4-flash' npx jest tests/eval/eval.test.ts --runInBand --no-coverage --verbose
+```
+
+Notes:
+
+- `--runInBand` only keeps Jest in one worker; the harness runs the eval matrix with `Promise.all`.
+- `RUN_EVAL=1` is required so ordinary test runs do not hit live provider APIs.
+- `EVAL_TOOL_SET=meta` restricts scenarios to the production `getTools`/`useTools` contract.
+- `EVAL_SCENARIO_NAMES` narrows a run to specific scenario names.
+- `EVAL_TRACE_STREAM=1` writes per-scenario JSONL traces under `test-artifacts/traces/` as chunks, tool calls, tool events, and assertions arrive.
+- API keys are read from process env or repo `.env`; never print credentials.
+- Reports are written under `test-artifacts/`.
+
+## Target Selection
+
+Preferred arbitrary target format:
+
+```bash
+EVAL_TARGETS='provider=model,provider=model'
+```
+
+Examples:
+
+```bash
+EVAL_TARGETS='openrouter=anthropic/claude-sonnet-4.6,openrouter=openai/gpt-5.4-mini'
+EVAL_TARGETS='openai=gpt-5.4,openrouter=openai/gpt-5.4'
+```
+
+Single-provider shorthand:
+
+```bash
+EVAL_PROVIDER=openrouter EVAL_MODELS='deepseek/deepseek-v4-pro,deepseek/deepseek-v4-flash'
+```
+
+Useful overrides:
+
+```bash
+EVAL_CONFIG=tests/eval/configs/live.yaml
+RUN_EVAL=1
+EVAL_MODE=live
+EVAL_SCENARIOS='tests/eval/scenarios/search-variations.eval.yaml'
+EVAL_SCENARIO_NAMES='simple-read,replace-content'
+EVAL_TOOL_SET=meta
+EVAL_TRACE_STREAM=1
+EVAL_MAX_RETRIES=3
+EVAL_RETRY_DELAY_MS=1000
+EVAL_RETRY_BACKOFF_MULTIPLIER=2
+EVAL_RETRY_MAX_DELAY_MS=30000
+EVAL_TIMEOUT_MS=120000
+```
+
+Retry notes:
+
+- The harness retries provider/server failures such as 408, 409, 425, 429, 5xx, timeouts, and transient transport errors with exponential backoff.
+- Behavioral scenario failures may still retry up to `maxRetries`, but auth/validation-only stream errors should fail fast.
+- Retry delays are per parallel job; one throttled model should not serialize the rest of the matrix.
+
+## Interpreting Results
+
+Separate these failure classes:
+
+- Provider/API failures: stream errors, auth failures, rate limits, transport errors.
+- Tool contract failures: missing `workspaceId`, `sessionId`, `memory`, or `goal`; wrong CLI flags; skipped `getTools`.
+- Task failures: valid tools called but wrong tool choice, wrong order, or incomplete multi-step plan.
+- Harness failures: zero loaded scenarios, non-production tool surface for a vault eval, or leftover generated test vault state.
+
+When the user asks how a model performs “in our environment,” report the `meta` live-run numbers first.

--- a/.codex/skills/nexus-eval-harness/agents/openai.yaml
+++ b/.codex/skills/nexus-eval-harness/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Nexus Eval Harness"
+  short_description: "Run parallel provider/model evals"
+  default_prompt: "Use $nexus-eval-harness to compare models in the live Nexus eval harness."
+
+policy:
+  allow_implicit_invocation: true

--- a/.skills/nexus-eval-harness/SKILL.md
+++ b/.skills/nexus-eval-harness/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: nexus-eval-harness
+description: Run or update the Nexus LLM eval harness for arbitrary provider/model matrices. Use when comparing models in the real vault-like tool environment, changing eval configs, adding eval scenarios, or debugging eval reports.
+---
+
+# Nexus Eval Harness
+
+Use this skill for full Nexus model-behavior evals, not simple provider availability checks.
+
+## Core Rule
+
+Use the shared harness in `tests/eval/eval.test.ts`. Do not create one-off runners unless the harness itself is broken and you are actively fixing it.
+
+The harness should run provider/model/scenario jobs in parallel. Avoid sequential loops for model comparisons.
+
+## Production-Like Vault Runs
+
+For the native vault environment, run live mode against the two-tool surface:
+
+```bash
+RUN_EVAL=1 EVAL_MODE=live EVAL_TOOL_SET=meta EVAL_TARGETS='openrouter=deepseek/deepseek-v4-pro,openrouter=deepseek/deepseek-v4-flash' npx jest tests/eval/eval.test.ts --runInBand --no-coverage --verbose
+```
+
+Notes:
+
+- `--runInBand` only keeps Jest in one worker; the harness runs the eval matrix with `Promise.all`.
+- `RUN_EVAL=1` is required so ordinary test runs do not hit live provider APIs.
+- `EVAL_TOOL_SET=meta` restricts scenarios to the production `getTools`/`useTools` contract.
+- `EVAL_SCENARIO_NAMES` narrows a run to specific scenario names.
+- `EVAL_TRACE_STREAM=1` writes per-scenario JSONL traces under `test-artifacts/traces/` as chunks, tool calls, tool events, and assertions arrive.
+- API keys are read from process env or repo `.env`; never print credentials.
+- Reports are written under `test-artifacts/`.
+
+## Target Selection
+
+Preferred arbitrary target format:
+
+```bash
+EVAL_TARGETS='provider=model,provider=model'
+```
+
+Examples:
+
+```bash
+EVAL_TARGETS='openrouter=anthropic/claude-sonnet-4.6,openrouter=openai/gpt-5.4-mini'
+EVAL_TARGETS='openai=gpt-5.4,openrouter=openai/gpt-5.4'
+```
+
+Single-provider shorthand:
+
+```bash
+EVAL_PROVIDER=openrouter EVAL_MODELS='deepseek/deepseek-v4-pro,deepseek/deepseek-v4-flash'
+```
+
+Useful overrides:
+
+```bash
+EVAL_CONFIG=tests/eval/configs/live.yaml
+RUN_EVAL=1
+EVAL_MODE=live
+EVAL_SCENARIOS='tests/eval/scenarios/search-variations.eval.yaml'
+EVAL_SCENARIO_NAMES='simple-read,replace-content'
+EVAL_TOOL_SET=meta
+EVAL_TRACE_STREAM=1
+EVAL_MAX_RETRIES=3
+EVAL_RETRY_DELAY_MS=1000
+EVAL_RETRY_BACKOFF_MULTIPLIER=2
+EVAL_RETRY_MAX_DELAY_MS=30000
+EVAL_TIMEOUT_MS=120000
+```
+
+Retry notes:
+
+- The harness retries provider/server failures such as 408, 409, 425, 429, 5xx, timeouts, and transient transport errors with exponential backoff.
+- Behavioral scenario failures may still retry up to `maxRetries`, but auth/validation-only stream errors should fail fast.
+- Retry delays are per parallel job; one throttled model should not serialize the rest of the matrix.
+
+## Interpreting Results
+
+Separate these failure classes:
+
+- Provider/API failures: stream errors, auth failures, rate limits, transport errors.
+- Tool contract failures: missing `workspaceId`, `sessionId`, `memory`, or `goal`; wrong CLI flags; skipped `getTools`.
+- Task failures: valid tools called but wrong tool choice, wrong order, or incomplete multi-step plan.
+- Harness failures: zero loaded scenarios, non-production tool surface for a vault eval, or leftover generated test vault state.
+
+When the user asks how a model performs “in our environment,” report the `meta` live-run numbers first.

--- a/.skills/nexus-eval-harness/agents/openai.yaml
+++ b/.skills/nexus-eval-harness/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Nexus Eval Harness"
+  short_description: "Run parallel provider/model evals"
+  default_prompt: "Use $nexus-eval-harness to compare models in the live Nexus eval harness."
+
+policy:
+  allow_implicit_invocation: true

--- a/tests/eval/ConfigLoader.ts
+++ b/tests/eval/ConfigLoader.ts
@@ -8,7 +8,18 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { parse as parseYaml } from 'yaml';
-import type { EvalConfig } from './types';
+import type { EvalConfig, ProviderConfig } from './types';
+
+const PROVIDER_API_KEY_ENV: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  google: 'GOOGLE_API_KEY',
+  groq: 'GROQ_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  perplexity: 'PERPLEXITY_API_KEY',
+  requesty: 'REQUESTY_API_KEY',
+};
 
 const DEFAULT_CONFIG: EvalConfig = {
   mode: 'mock',
@@ -24,6 +35,8 @@ const DEFAULT_CONFIG: EvalConfig = {
     temperature: 0,
     maxRetries: 1,
     retryDelayMs: 2000,
+    retryBackoffMultiplier: 2,
+    retryMaxDelayMs: 30_000,
     timeout: 120_000,
     systemPrompt: 'default',
   },
@@ -33,6 +46,7 @@ const DEFAULT_CONFIG: EvalConfig = {
     artifactsDir: 'test-artifacts/',
   },
   scenarios: 'tests/eval/scenarios/**/*.eval.yaml',
+  scenarioToolSet: 'all',
 };
 
 /**
@@ -41,23 +55,140 @@ const DEFAULT_CONFIG: EvalConfig = {
  */
 export function loadConfig(configPath?: string): EvalConfig {
   const resolvedPath = configPath || process.env.EVAL_CONFIG;
+  let config: EvalConfig;
 
   if (!resolvedPath) {
-    return DEFAULT_CONFIG;
+    config = DEFAULT_CONFIG;
+  } else {
+    const fullPath = path.isAbsolute(resolvedPath)
+      ? resolvedPath
+      : path.resolve(process.cwd(), resolvedPath);
+
+    if (!fs.existsSync(fullPath)) {
+      throw new Error(`Eval config not found: ${fullPath}`);
+    }
+
+    const raw = fs.readFileSync(fullPath, 'utf-8');
+    const parsed = parseYaml(raw) as Partial<EvalConfig>;
+
+    config = mergeWithDefaults(parsed);
   }
 
-  const fullPath = path.isAbsolute(resolvedPath)
-    ? resolvedPath
-    : path.resolve(process.cwd(), resolvedPath);
+  return applyEnvOverrides(config);
+}
 
-  if (!fs.existsSync(fullPath)) {
-    throw new Error(`Eval config not found: ${fullPath}`);
+function applyEnvOverrides(config: EvalConfig): EvalConfig {
+  const targets = getEvalTargets(config);
+  const modeOverride = getEnv('EVAL_MODE');
+  const scenariosOverride = getEnv('EVAL_SCENARIOS');
+  const toolSetOverride = getEnv('EVAL_TOOL_SET');
+  const scenarioNamesOverride = getListEnv('EVAL_SCENARIO_NAMES');
+
+  return {
+    ...config,
+    mode: modeOverride === 'mock' || modeOverride === 'live'
+      ? modeOverride
+      : config.mode,
+    providers: targets ?? config.providers,
+    defaults: applyDefaultEnvOverrides(config.defaults),
+    scenarios: scenariosOverride || config.scenarios,
+    scenarioToolSet: isScenarioToolSet(toolSetOverride)
+      ? toolSetOverride
+      : config.scenarioToolSet,
+    scenarioNames: scenarioNamesOverride ?? config.scenarioNames,
+  };
+}
+
+function applyDefaultEnvOverrides(defaults: EvalConfig['defaults']): EvalConfig['defaults'] {
+  return {
+    ...defaults,
+    maxRetries: getNumberEnv('EVAL_MAX_RETRIES') ?? defaults.maxRetries,
+    retryDelayMs: getNumberEnv('EVAL_RETRY_DELAY_MS') ?? defaults.retryDelayMs,
+    retryBackoffMultiplier: getNumberEnv('EVAL_RETRY_BACKOFF_MULTIPLIER')
+      ?? defaults.retryBackoffMultiplier,
+    retryMaxDelayMs: getNumberEnv('EVAL_RETRY_MAX_DELAY_MS') ?? defaults.retryMaxDelayMs,
+    timeout: getNumberEnv('EVAL_TIMEOUT_MS') ?? defaults.timeout,
+  };
+}
+
+function getEvalTargets(config: EvalConfig): Record<string, ProviderConfig> | null {
+  const targetSpec = getEnv('EVAL_TARGETS');
+  if (targetSpec) {
+    return parseEvalTargets(targetSpec, config);
   }
 
-  const raw = fs.readFileSync(fullPath, 'utf-8');
-  const parsed = parseYaml(raw) as Partial<EvalConfig>;
+  const provider = getEnv('EVAL_PROVIDER');
+  const modelList = getEnv('EVAL_MODELS') || getEnv('EVAL_MODEL');
+  if (!provider && !modelList) {
+    return null;
+  }
 
-  return mergeWithDefaults(parsed);
+  if (!provider || !modelList) {
+    throw new Error('EVAL_PROVIDER and EVAL_MODEL/EVAL_MODELS must be set together');
+  }
+
+  return parseEvalTargets(
+    modelList
+      .split(',')
+      .map((model) => `${provider}=${model}`)
+      .join(','),
+    config
+  );
+}
+
+function parseEvalTargets(spec: string, config: EvalConfig): Record<string, ProviderConfig> {
+  const providers: Record<string, ProviderConfig> = {};
+  const entries = spec
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length === 0) {
+    throw new Error('EVAL_TARGETS did not contain any provider=model entries');
+  }
+
+  for (const entry of entries) {
+    const separatorIndex = entry.indexOf('=');
+    if (separatorIndex <= 0 || separatorIndex === entry.length - 1) {
+      throw new Error(
+        `Invalid EVAL_TARGETS entry "${entry}". Use provider=model, e.g. openrouter=deepseek/deepseek-v4-flash`
+      );
+    }
+
+    const provider = entry.slice(0, separatorIndex).trim();
+    const model = normalizeModelForProvider(provider, entry.slice(separatorIndex + 1).trim());
+
+    const existing = providers[provider] ?? {
+      apiKeyEnv: config.providers[provider]?.apiKeyEnv ?? PROVIDER_API_KEY_ENV[provider],
+      models: [],
+      enabled: true,
+    };
+
+    if (!existing.apiKeyEnv) {
+      throw new Error(
+        `No API key env var is known for provider "${provider}". Add it to the eval config providers block.`
+      );
+    }
+
+    if (!existing.models.includes(model)) {
+      existing.models.push(model);
+    }
+    providers[provider] = existing;
+  }
+
+  return providers;
+}
+
+function normalizeModelForProvider(provider: string, model: string): string {
+  if ((provider === 'openai' || provider === 'openai-codex') && model.startsWith('openai/')) {
+    return model.slice('openai/'.length);
+  }
+
+  return model;
+}
+
+function isScenarioToolSet(value: string | undefined): value is NonNullable<EvalConfig['scenarioToolSet']> {
+  return value === 'all' || value === 'meta' || value === 'nexus' || value === 'simple';
 }
 
 function mergeWithDefaults(partial: Partial<EvalConfig>): EvalConfig {
@@ -74,14 +205,72 @@ function mergeWithDefaults(partial: Partial<EvalConfig>): EvalConfig {
       ...partial.capture,
     },
     scenarios: partial.scenarios ?? DEFAULT_CONFIG.scenarios,
+    scenarioToolSet: partial.scenarioToolSet ?? DEFAULT_CONFIG.scenarioToolSet,
+    scenarioNames: partial.scenarioNames,
   };
+}
+
+function readDotEnv(): Map<string, string> {
+  const envPath = path.join(process.cwd(), '.env');
+  const values = new Map<string, string>();
+
+  if (!fs.existsSync(envPath)) {
+    return values;
+  }
+
+  const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    values.set(match[1], match[2].replace(/^['"]|['"]$/g, ''));
+  }
+
+  return values;
+}
+
+const DOT_ENV = readDotEnv();
+
+function getEnv(name: string): string | undefined {
+  return process.env[name] || DOT_ENV.get(name);
+}
+
+function getNumberEnv(name: string): number | undefined {
+  const value = getEnv(name);
+  if (!value) {
+    return undefined;
+  }
+
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+function getListEnv(name: string): string[] | undefined {
+  const value = getEnv(name);
+  if (!value) {
+    return undefined;
+  }
+
+  const values = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  return values.length > 0 ? values : undefined;
 }
 
 /**
  * Resolve an API key from an env var name. Returns undefined if not set.
  */
 export function resolveApiKey(envVarName: string): string | undefined {
-  return process.env[envVarName];
+  return getEnv(envVarName);
 }
 
 /**

--- a/tests/eval/EvalRunner.ts
+++ b/tests/eval/EvalRunner.ts
@@ -22,6 +22,8 @@
  * to the executor for getTools schema responses.
  */
 
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { StreamingOrchestrator } from '../../src/services/llm/core/StreamingOrchestrator';
 import type { BaseAdapter } from '../../src/services/llm/adapters/BaseAdapter';
 import type { ConversationMessage, StreamingOptions } from '../../src/services/llm/core/ProviderMessageBuilder';
@@ -46,6 +48,240 @@ interface ProviderEntry {
   id: string;
   apiKey: string;
   models: string[];
+}
+
+interface RetryDecision {
+  retryable: boolean;
+  reason: string;
+}
+
+interface EvalTrace {
+  path: string;
+  write(event: string, data?: Record<string, unknown>): void;
+}
+
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504]);
+
+const RETRYABLE_ERROR_PATTERNS = [
+  /\b408\b/,
+  /\b409\b/,
+  /\b425\b/,
+  /\b429\b/,
+  /\b500\b/,
+  /\b502\b/,
+  /\b503\b/,
+  /\b504\b/,
+  /rate limit/i,
+  /too many requests/i,
+  /server error/i,
+  /temporarily unavailable/i,
+  /service unavailable/i,
+  /bad gateway/i,
+  /gateway timeout/i,
+  /timeout/i,
+  /timed out/i,
+  /econnreset/i,
+  /econnrefused/i,
+  /etimedout/i,
+  /eai_again/i,
+  /enotfound/i,
+  /socket hang up/i,
+  /network error/i,
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function readStatusCode(error: unknown): number | undefined {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  const candidates = [
+    error.status,
+    error.statusCode,
+    error.code,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'number') {
+      return candidate;
+    }
+    if (typeof candidate === 'string' && /^\d+$/.test(candidate)) {
+      return Number(candidate);
+    }
+  }
+
+  const response = error.response;
+  if (isRecord(response)) {
+    const responseStatus = response.status ?? response.statusCode;
+    if (typeof responseStatus === 'number') {
+      return responseStatus;
+    }
+    if (typeof responseStatus === 'string' && /^\d+$/.test(responseStatus)) {
+      return Number(responseStatus);
+    }
+  }
+
+  return undefined;
+}
+
+function readErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (isRecord(error) && typeof error.message === 'string') {
+    return error.message;
+  }
+
+  return String(error);
+}
+
+export function isRetryableEvalError(error: unknown): boolean {
+  const statusCode = readStatusCode(error);
+  if (statusCode !== undefined && RETRYABLE_STATUS_CODES.has(statusCode)) {
+    return true;
+  }
+
+  const message = readErrorMessage(error);
+  return RETRYABLE_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function calculateRetryDelayMs(attemptIndex: number, config: EvalConfig): number {
+  const baseDelayMs = Math.max(0, config.defaults.retryDelayMs);
+  if (baseDelayMs === 0) {
+    return 0;
+  }
+
+  const multiplier = Math.max(1, config.defaults.retryBackoffMultiplier);
+  const maxDelayMs = Math.max(baseDelayMs, config.defaults.retryMaxDelayMs);
+  const delayMs = baseDelayMs * Math.pow(multiplier, attemptIndex);
+
+  return Math.min(delayMs, maxDelayMs);
+}
+
+export function calculateMaxRetryDelayMs(maxRetries: number, config: EvalConfig): number {
+  let totalDelayMs = 0;
+  for (let attemptIndex = 0; attemptIndex < maxRetries; attemptIndex++) {
+    totalDelayMs += calculateRetryDelayMs(attemptIndex, config);
+  }
+  return totalDelayMs;
+}
+
+function collectTurnErrors(turnResults: TurnResult[]): string[] {
+  return turnResults
+    .filter((turn) => !turn.passed)
+    .flatMap((turn) => turn.errors);
+}
+
+function getRetryDecisionForTurnResults(turnResults: TurnResult[]): RetryDecision | null {
+  const errors = collectTurnErrors(turnResults);
+  if (errors.length === 0) {
+    return null;
+  }
+
+  const streamErrors = errors.filter((error) => error.startsWith('Stream error:'));
+  if (streamErrors.length > 0) {
+    const retryableStreamError = streamErrors.find((error) => isRetryableEvalError(error));
+    if (retryableStreamError) {
+      return {
+        retryable: true,
+        reason: retryableStreamError,
+      };
+    }
+
+    if (streamErrors.length === errors.length) {
+      return {
+        retryable: false,
+        reason: streamErrors.join('; '),
+      };
+    }
+  }
+
+  return {
+    retryable: true,
+    reason: errors.join('; '),
+  };
+}
+
+function inferSeedFiles(scenario: EvalScenario): Record<string, string> {
+  const seedFiles: Record<string, string> = {
+    ...(scenario.seedFiles ?? {}),
+  };
+
+  for (const turn of scenario.turns) {
+    const candidatePaths = extractMarkdownPaths(turn.userMessage ?? '');
+    for (const response of Object.values(turn.mockResponses ?? {})) {
+      collectSeedFilesFromValue(response.result, seedFiles, candidatePaths);
+    }
+  }
+
+  return seedFiles;
+}
+
+function collectSeedFilesFromValue(
+  value: unknown,
+  seedFiles: Record<string, string>,
+  candidatePaths: string[],
+): void {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSeedFilesFromValue(entry, seedFiles, candidatePaths);
+    }
+    return;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.path === 'string' && typeof record.content === 'string') {
+    seedFiles[record.path] = record.content;
+  } else if (typeof record.content === 'string' && candidatePaths.length > 0) {
+    seedFiles[candidatePaths[0]] ??= record.content;
+  }
+
+  for (const child of Object.values(record)) {
+    collectSeedFilesFromValue(child, seedFiles, candidatePaths);
+  }
+}
+
+function extractMarkdownPaths(value: string): string[] {
+  return value.match(/[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)*\.md/g) ?? [];
+}
+
+function createTrace(runId: string, config: EvalConfig): EvalTrace | undefined {
+  if (process.env.EVAL_TRACE_STREAM !== '1') {
+    return undefined;
+  }
+
+  const traceDir = path.resolve(process.cwd(), config.capture.artifactsDir, 'traces');
+  fs.mkdirSync(traceDir, { recursive: true });
+
+  const safeRunId = sanitizeFilePart(runId);
+  const tracePath = path.join(traceDir, `eval-trace-${safeRunId}-${Date.now()}.jsonl`);
+
+  return {
+    path: tracePath,
+    write(event: string, data: Record<string, unknown> = {}) {
+      fs.appendFileSync(
+        tracePath,
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          event,
+          ...data,
+        }) + '\n',
+        'utf-8'
+      );
+    },
+  };
+}
+
+function sanitizeFilePart(value: string): string {
+  return value.replace(/[^a-zA-Z0-9_-]/g, '_');
 }
 
 /**
@@ -97,15 +333,29 @@ export async function runScenario(
   config: EvalConfig
 ): Promise<ScenarioResult> {
   const startTime = Date.now();
+  const runId = `${provider.id}-${model.replace(/[\\/]/g, '_')}-${scenario.name}`;
+  const trace = createTrace(runId, config);
   const temperature = scenario.temperature ?? config.defaults.temperature;
   const maxRetries = scenario.maxRetries ?? config.defaults.maxRetries;
   const systemPrompt = scenario.systemPrompt ?? config.defaults.systemPrompt;
 
   let lastError: string | undefined;
   let retryCount = 0;
+  let lastTurnResults: TurnResult[] = [];
+
+  trace?.write('scenario_start', {
+    scenario: scenario.name,
+    description: scenario.description,
+    provider: provider.id,
+    model,
+    mode: config.mode,
+    maxRetries,
+  });
 
   // Retry loop
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    trace?.write('attempt_start', { attempt });
+
     try {
       const turnResults = await executeScenario(
         scenario,
@@ -114,56 +364,86 @@ export async function runScenario(
         tools,
         systemPrompt,
         temperature,
-        config
+        config,
+        trace
       );
 
       const allPassed = turnResults.every((t) => t.passed);
+      lastTurnResults = turnResults;
 
-      if (allPassed || attempt === maxRetries) {
+      if (allPassed) {
         return {
           scenario: scenario.name,
           description: scenario.description,
           provider: provider.id,
           model,
-          passed: allPassed,
+          passed: true,
           turns: turnResults,
           totalDurationMs: Date.now() - startTime,
           retryCount,
-          error: allPassed ? undefined : lastError,
+          tracePath: trace?.path,
         };
       }
 
-      // Retry on failure
-      retryCount++;
-      lastError = turnResults
-        .filter((t) => !t.passed)
-        .flatMap((t) => t.errors)
-        .join('; ');
+      const retryDecision = getRetryDecisionForTurnResults(turnResults);
+      lastError = retryDecision?.reason;
 
-      if (config.defaults.retryDelayMs > 0) {
-        await delay(config.defaults.retryDelayMs);
-      }
-    } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
-      retryCount++;
-
-      if (attempt === maxRetries) {
+      if (attempt === maxRetries || retryDecision?.retryable === false) {
         return {
           scenario: scenario.name,
           description: scenario.description,
           provider: provider.id,
           model,
           passed: false,
-          turns: [],
+          turns: turnResults,
           totalDurationMs: Date.now() - startTime,
           retryCount,
           error: lastError,
+          tracePath: trace?.path,
         };
       }
 
-      if (config.defaults.retryDelayMs > 0) {
-        await delay(config.defaults.retryDelayMs);
+      retryCount++;
+      const delayMs = calculateRetryDelayMs(attempt, config);
+      trace?.write('retry_scheduled', {
+        attempt,
+        nextAttempt: attempt + 1,
+        delayMs,
+        reason: lastError,
+      });
+      await delay(delayMs);
+    } catch (err) {
+      lastError = readErrorMessage(err);
+      trace?.write('attempt_error', {
+        attempt,
+        retryable: isRetryableEvalError(err),
+        error: lastError,
+      });
+
+      if (attempt === maxRetries || !isRetryableEvalError(err)) {
+        return {
+          scenario: scenario.name,
+          description: scenario.description,
+          provider: provider.id,
+          model,
+          passed: false,
+          turns: lastTurnResults,
+          totalDurationMs: Date.now() - startTime,
+          retryCount,
+          error: lastError,
+          tracePath: trace?.path,
+        };
       }
+
+      retryCount++;
+      const delayMs = calculateRetryDelayMs(attempt, config);
+      trace?.write('retry_scheduled', {
+        attempt,
+        nextAttempt: attempt + 1,
+        delayMs,
+        reason: lastError,
+      });
+      await delay(delayMs);
     }
   }
 
@@ -173,10 +453,11 @@ export async function runScenario(
     provider: provider.id,
     model,
     passed: false,
-    turns: [],
+    turns: lastTurnResults,
     totalDurationMs: Date.now() - startTime,
     retryCount,
     error: lastError ?? 'Unknown error',
+    tracePath: trace?.path,
   };
 }
 
@@ -217,6 +498,7 @@ async function createToolExecutor(
   config: EvalConfig,
   tools: Tool[],
   runId: string,
+  scenario: EvalScenario,
 ): Promise<{ executor: IToolExecutor & { getCapturedCalls(): CapturedToolCall[]; resetCalls(): void }; cleanup?: () => void }> {
   if (config.mode === 'live') {
     const path = await import('node:path');
@@ -224,7 +506,7 @@ async function createToolExecutor(
     const sanitizedRunId = runId.replace(/[^a-zA-Z0-9_-]/g, '_');
     const testVaultPath = path.join(testVaultRoot, sanitizedRunId);
     const liveExecutor = new LiveToolExecutor({ testVaultPath });
-    await liveExecutor.initialize();
+    await liveExecutor.reset(inferSeedFiles(scenario));
     return { executor: liveExecutor };
   }
 
@@ -242,10 +524,11 @@ async function executeScenario(
   tools: Tool[],
   systemPrompt: string,
   temperature: number,
-  config: EvalConfig
+  config: EvalConfig,
+  trace?: EvalTrace
 ): Promise<TurnResult[]> {
   const runId = `${provider.id}-${model.replace(/[\\/]/g, '_')}-${scenario.name}`;
-  const { executor: toolExecutor } = await createToolExecutor(config, tools, runId);
+  const { executor: toolExecutor } = await createToolExecutor(config, tools, runId, scenario);
   const adapter = await createAdapter(provider);
   const registry = new EvalAdapterRegistry([[provider.id, adapter]]);
 
@@ -268,6 +551,13 @@ async function executeScenario(
 
   for (const exchange of exchanges) {
     const exchangeStart = Date.now();
+    const turnIndex = turnResults.length;
+
+    trace?.write('exchange_start', {
+      turnIndex,
+      userMessage: exchange.userMessage,
+      expectedTools: exchange.rounds.flatMap((round) => round.expectedTools),
+    });
 
     // Register ALL mock responses for ALL rounds in this exchange upfront.
     // The orchestrator's internal pingpong will call the tool executor
@@ -287,6 +577,10 @@ async function executeScenario(
         role: 'user',
         content: exchange.userMessage,
       });
+      trace?.write('user_message', {
+        turnIndex,
+        content: exchange.userMessage,
+      });
     }
 
     // ONE generateResponseStream call — the orchestrator handles ALL tool rounds
@@ -299,6 +593,13 @@ async function executeScenario(
       systemPrompt,
       tools,
       temperature,
+      onToolEvent: (event, data) => {
+        trace?.write('tool_event', {
+          turnIndex,
+          toolEvent: event,
+          data: data as Record<string, unknown>,
+        });
+      },
     };
 
     let textContent = '';
@@ -312,11 +613,36 @@ async function executeScenario(
       for await (const yield_ of stream) {
         if (yield_.chunk) {
           textContent += yield_.chunk;
+          trace?.write('stream_chunk', {
+            turnIndex,
+            chunk: yield_.chunk,
+          });
+        }
+
+        if (yield_.reasoning) {
+          trace?.write('stream_reasoning', {
+            turnIndex,
+            reasoning: yield_.reasoning,
+            reasoningComplete: yield_.reasoningComplete,
+          });
+        }
+
+        if (yield_.toolCalls && yield_.toolCalls.length > 0) {
+          trace?.write('stream_tool_calls', {
+            turnIndex,
+            toolCalls: yield_.toolCalls,
+            toolCallsReady: yield_.toolCallsReady,
+          });
         }
       }
     } catch (err) {
       // Stream error — record as failed turn
       const errMsg = err instanceof Error ? err.message : String(err);
+      trace?.write('stream_error', {
+        turnIndex,
+        error: errMsg,
+        capturedCalls: toolExecutor.getCapturedCalls(),
+      });
       turnResults.push({
         turnIndex: turnResults.length,
         passed: false,
@@ -331,6 +657,11 @@ async function executeScenario(
 
     // Collect ALL tool calls that happened during this exchange's streaming response
     const capturedCalls = toolExecutor.getCapturedCalls();
+    trace?.write('captured_calls', {
+      turnIndex,
+      capturedCalls,
+      textContent,
+    });
 
     // Assert tool calls match expectations.
     // When allowReorder is set, check that all expected tools appear anywhere
@@ -343,6 +674,14 @@ async function executeScenario(
     const hallucinationAssertion = assertNoHallucinatedTools(capturedCalls, validToolNames);
 
     const errors = [...roundAssertion.errors, ...hallucinationAssertion.errors];
+    trace?.write('assertion_result', {
+      turnIndex,
+      passed: errors.length === 0,
+      errors,
+      expectedTools: exchange.rounds.flatMap(r => r.expectedTools),
+      actualToolCalls: capturedCalls,
+      textContent: textContent.trim(),
+    });
 
     turnResults.push({
       turnIndex: turnResults.length,

--- a/tests/eval/ReportGenerator.ts
+++ b/tests/eval/ReportGenerator.ts
@@ -64,12 +64,23 @@ export function generateReport(runResult: EvalRunResult, config: EvalConfig): st
       if (fail.error) {
         lines.push(`- **Error**: ${fail.error}`);
       }
+      if (fail.tracePath) {
+        lines.push(`- **Trace**: ${fail.tracePath}`);
+      }
 
       for (const turn of fail.turns.filter((t) => !t.passed)) {
         lines.push(`- **Turn ${turn.turnIndex + 1}**: ${turn.errors.join('; ')}`);
+        if (turn.textContent.trim()) {
+          lines.push(`  - Response: ${formatInlineSnippet(turn.textContent, 1000)}`);
+        }
         if (turn.actualToolCalls.length > 0) {
           const callNames = turn.actualToolCalls.map((c) => c.name).join(', ');
           lines.push(`  - Actual calls: [${callNames}]`);
+          for (const call of turn.actualToolCalls) {
+            lines.push(
+              `    - ${call.name} args: ${formatInlineSnippet(JSON.stringify(call.args), 500)}`
+            );
+          }
         }
       }
       lines.push('');
@@ -114,4 +125,13 @@ function shortModel(model: string): string {
   // "anthropic/claude-sonnet-4.6" -> "claude-sonnet-4.6"
   const parts = model.split('/');
   return parts.length > 1 ? parts[parts.length - 1] : model;
+}
+
+function formatInlineSnippet(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) {
+    return `\`${normalized}\``;
+  }
+
+  return `\`${normalized.slice(0, maxLength)}...[truncated]\``;
 }

--- a/tests/eval/ScenarioLoader.ts
+++ b/tests/eval/ScenarioLoader.ts
@@ -24,6 +24,10 @@ export async function loadScenarios(
   basePath?: string
 ): Promise<EvalScenario[]> {
   const cwd = basePath || process.cwd();
+  const directPath = path.resolve(cwd, pattern);
+  if (fs.existsSync(directPath) && fs.statSync(directPath).isFile()) {
+    return loadScenarioFiles([directPath]);
+  }
 
   // Extract the base directory and file suffix from the pattern
   // e.g., "tests/eval/scenarios/**/*.eval.yaml" -> dir="tests/eval/scenarios", suffix=".eval.yaml"
@@ -43,9 +47,13 @@ export async function loadScenarios(
     return [];
   }
 
+  return loadScenarioFiles(files.sort());
+}
+
+function loadScenarioFiles(files: string[]): EvalScenario[] {
   const scenarios: EvalScenario[] = [];
 
-  for (const file of files.sort()) {
+  for (const file of files) {
     const raw = fs.readFileSync(file, 'utf-8');
     const parsed = parseYaml(raw);
     const fileName = path.basename(file);

--- a/tests/eval/configs/default.yaml
+++ b/tests/eval/configs/default.yaml
@@ -18,6 +18,8 @@ defaults:
   temperature: 0
   maxRetries: 1
   retryDelayMs: 2000
+  retryBackoffMultiplier: 2
+  retryMaxDelayMs: 30000
   timeout: 120000
   systemPrompt: default
 

--- a/tests/eval/eval.test.ts
+++ b/tests/eval/eval.test.ts
@@ -7,16 +7,19 @@
  *
  * Usage:
  *   # Run with default config
- *   npx jest tests/eval/eval.test.ts --no-coverage --verbose
+ *   RUN_EVAL=1 npx jest tests/eval/eval.test.ts --no-coverage --verbose
  *
  *   # Run with specific config
- *   EVAL_CONFIG=tests/eval/configs/default.yaml npx jest tests/eval/eval.test.ts --no-coverage --verbose
+ *   RUN_EVAL=1 EVAL_CONFIG=tests/eval/configs/default.yaml npx jest tests/eval/eval.test.ts --no-coverage --verbose
+ *
+ *   # Run arbitrary live provider/model targets in parallel
+ *   RUN_EVAL=1 EVAL_MODE=live EVAL_TOOL_SET=meta EVAL_TARGETS='openrouter=deepseek/deepseek-v4-pro,openrouter=deepseek/deepseek-v4-flash' npx jest tests/eval/eval.test.ts --runInBand --no-coverage --verbose
  */
 
 import { loadConfig, getEnabledProviders } from './ConfigLoader';
 import { loadScenarios } from './ScenarioLoader';
 import { RequestCapture } from './RequestCapture';
-import { runScenario } from './EvalRunner';
+import { calculateMaxRetryDelayMs, runScenario } from './EvalRunner';
 import { generateReport, saveReport } from './ReportGenerator';
 import { META_TOOLS, NEXUS_TOOLS, SIMPLE_TOOLS } from './fixtures/tools';
 import { DEFAULT_SYSTEM_PROMPT, MINIMAL_SYSTEM_PROMPT, initializeSystemPrompts } from './fixtures/system-prompt';
@@ -31,7 +34,9 @@ const config = loadConfig();
 const enabledProviders = getEnabledProviders(config);
 const capture = new RequestCapture();
 
-const RUN_EVAL = enabledProviders.length > 0;
+const RUN_EVAL = process.env.RUN_EVAL === '1' && enabledProviders.length > 0;
+
+(globalThis as typeof globalThis & { require?: NodeRequire }).require = require;
 
 // Install request capture + initialize production system prompts
 beforeAll(async () => {
@@ -70,6 +75,23 @@ function buildModelReportPrefix(providerId: string, model: string): string {
   return `eval-report-${providerId}-${model.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
 }
 
+function shouldRunScenario(scenario: EvalScenario, providerId: string, model: string): boolean {
+  if (config.scenarioNames && !config.scenarioNames.includes(scenario.name)) {
+    return false;
+  }
+
+  if (config.scenarioToolSet && config.scenarioToolSet !== 'all') {
+    const scenarioToolSet = scenario.toolSet ?? 'meta';
+    if (scenarioToolSet !== config.scenarioToolSet) {
+      return false;
+    }
+  }
+
+  if (scenario.providers && !scenario.providers.includes(providerId)) return false;
+  if (scenario.models && !scenario.models.includes(model)) return false;
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Scenario loading + test generation
 // ---------------------------------------------------------------------------
@@ -81,23 +103,122 @@ describe('LLM Eval Harness', () => {
         .filter(([, p]) => p.enabled)
         .map(([, p]) => p.apiKeyEnv);
       console.log(
-        `\nEval harness skipped: set one of [${missingVars.join(', ')}] to enable.`
+        `\nEval harness skipped: set RUN_EVAL=1 and API key env vars [${missingVars.join(', ')}] to enable.`
       );
       expect(true).toBe(true);
     });
     return;
   }
 
-  let scenarios: EvalScenario[] = [];
   const allResults: ScenarioResult[] = [];
   const startTime = Date.now();
+  const testTimeoutMs = (
+    config.defaults.timeout * (config.defaults.maxRetries + 1) * 2
+  ) + calculateMaxRetryDelayMs(config.defaults.maxRetries, config) + 10_000;
 
-  beforeAll(async () => {
-    scenarios = await loadScenarios(config.scenarios);
+  it('runs the configured provider/model/scenario matrix in parallel', async () => {
+    const scenarios = await loadScenarios(config.scenarios);
     if (scenarios.length === 0) {
       console.warn('[Eval] No scenarios loaded — check scenarios glob pattern');
     }
-  });
+
+    const jobs = enabledProviders.flatMap((provider) =>
+      provider.models.flatMap((model) =>
+        scenarios
+          .filter((scenario) => shouldRunScenario(scenario, provider.id, model))
+          .map((scenario) => ({ provider, model, scenario }))
+      )
+    );
+
+    if (jobs.length === 0) {
+      console.warn('[Eval] No runnable provider/model/scenario jobs after filters');
+    }
+
+    const results = await Promise.all(jobs.map(async ({ provider, model, scenario }) => {
+      const shortModel = model.split('/').pop() || model;
+      const resolvedScenario = {
+        ...scenario,
+        systemPrompt: resolveSystemPrompt(
+          scenario.systemPrompt ?? config.defaults.systemPrompt
+        ),
+      };
+
+      console.log(`  [${provider.id}/${shortModel}] Running: ${scenario.name}`);
+
+      const tools = resolveToolSet(scenario.toolSet);
+      const captureScopeId = sanitizeScopeId(`${provider.id}_${shortModel}_${scenario.name}`);
+
+      const result = await capture.runWithScope(captureScopeId, async () => {
+        return await runScenario(
+          resolvedScenario,
+          provider,
+          model,
+          tools,
+          config
+        );
+      });
+
+      if (!result.passed && config.capture.dumpOnFailure) {
+        const dumpPath = capture.dumpScopeOnFailure(
+          captureScopeId,
+          config.capture.artifactsDir
+        );
+        if (dumpPath) {
+          console.log(`  [${provider.id}/${shortModel}] Request capture dumped: ${dumpPath}`);
+        }
+      }
+
+      const status = result.passed ? 'PASS' : 'FAIL';
+      const turnsPassed = result.turns.filter((t) => t.passed).length;
+      console.log(
+        `  [${provider.id}/${shortModel}] ${status}: ${scenario.name} (${turnsPassed}/${result.turns.length} turns, ${(result.totalDurationMs / 1000).toFixed(1)}s)`
+      );
+
+      if (!result.passed) {
+        for (const turn of result.turns.filter((t) => !t.passed)) {
+          console.log(`    Turn ${turn.turnIndex + 1}: ${turn.errors.join('; ')}`);
+        }
+      }
+
+      return result;
+    }));
+
+    allResults.push(...results);
+
+    const resultsByModel = new Map<string, ScenarioResult[]>();
+    for (const result of results) {
+      const key = `${result.provider}:${result.model}`;
+      const modelResults = resultsByModel.get(key) ?? [];
+      modelResults.push(result);
+      resultsByModel.set(key, modelResults);
+    }
+
+    for (const [key, modelResults] of resultsByModel) {
+      const [providerId, ...modelParts] = key.split(':');
+      const model = modelParts.join(':');
+      const shortModel = model.split('/').pop() || model;
+      const modelRunResult = {
+        config: process.env.EVAL_CONFIG || 'default',
+        mode: config.mode,
+        results: modelResults,
+        startTime,
+        endTime: Date.now(),
+      };
+
+      const modelReport = generateReport(modelRunResult, config);
+      const modelReportPath = saveReport(
+        modelReport,
+        config.capture.artifactsDir,
+        buildModelReportPrefix(providerId, shortModel),
+      );
+
+      const passed = modelResults.filter((r) => r.passed).length;
+      console.log(`  [${providerId}/${shortModel}] Report saved: ${modelReportPath}`);
+      console.log(`\n  [${providerId}/${shortModel}] Summary: ${passed}/${modelResults.length} scenarios passed`);
+    }
+
+    expect(results.length).toBeGreaterThan(0);
+  }, testTimeoutMs);
 
   afterAll(() => {
     // Generate and save report
@@ -116,108 +237,6 @@ describe('LLM Eval Harness', () => {
       console.log(report);
     }
   });
-
-  // Create test cases for each provider+model.
-  // Each model test runs concurrently, and each test already fans out all
-  // runnable scenarios in parallel via Promise.all.
-  for (const provider of enabledProviders) {
-    for (const model of provider.models) {
-      const shortModel = model.split('/').pop() || model;
-
-      describe(`${provider.id}/${shortModel}`, () => {
-        // We use a dynamic concurrent test that loads and runs all scenarios
-        // since scenarios are loaded asynchronously in beforeAll.
-        it.concurrent('runs all eval scenarios', async () => {
-          if (scenarios.length === 0) {
-            console.warn('No scenarios to run');
-            return;
-          }
-
-          const runnableScenarios = scenarios.filter((scenario) => {
-            if (scenario.providers && !scenario.providers.includes(provider.id)) return false;
-            if (scenario.models && !scenario.models.includes(model)) return false;
-            return true;
-          });
-
-          const results = await Promise.all(runnableScenarios.map(async (scenario) => {
-            const resolvedScenario = {
-              ...scenario,
-              systemPrompt: resolveSystemPrompt(
-                scenario.systemPrompt ?? config.defaults.systemPrompt
-              ),
-            };
-
-            console.log(`  [${shortModel}] Running: ${scenario.name}`);
-
-            const tools = resolveToolSet(scenario.toolSet);
-            const captureScopeId = sanitizeScopeId(`${provider.id}_${shortModel}_${scenario.name}`);
-
-            const result = await capture.runWithScope(captureScopeId, async () => {
-              return await runScenario(
-                resolvedScenario,
-                provider,
-                model,
-                tools,
-                config
-              );
-            });
-
-            if (!result.passed && config.capture.dumpOnFailure) {
-              const dumpPath = capture.dumpScopeOnFailure(
-                captureScopeId,
-                config.capture.artifactsDir
-              );
-              if (dumpPath) {
-                console.log(`  [${shortModel}] Request capture dumped: ${dumpPath}`);
-              }
-            }
-
-            const status = result.passed ? 'PASS' : 'FAIL';
-            const turnsPassed = result.turns.filter((t) => t.passed).length;
-            console.log(
-              `  [${shortModel}] ${status}: ${scenario.name} (${turnsPassed}/${result.turns.length} turns, ${(result.totalDurationMs / 1000).toFixed(1)}s)`
-            );
-
-            if (!result.passed) {
-              for (const turn of result.turns.filter((t) => !t.passed)) {
-                console.log(`    Turn ${turn.turnIndex + 1}: ${turn.errors.join('; ')}`);
-              }
-            }
-
-            return result;
-          }));
-
-          allResults.push(...results);
-
-          // Assert at least one scenario ran
-          expect(results.length).toBeGreaterThan(0);
-
-          const modelRunResult = {
-            config: process.env.EVAL_CONFIG || 'default',
-            mode: config.mode,
-            results,
-            startTime,
-            endTime: Date.now(),
-          };
-
-          const modelReport = generateReport(modelRunResult, config);
-          const modelReportPath = saveReport(
-            modelReport,
-            config.capture.artifactsDir,
-            buildModelReportPrefix(provider.id, shortModel),
-          );
-
-          console.log(`  [${shortModel}] Report saved: ${modelReportPath}`);
-
-          // Log summary
-          const passed = results.filter((r) => r.passed).length;
-          console.log(
-            `\n  [${shortModel}] Summary: ${passed}/${results.length} scenarios passed`
-          );
-        }, config.defaults.timeout * scenarios.length || 600_000);
-      });
-    }
-  }
 
   // Summary test
   describe('Configuration summary', () => {

--- a/tests/eval/fixtures/tools.ts
+++ b/tests/eval/fixtures/tools.ts
@@ -48,6 +48,39 @@ export const NEXUS_TOOLS: Tool[] = [
   {
     type: 'function',
     function: {
+      name: 'contentManager_insert',
+      description: 'Insert content into a note file at a specific position.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Path to the file to update' },
+          content: { type: 'string', description: 'Content to insert' },
+          position: { type: 'string', description: 'Insertion position' },
+          lineNumber: { type: 'number', description: 'Optional line number' },
+        },
+        required: ['path', 'content', 'position'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'contentManager_replace',
+      description: 'Replace text in a note file.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Path to the file to update' },
+          search: { type: 'string', description: 'Text to find' },
+          replace: { type: 'string', description: 'Replacement text' },
+        },
+        required: ['path', 'search', 'replace'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'storageManager_move',
       description: 'Move a file or folder to a new location.',
       parameters: {
@@ -57,6 +90,49 @@ export const NEXUS_TOOLS: Tool[] = [
           destination: { type: 'string', description: 'Destination path' },
         },
         required: ['path', 'destination'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'storageManager_copy',
+      description: 'Copy a file or folder to a new location.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Current path of the file or folder' },
+          destination: { type: 'string', description: 'Destination path' },
+        },
+        required: ['path', 'destination'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'storageManager_archive',
+      description: 'Archive a file or folder.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Path of the file or folder to archive' },
+        },
+        required: ['path'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'storageManager_createFolder',
+      description: 'Create a new folder.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: { type: 'string', description: 'Path of the folder to create' },
+        },
+        required: ['path'],
       },
     },
   },
@@ -84,6 +160,22 @@ export const NEXUS_TOOLS: Tool[] = [
         properties: {
           query: { type: 'string', description: 'Search query text' },
           limit: { type: 'number', description: 'Maximum number of results to return' },
+        },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'searchManager_searchDirectory',
+      description: 'Search for files and folders by path or name.',
+      parameters: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'Directory search query text' },
+          paths: { type: 'array', items: { type: 'string' }, description: 'Paths to search within' },
+          searchType: { type: 'string', description: 'Search type filter' },
         },
         required: ['query'],
       },

--- a/tests/eval/scenarios/content-operations.eval.yaml
+++ b/tests/eval/scenarios/content-operations.eval.yaml
@@ -4,6 +4,13 @@
 - name: simple-read
   description: Direct request to read a specific file
   toolSet: meta
+  seedFiles:
+    docs/api-reference.md: |
+      # API Reference
+
+      Endpoints:
+      - GET /users
+      - POST /users
   turns:
     - userMessage: "Show me the contents of docs/api-reference.md"
       expectedTools:
@@ -169,6 +176,13 @@
 - name: replace-content
   description: User asks to replace specific text in a note
   toolSet: meta
+  seedFiles:
+    notes/config.md: |
+      # Config
+
+      environment: staging
+      apiBaseUrl: https://staging.example.com
+      deployTarget: staging
   turns:
     - userMessage: "In notes/config.md, replace 'staging' with 'production' everywhere"
       expectedTools:

--- a/tests/eval/types.ts
+++ b/tests/eval/types.ts
@@ -25,6 +25,8 @@ export interface EvalDefaults {
   temperature: number;
   maxRetries: number;
   retryDelayMs: number;
+  retryBackoffMultiplier: number;
+  retryMaxDelayMs: number;
   timeout: number;
   systemPrompt: string;
 }
@@ -36,6 +38,17 @@ export interface EvalConfig {
   defaults: EvalDefaults;
   capture: CaptureConfig;
   scenarios: string;
+  /**
+   * Optional scenario tool-surface filter.
+   * - 'all': run every scenario regardless of toolSet
+   * - 'meta': production two-tool architecture only
+   * - 'nexus' / 'simple': targeted legacy/direct tool surfaces
+   */
+  scenarioToolSet?: ToolSetType | 'all';
+  /**
+   * Optional scenario-name filter for focused debugging runs.
+   */
+  scenarioNames?: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -71,6 +84,11 @@ export type ToolSetType = 'meta' | 'nexus' | 'simple';
 export interface EvalScenario {
   name: string;
   description: string;
+  /**
+   * Files to seed into the headless live test vault before this scenario runs.
+   * Mock mode ignores this because mockResponses provide tool outputs directly.
+   */
+  seedFiles?: Record<string, string>;
   providers?: string[];
   models?: string[];
   temperature?: number;
@@ -131,6 +149,7 @@ export interface ScenarioResult {
   totalDurationMs: number;
   retryCount: number;
   error?: string;
+  tracePath?: string;
 }
 
 export interface EvalRunResult {

--- a/tests/unit/EvalConfigLoader.test.ts
+++ b/tests/unit/EvalConfigLoader.test.ts
@@ -1,0 +1,104 @@
+describe('EvalConfigLoader', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.EVAL_TARGETS;
+    delete process.env.EVAL_PROVIDER;
+    delete process.env.EVAL_MODEL;
+    delete process.env.EVAL_MODELS;
+    delete process.env.EVAL_MODE;
+    delete process.env.EVAL_SCENARIOS;
+    delete process.env.EVAL_SCENARIO_NAMES;
+    delete process.env.EVAL_TOOL_SET;
+    delete process.env.EVAL_MAX_RETRIES;
+    delete process.env.EVAL_RETRY_DELAY_MS;
+    delete process.env.EVAL_RETRY_BACKOFF_MULTIPLIER;
+    delete process.env.EVAL_RETRY_MAX_DELAY_MS;
+    delete process.env.EVAL_TIMEOUT_MS;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('overrides providers from arbitrary EVAL_TARGETS entries', async () => {
+    process.env.EVAL_TARGETS = [
+      'openrouter=deepseek/deepseek-v4-pro',
+      'openrouter=deepseek/deepseek-v4-flash',
+      'openai=openai/gpt-5.4',
+    ].join(',');
+
+    const { loadConfig } = await import('../eval/ConfigLoader');
+    const config = loadConfig();
+
+    expect(Object.keys(config.providers).sort()).toEqual(['openai', 'openrouter']);
+    expect(config.providers.openrouter).toMatchObject({
+      apiKeyEnv: 'OPENROUTER_API_KEY',
+      enabled: true,
+      models: ['deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-flash'],
+    });
+    expect(config.providers.openai).toMatchObject({
+      apiKeyEnv: 'OPENAI_API_KEY',
+      enabled: true,
+      models: ['gpt-5.4'],
+    });
+  });
+
+  it('supports single-provider shorthand and eval filters', async () => {
+    process.env.EVAL_PROVIDER = 'openrouter';
+    process.env.EVAL_MODELS = 'anthropic/claude-sonnet-4.6,openai/gpt-5.4-mini';
+    process.env.EVAL_MODE = 'live';
+    process.env.EVAL_SCENARIOS = 'tests/eval/scenarios/search-variations.eval.yaml';
+    process.env.EVAL_SCENARIO_NAMES = 'simple-read,replace-content,create-folder-structure';
+    process.env.EVAL_TOOL_SET = 'meta';
+    process.env.EVAL_MAX_RETRIES = '3';
+    process.env.EVAL_RETRY_DELAY_MS = '500';
+    process.env.EVAL_RETRY_BACKOFF_MULTIPLIER = '3';
+    process.env.EVAL_RETRY_MAX_DELAY_MS = '10000';
+    process.env.EVAL_TIMEOUT_MS = '90000';
+
+    const { loadConfig } = await import('../eval/ConfigLoader');
+    const config = loadConfig();
+
+    expect(config.mode).toBe('live');
+    expect(config.scenarios).toBe('tests/eval/scenarios/search-variations.eval.yaml');
+    expect(config.scenarioNames).toEqual([
+      'simple-read',
+      'replace-content',
+      'create-folder-structure',
+    ]);
+    expect(config.scenarioToolSet).toBe('meta');
+    expect(config.defaults).toMatchObject({
+      maxRetries: 3,
+      retryDelayMs: 500,
+      retryBackoffMultiplier: 3,
+      retryMaxDelayMs: 10000,
+      timeout: 90000,
+    });
+    expect(config.providers).toEqual({
+      openrouter: {
+        apiKeyEnv: 'OPENROUTER_API_KEY',
+        enabled: true,
+        models: ['anthropic/claude-sonnet-4.6', 'openai/gpt-5.4-mini'],
+      },
+    });
+  });
+
+  it('resolves enabled provider API keys from process env', async () => {
+    process.env.EVAL_TARGETS = 'openrouter=deepseek/deepseek-v4-flash';
+    process.env.OPENROUTER_API_KEY = 'test-openrouter-key';
+
+    const { getEnabledProviders, loadConfig } = await import('../eval/ConfigLoader');
+    const providers = getEnabledProviders(loadConfig());
+
+    expect(providers).toEqual([
+      {
+        id: 'openrouter',
+        apiKey: 'test-openrouter-key',
+        models: ['deepseek/deepseek-v4-flash'],
+      },
+    ]);
+  });
+});

--- a/tests/unit/EvalRunnerRetry.test.ts
+++ b/tests/unit/EvalRunnerRetry.test.ts
@@ -1,0 +1,50 @@
+import {
+  calculateMaxRetryDelayMs,
+  calculateRetryDelayMs,
+  isRetryableEvalError,
+} from '../eval/EvalRunner';
+import type { EvalConfig } from '../eval/types';
+
+const config: EvalConfig = {
+  mode: 'live',
+  providers: {},
+  defaults: {
+    temperature: 0,
+    maxRetries: 4,
+    retryDelayMs: 500,
+    retryBackoffMultiplier: 2,
+    retryMaxDelayMs: 2_000,
+    timeout: 120_000,
+    systemPrompt: 'default',
+  },
+  capture: {
+    enabled: false,
+    dumpOnFailure: false,
+    artifactsDir: 'test-artifacts/',
+  },
+  scenarios: 'tests/eval/scenarios/**/*.eval.yaml',
+};
+
+describe('EvalRunner retry helpers', () => {
+  it('identifies rate limits, server errors, and transient transport failures as retryable', () => {
+    expect(isRetryableEvalError(new Error('OpenRouter returned HTTP 429 rate limit'))).toBe(true);
+    expect(isRetryableEvalError(new Error('Provider stream failed with 503 Service unavailable'))).toBe(true);
+    expect(isRetryableEvalError(new Error('socket hang up'))).toBe(true);
+    expect(isRetryableEvalError({ status: 500, message: 'Internal server error' })).toBe(true);
+    expect(isRetryableEvalError({ response: { status: 504 }, message: 'Gateway timeout' })).toBe(true);
+  });
+
+  it('does not retry authentication and validation failures', () => {
+    expect(isRetryableEvalError(new Error('HTTP 401 Unauthorized'))).toBe(false);
+    expect(isRetryableEvalError(new Error('HTTP 400 invalid request'))).toBe(false);
+    expect(isRetryableEvalError({ status: 403, message: 'Forbidden' })).toBe(false);
+  });
+
+  it('calculates capped exponential backoff delays', () => {
+    expect(calculateRetryDelayMs(0, config)).toBe(500);
+    expect(calculateRetryDelayMs(1, config)).toBe(1_000);
+    expect(calculateRetryDelayMs(2, config)).toBe(2_000);
+    expect(calculateRetryDelayMs(3, config)).toBe(2_000);
+    expect(calculateMaxRetryDelayMs(4, config)).toBe(5_500);
+  });
+});


### PR DESCRIPTION
## Summary

Expands the LLM eval harness in `tests/eval/`: retry-on-transient-error, structured YAML config, broader scenario coverage, and a new `/nexus-eval-harness` skill for invoking it.

**1 commit:**
- `6e44ae08` feat(eval): expand harness with retry, structured config, scenario coverage + nexus-eval-harness skill

## Why

Slice 5/5 of the workspace/memory/search batch refactor. The current eval harness is at 27/30 pass (90%) with multi-model coverage — this slice tightens the failure modes (transient API errors no longer count as test failures) and adds the skill so the harness is reproducibly invokable.

## Test plan
- [x] `npm test` green standalone against main (2474 pass / 1 pre-existing ModelAgentManager fail / 12 skip)
- [ ] Manual: run `tests/eval/eval.test.ts` against the live providers configured in `tests/eval/configs/default.yaml`
- [ ] Manual: invoke `/nexus-eval-harness` from a fresh session, verify it produces the expected report

🤖 Generated with [Claude Code](https://claude.com/claude-code)