### PR TITLE
fix(storage): event-based waitForQueryReady + await before legacy fallback (#190)

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -172,6 +172,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
     percent: 0,
     statusText: ''
   };
+  private queryReadyWaiters: Array<(ready: boolean) => void> = [];
 
   // Deferred initialization support
   private initPromise: Promise<void> | null = null;
@@ -522,6 +523,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
       percent: 100,
       statusText: 'Local chat index updated'
     };
+    this.settleQueryReadyWaiters(true);
   }
 
   private failStartupHydration(error: string): void {
@@ -535,6 +537,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
       statusText: 'Local chat index update failed',
       error
     };
+    this.settleQueryReadyWaiters(false);
   }
 
   private clearStartupHydrationState(): void {
@@ -547,6 +550,16 @@ export class HybridStorageAdapter implements IStorageAdapter {
       percent: 0,
       statusText: ''
     };
+    this.settleQueryReadyWaiters(true);
+  }
+
+  private settleQueryReadyWaiters(ready: boolean): void {
+    if (this.queryReadyWaiters.length === 0) return;
+    const waiters = this.queryReadyWaiters;
+    this.queryReadyWaiters = [];
+    for (const resolve of waiters) {
+      try { resolve(ready); } catch { /* swallow — waiter already settled */ }
+    }
   }
 
   /**
@@ -730,22 +743,37 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.initialized && !this.initError;
   }
 
-  async waitForQueryReady(maxWaitMs = 60_000): Promise<boolean> {
-    const ready = await this.waitForReady();
-    if (!ready) {
-      return false;
-    }
+  waitForQueryReady(maxWaitMs = 60_000): Promise<boolean> {
+    if (this.isQueryReady()) return Promise.resolve(true);
+    if (this.initialized && this.initError) return Promise.resolve(false);
 
-    const deadline = Date.now() + maxWaitMs;
-    while (this.startupHydrationState.phase === 'running') {
-      if (Date.now() >= deadline) {
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        this.queryReadyWaiters = this.queryReadyWaiters.filter(w => w !== settle);
+        resolve(value);
+      };
+      const timer = setTimeout(() => {
         console.error('[HybridStorageAdapter] waitForQueryReady timed out after', maxWaitMs, 'ms');
-        return false;
-      }
-      await new Promise(resolve => setTimeout(resolve, 250));
-    }
+        settle(false);
+      }, maxWaitMs);
+      this.queryReadyWaiters.push(settle);
 
-    return this.isQueryReady();
+      if (!this.initialized && this.initPromise) {
+        this.initPromise
+          .then(() => {
+            if (this.initError) {
+              settle(false);
+            } else if (this.isQueryReady()) {
+              settle(true);
+            }
+          })
+          .catch(() => settle(false));
+      }
+    });
   }
 
   /**

--- a/src/services/helpers/DualBackendExecutor.ts
+++ b/src/services/helpers/DualBackendExecutor.ts
@@ -16,7 +16,15 @@ export type StorageAdapterOrGetter = IStorageAdapter | (() => IStorageAdapter | 
 
 type QueryAwareStorageAdapter = IStorageAdapter & {
   isQueryReady?: () => boolean;
+  waitForQueryReady?: (maxWaitMs?: number) => Promise<boolean>;
 };
+
+function getRawAdapter(adapterOrGetter: StorageAdapterOrGetter): QueryAwareStorageAdapter | undefined {
+  if (typeof adapterOrGetter === 'function') {
+    return adapterOrGetter() as QueryAwareStorageAdapter | undefined;
+  }
+  return adapterOrGetter as QueryAwareStorageAdapter | undefined;
+}
 
 /**
  * Resolve a StorageAdapterOrGetter to a ready IStorageAdapter, or undefined.
@@ -92,17 +100,27 @@ export async function withDualBackend<T>(
 /**
  * Execute a dual-backend read operation.
  *
- * Routes to SQLite only when the adapter reports that read queries are safe.
- * Falls back to legacy storage during startup hydration windows.
+ * Routes to SQLite when query-ready. If the adapter is initialized but still
+ * hydrating, awaits `waitForQueryReady()` (event-driven; timeout is a safety
+ * net for stuck hydration) before falling through to legacy. This closes the
+ * race window where reads issued during startup silently hit a stale legacy
+ * view (issue #190).
  */
 export async function withReadableBackend<T>(
   adapterOrGetter: StorageAdapterOrGetter,
   adapterFn: (adapter: IStorageAdapter) => T | Promise<T>,
   legacyFn: () => T | Promise<T>
 ): Promise<T> {
-  const adapter = resolveReadableAdapter(adapterOrGetter);
-  if (adapter) {
-    return adapterFn(adapter);
+  let adapter = resolveReadableAdapter(adapterOrGetter);
+  if (adapter) return adapterFn(adapter);
+
+  const raw = getRawAdapter(adapterOrGetter);
+  if (raw && raw.isReady() && typeof raw.waitForQueryReady === 'function') {
+    const ready = await raw.waitForQueryReady();
+    if (ready) {
+      adapter = resolveReadableAdapter(adapterOrGetter);
+      if (adapter) return adapterFn(adapter);
+    }
   }
   return legacyFn();
 }

--- a/tests/unit/DualBackendExecutor.test.ts
+++ b/tests/unit/DualBackendExecutor.test.ts
@@ -111,4 +111,82 @@ describe('DualBackendExecutor', () => {
 
     expect(result).toBe('adapter');
   });
+
+  it('withReadableBackend awaits waitForQueryReady when hydrating, then uses adapter on success', async () => {
+    let queryReady = false;
+    const adapter = createAdapter({
+      isReady: () => true,
+      isQueryReady: () => queryReady,
+      waitForQueryReady: async () => {
+        queryReady = true;
+        return true;
+      }
+    } as Partial<IStorageAdapter> & {
+      isQueryReady?: () => boolean;
+      waitForQueryReady?: () => Promise<boolean>;
+    });
+
+    const result = await withReadableBackend(
+      adapter,
+      async () => 'adapter',
+      async () => 'legacy'
+    );
+
+    expect(result).toBe('adapter');
+  });
+
+  it('withReadableBackend falls through to legacy when waitForQueryReady resolves false', async () => {
+    const adapter = createAdapter({
+      isReady: () => true,
+      isQueryReady: () => false,
+      waitForQueryReady: async () => false
+    } as Partial<IStorageAdapter> & {
+      isQueryReady?: () => boolean;
+      waitForQueryReady?: () => Promise<boolean>;
+    });
+
+    const result = await withReadableBackend(
+      adapter,
+      async () => 'adapter',
+      async () => 'legacy'
+    );
+
+    expect(result).toBe('legacy');
+  });
+
+  it('withReadableBackend does not call waitForQueryReady when adapter is already query-ready', async () => {
+    const waitSpy = jest.fn(async () => true);
+    const adapter = createAdapter({
+      isReady: () => true,
+      isQueryReady: () => true,
+      waitForQueryReady: waitSpy
+    } as Partial<IStorageAdapter> & {
+      isQueryReady?: () => boolean;
+      waitForQueryReady?: () => Promise<boolean>;
+    });
+
+    const result = await withReadableBackend(
+      adapter,
+      async () => 'adapter',
+      async () => 'legacy'
+    );
+
+    expect(result).toBe('adapter');
+    expect(waitSpy).not.toHaveBeenCalled();
+  });
+
+  it('withReadableBackend falls through immediately when adapter has no waitForQueryReady (back-compat)', async () => {
+    const adapter = createAdapter({
+      isReady: () => true,
+      isQueryReady: () => false
+    });
+
+    const result = await withReadableBackend(
+      adapter,
+      async () => 'adapter',
+      async () => 'legacy'
+    );
+
+    expect(result).toBe('legacy');
+  });
 });

--- a/tests/unit/HybridStorageAdapter.test.ts
+++ b/tests/unit/HybridStorageAdapter.test.ts
@@ -103,6 +103,86 @@ describe('HybridStorageAdapter', () => {
     });
   });
 
+  describe('waitForQueryReady (event-based)', () => {
+    type AdapterPrivates = HybridStorageAdapter & {
+      initialized: boolean;
+      initError: Error | null;
+      initPromise?: Promise<void>;
+      startupHydrationState: { phase: 'idle' | 'running' | 'complete' | 'error'; [k: string]: unknown };
+      queryReadyWaiters: Array<(ready: boolean) => void>;
+      completeStartupHydration: () => void;
+      failStartupHydration: (error: string) => void;
+      clearStartupHydrationState: () => void;
+    };
+
+    function makeAdapter(phase: 'idle' | 'running' | 'complete' | 'error' = 'running'): AdapterPrivates {
+      const a = Object.create(HybridStorageAdapter.prototype) as AdapterPrivates;
+      a.initialized = true;
+      a.initError = null;
+      a.startupHydrationState = {
+        phase,
+        isBlocking: phase === 'running',
+        stage: '',
+        progress: 0,
+        total: 1,
+        percent: 0,
+        statusText: ''
+      };
+      a.queryReadyWaiters = [];
+      return a;
+    }
+
+    it('returns true immediately when already query-ready', async () => {
+      const a = makeAdapter('idle');
+      await expect(a.waitForQueryReady(50)).resolves.toBe(true);
+    });
+
+    it('resolves true when completeStartupHydration fires', async () => {
+      const a = makeAdapter('running');
+      const pending = a.waitForQueryReady(5_000);
+      expect(a.queryReadyWaiters).toHaveLength(1);
+      a.completeStartupHydration();
+      await expect(pending).resolves.toBe(true);
+      expect(a.queryReadyWaiters).toHaveLength(0);
+    });
+
+    it('resolves true when clearStartupHydrationState fires', async () => {
+      const a = makeAdapter('running');
+      const pending = a.waitForQueryReady(5_000);
+      a.clearStartupHydrationState();
+      await expect(pending).resolves.toBe(true);
+    });
+
+    it('resolves false when failStartupHydration fires', async () => {
+      const a = makeAdapter('running');
+      const pending = a.waitForQueryReady(5_000);
+      a.failStartupHydration('boom');
+      await expect(pending).resolves.toBe(false);
+    });
+
+    it('resolves false on timeout when no transition fires', async () => {
+      const a = makeAdapter('running');
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await expect(a.waitForQueryReady(20)).resolves.toBe(false);
+        expect(a.queryReadyWaiters).toHaveLength(0);
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('settles all concurrent waiters at the same transition', async () => {
+      const a = makeAdapter('running');
+      const p1 = a.waitForQueryReady(5_000);
+      const p2 = a.waitForQueryReady(5_000);
+      const p3 = a.waitForQueryReady(5_000);
+      expect(a.queryReadyWaiters).toHaveLength(3);
+      a.completeStartupHydration();
+      await expect(Promise.all([p1, p2, p3])).resolves.toEqual([true, true, true]);
+      expect(a.queryReadyWaiters).toHaveLength(0);
+    });
+  });
+
   describe('reconcileMissingConversations', () => {
     it('replays missing conversation JSONL files into SQLite cache', async () => {
       const adapter = Object.create(HybridStorageAdapter.prototype) as HybridStorageAdapter & {


### PR DESCRIPTION
## Summary

Closes the SQLite-hydration read race diagnosed by @gcp007-ops in #190. During the 1–3s warm hydration window after `Cmd+P → Reload` (or 30–60s on cold boot), `loadWorkspace` returned `Workspace not found` and `listStates` silently returned `data: []` because `withReadableBackend` fell through to the legacy backend whenever `isQueryReady()` was false. The legacy `WorkspaceService.getWorkspace` returns either `null` or `sessions: {}` during hydration, masquerading as a legitimate empty result.

Fixes #190.

## Changes

**1. `HybridStorageAdapter.waitForQueryReady` — event-based, not polling.**
The prior implementation polled every 250ms with a 60s timeout. The new implementation registers a waiter synchronously and is settled by the existing phase transitions:
- `completeStartupHydration()` → resolve `true`
- `clearStartupHydrationState()` → resolve `true`
- `failStartupHydration()` → resolve `false`
- 60s timeout → resolve `false` (safety net only — primary mechanism is event-driven)

Synchronous registration sidesteps a microtask race where transitions firing between `waitForReady()`'s `await` and the waiter being pushed would have been lost. When init is still pending, hooks into `initPromise` to detect terminal states.

**2. `DualBackendExecutor.withReadableBackend` — await once before falling through.**
- Adapter already query-ready → fast path (no await)
- Adapter initialized but hydrating → suspend until hydration event, then take adapter path
- Adapter init failed / hydration timed out → fall through to legacy (current behavior, now signal-driven)
- Adapter has no `waitForQueryReady` → fall through immediately (back-compat)

## Why event-based, not just a longer poll

The contributor flagged that timeout-based logic isn't robust. Polling burns wakeups during normal hydration; the timeout becomes load-bearing on slow hardware; and a stuck process can't tell hydration-running from hydration-wedged. Event-based reduces the timeout to a true safety net — if hydration fires, callers wake on the same tick the phase transitions.

## Test plan

- [x] `npm test` — 2553 pass / 1 pre-existing `ModelAgentManager` fail (unchanged, predates this PR) / 12 skip
- [x] `npm run build` — clean (lint + tsc + esbuild + connector generation)
- [x] 6 new `HybridStorageAdapter` tests: immediate-ready, complete/clear/fail transitions, timeout safety net, concurrent waiter settlement
- [x] 4 new `DualBackendExecutor` tests: await-then-adapter, await-fail-then-legacy, fast-path skip, back-compat when `waitForQueryReady` is absent
- [ ] Manual: `Cmd+P → Reload`, immediately call `loadWorkspace` — expect populated result (no longer "Workspace not found"); expect `listStates` to return populated rather than silent `[]`

## Out of scope

The contributor also noted that `listStates` (no workspace filter) silently scopes to the global `default` workspace, and recommended echoing the resolved `workspaceId` in every envelope. Those are independent issues — happy to file follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)