### PR TITLE
fix(tools): strip outer array brackets when JSON-array literal fails to parse (#200)

### DIFF
--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -312,7 +312,7 @@ function coerceValue(raw: string, type: string): unknown {
     if (jsonItems !== null) {
       return jsonItems.map((item: unknown) => coerceArrayItem(item, itemType));
     }
-    return splitCsvRespectingQuotes(raw).map(item => coerceValue(item, itemType));
+    return splitCsvRespectingQuotes(stripOuterArrayBrackets(raw)).map(item => coerceValue(item, itemType));
   }
 
   if (type === 'object') {
@@ -340,13 +340,62 @@ function coerceValue(raw: string, type: string): unknown {
         // Malformed JSON → fall through to CSV split.
       }
     }
-    const items = splitCsvRespectingQuotes(raw);
+    const items = splitCsvRespectingQuotes(stripOuterArrayBrackets(raw));
     if (items.length >= 2) return items;
     if (items.length === 1) return items[0];
     return raw;
   }
 
   return raw;
+}
+
+/**
+ * If `raw` is wrapped by a single outer `[...]` pair (depth returns to zero
+ * exactly at the final char), return the unwrapped inner content. Otherwise
+ * return `raw` unchanged. Quote-aware: brackets inside `"..."` or `'...'`
+ * don't affect depth.
+ *
+ * Bug this guards: `set-property --value "[[[A]],[[B]],[[C]]]"` where the
+ * caller intends an array of three Obsidian wikilinks. JSON.parse fails
+ * (wikilinks aren't valid JSON), and the previous CSV fallback split the
+ * raw string verbatim — the outer `[` stayed glued to the first item and
+ * the outer `]` stayed glued to the last, writing `[[[A]]` and `[[C]]]` to
+ * the frontmatter. Stripping the outer pair first leaves `[[A]],[[B]],[[C]]`,
+ * which CSV-splits cleanly into `["[[A]]", "[[B]]", "[[C]]"]`.
+ *
+ * Bare CSV like `[[A]],[[B]]` (no outer wrapper) is preserved: depth zeroes
+ * out mid-string at the close of the first wikilink, so the function bails
+ * and returns `raw` unchanged.
+ *
+ * Issue: ProfSynapse/nexus#TBD.
+ */
+export function stripOuterArrayBrackets(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) return raw;
+
+  let depth = 0;
+  let quote: '"' | '\'' | null = null;
+  let escaped = false;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const ch = trimmed[i];
+    if (escaped) { escaped = false; continue; }
+    if (ch === '\\') { escaped = true; continue; }
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === '\'') { quote = ch; continue; }
+    if (ch === '[') depth += 1;
+    else if (ch === ']') {
+      depth -= 1;
+      // Outer pair only matches if depth zeroes out exactly at the final char.
+      // An earlier zero-depth (e.g. `[[A]],[[B]]`) means there's no single
+      // outer pair — leave `raw` alone so the CSV splitter sees it as-is.
+      if (depth === 0 && i < trimmed.length - 1) return raw;
+    }
+  }
+  if (depth !== 0) return raw; // unbalanced — don't touch
+  return trimmed.slice(1, -1);
 }
 
 function coerceArrayItem(item: unknown, itemType: string): unknown {

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -587,16 +587,16 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       expect(call.params.tags).toEqual(['[broken']);
     });
 
-    it('falls back to CSV split on multi-item malformed JSON and preserves all items', () => {
+    it('strips outer array literal brackets on multi-item malformed JSON and preserves all items', () => {
       // `[a,b,c]` wraps with [] so the JSON-parse branch IS attempted, then
-      // throws (unquoted identifiers). The catch falls through to
-      // splitCsvRespectingQuotes, which splits on top-level commas. This is
-      // the real proof that the fallback preserves every item, not just the
-      // single-token case above.
+      // throws (unquoted identifiers). Outer `[...]` is then stripped by
+      // stripOuterArrayBrackets and the inner CSV splits on top-level commas
+      // — the wikilink frontmatter bug fix path. (Previously the outer
+      // brackets stayed glued to the first/last items.)
       const [call] = makeNormalizer().normalizeExecutionCalls({
         tool: 'numeric convert --tags "[a,b,c]"',
       });
-      expect(call.params.tags).toEqual(['[a', 'b', 'c]']);
+      expect(call.params.tags).toEqual(['a', 'b', 'c']);
     });
 
     it('non-wrapped multi-item raw input skips JSON branch and CSV-splits', () => {
@@ -714,15 +714,39 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       expect(call.params.value).toBe('   ');
     });
 
-    it('bracket-wrapped malformed JSON falls through to CSV split', () => {
-      // `[a,b,c]` wraps in brackets so the JSON branch is attempted, fails
-      // on unquoted identifiers, and falls through to splitCsvRespectingQuotes.
-      // Outer brackets stay attached to the first/last items. Matches the
-      // array<string> branch's fallback behavior (see Bug #2 characterization).
+    it('bracket-wrapped malformed JSON strips outer brackets before CSV split', () => {
+      // `[a,b,c]` wraps in brackets so the JSON branch is attempted and fails
+      // on unquoted identifiers. Previously the fallback split the raw string
+      // verbatim, gluing `[` to the first item and `]` to the last. Now the
+      // outer pair is stripped first via stripOuterArrayBrackets, recovering
+      // the intended three-item array.
       const [call] = makeNormalizer().normalizeExecutionCalls({
         tool: 'one-of set-prop "[a,b,c]"',
       });
-      expect(call.params.value).toEqual(['[a', 'b', 'c]']);
+      expect(call.params.value).toEqual(['a', 'b', 'c']);
+    });
+
+    it('Obsidian wikilinks wrapped in array literal — triple-bracket repro', () => {
+      // Real-world bug: setProperty --value "[[[A]],[[B]],[[C]]]" intends an
+      // array of three Obsidian wikilinks. JSON.parse fails (wikilinks aren't
+      // valid JSON); fallback used to split the raw string and write
+      // `[[[A]]` and `[[C]]]` to frontmatter. Now the outer `[...]` is
+      // stripped first, leaving `[[A]],[[B]],[[C]]` which CSV-splits cleanly.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[[[A]],[[B]],[[C]]]"',
+      });
+      expect(call.params.value).toEqual(['[[A]]', '[[B]]', '[[C]]']);
+    });
+
+    it('bare CSV of wikilinks (no outer wrapper) preserved unchanged', () => {
+      // Counter-case: `[[A]],[[B]]` starts with `[` and ends with `]` but the
+      // outer pair is part of a wikilink, not a wrapper. stripOuterArrayBrackets
+      // must detect that depth zeroes out before the final char and leave the
+      // raw string alone, so CSV-split sees both wikilinks intact.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[[A]],[[B]]"',
+      });
+      expect(call.params.value).toEqual(['[[A]]', '[[B]]']);
     });
 
     it('bracket-prefix-only (no closing bracket) skips JSON and splits as CSV', () => {
@@ -931,6 +955,26 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
         tool: 'storage archive --paths "a,,b,"',
       });
       expect(call.params.paths).toEqual(['a', 'b']);
+    });
+
+    it('outer-bracket-wrapped non-JSON CSV strips outer brackets before split', () => {
+      // Symmetric with the oneOfArray fix: a `--flag "[a,b,c]"` value where the
+      // caller used array-literal shape but JSON.parse can't handle unquoted
+      // identifiers. Outer pair stripped, inner CSV-split clean.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths "[a,b,c]"',
+      });
+      expect(call.params.paths).toEqual(['a', 'b', 'c']);
+    });
+
+    it('Obsidian wikilinks wrapped in array literal — array<string> path', () => {
+      // The setProperty bug also reaches the array<string> branch when a tool
+      // schema declares an explicit `array: { items: { type: 'string' } }`.
+      // Same fix applies via stripOuterArrayBrackets.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths "[[[A]],[[B]]]"',
+      });
+      expect(call.params.paths).toEqual(['[[A]]', '[[B]]']);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes #200. `setProperty` (and any `array<X>` / `oneOfArray` flag in the CLI normalizer) corrupted array values when callers passed a JSON-array-literal-shaped string whose contents weren't valid JSON. The outer `[` ended up glued to the first item and `]` to the last — producing malformed wikilinks like `[[[A]]` and `[[C]]]` in frontmatter and silently breaking link/Dataview resolution. Reporter observed the bug in production on nine notes in a real vault.

## Fix

Adds `stripOuterArrayBrackets(raw)` in `src/agents/toolManager/services/ToolCliNormalizer.ts` — a depth-counting, quote-aware helper that unwraps a single outer `[...]` pair only when the bracket depth returns to zero exactly at the final character. Bare CSV like `[[A]],[[B]]` (depth zeroes mid-string at the close of the first wikilink) is left untouched. Applied on the CSV-fallback path of both the `array<X>` branch (`coerceValue` line 315) and the `oneOfArray` branch (line 343). The JSON-parse path is unchanged, so the documented workaround (`["[[A]]","[[B]]","[[C]]"]`) and well-formed `[1,2,3]` etc. continue to behave identically.

Disambiguation table the helper handles correctly:

| Input | Behavior |
|---|---|
| `[[[A]],[[B]],[[C]]]` | Strip → `['[[A]]','[[B]]','[[C]]']` |
| `[[A]],[[B]]` (bare CSV) | Leave alone → `['[[A]]','[[B]]']` |
| `[a,b,c]` | Strip → `['a','b','c']` |
| `[broken` (no closing bracket) | Leave alone → `['[broken']` |

Patch authored by @gcp007-ops (cherry-picked from `gcp007-ops/nexus:fix/coerce-value-array-literal-strip-outer-brackets`).

## Test plan

- [x] `npm test -- tests/unit/ToolManagerCliSyntax.test.ts` — 170/170 pass, including 3 new positive tests: triple-bracket wikilink repro on `oneOfArray`, bare-CSV-of-wikilinks counter-case, and triple-bracket repro on `array<string>` path.
- [x] Two pinned-broken tests at `tests/unit/ToolManagerCliSyntax.test.ts:599` and `:725` updated from characterizing the bug (`['[a','b','c]']`) to asserting the corrected behavior (`['a','b','c']`).
- [x] `npm test` — full suite 2623/2624 pass; the single failure (`ModelAgentManager.test.ts:242`) is a pre-existing failure documented in CLAUDE.md that reproduces on `main` and is unrelated to this change.
- [ ] Manual smoke: `useTools` with `content set-property --value "[[[A]],[[B]],[[C]]]" --mode replace` writes three clean wikilinks to frontmatter (recommended before merge).

https://claude.ai/code/session_01NAnvUoRTtjBZgTFpi7meFE

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAnvUoRTtjBZgTFpi7meFE)_