### PR TITLE
feat(llm): add DeepSeek as first-class cloud provider (#204)

### DIFF
--- a/src/agents/ingestManager/tools/ingestTool.ts
+++ b/src/agents/ingestManager/tools/ingestTool.ts
@@ -204,6 +204,7 @@ function formatProviderName(provider: string): string {
   const nameMap: Record<string, string> = {
     openai: 'OpenAI',
     groq: 'Groq',
+    deepseek: 'DeepSeek',
     google: 'Google Gemini',
     openrouter: 'OpenRouter',
     mistral: 'Mistral',

--- a/src/agents/ingestManager/tools/services/VisionMessageFormatter.ts
+++ b/src/agents/ingestManager/tools/services/VisionMessageFormatter.ts
@@ -15,6 +15,7 @@ const PROVIDER_FAMILY_MAP: Record<string, VisionProviderFamily> = {
   'openai-codex': 'openai',
   'github-copilot': 'openai',
   groq: 'openai',
+  deepseek: 'openai',
   openrouter: 'openai',
   mistral: 'openai',
   requesty: 'openai',

--- a/src/components/shared/ModelDropdownRenderer.ts
+++ b/src/components/shared/ModelDropdownRenderer.ts
@@ -23,6 +23,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   'google-gemini-cli': 'Gemini CLI',
   mistral: 'Mistral AI',
   groq: 'Groq',
+  deepseek: 'DeepSeek',
   deepgram: 'Deepgram',
   assemblyai: 'AssemblyAI',
   openrouter: 'OpenRouter',

--- a/src/services/llm/adapters/deepseek/DeepSeekAdapter.ts
+++ b/src/services/llm/adapters/deepseek/DeepSeekAdapter.ts
@@ -1,0 +1,375 @@
+/**
+ * DeepSeek Adapter
+ *
+ * DeepSeek exposes an OpenAI-compatible REST surface at
+ * https://api.deepseek.com with Bearer-token auth. Notable differences from
+ * upstream OpenAI:
+ *   - Thinking mode is opt-in via the `thinking: { type, reasoning_effort }`
+ *     request param (NOT the top-level `reasoning_effort` shape Groq uses).
+ *   - Reasoning text is surfaced in `delta.reasoning_content` (streaming) or
+ *     `message.reasoning_content` (non-streaming) and is mapped onto the
+ *     unified StreamChunk.reasoning / LLMResponse.metadata.reasoning fields.
+ *   - `frequency_penalty` and `presence_penalty` are NOT supported and must
+ *     be stripped from outbound requests even when our shared GenerateOptions
+ *     carries them.
+ *
+ * Mirrors the shape of GroqAdapter (closest sibling: OpenAI-compatible + SSE
+ * via processNodeStream) intentionally. Do not consolidate into a generic
+ * adapter — DeepSeek's thinking shape and reasoning_content surface are
+ * provider-specific.
+ */
+
+import { BaseAdapter } from '../BaseAdapter';
+import {
+  GenerateOptions,
+  StreamChunk,
+  LLMResponse,
+  ModelInfo,
+  ProviderCapabilities,
+  ModelPricing,
+  Tool,
+  TokenUsage
+} from '../types';
+import type { SSEToolCall } from '../../streaming/SSEStreamProcessor';
+import {
+  DEEPSEEK_MODELS,
+  DEEPSEEK_DEFAULT_MODEL,
+  isDeepSeekThinkingModel,
+  resolveDeepSeekApiModel
+} from './DeepSeekModels';
+
+interface DeepSeekChatCompletionUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_cache_hit_tokens?: number;
+  prompt_cache_miss_tokens?: number;
+}
+
+interface DeepSeekChatCompletionMessage {
+  content?: string;
+  reasoning_content?: string;
+  tool_calls?: unknown[];
+}
+
+interface DeepSeekChatCompletionChoice {
+  delta?: DeepSeekChatCompletionMessage & {
+    content?: string;
+    reasoning_content?: string;
+    tool_calls?: unknown[];
+  };
+  message?: DeepSeekChatCompletionMessage;
+  finish_reason?: string | null;
+}
+
+interface DeepSeekChatCompletionResponse {
+  choices: DeepSeekChatCompletionChoice[];
+  usage?: DeepSeekChatCompletionUsage;
+}
+
+type DeepSeekChatCompletionMessageParam = Record<string, unknown>;
+
+function isDeepSeekChatCompletionResponse(parsed: unknown): parsed is DeepSeekChatCompletionResponse {
+  if (!parsed || typeof parsed !== 'object') {
+    return false;
+  }
+  return Array.isArray((parsed as Record<string, unknown>).choices);
+}
+
+/**
+ * Map our unified ThinkingEffort ('low' | 'medium' | 'high') onto DeepSeek's
+ * accepted reasoning_effort values ('high' | 'max'). DeepSeek does not have a
+ * 'low' tier; we surface 'high' as the entry point and reserve 'max' for the
+ * 'high' setting (which our UI treats as the most aggressive option).
+ */
+function mapDeepSeekReasoningEffort(effort: 'low' | 'medium' | 'high'): 'high' | 'max' {
+  return effort === 'high' ? 'max' : 'high';
+}
+
+export class DeepSeekAdapter extends BaseAdapter {
+  readonly name = 'deepseek';
+  readonly baseUrl = 'https://api.deepseek.com';
+
+  constructor(apiKey: string, model?: string) {
+    super(apiKey, model || DEEPSEEK_DEFAULT_MODEL);
+    this.initializeCache();
+  }
+
+  async generateUncached(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
+    try {
+      if (options?.tools && options.tools.length > 0) {
+        throw new Error('Tool execution requires streaming. Use generateStreamAsync() instead.');
+      }
+      return await this.generateWithChatCompletions(prompt, options);
+    } catch (error) {
+      this.handleError(error, 'generation');
+    }
+  }
+
+  async* generateStreamAsync(prompt: string, options?: GenerateOptions): AsyncGenerator<StreamChunk, void, unknown> {
+    try {
+      const requestBody = this.buildRequestBody(prompt, options, true);
+
+      const nodeStream = await this.requestStream({
+        url: `${this.baseUrl}/chat/completions`,
+        operation: 'streaming generation',
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestBody),
+        timeoutMs: 120_000
+      });
+
+      yield* this.processNodeStream(nodeStream, {
+        debugLabel: 'DeepSeek',
+        extractContent: (chunk) => {
+          if (!isDeepSeekChatCompletionResponse(chunk)) return null;
+          return chunk.choices[0]?.delta?.content || null;
+        },
+        extractReasoning: (chunk) => {
+          if (!isDeepSeekChatCompletionResponse(chunk)) return null;
+          const reasoning = chunk.choices[0]?.delta?.reasoning_content;
+          if (typeof reasoning === 'string' && reasoning.length > 0) {
+            return { text: reasoning, complete: false };
+          }
+          return null;
+        },
+        extractToolCalls: (chunk) => {
+          if (!isDeepSeekChatCompletionResponse(chunk)) return null;
+          return (chunk.choices[0]?.delta?.tool_calls || null) as SSEToolCall[] | null;
+        },
+        extractFinishReason: (chunk) => {
+          if (!isDeepSeekChatCompletionResponse(chunk)) return null;
+          return chunk.choices[0]?.finish_reason ?? null;
+        },
+        extractUsage: (chunk) => {
+          if (!chunk || typeof chunk !== 'object') return undefined;
+          const usage = (chunk as unknown as DeepSeekChatCompletionResponse).usage;
+          if (!usage) return undefined;
+          return {
+            prompt_tokens: usage.prompt_tokens,
+            completion_tokens: usage.completion_tokens,
+            total_tokens: usage.total_tokens
+          };
+        },
+        accumulateToolCalls: true,
+        toolCallThrottling: {
+          initialYield: true,
+          progressInterval: 50
+        }
+      });
+    } catch (error) {
+      console.error('[DeepSeekAdapter] Streaming error:', error);
+      throw error;
+    }
+  }
+
+  listModels(): Promise<ModelInfo[]> {
+    try {
+      return Promise.resolve(DEEPSEEK_MODELS.map(model => ({
+        id: model.apiName,
+        name: model.name,
+        contextWindow: model.contextWindow,
+        maxOutputTokens: model.maxTokens,
+        supportsJSON: model.capabilities.supportsJSON,
+        supportsImages: model.capabilities.supportsImages,
+        supportsFunctions: model.capabilities.supportsFunctions,
+        supportsStreaming: model.capabilities.supportsStreaming,
+        supportsThinking: model.capabilities.supportsThinking,
+        pricing: {
+          inputPerMillion: model.inputCostPerMillion,
+          outputPerMillion: model.outputCostPerMillion,
+          currency: 'USD',
+          lastUpdated: new Date().toISOString()
+        }
+      })));
+    } catch (error) {
+      this.handleError(error, 'listing models');
+      return Promise.resolve([]);
+    }
+  }
+
+  getCapabilities(): ProviderCapabilities {
+    return {
+      supportsStreaming: true,
+      streamingMode: 'streaming',
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsThinking: true,
+      maxContextWindow: 1_000_000,
+      supportedFeatures: [
+        'messages',
+        'function_calling',
+        'streaming',
+        'json_mode',
+        'thinking_mode',
+        'reasoning_content'
+      ]
+    };
+  }
+
+  getModelPricing(modelId: string): Promise<ModelPricing | null> {
+    const model = DEEPSEEK_MODELS.find(m => m.apiName === modelId);
+    if (!model) return Promise.resolve(null);
+
+    return Promise.resolve({
+      rateInputPerMillion: model.inputCostPerMillion,
+      rateOutputPerMillion: model.outputCostPerMillion,
+      currency: 'USD'
+    });
+  }
+
+  private async generateWithChatCompletions(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
+    const requestBody = this.buildRequestBody(prompt, options, false);
+
+    const response = await this.request<DeepSeekChatCompletionResponse>({
+      url: `${this.baseUrl}/chat/completions`,
+      operation: 'generation',
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(requestBody),
+      timeoutMs: 60_000
+    });
+    this.assertOk(response, `DeepSeek generation failed: HTTP ${response.status}`);
+
+    const responseJson = response.json as DeepSeekChatCompletionResponse;
+    const choice = responseJson.choices[0];
+    if (!choice) {
+      throw new Error('No response from DeepSeek');
+    }
+
+    const text = choice.message?.content || '';
+    const reasoning = choice.message?.reasoning_content;
+    const usage = this.extractUsage(responseJson);
+    const finishReason = this.mapFinishReason(choice.finish_reason ?? null);
+
+    const metadata: Record<string, unknown> = {};
+    if (typeof reasoning === 'string' && reasoning.length > 0) {
+      metadata.reasoning = reasoning;
+    }
+
+    const apiModel = resolveDeepSeekApiModel(options?.model || this.currentModel);
+    return this.buildLLMResponse(
+      text,
+      // Surface the user-facing model id (preserving -thinking suffix) so
+      // pricing/registry lookups still resolve correctly.
+      options?.model || this.currentModel,
+      usage,
+      Object.keys(metadata).length > 0 ? metadata : undefined,
+      finishReason
+    ).then((built) => {
+      // Store the wire-side model id for telemetry consumers that want it.
+      if (built.metadata) {
+        built.metadata.apiModel = apiModel;
+      }
+      return built;
+    });
+  }
+
+  /**
+   * Build the request body for /chat/completions. Centralized so streaming
+   * and non-streaming paths share the exact same shape — including the
+   * thinking-mode toggle and the explicit drop of frequency/presence
+   * penalties.
+   */
+  private buildRequestBody(prompt: string, options: GenerateOptions | undefined, stream: boolean): Record<string, unknown> {
+    const userModel = options?.model || this.currentModel;
+    const apiModel = resolveDeepSeekApiModel(userModel);
+
+    const body: Record<string, unknown> = {
+      model: apiModel,
+      messages: this.buildMessagesForRequest(prompt, options),
+      temperature: options?.temperature,
+      max_tokens: options?.maxTokens,
+      top_p: options?.topP,
+      stop: options?.stopSequences,
+      response_format: options?.jsonMode ? { type: 'json_object' } : undefined,
+      stream
+    };
+
+    if (options?.tools && options.tools.length > 0) {
+      body.tools = this.convertTools(options.tools);
+    }
+
+    // Note: frequency_penalty and presence_penalty are intentionally NOT
+    // forwarded to DeepSeek. The API removed support and including them
+    // results in a 400 error response.
+
+    const thinkingRequested = isDeepSeekThinkingModel(userModel) || options?.enableThinking === true;
+    if (thinkingRequested) {
+      const effort = options?.thinkingEffort || 'medium';
+      body.thinking = {
+        type: 'enabled',
+        reasoning_effort: mapDeepSeekReasoningEffort(effort)
+      };
+    }
+
+    // Strip undefined keys so we don't emit `"temperature": undefined`
+    // through JSON.stringify (which silently drops them but pollutes diffs).
+    for (const key of Object.keys(body)) {
+      if (body[key] === undefined) {
+        delete body[key];
+      }
+    }
+
+    return body;
+  }
+
+  private convertTools(tools: Tool[]): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> {
+    return tools.map(tool => {
+      if (tool.type === 'function' && tool.function) {
+        return {
+          type: 'function' as const,
+          function: {
+            name: tool.function.name,
+            description: tool.function.description,
+            parameters: tool.function.parameters
+          }
+        };
+      }
+      throw new Error(`Unsupported tool type: ${tool.type}`);
+    });
+  }
+
+  private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
+    if (!reason) return 'stop';
+    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
+      stop: 'stop',
+      length: 'length',
+      tool_calls: 'tool_calls',
+      content_filter: 'content_filter'
+    };
+    return reasonMap[reason] || 'stop';
+  }
+
+  protected extractUsage(response: DeepSeekChatCompletionResponse): TokenUsage | undefined {
+    const usage = response?.usage;
+    if (!usage) return undefined;
+    return {
+      promptTokens: usage.prompt_tokens || 0,
+      completionTokens: usage.completion_tokens || 0,
+      totalTokens: usage.total_tokens || 0,
+      ...(usage.prompt_cache_hit_tokens !== undefined && { cachedTokens: usage.prompt_cache_hit_tokens })
+    };
+  }
+
+  private buildMessagesForRequest(prompt: string, options?: GenerateOptions): DeepSeekChatCompletionMessageParam[] {
+    if (options?.conversationHistory && options.conversationHistory.length > 0) {
+      const messages = options.conversationHistory;
+      if (options.systemPrompt) {
+        const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
+        if (!hasSystem) {
+          return [{ role: 'system', content: options.systemPrompt }, ...messages];
+        }
+      }
+      return messages;
+    }
+    return this.buildMessages(prompt, options?.systemPrompt);
+  }
+}

--- a/src/services/llm/adapters/deepseek/DeepSeekModels.ts
+++ b/src/services/llm/adapters/deepseek/DeepSeekModels.ts
@@ -1,0 +1,111 @@
+/**
+ * DeepSeek Model Specifications
+ *
+ * DeepSeek provides cost-efficient OpenAI-compatible models with very large
+ * (1M token) context windows and a proprietary thinking-mode toggle.
+ *
+ * Thinking mode is enabled per-request via the
+ * `thinking: { type: 'enabled', reasoning_effort }` body parameter; the API
+ * surfaces reasoning text in `delta.reasoning_content` (streaming) or
+ * `message.reasoning_content` (non-streaming). For UI/registry purposes we
+ * expose a thinking variant for each base model so users can pick one or the
+ * other from a single dropdown.
+ */
+
+import { ModelSpec } from '../modelTypes';
+
+export const DEEPSEEK_MODELS: ModelSpec[] = [
+  // Flash — cost-optimized, non-thinking default
+  {
+    provider: 'deepseek',
+    name: 'DeepSeek V4 Flash',
+    apiName: 'deepseek-v4-flash',
+    contextWindow: 1_000_000,
+    maxTokens: 65_536, // API supports up to 384K, capped here for safety with downstream buildLLMResponse
+    inputCostPerMillion: 0.14,
+    outputCostPerMillion: 0.28,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: false
+    }
+  },
+  {
+    provider: 'deepseek',
+    name: 'DeepSeek V4 Flash (Thinking)',
+    apiName: 'deepseek-v4-flash-thinking',
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+    inputCostPerMillion: 0.14,
+    outputCostPerMillion: 0.28,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Pro — higher quality. Pricing reflects 75% promotional discount valid through 2026-05-31.
+  // Original list price: $1.74 input / $3.48 output per 1M tokens.
+  {
+    provider: 'deepseek',
+    name: 'DeepSeek V4 Pro',
+    apiName: 'deepseek-v4-pro',
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+    inputCostPerMillion: 0.435,
+    outputCostPerMillion: 0.87,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: false
+    }
+  },
+  {
+    provider: 'deepseek',
+    name: 'DeepSeek V4 Pro (Thinking)',
+    apiName: 'deepseek-v4-pro-thinking',
+    contextWindow: 1_000_000,
+    maxTokens: 65_536,
+    inputCostPerMillion: 0.435,
+    outputCostPerMillion: 0.87,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  }
+];
+
+export const DEEPSEEK_DEFAULT_MODEL = 'deepseek-v4-flash';
+
+/**
+ * Returns true if a DeepSeek model id maps to a thinking-capable variant.
+ * Used by the adapter to decide whether to send the `thinking` request param
+ * when the user has enabled thinking via settings or selected a *-thinking
+ * model directly.
+ */
+export function isDeepSeekThinkingModel(modelId: string): boolean {
+  return modelId.endsWith('-thinking');
+}
+
+/**
+ * Resolve the underlying API model id. DeepSeek treats
+ * `deepseek-v4-flash-thinking` as the same wire model as `deepseek-v4-flash`
+ * — the difference is the `thinking` request param. We strip the suffix
+ * before sending to the wire.
+ */
+export function resolveDeepSeekApiModel(modelId: string): string {
+  if (modelId.endsWith('-thinking')) {
+    return modelId.slice(0, -'-thinking'.length);
+  }
+  return modelId;
+}

--- a/src/services/llm/adapters/types.ts
+++ b/src/services/llm/adapters/types.ts
@@ -6,7 +6,7 @@
 /**
  * Supported LLM providers
  */
-export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'anthropic-claude-code' | 'google' | 'google-gemini-cli' | 'github-copilot' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
+export type SupportedProvider = 'openai' | 'openai-codex' | 'openrouter' | 'anthropic' | 'anthropic-claude-code' | 'google' | 'google-gemini-cli' | 'github-copilot' | 'deepseek' | 'groq' | 'mistral' | 'perplexity' | 'requesty';
 
 export interface GenerateOptions {
   model?: string;

--- a/src/services/llm/core/AdapterRegistry.ts
+++ b/src/services/llm/core/AdapterRegistry.ts
@@ -251,6 +251,11 @@ export class AdapterRegistry implements IAdapterRegistry {
       return new GroqAdapter(config.apiKey);
     });
 
+    await this.initializeProviderAsync('deepseek', providers.deepseek, async (config) => {
+      const { DeepSeekAdapter } = await import('../adapters/deepseek/DeepSeekAdapter');
+      return new DeepSeekAdapter(config.apiKey);
+    });
+
     // ═══════════════════════════════════════════════════════════════════════════
     // DESKTOP-ONLY PROVIDERS
     // ═══════════════════════════════════════════════════════════════════════════

--- a/src/services/llm/providers/ProviderManager.ts
+++ b/src/services/llm/providers/ProviderManager.ts
@@ -338,6 +338,11 @@ export class LLMProviderManager {
         description: 'Ultra-fast inference speeds for quick responses'
       },
       {
+        id: 'deepseek',
+        name: 'DeepSeek',
+        description: 'Cost-efficient reasoning models with 1M context'
+      },
+      {
         id: 'deepgram',
         name: 'Deepgram',
         description: 'Specialized speech-to-text with strong word timing and transcript structure'

--- a/src/services/llm/utils/ThinkingEffortMapper.ts
+++ b/src/services/llm/utils/ThinkingEffortMapper.ts
@@ -35,6 +35,23 @@ export interface ProviderThinkingConfig {
   groq?: {
     reasoning_effort: 'low' | 'medium' | 'high';
   };
+  // DeepSeek: thinking.{type, reasoning_effort}
+  deepseek?: {
+    thinking: {
+      type: 'enabled';
+      reasoning_effort: 'high' | 'max';
+    };
+  };
+}
+
+/**
+ * Map our unified ThinkingEffort to DeepSeek's accepted reasoning_effort
+ * values. DeepSeek only supports 'high' and 'max'; we treat 'high' as the
+ * most aggressive option and use it for our internal 'high' setting, while
+ * 'low' and 'medium' both downshift to 'high' (the entry point).
+ */
+function mapDeepSeekEffort(effort: ThinkingEffort): 'high' | 'max' {
+  return effort === 'high' ? 'max' : 'high';
 }
 
 /**
@@ -124,6 +141,23 @@ export class ThinkingEffortMapper {
   }
 
   /**
+   * Get DeepSeek thinking parameters.
+   * DeepSeek's request body shape is { thinking: { type, reasoning_effort } }
+   * — distinct from Groq's top-level reasoning_effort.
+   */
+  static getDeepSeekParams(settings: ThinkingSettings): { thinking?: { type: 'enabled'; reasoning_effort: 'high' | 'max' } } | null {
+    if (!settings.enabled) {
+      return null;
+    }
+    return {
+      thinking: {
+        type: 'enabled',
+        reasoning_effort: mapDeepSeekEffort(settings.effort)
+      }
+    };
+  }
+
+  /**
    * Get provider-specific thinking configuration based on provider ID
    */
   static getProviderConfig(providerId: string, settings: ThinkingSettings): ProviderThinkingConfig | null {
@@ -167,6 +201,15 @@ export class ThinkingEffortMapper {
             reasoning_effort: settings.effort
           }
         };
+      case 'deepseek':
+        return {
+          deepseek: {
+            thinking: {
+              type: 'enabled',
+              reasoning_effort: mapDeepSeekEffort(settings.effort)
+            }
+          }
+        };
       default:
         // Unknown provider - return null
         return null;
@@ -177,7 +220,7 @@ export class ThinkingEffortMapper {
    * Check if a provider supports thinking/reasoning features
    */
   static providerSupportsThinking(providerId: string): boolean {
-    const supportedProviders = ['anthropic', 'openai', 'google', 'gemini', 'openrouter', 'groq'];
+    const supportedProviders = ['anthropic', 'openai', 'google', 'gemini', 'openrouter', 'groq', 'deepseek'];
     return supportedProviders.includes(providerId.toLowerCase());
   }
 

--- a/src/services/llm/validation/ValidationService.ts
+++ b/src/services/llm/validation/ValidationService.ts
@@ -130,6 +130,9 @@ export class LLMValidationService {
         case 'groq':
           result = await this.validateGroq(apiKey);
           break;
+        case 'deepseek':
+          result = await this.validateDeepSeek(apiKey);
+          break;
         case 'deepgram':
           result = await this.validateDeepgram(apiKey);
           break;
@@ -328,6 +331,39 @@ export class LLMValidationService {
       return { 
         success: false, 
         error: error instanceof Error ? error.message : 'Groq API key validation failed' 
+      };
+    }
+  }
+
+  private static async validateDeepSeek(apiKey: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      const response = await this.requestWithTimeout('deepseek', 'DeepSeek validation', {
+        url: 'https://api.deepseek.com/chat/completions',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: 'deepseek-v4-flash',
+          messages: [{ role: 'user', content: 'Hi' }],
+          max_tokens: 5
+        })
+      });
+
+      if (response.status >= 200 && response.status < 300) {
+        return { success: true };
+      } else {
+        const errorData = (response.json ?? {});
+        return {
+          success: false,
+          error: errorData.error?.message || `HTTP ${response.status}`
+        };
+      }
+    } catch (error: unknown) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'DeepSeek API key validation failed'
       };
     }
   }

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -125,6 +125,12 @@ export class ProvidersTab {
             signupUrl: 'https://console.groq.com/keys',
             category: 'cloud'
         },
+        deepseek: {
+            name: 'DeepSeek',
+            keyFormat: 'sk-...',
+            signupUrl: 'https://platform.deepseek.com/api_keys',
+            category: 'cloud'
+        },
         deepgram: {
             name: 'Deepgram',
             keyFormat: 'dg_...',
@@ -487,7 +493,7 @@ export class ProvidersTab {
             groups.push({ title: 'LOCAL PROVIDERS', items: localItems });
         }
 
-        const cloudIds = ['openai', 'anthropic', 'google', 'mistral', 'groq', 'deepgram', 'assemblyai', 'openrouter', 'requesty', 'perplexity', 'github-copilot'];
+        const cloudIds = ['openai', 'anthropic', 'google', 'mistral', 'groq', 'deepseek', 'deepgram', 'assemblyai', 'openrouter', 'requesty', 'perplexity', 'github-copilot'];
         const cloudItems = cloudIds
             .map(id => this.buildProviderCardItem(id, settings))
             .filter((item): item is ProviderCardItem => item !== null);

--- a/src/types/llm/ProviderTypes.ts
+++ b/src/types/llm/ProviderTypes.ts
@@ -121,6 +121,10 @@ export const DEFAULT_LLM_PROVIDER_SETTINGS: LLMProviderSettings = {
       apiKey: '',
       enabled: false
     },
+    deepseek: {
+      apiKey: '',
+      enabled: false
+    },
     deepgram: {
       apiKey: '',
       enabled: false

--- a/src/ui/chat/utils/ProviderUtils.ts
+++ b/src/ui/chat/utils/ProviderUtils.ts
@@ -24,6 +24,7 @@ export class ProviderUtils {
       'cohere': 'Cohere',
       'huggingface': 'Hugging Face',
       'groq': 'Groq',
+      'deepseek': 'DeepSeek',
       'perplexity': 'Perplexity',
       'requesty': 'Requesty'
     };
@@ -90,7 +91,8 @@ export class ProviderUtils {
       'cohere': '#39c6b9',
       'huggingface': '#ff9a00',
       'deepgram': '#13ef93',
-      'assemblyai': '#4f46e5'
+      'assemblyai': '#4f46e5',
+      'deepseek': '#4d6bfe'
     };
     return colors[providerId] || '#6b7280';
   }
@@ -114,7 +116,8 @@ export class ProviderUtils {
       'cohere': '🧬',
       'huggingface': '🤗',
       'deepgram': '🎙️',
-      'assemblyai': '📝'
+      'assemblyai': '📝',
+      'deepseek': '🐋'
     };
     return icons[providerId] || '🤖';
   }
@@ -151,7 +154,8 @@ export class ProviderUtils {
       'cohere': 'COH',
       'huggingface': 'HF',
       'deepgram': 'DGM',
-      'assemblyai': 'AAI'
+      'assemblyai': 'AAI',
+      'deepseek': 'DSK'
     };
     return abbreviations[providerId] || providerId.substring(0, 3).toUpperCase();
   }
@@ -172,6 +176,7 @@ export class ProviderUtils {
       'openrouter',
       'google',      // ✅ Google Gemini streaming via generateContentStream
       'groq',        // ✅ Groq streaming support
+      'deepseek',    // ✅ DeepSeek streaming via OpenAI-compatible SSE
       'github-copilot' // ✅ GitHub Copilot streaming via OpenAI-compatible SSE
     ];
     return streamingProviders.includes(providerId);
@@ -188,6 +193,7 @@ export class ProviderUtils {
       'webllm',      // ✅ [TOOL_CALLS] content format for fine-tuned models
       'openrouter',  // ✅ OpenAI-compatible function calling
       'groq',        // ✅ OpenAI-compatible function calling
+      'deepseek',    // ✅ OpenAI-compatible function calling
       'mistral',     // ✅ Native Mistral function calling
       'requesty',    // ✅ OpenAI-compatible function calling
       'anthropic',   // ✅ Native Claude tool calling
@@ -248,7 +254,7 @@ export class ProviderUtils {
       streaming: this.supportsStreaming(providerId),
       functionCalling: this.supportsFunctionCalling(providerId),
       imageInput: ['openai', 'anthropic', 'anthropic-claude-code', 'google', 'google-gemini-cli', 'github-copilot'].includes(providerId),
-      jsonMode: ['openai', 'mistral'].includes(providerId)
+      jsonMode: ['openai', 'mistral', 'deepseek'].includes(providerId)
     };
   }
 }

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-05-07T19:52:05.848Z
+ * Generated: 2026-05-08T13:07:36.743Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -170,6 +170,8 @@ export const MOBILE_COMPATIBLE_PROVIDERS = [
     'google',       // Uses requestUrl-backed REST transport
     'mistral',      // Uses requestUrl-backed REST transport
     'groq',         // Uses requestUrl-backed REST transport
+    'deepseek',     // Uses requestUrl-backed REST transport
+
     'openrouter',   // Uses fetch - 400+ models via unified API
     'requesty',     // Uses fetch - Router for multiple providers
     'perplexity',   // Uses fetch - Web search focused

--- a/tests/services/llm/adapters/deepseek/DeepSeekAdapter.test.ts
+++ b/tests/services/llm/adapters/deepseek/DeepSeekAdapter.test.ts
@@ -1,0 +1,275 @@
+/**
+ * DeepSeekAdapter Unit Tests
+ *
+ * Covers:
+ *   - Streaming reasoning_content surfacing onto StreamChunk.reasoning
+ *   - Non-streaming reasoning_content surfacing onto LLMResponse.metadata.reasoning
+ *   - Thinking-mode request body (thinking: { type, reasoning_effort })
+ *   - frequency_penalty / presence_penalty are NOT forwarded
+ *   - -thinking model id triggers thinking even when options.thinking is unset
+ */
+
+import { DeepSeekAdapter } from '../../../../../src/services/llm/adapters/deepseek/DeepSeekAdapter';
+import type { GenerateOptions, StreamChunk } from '../../../../../src/services/llm/adapters/types';
+import { ThinkingEffortMapper } from '../../../../../src/services/llm/utils/ThinkingEffortMapper';
+
+type AdapterPrototype = {
+  // We override these on the instance via casting; they exist on BaseAdapter.
+  requestStream: (config: { url: string; body?: string; headers?: Record<string, string>; method?: string }) => Promise<AsyncIterable<string>>;
+  request: <T>(config: { url: string; body?: string; headers?: Record<string, string> }) => Promise<{ status: number; ok: boolean; json: T; text: string; headers: Record<string, string>; arrayBuffer: ArrayBuffer }>;
+  assertOk: (response: unknown) => unknown;
+};
+
+/**
+ * Build an async iterable that yields each provided string as a separate
+ * "chunk" from the underlying Node stream. The SSE parser inside
+ * processNodeStream will reassemble events from these.
+ */
+function makeSseStream(events: string[]): AsyncIterable<string> {
+  const sseText = events.map(e => `data: ${e}\n\n`).join('') + 'data: [DONE]\n\n';
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield sseText;
+    }
+  };
+}
+
+async function collectStream(gen: AsyncGenerator<StreamChunk, void, unknown>): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = [];
+  for await (const chunk of gen) {
+    out.push(chunk);
+  }
+  return out;
+}
+
+describe('DeepSeekAdapter', () => {
+  let adapter: DeepSeekAdapter;
+  let capturedRequests: Array<{ url: string; body: unknown; headers?: Record<string, string> }>;
+
+  beforeEach(() => {
+    adapter = new DeepSeekAdapter('sk-test-key');
+    capturedRequests = [];
+  });
+
+  describe('streaming', () => {
+    it('extracts delta.content into StreamChunk.content', async () => {
+      const events = [
+        JSON.stringify({ choices: [{ delta: { content: 'Hello' } }] }),
+        JSON.stringify({ choices: [{ delta: { content: ' world' } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }], usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 } })
+      ];
+
+      (adapter as unknown as AdapterPrototype).requestStream = async (config) => {
+        capturedRequests.push({ url: config.url, body: JSON.parse(config.body || '{}') as unknown });
+        return makeSseStream(events);
+      };
+
+      const chunks = await collectStream(adapter.generateStreamAsync('hi'));
+      const text = chunks.map(c => c.content).join('');
+      expect(text).toContain('Hello world');
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage?.totalTokens).toBe(7);
+    });
+
+    it('extracts delta.reasoning_content into StreamChunk.reasoning', async () => {
+      const events = [
+        JSON.stringify({ choices: [{ delta: { reasoning_content: 'Let me think' } }] }),
+        JSON.stringify({ choices: [{ delta: { reasoning_content: ' about this.' } }] }),
+        JSON.stringify({ choices: [{ delta: { content: 'Answer.' } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })
+      ];
+
+      (adapter as unknown as AdapterPrototype).requestStream = async () => makeSseStream(events);
+
+      const chunks = await collectStream(adapter.generateStreamAsync('hi'));
+      const reasoningChunks = chunks.filter(c => c.reasoning);
+      const reasoningText = reasoningChunks.map(c => c.reasoning).join('');
+      expect(reasoningText).toBe('Let me think about this.');
+
+      const contentChunks = chunks.filter(c => c.content && !c.complete);
+      expect(contentChunks.map(c => c.content).join('')).toBe('Answer.');
+    });
+
+    it('does NOT yield reasoning chunks when reasoning_content is absent', async () => {
+      const events = [
+        JSON.stringify({ choices: [{ delta: { content: 'hi' } }] }),
+        JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })
+      ];
+      (adapter as unknown as AdapterPrototype).requestStream = async () => makeSseStream(events);
+
+      const chunks = await collectStream(adapter.generateStreamAsync('hi'));
+      expect(chunks.every(c => !c.reasoning)).toBe(true);
+    });
+  });
+
+  describe('non-streaming', () => {
+    it('surfaces message.reasoning_content on LLMResponse.metadata.reasoning', async () => {
+      (adapter as unknown as AdapterPrototype).request = (async () => ({
+        ok: true,
+        status: 200,
+        json: {
+          choices: [{
+            message: {
+              content: 'Final answer.',
+              reasoning_content: 'Working through the problem...'
+            },
+            finish_reason: 'stop'
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+        },
+        text: '',
+        headers: {},
+        arrayBuffer: new ArrayBuffer(0)
+      })) as AdapterPrototype['request'];
+      (adapter as unknown as AdapterPrototype).assertOk = (r: unknown) => r;
+
+      const response = await adapter.generateUncached('test');
+      expect(response.text).toBe('Final answer.');
+      expect(response.metadata?.reasoning).toBe('Working through the problem...');
+    });
+
+    it('omits metadata.reasoning when reasoning_content is missing', async () => {
+      (adapter as unknown as AdapterPrototype).request = (async () => ({
+        ok: true,
+        status: 200,
+        json: {
+          choices: [{ message: { content: 'plain answer' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+        },
+        text: '',
+        headers: {},
+        arrayBuffer: new ArrayBuffer(0)
+      })) as AdapterPrototype['request'];
+      (adapter as unknown as AdapterPrototype).assertOk = (r: unknown) => r;
+
+      const response = await adapter.generateUncached('test');
+      expect(response.metadata?.reasoning).toBeUndefined();
+    });
+  });
+
+  describe('thinking-mode request body', () => {
+    async function captureRequestBody(options: GenerateOptions): Promise<Record<string, unknown>> {
+      let captured: Record<string, unknown> = {};
+      (adapter as unknown as AdapterPrototype).requestStream = async (config) => {
+        captured = JSON.parse(config.body || '{}') as Record<string, unknown>;
+        return makeSseStream([
+          JSON.stringify({ choices: [{ delta: { content: 'x' } }] }),
+          JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })
+        ]);
+      };
+      // Drain the stream so requestStream actually fires.
+      for await (const _ of adapter.generateStreamAsync('hi', options)) { /* drain */ }
+      return captured;
+    }
+
+    it('includes thinking param when options.enableThinking is true', async () => {
+      const body = await captureRequestBody({ enableThinking: true, thinkingEffort: 'medium' });
+      expect(body.thinking).toEqual({ type: 'enabled', reasoning_effort: 'high' });
+    });
+
+    it('maps thinkingEffort=high to reasoning_effort=max', async () => {
+      const body = await captureRequestBody({ enableThinking: true, thinkingEffort: 'high' });
+      expect(body.thinking).toEqual({ type: 'enabled', reasoning_effort: 'max' });
+    });
+
+    it('maps thinkingEffort=low to reasoning_effort=high (entry tier)', async () => {
+      const body = await captureRequestBody({ enableThinking: true, thinkingEffort: 'low' });
+      expect(body.thinking).toEqual({ type: 'enabled', reasoning_effort: 'high' });
+    });
+
+    it('omits thinking param when options.enableThinking is false', async () => {
+      const body = await captureRequestBody({ enableThinking: false });
+      expect(body.thinking).toBeUndefined();
+    });
+
+    it('triggers thinking when model id ends in -thinking even without enableThinking', async () => {
+      const body = await captureRequestBody({ model: 'deepseek-v4-pro-thinking' });
+      expect(body.thinking).toEqual({ type: 'enabled', reasoning_effort: 'high' });
+      // And the wire model id should be the base, suffix stripped.
+      expect(body.model).toBe('deepseek-v4-pro');
+    });
+  });
+
+  describe('penalty stripping', () => {
+    it('does NOT include frequency_penalty or presence_penalty in the request body', async () => {
+      let captured: Record<string, unknown> = {};
+      (adapter as unknown as AdapterPrototype).requestStream = async (config) => {
+        captured = JSON.parse(config.body || '{}') as Record<string, unknown>;
+        return makeSseStream([
+          JSON.stringify({ choices: [{ delta: { content: 'x' } }] }),
+          JSON.stringify({ choices: [{ delta: {}, finish_reason: 'stop' }] })
+        ]);
+      };
+
+      for await (const _ of adapter.generateStreamAsync('hi', {
+        frequencyPenalty: 0.5,
+        presencePenalty: 0.5,
+        temperature: 0.7
+      })) { /* drain */ }
+
+      expect(captured.frequency_penalty).toBeUndefined();
+      expect(captured.presence_penalty).toBeUndefined();
+      // Sanity: temperature still threads through.
+      expect(captured.temperature).toBe(0.7);
+    });
+  });
+
+  describe('ThinkingEffortMapper integration', () => {
+    it('getDeepSeekParams returns null when disabled', () => {
+      expect(ThinkingEffortMapper.getDeepSeekParams({ enabled: false, effort: 'medium' })).toBeNull();
+    });
+
+    it('getDeepSeekParams maps high -> max, low/medium -> high', () => {
+      expect(ThinkingEffortMapper.getDeepSeekParams({ enabled: true, effort: 'high' }))
+        .toEqual({ thinking: { type: 'enabled', reasoning_effort: 'max' } });
+      expect(ThinkingEffortMapper.getDeepSeekParams({ enabled: true, effort: 'medium' }))
+        .toEqual({ thinking: { type: 'enabled', reasoning_effort: 'high' } });
+      expect(ThinkingEffortMapper.getDeepSeekParams({ enabled: true, effort: 'low' }))
+        .toEqual({ thinking: { type: 'enabled', reasoning_effort: 'high' } });
+    });
+
+    it('getProviderConfig handles deepseek case', () => {
+      const config = ThinkingEffortMapper.getProviderConfig('deepseek', { enabled: true, effort: 'high' });
+      expect(config?.deepseek).toEqual({ thinking: { type: 'enabled', reasoning_effort: 'max' } });
+    });
+
+    it('providerSupportsThinking returns true for deepseek', () => {
+      expect(ThinkingEffortMapper.providerSupportsThinking('deepseek')).toBe(true);
+    });
+  });
+
+  describe('capabilities and listModels', () => {
+    it('reports thinking + 1M context', () => {
+      const caps = adapter.getCapabilities();
+      expect(caps.supportsThinking).toBe(true);
+      expect(caps.maxContextWindow).toBe(1_000_000);
+      expect(caps.supportsImages).toBe(false);
+      expect(caps.supportsFunctions).toBe(true);
+    });
+
+    it('lists 4 model entries (flash, flash-thinking, pro, pro-thinking)', async () => {
+      const models = await adapter.listModels();
+      expect(models.map(m => m.id).sort()).toEqual([
+        'deepseek-v4-flash',
+        'deepseek-v4-flash-thinking',
+        'deepseek-v4-pro',
+        'deepseek-v4-pro-thinking'
+      ]);
+    });
+
+    it('returns pricing for each model', async () => {
+      const flash = await adapter.getModelPricing('deepseek-v4-flash');
+      expect(flash?.rateInputPerMillion).toBe(0.14);
+      expect(flash?.rateOutputPerMillion).toBe(0.28);
+
+      const pro = await adapter.getModelPricing('deepseek-v4-pro');
+      expect(pro?.rateInputPerMillion).toBe(0.435);
+      expect(pro?.rateOutputPerMillion).toBe(0.87);
+
+      const unknown = await adapter.getModelPricing('does-not-exist');
+      expect(unknown).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds DeepSeek as a direct cloud provider (alongside OpenAI / Anthropic / Google / Mistral / Groq / OpenRouter / etc.). Resolves #204.

DeepSeek's API is OpenAI-compatible, so the adapter is structurally a Groq-clone that plugs into the existing two-sided thinking abstraction (`ThinkingEffortMapper` for input, unified `StreamChunk.reasoning` for output) — the chat UI renders DeepSeek reasoning blocks for free, exactly like Claude / o-series / Gemini / Groq today.

### Models

| Model | Context | Max output | Pricing (in / out per 1M) | Cache hit |
|---|---|---|---|---|
| `deepseek-v4-flash` | 1M | 384K | $0.14 / $0.28 | $0.0028 |
| `deepseek-v4-pro` | 1M | 384K | $0.435 / $0.87 (75% off until 2026-05-31) | discounted |

Each ships with a `-thinking` variant. Thinking mode uses DeepSeek's proprietary `thinking: { type: "enabled", reasoning_effort: "high" \| "max" }` request shape (NOT OpenAI's `reasoning.effort`), and surfaces reasoning via `delta.reasoning_content` (streaming) or `message.reasoning_content` (non-streaming). The unified `ThinkingEffortMapper.getDeepSeekParams` handles request-side translation; the adapter's stream extractor maps `reasoning_content` → `StreamChunk.reasoning`.

### What changed

- New: `DeepSeekAdapter.ts` (375 LoC), `DeepSeekModels.ts` (111 LoC), `DeepSeekAdapter.test.ts` (275 LoC, 18 tests)
- Wired through 13 touchpoints: `SupportedProvider` union, `AdapterRegistry`, `ProviderTypes` defaults, `ProviderManager` def, `ValidationService`, `ThinkingEffortMapper` (incl. `ProviderThinkingConfig` interface + `supportedProviders` list), `platform.ts` mobile-compatible list, `ModelDropdownRenderer`, `ProviderUtils` (display name, color, emoji, abbreviation, streaming/functions/JSON lists), `ProvidersTab` (+`cloudIds`), `VisionMessageFormatter`, `ingestTool` labels
- `frequency_penalty` / `presence_penalty` are stripped from outgoing requests (DeepSeek removed support)
- Mobile-compatible (uses `requestUrl`-backed REST transport)

### Test plan

- [x] `npx jest tests/services/llm/adapters/deepseek` — 18/18 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [ ] Manual smoke: enter API key in Settings → Providers → DeepSeek, send a message with `deepseek-v4-flash`, send a tool-using message with `deepseek-v4-flash-thinking`, verify reasoning block renders in the chat UI

### Follow-ups (not blocking)

- `ProviderManager.ts` (659 LoC) and `ProvidersTab.ts` (645 LoC) crossed the 600-line maintainability threshold from the wiring additions. Both are pre-existing tech-debt watch items — refactor when next touched, not as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)