### PR TITLE
feat(models): add Gemini 3.5 Flash

### DIFF
--- a/src/services/llm/adapters/google/GoogleModels.ts
+++ b/src/services/llm/adapters/google/GoogleModels.ts
@@ -1,12 +1,12 @@
 /**
  * Google Model Specifications
- * Updated March 2026 with Gemini 3.1 models
+ * Updated May 2026 with Gemini 3.5 models
  */
 
 import { ModelSpec } from '../modelTypes';
 
 export const GOOGLE_MODELS: ModelSpec[] = [
-  // Gemini 3.1 models (latest)
+  // Gemini 3.1 models
   {
     provider: 'google',
     name: 'Gemini 3.1 Pro Preview',

--- a/src/services/llm/adapters/google/GoogleModels.ts
+++ b/src/services/llm/adapters/google/GoogleModels.ts
@@ -40,6 +40,24 @@ export const GOOGLE_MODELS: ModelSpec[] = [
     }
   },
 
+  // Gemini 3.5 models
+  {
+    provider: 'google',
+    name: 'Gemini 3.5 Flash',
+    apiName: 'gemini-3.5-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 1.50,
+    outputCostPerMillion: 9.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
   // Gemini 3.0 models
   {
     provider: 'google',

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -283,6 +283,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'Gemini 3.5 Flash',
+    apiName: 'google/gemini-3.5-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 1.50,
+    outputCostPerMillion: 9.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'GPT-5',
     apiName: 'openai/gpt-5',
     contextWindow: 400000,

--- a/tests/debug/provider-model-live-smoke.test.ts
+++ b/tests/debug/provider-model-live-smoke.test.ts
@@ -61,22 +61,11 @@ interface SmokeTarget {
 const RUN_LIVE = process.env.RUN_MODEL_SMOKE === '1';
 const PROVIDERS: SmokeProvider[] = ['openai', 'openrouter', 'openai-codex', 'google'];
 
-function findDotEnv(): string | null {
-  const candidates = [
-    path.join(process.cwd(), '.env'),
-    '/Users/jrosenbaum/Documents/Code/.obsidian/plugins/claudesidian-mcp/.env',
-  ];
-  for (const c of candidates) {
-    if (fs.existsSync(c)) return c;
-  }
-  return null;
-}
-
 function readDotEnv(): Map<string, string> {
-  const envPath = findDotEnv();
+  const envPath = path.join(process.cwd(), '.env');
   const values = new Map<string, string>();
 
-  if (!envPath) {
+  if (!fs.existsSync(envPath)) {
     return values;
   }
 

--- a/tests/debug/provider-model-live-smoke.test.ts
+++ b/tests/debug/provider-model-live-smoke.test.ts
@@ -231,7 +231,7 @@ async function callModel(target: SmokeTarget): Promise<LLMResponse> {
 
   // Codex currently rejects max_output_tokens on the OAuth endpoint.
   if (target.provider !== 'openai-codex') {
-    options.maxTokens = Number(getEnv('MODEL_SMOKE_MAX_TOKENS') || 16);
+    options.maxTokens = Number(getEnv('MODEL_SMOKE_MAX_TOKENS') || 64);
   }
 
   return adapter.generateUncached(

--- a/tests/debug/provider-model-live-smoke.test.ts
+++ b/tests/debug/provider-model-live-smoke.test.ts
@@ -30,11 +30,12 @@ import { DEFAULT_MODELS } from '../../src/services/llm/adapters/ModelRegistry';
 import { OpenAIAdapter } from '../../src/services/llm/adapters/openai/OpenAIAdapter';
 import { OpenRouterAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterAdapter';
 import { OpenAICodexAdapter, type CodexOAuthTokens } from '../../src/services/llm/adapters/openai-codex/OpenAICodexAdapter';
+import { GoogleAdapter } from '../../src/services/llm/adapters/google/GoogleAdapter';
 import type { GenerateOptions, LLMResponse } from '../../src/services/llm/adapters/types';
 
 jest.setTimeout(240_000);
 
-type SmokeProvider = 'openai' | 'openrouter' | 'openai-codex';
+type SmokeProvider = 'openai' | 'openrouter' | 'openai-codex' | 'google';
 
 interface ProviderSettingsShape {
   llmProviders?: {
@@ -58,13 +59,24 @@ interface SmokeTarget {
 }
 
 const RUN_LIVE = process.env.RUN_MODEL_SMOKE === '1';
-const PROVIDERS: SmokeProvider[] = ['openai', 'openrouter', 'openai-codex'];
+const PROVIDERS: SmokeProvider[] = ['openai', 'openrouter', 'openai-codex', 'google'];
+
+function findDotEnv(): string | null {
+  const candidates = [
+    path.join(process.cwd(), '.env'),
+    '/Users/jrosenbaum/Documents/Code/.obsidian/plugins/claudesidian-mcp/.env',
+  ];
+  for (const c of candidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
 
 function readDotEnv(): Map<string, string> {
-  const envPath = path.join(process.cwd(), '.env');
+  const envPath = findDotEnv();
   const values = new Map<string, string>();
 
-  if (!fs.existsSync(envPath)) {
+  if (!envPath) {
     return values;
   }
 
@@ -123,6 +135,10 @@ function normalizeModelForProvider(provider: SmokeProvider, model: string): stri
     return model.slice('openai/'.length);
   }
 
+  if (provider === 'google' && model.startsWith('google/')) {
+    return model.slice('google/'.length);
+  }
+
   return model;
 }
 
@@ -132,6 +148,7 @@ function getProviderModel(provider: SmokeProvider): string {
     openai: getEnv('OPENAI_SMOKE_MODEL'),
     openrouter: getEnv('OPENROUTER_SMOKE_MODEL'),
     'openai-codex': getEnv('CODEX_SMOKE_MODEL'),
+    google: getEnv('GOOGLE_SMOKE_MODEL'),
   }[provider];
 
   const model = providerOverride || sharedOverride || DEFAULT_MODELS[provider];
@@ -184,7 +201,7 @@ function setRequestUrlToRealFetch(): void {
   });
 }
 
-function createAdapter(provider: SmokeProvider): OpenAIAdapter | OpenRouterAdapter | OpenAICodexAdapter {
+function createAdapter(provider: SmokeProvider): OpenAIAdapter | OpenRouterAdapter | OpenAICodexAdapter | GoogleAdapter {
   if (provider === 'openai') {
     const apiKey = getEnv('OPENAI_API_KEY');
     if (!apiKey) {
@@ -199,6 +216,14 @@ function createAdapter(provider: SmokeProvider): OpenAIAdapter | OpenRouterAdapt
       throw new Error('OPENROUTER_API_KEY is required for OpenRouter smoke tests');
     }
     return new OpenRouterAdapter(apiKey);
+  }
+
+  if (provider === 'google') {
+    const apiKey = getEnv('GEMINI_API_KEY');
+    if (!apiKey) {
+      throw new Error('GEMINI_API_KEY is required for Google smoke tests');
+    }
+    return new GoogleAdapter(apiKey);
   }
 
   const tokens = loadCodexTokensFromLocalDataJson();

--- a/tests/eval/configs/gemini-3.5-flash.yaml
+++ b/tests/eval/configs/gemini-3.5-flash.yaml
@@ -1,0 +1,23 @@
+mode: live
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - google/gemini-3.5-flash
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -49,3 +49,25 @@ describe('ModelRegistry GPT-5.5 models', () => {
     expect(DEFAULT_MODELS['openai-codex']).toBe('gpt-5.5');
   });
 });
+
+describe('ModelRegistry Gemini 3.5 Flash models', () => {
+  it('registers Gemini 3.5 Flash for Google', () => {
+    expect(ModelRegistry.findModel('google', 'gemini-3.5-flash')).toEqual(expect.objectContaining({
+      name: 'Gemini 3.5 Flash',
+      contextWindow: 1048576,
+      maxTokens: 65536,
+      inputCostPerMillion: 1.5,
+      outputCostPerMillion: 9
+    }));
+  });
+
+  it('registers Gemini 3.5 Flash for OpenRouter with the provider namespace', () => {
+    expect(ModelRegistry.findModel('openrouter', 'google/gemini-3.5-flash')).toEqual(expect.objectContaining({
+      name: 'Gemini 3.5 Flash',
+      contextWindow: 1048576,
+      maxTokens: 65536,
+      inputCostPerMillion: 1.5,
+      outputCostPerMillion: 9
+    }));
+  });
+});


### PR DESCRIPTION
## Summary
- add Gemini 3.5 Flash to the direct Google model registry
- add Gemini 3.5 Flash to OpenRouter as `google/gemini-3.5-flash`
- extend the provider live smoke harness to cover Google models and add a Gemini 3.5 Flash eval config
- add focused registry coverage for the new Google and OpenRouter model IDs

## Model facts checked
- Google Gemini API pricing lists `gemini-3.5-flash` at $1.50 input / $9.00 output per 1M tokens.
- Google DeepMind's Gemini 3.5 Flash model card lists up to 1M input context and 64K output tokens.
- OpenRouter lists `google/gemini-3.5-flash` with $1.50 input / $9 output per 1M and 1M context.
- Provider defaults were not changed.

## Validation
- npx jest tests/unit/ModelRegistry.test.ts --runInBand --no-coverage --verbose
- RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=google MODEL_SMOKE_MODEL=gemini-3.5-flash npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
- RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=google/gemini-3.5-flash npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
- npm run build
- git diff --check

## Notes
- A full Gemini 3.5 Flash eval harness run was attempted separately and reached live OpenRouter calls, but timed out after 492s with 16/35 scenarios passing. That run exposed stale eval command fixtures; those are tracked separately in #211.
