### PR TITLE
feat: state CRUA tools + states management UI (#215)

### DIFF
--- a/src/agents/memoryManager/memoryManager.ts
+++ b/src/agents/memoryManager/memoryManager.ts
@@ -13,6 +13,8 @@ import type { WorkspaceTaskSummary } from '../taskManager/types';
 import { CreateStateTool } from './tools/states/createState';
 import { ListStatesTool } from './tools/states/listStates';
 import { LoadStateTool } from './tools/states/loadState';
+import { UpdateStateTool } from './tools/states/updateState';
+import { ArchiveStateTool } from './tools/states/archiveState';
 import { CreateWorkspaceTool } from './tools/workspaces/createWorkspace';
 import { ListWorkspacesTool } from './tools/workspaces/listWorkspaces';
 import { LoadWorkspaceTool } from './tools/workspaces/loadWorkspace';
@@ -102,7 +104,7 @@ export class MemoryManagerAgent extends BaseAgent {
     this.workspaceService = workspaceService;
     this.customPromptStorage = customPromptStorage;
 
-    // Register state tools (3 tools: create, list, load) - lazy loaded
+    // Register state tools (5 tools: create, list, load, update, archive) - lazy loaded
     this.registerLazyTool({
       slug: 'createState', name: 'Create State',
       description: 'Create a state with restoration context for later resumption',
@@ -120,6 +122,18 @@ export class MemoryManagerAgent extends BaseAgent {
       description: 'Load a saved workspace-scoped state with restored context',
       version: '2.0.0',
       factory: () => new LoadStateTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'updateState', name: 'Update State',
+      description: 'Update state metadata (name, description, tags). Snapshot context is immutable.',
+      version: '1.0.0',
+      factory: () => new UpdateStateTool(this),
+    });
+    this.registerLazyTool({
+      slug: 'archiveState', name: 'Archive State',
+      description: 'Archive a state (soft delete). State will be hidden from lists but can be restored.',
+      version: '1.0.0',
+      factory: () => new ArchiveStateTool(this),
     });
 
     // Register workspace tools (6 tools: create, list, load, update, archive, run) - lazy loaded

--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -710,17 +710,23 @@ export class MemoryService {
     sessionId: string,
     stateId: string
   ): Promise<void> {
-    const workspace = await this.workspaceService.getWorkspace(workspaceId);
+    return withDualBackend(
+      this.storageAdapterOrGetter,
+      async (adapter) => {
+        await adapter.deleteState(stateId);
+      },
+      async () => {
+        const workspace = await this.workspaceService.getWorkspace(workspaceId);
 
-    if (!workspace || !workspace.sessions[sessionId]) {
-      throw new Error('Session not found');
-    }
+        if (!workspace || !workspace.sessions[sessionId]) {
+          throw new Error('Session not found');
+        }
 
-    // Delete the state
-    delete workspace.sessions[sessionId].states[stateId];
+        delete workspace.sessions[sessionId].states[stateId];
 
-    // Save workspace
-    await this.workspaceService.updateWorkspace(workspaceId, workspace);
+        await this.workspaceService.updateWorkspace(workspaceId, workspace);
+      }
+    );
   }
 
 }

--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -670,7 +670,12 @@ export class MemoryService {
   }
 
   /**
-   * Update state
+   * Update an existing state's mutable fields. The inner snapshot `content`
+   * (WorkspaceState) is replaced wholesale when `state` is provided; other
+   * fields (`name`, `description`, `tags`) are patched independently.
+   *
+   * Routes through WorkspaceService.updateState, which writes a state_updated
+   * event to JSONL and patches the SQLite cache via the storage adapter.
    */
   async updateState(
     workspaceId: string,
@@ -678,24 +683,23 @@ export class MemoryService {
     stateId: string,
     updates: Partial<{
       name: string;
+      description: string;
+      tags: string[];
       state: WorkspaceState;
     }>
   ): Promise<void> {
-    const workspace = await this.workspaceService.getWorkspace(workspaceId);
+    const adapterUpdates: {
+      name?: string;
+      description?: string;
+      tags?: string[];
+      content?: unknown;
+    } = {};
+    if (updates.name !== undefined) adapterUpdates.name = updates.name;
+    if (updates.description !== undefined) adapterUpdates.description = updates.description;
+    if (updates.tags !== undefined) adapterUpdates.tags = updates.tags;
+    if (updates.state !== undefined) adapterUpdates.content = updates.state;
 
-    if (!workspace || !workspace.sessions[sessionId] || !workspace.sessions[sessionId].states[stateId]) {
-      throw new Error('State not found');
-    }
-
-    // Update the state
-    const state = workspace.sessions[sessionId].states[stateId];
-    workspace.sessions[sessionId].states[stateId] = {
-      ...state,
-      ...updates
-    };
-
-    // Save workspace
-    await this.workspaceService.updateWorkspace(workspaceId, workspace);
+    await this.workspaceService.updateState(workspaceId, sessionId, stateId, adapterUpdates);
   }
 
   /**

--- a/src/agents/memoryManager/tools/index.ts
+++ b/src/agents/memoryManager/tools/index.ts
@@ -1,7 +1,9 @@
-// State tools (3 tools: create, list, load)
+// State tools (5 tools: create, list, load, update, archive)
 export { CreateStateTool } from './states/createState';
 export { ListStatesTool } from './states/listStates';
 export { LoadStateTool } from './states/loadState';
+export { UpdateStateTool } from './states/updateState';
+export { ArchiveStateTool } from './states/archiveState';
 
 // Workspace tools (5 tools: create, list, load, update, archive)
 export * from './workspaces';

--- a/src/agents/memoryManager/tools/states/archiveState.ts
+++ b/src/agents/memoryManager/tools/states/archiveState.ts
@@ -1,0 +1,152 @@
+/**
+ * Location: src/agents/memoryManager/tools/states/archiveState.ts
+ * Purpose: Archive a state (soft delete) by toggling the isArchived flag in
+ * its WorkspaceState.state.metadata. Mirrors archiveWorkspace.
+ *
+ * Used by: MemoryManager agent for state archival operations.
+ */
+
+import { BaseTool } from '../../../baseTool';
+import { MemoryManagerAgent } from '../../memoryManager';
+import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
+import type { ToolStatusTense } from '../../../interfaces/ITool';
+import { createErrorMessage } from '../../../../utils/errorUtils';
+import { CommonResult, CommonParameters } from '../../../../types/mcp/AgentTypes';
+import { GLOBAL_WORKSPACE_ID } from '../../../../services/WorkspaceService';
+import type { WorkspaceState } from '../../../../database/types/session/SessionTypes';
+
+interface StateListItem {
+    id: string;
+    name: string;
+    sessionId?: string;
+    state?: WorkspaceState;
+}
+
+export interface ArchiveStateParameters extends CommonParameters {
+    name: string;
+    restore?: boolean;
+}
+
+export interface ArchiveStateResult extends CommonResult {
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * ArchiveStateTool - Soft delete a state by setting metadata.isArchived flag.
+ */
+export class ArchiveStateTool extends BaseTool<ArchiveStateParameters, ArchiveStateResult> {
+    constructor(private agent: MemoryManagerAgent) {
+        super(
+            'archiveState',
+            'Archive State',
+            'Archive a state (soft delete). State will be hidden from lists but can be restored.',
+            '1.0.0'
+        );
+    }
+
+    async execute(params: ArchiveStateParameters): Promise<ArchiveStateResult> {
+        try {
+            const memoryService = await this.agent.getMemoryServiceAsync();
+            if (!memoryService) {
+                return this.prepareResult(false, undefined, 'Memory service not available');
+            }
+            const workspaceService = await this.agent.getWorkspaceServiceAsync();
+            if (!workspaceService) {
+                return this.prepareResult(false, undefined, 'Workspace service not available');
+            }
+
+            const inheritedContext = this.getInheritedWorkspaceContext(params);
+            const workspaceIdentifier = inheritedContext?.workspaceId || GLOBAL_WORKSPACE_ID;
+            const workspace = await workspaceService.getWorkspaceByNameOrId(workspaceIdentifier);
+            if (!workspace) {
+                return this.prepareResult(false, undefined, `Workspace not found: ${workspaceIdentifier}`);
+            }
+
+            const statesResult = await memoryService.getStates(workspace.id);
+            const match = (statesResult.items as unknown as StateListItem[]).find(
+                (s) => s.id === params.name || s.name === params.name
+            );
+            if (!match) {
+                return this.prepareResult(false, undefined, `State "${params.name}" not found. Use listStates to see available states.`);
+            }
+
+            const existingState = match.state;
+            if (!existingState) {
+                return this.prepareResult(false, undefined, `State "${params.name}" data is missing.`);
+            }
+
+            const isRestore = params.restore === true;
+            const currentArchived = existingState.state?.metadata?.isArchived === true;
+
+            if (isRestore && !currentArchived) {
+                return this.prepareResult(false, undefined, `State "${params.name}" is not archived.`);
+            }
+            if (!isRestore && currentArchived) {
+                return this.prepareResult(false, undefined, `State "${params.name}" is already archived.`);
+            }
+
+            const sessionId = match.sessionId || existingState.sessionId;
+            if (!sessionId) {
+                return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
+            }
+
+            const nextState: WorkspaceState = {
+                ...existingState,
+                state: {
+                    workspace: existingState.state?.workspace ?? null,
+                    recentTraces: existingState.state?.recentTraces ?? [],
+                    contextFiles: existingState.state?.contextFiles ?? [],
+                    metadata: {
+                        ...(existingState.state?.metadata ?? {}),
+                        isArchived: !isRestore
+                    }
+                }
+            };
+
+            await memoryService.updateState(workspace.id, sessionId, match.id, { state: nextState });
+
+            return this.prepareResult(true);
+        } catch (error) {
+            return this.prepareResult(false, undefined, createErrorMessage('Error archiving state: ', error));
+        }
+    }
+
+    getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+        const isRestore = params?.restore === true;
+        const v = isRestore
+            ? verbs('Restoring state', 'Restored state', 'Failed to restore state')
+            : verbs('Archiving state', 'Archived state', 'Failed to archive state');
+        return labelNamed(v, params, tense, ['name']);
+    }
+
+    getParameterSchema(): Record<string, unknown> {
+        const toolSchema = {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Name or ID of the state to archive or restore (REQUIRED).'
+                },
+                restore: {
+                    type: 'boolean',
+                    description: 'If true, restores the state from archive. If false/omitted, archives the state.'
+                }
+            },
+            required: ['name']
+        };
+
+        return this.getMergedSchema(toolSchema);
+    }
+
+    getResultSchema(): Record<string, unknown> {
+        return {
+            type: 'object',
+            properties: {
+                success: { type: 'boolean', description: 'Whether the operation succeeded' },
+                error: { type: 'string', description: 'Error message if failed (includes recovery guidance)' }
+            },
+            required: ['success']
+        };
+    }
+}

--- a/src/agents/memoryManager/tools/states/archiveState.ts
+++ b/src/agents/memoryManager/tools/states/archiveState.ts
@@ -71,7 +71,12 @@ export class ArchiveStateTool extends BaseTool<ArchiveStateParameters, ArchiveSt
                 return this.prepareResult(false, undefined, `State "${params.name}" not found. Use listStates to see available states.`);
             }
 
-            const existingState = match.state;
+            const sessionId = match.sessionId || match.state?.sessionId;
+            if (!sessionId) {
+                return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
+            }
+
+            const existingState = await memoryService.getState(workspace.id, sessionId, match.id);
             if (!existingState) {
                 return this.prepareResult(false, undefined, `State "${params.name}" data is missing.`);
             }
@@ -84,11 +89,6 @@ export class ArchiveStateTool extends BaseTool<ArchiveStateParameters, ArchiveSt
             }
             if (!isRestore && currentArchived) {
                 return this.prepareResult(false, undefined, `State "${params.name}" is already archived.`);
-            }
-
-            const sessionId = match.sessionId || existingState.sessionId;
-            if (!sessionId) {
-                return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
             }
 
             const nextState: WorkspaceState = {

--- a/src/agents/memoryManager/tools/states/updateState.ts
+++ b/src/agents/memoryManager/tools/states/updateState.ts
@@ -1,0 +1,159 @@
+/**
+ * Location: src/agents/memoryManager/tools/states/updateState.ts
+ * Purpose: Update mutable metadata on an existing state (name, description,
+ * tags). The inner snapshot context (conversationContext, activeTask,
+ * activeFiles, nextSteps) is intentionally immutable — states are snapshots.
+ *
+ * Used by: MemoryManager agent for state metadata updates.
+ */
+
+import { BaseTool } from '../../../baseTool';
+import { MemoryManagerAgent } from '../../memoryManager';
+import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
+import type { ToolStatusTense } from '../../../interfaces/ITool';
+import { createErrorMessage } from '../../../../utils/errorUtils';
+import { CommonResult, CommonParameters } from '../../../../types/mcp/AgentTypes';
+import { GLOBAL_WORKSPACE_ID } from '../../../../services/WorkspaceService';
+import type { WorkspaceState } from '../../../../database/types/session/SessionTypes';
+
+interface StateListItem {
+    id: string;
+    name: string;
+    sessionId?: string;
+    state?: WorkspaceState;
+}
+
+export interface UpdateStateParameters extends CommonParameters {
+    name: string;
+    newName?: string;
+    description?: string;
+    tags?: string[];
+}
+
+export interface UpdateStateResult extends CommonResult {
+    success: boolean;
+    error?: string;
+}
+
+/**
+ * UpdateStateTool - Modify state metadata (name, description, tags).
+ * The inner snapshot context remains frozen.
+ */
+export class UpdateStateTool extends BaseTool<UpdateStateParameters, UpdateStateResult> {
+    constructor(private agent: MemoryManagerAgent) {
+        super(
+            'updateState',
+            'Update State',
+            'Update state metadata (name, description, tags). Snapshot context is immutable.',
+            '1.0.0'
+        );
+    }
+
+    async execute(params: UpdateStateParameters): Promise<UpdateStateResult> {
+        try {
+            const memoryService = await this.agent.getMemoryServiceAsync();
+            if (!memoryService) {
+                return this.prepareResult(false, undefined, 'Memory service not available');
+            }
+            const workspaceService = await this.agent.getWorkspaceServiceAsync();
+            if (!workspaceService) {
+                return this.prepareResult(false, undefined, 'Workspace service not available');
+            }
+
+            if (
+                params.newName === undefined &&
+                params.description === undefined &&
+                params.tags === undefined
+            ) {
+                return this.prepareResult(
+                    false,
+                    undefined,
+                    'No updates provided. Pass at least one of: newName, description, tags.'
+                );
+            }
+
+            const inheritedContext = this.getInheritedWorkspaceContext(params);
+            const workspaceIdentifier = inheritedContext?.workspaceId || GLOBAL_WORKSPACE_ID;
+            const workspace = await workspaceService.getWorkspaceByNameOrId(workspaceIdentifier);
+            if (!workspace) {
+                return this.prepareResult(false, undefined, `Workspace not found: ${workspaceIdentifier}`);
+            }
+
+            const statesResult = await memoryService.getStates(workspace.id);
+            const match = (statesResult.items as unknown as StateListItem[]).find(
+                (s) => s.id === params.name || s.name === params.name
+            );
+            if (!match) {
+                return this.prepareResult(false, undefined, `State "${params.name}" not found. Use listStates to see available states.`);
+            }
+
+            const sessionId = match.sessionId || match.state?.sessionId;
+            if (!sessionId) {
+                return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
+            }
+
+            if (params.newName !== undefined && params.newName !== match.name) {
+                const conflict = (statesResult.items as unknown as StateListItem[]).find(
+                    (s) => s.id !== match.id && s.name === params.newName
+                );
+                if (conflict) {
+                    return this.prepareResult(false, undefined, `State name "${params.newName}" is already in use.`);
+                }
+            }
+
+            const updates: Partial<{ name: string; description: string; tags: string[] }> = {};
+            if (params.newName !== undefined) updates.name = params.newName;
+            if (params.description !== undefined) updates.description = params.description;
+            if (params.tags !== undefined) updates.tags = params.tags;
+
+            await memoryService.updateState(workspace.id, sessionId, match.id, updates);
+
+            return this.prepareResult(true);
+        } catch (error) {
+            return this.prepareResult(false, undefined, createErrorMessage('Error updating state: ', error));
+        }
+    }
+
+    getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+        return labelNamed(verbs('Updating state', 'Updated state', 'Failed to update state'), params, tense, ['name']);
+    }
+
+    getParameterSchema(): Record<string, unknown> {
+        const toolSchema = {
+            type: 'object',
+            properties: {
+                name: {
+                    type: 'string',
+                    description: 'Name or ID of the state to update (REQUIRED). This selects the target state.'
+                },
+                newName: {
+                    type: 'string',
+                    description: 'New name for the state (optional). This renames the state; it is not the target identifier.'
+                },
+                description: {
+                    type: 'string',
+                    description: 'New description for the state (optional).'
+                },
+                tags: {
+                    type: 'array',
+                    items: { type: 'string' },
+                    description: 'New tags array for the state (optional, replaces the prior tag list).'
+                }
+            },
+            required: ['name']
+        };
+
+        return this.getMergedSchema(toolSchema);
+    }
+
+    getResultSchema(): Record<string, unknown> {
+        return {
+            type: 'object',
+            properties: {
+                success: { type: 'boolean', description: 'Whether the operation succeeded' },
+                error: { type: 'string', description: 'Error message if failed (includes recovery guidance)' }
+            },
+            required: ['success']
+        };
+    }
+}

--- a/src/components/workspace/StatesSectionRenderer.ts
+++ b/src/components/workspace/StatesSectionRenderer.ts
@@ -1,0 +1,453 @@
+/**
+ * StatesSectionRenderer — Renders the "States" management section inside the
+ * workspace detail view. Mirrors the renderProjectsSection pattern in
+ * WorkspaceDetailRenderer.
+ *
+ * UI surface (workspace-scoped):
+ * - List all states for the workspace (with Show archived toggle)
+ * - Edit (rename + description) via modal
+ * - Archive / Restore (reversible)
+ * - Delete (permanent, with confirmation)
+ *
+ * The renderer is stateless beyond an in-memory cache of fetched states and
+ * the "show archived" toggle. Data CRUD is delegated to the injected
+ * `StatesSectionService` so this file stays free of storage-adapter and
+ * MemoryService coupling.
+ */
+
+import { App, ButtonComponent, Component, Modal, Notice, TextAreaComponent, TextComponent, ToggleComponent, setIcon } from 'obsidian';
+
+/**
+ * State summary shown in the list. Matches the projection returned by
+ * MemoryService.getStates(workspaceId) item shape.
+ */
+export interface StateSummary {
+    id: string;
+    name: string;
+    description?: string;
+    sessionId?: string;
+    workspaceId?: string;
+    created: number;
+    tags?: string[];
+    isArchived?: boolean;
+}
+
+/**
+ * Patch shape accepted by updateState. Optional fields = "leave alone".
+ */
+export interface StateUpdatePatch {
+    name?: string;
+    description?: string;
+    tags?: string[];
+}
+
+/**
+ * Service contract the StatesSectionRenderer depends on. Implemented in
+ * WorkspacesTab by adapting MemoryService + HybridStorageAdapter.
+ */
+export interface StatesSectionService {
+    listStates(workspaceId: string, includeArchived: boolean): Promise<StateSummary[]>;
+    updateState(workspaceId: string, sessionId: string, stateId: string, patch: StateUpdatePatch): Promise<void>;
+    archiveState(workspaceId: string, sessionId: string, stateId: string, restore: boolean): Promise<void>;
+    deleteState(workspaceId: string, sessionId: string, stateId: string): Promise<void>;
+}
+
+export class StatesSectionRenderer {
+    private container?: HTMLElement;
+    private listContainer?: HTMLElement;
+    private workspaceId?: string;
+    private includeArchived = false;
+    private cachedStates: StateSummary[] = [];
+    private isLoading = false;
+    private loadError: string | null = null;
+
+    constructor(
+        private app: App,
+        private service: StatesSectionService,
+        private component?: Component
+    ) {}
+
+    /**
+     * Render the States section into the given container.
+     * Idempotent — clears prior contents and re-renders.
+     */
+    render(container: HTMLElement, workspaceId: string | undefined): void {
+        this.container = container;
+        this.workspaceId = workspaceId;
+        container.empty();
+
+        const section = container.createDiv('nexus-form-section nexus-states-section');
+        section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
+
+        if (!workspaceId) {
+            section.createEl('p', {
+                text: 'Save this workspace before managing states.',
+                cls: 'nexus-form-hint'
+            });
+            return;
+        }
+
+        section.createEl('p', {
+            text: 'Snapshots of workspace context that can be resumed later. Edit, archive, or delete states here.',
+            cls: 'nexus-form-hint'
+        });
+
+        // Toolbar: archived toggle + refresh
+        const toolbar = section.createDiv('nexus-states-toolbar');
+        const archivedLabel = toolbar.createDiv('nexus-states-archived-toggle');
+        archivedLabel.createSpan({ text: 'Show archived', cls: 'nexus-states-toolbar-label' });
+        new ToggleComponent(archivedLabel)
+            .setValue(this.includeArchived)
+            .onChange((value) => {
+                this.includeArchived = value;
+                void this.loadAndRender();
+            });
+
+        new ButtonComponent(toolbar)
+            .setButtonText('Refresh')
+            .onClick(() => { void this.loadAndRender(); });
+
+        this.listContainer = section.createDiv('nexus-states-list');
+        void this.loadAndRender();
+    }
+
+    /**
+     * Re-fetch the workspace's states and re-render the list area.
+     * Errors are surfaced inline (no Notice spam from background refreshes).
+     */
+    private async loadAndRender(): Promise<void> {
+        if (!this.workspaceId || !this.listContainer) return;
+
+        this.isLoading = true;
+        this.loadError = null;
+        this.renderList();
+
+        try {
+            this.cachedStates = await this.service.listStates(this.workspaceId, this.includeArchived);
+        } catch (error) {
+            console.error('[StatesSectionRenderer] Failed to load states:', error);
+            this.loadError = 'Failed to load states.';
+            this.cachedStates = [];
+        } finally {
+            this.isLoading = false;
+            this.renderList();
+        }
+    }
+
+    private renderList(): void {
+        const list = this.listContainer;
+        if (!list) return;
+        list.empty();
+
+        if (this.isLoading) {
+            list.createEl('p', {
+                text: 'Loading states...',
+                cls: 'nexus-loading-message'
+            });
+            return;
+        }
+
+        if (this.loadError) {
+            list.createEl('p', {
+                text: this.loadError,
+                cls: 'nexus-form-hint nexus-states-error'
+            });
+            return;
+        }
+
+        if (this.cachedStates.length === 0) {
+            list.createEl('p', {
+                text: this.includeArchived
+                    ? 'No states yet.'
+                    : 'No active states. Toggle "Show archived" to see archived states.',
+                cls: 'nexus-form-hint'
+            });
+            return;
+        }
+
+        const sorted = [...this.cachedStates].sort((a, b) => b.created - a.created);
+        for (const state of sorted) {
+            this.renderStateRow(list, state);
+        }
+    }
+
+    private renderStateRow(container: HTMLElement, state: StateSummary): void {
+        const row = container.createDiv('nexus-states-row');
+        if (state.isArchived) {
+            row.addClass('nexus-states-row--archived');
+        }
+
+        const main = row.createDiv('nexus-states-row-main');
+        const titleEl = main.createDiv('nexus-states-row-title');
+        titleEl.setText(state.name || 'Untitled state');
+        if (state.isArchived) {
+            titleEl.createSpan({ text: 'Archived', cls: 'nexus-states-archived-badge' });
+        }
+
+        const meta = main.createDiv('nexus-states-row-meta');
+        meta.setText(this.formatMeta(state));
+
+        if (state.description) {
+            const desc = main.createDiv('nexus-states-row-description');
+            desc.setText(state.description);
+        }
+
+        const actions = row.createDiv('nexus-states-row-actions');
+
+        // Edit
+        const editBtn = actions.createEl('button', {
+            cls: 'clickable-icon nexus-states-action-btn',
+            attr: { 'aria-label': 'Edit state' }
+        });
+        setIcon(editBtn, 'edit');
+        this.safeRegisterDomEvent(editBtn, 'click', () => this.openEditModal(state));
+
+        // Archive / Restore
+        const archiveBtn = actions.createEl('button', {
+            cls: 'clickable-icon nexus-states-action-btn',
+            attr: { 'aria-label': state.isArchived ? 'Restore state' : 'Archive state' }
+        });
+        setIcon(archiveBtn, state.isArchived ? 'archive-restore' : 'archive');
+        this.safeRegisterDomEvent(archiveBtn, 'click', () => { void this.toggleArchive(state); });
+
+        // Delete
+        const deleteBtn = actions.createEl('button', {
+            cls: 'clickable-icon nexus-states-action-btn nexus-states-delete-btn',
+            attr: { 'aria-label': 'Delete state' }
+        });
+        setIcon(deleteBtn, 'trash');
+        this.safeRegisterDomEvent(deleteBtn, 'click', () => { void this.confirmAndDelete(state); });
+    }
+
+    private formatMeta(state: StateSummary): string {
+        const parts: string[] = [];
+        if (state.created) {
+            parts.push(new Date(state.created).toLocaleString());
+        }
+        if (state.tags && state.tags.length > 0) {
+            parts.push(state.tags.map(t => `#${t}`).join(' '));
+        }
+        return parts.join(' • ');
+    }
+
+    private openEditModal(state: StateSummary): void {
+        if (!this.workspaceId) return;
+        const sessionId = state.sessionId;
+        if (!sessionId) {
+            new Notice('Cannot edit state: missing sessionId');
+            return;
+        }
+        const workspaceId = this.workspaceId;
+        const modal = new StateEditModal(this.app, state, async (patch) => {
+            try {
+                await this.service.updateState(workspaceId, sessionId, state.id, patch);
+                new Notice('State updated');
+                await this.loadAndRender();
+            } catch (error) {
+                console.error('[StatesSectionRenderer] Failed to update state:', error);
+                new Notice('Failed to update state');
+            }
+        });
+        modal.open();
+    }
+
+    private async toggleArchive(state: StateSummary): Promise<void> {
+        if (!this.workspaceId) return;
+        const sessionId = state.sessionId;
+        if (!sessionId) {
+            new Notice('Cannot archive state: missing sessionId');
+            return;
+        }
+        try {
+            const restore = !!state.isArchived;
+            await this.service.archiveState(this.workspaceId, sessionId, state.id, restore);
+            new Notice(restore ? 'State restored' : 'State archived');
+            await this.loadAndRender();
+        } catch (error) {
+            console.error('[StatesSectionRenderer] Failed to archive state:', error);
+            new Notice('Failed to archive state');
+        }
+    }
+
+    private async confirmAndDelete(state: StateSummary): Promise<void> {
+        if (!this.workspaceId) return;
+        const sessionId = state.sessionId;
+        if (!sessionId) {
+            new Notice('Cannot delete state: missing sessionId');
+            return;
+        }
+        const workspaceId = this.workspaceId;
+        const confirmed = await this.confirmDelete(state.name || 'Untitled state');
+        if (!confirmed) return;
+        try {
+            await this.service.deleteState(workspaceId, sessionId, state.id);
+            new Notice('State deleted');
+            await this.loadAndRender();
+        } catch (error) {
+            console.error('[StatesSectionRenderer] Failed to delete state:', error);
+            new Notice('Failed to delete state');
+        }
+    }
+
+    private confirmDelete(stateName: string): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            const modal = new StateDeleteConfirmModal(this.app, stateName, resolve);
+            modal.open();
+        });
+    }
+
+    private safeRegisterDomEvent<K extends keyof HTMLElementEventMap>(
+        el: HTMLElement,
+        type: K,
+        handler: (ev: HTMLElementEventMap[K]) => void
+    ): void {
+        if (this.component) {
+            this.component.registerDomEvent(el, type, handler);
+        } else {
+            el.addEventListener(type, handler);
+        }
+    }
+}
+
+/**
+ * Modal for renaming a state and editing its description.
+ * Mirrors the WorkspaceDeleteConfirmModal modal style used elsewhere in
+ * WorkspacesTab.
+ */
+class StateEditModal extends Modal {
+    private resolved = false;
+    private nameValue: string;
+    private descriptionValue: string;
+
+    constructor(
+        app: App,
+        private readonly state: StateSummary,
+        private readonly onSave: (patch: StateUpdatePatch) => Promise<void>
+    ) {
+        super(app);
+        this.nameValue = state.name || '';
+        this.descriptionValue = state.description || '';
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('nexus-state-edit-modal');
+
+        contentEl.createEl('h2', { text: 'Edit state' });
+
+        contentEl.createEl('label', {
+            text: 'Name',
+            cls: 'nexus-state-edit-label'
+        });
+        const nameInput = new TextComponent(contentEl);
+        nameInput.setValue(this.nameValue);
+        nameInput.inputEl.addClass('nexus-state-edit-input');
+        nameInput.onChange((value) => {
+            this.nameValue = value;
+        });
+
+        contentEl.createEl('label', {
+            text: 'Description',
+            cls: 'nexus-state-edit-label'
+        });
+        const descInput = new TextAreaComponent(contentEl);
+        descInput.setValue(this.descriptionValue);
+        descInput.inputEl.addClass('nexus-state-edit-textarea');
+        descInput.onChange((value) => {
+            this.descriptionValue = value;
+        });
+
+        const buttonRow = contentEl.createDiv('modal-button-container');
+
+        new ButtonComponent(buttonRow)
+            .setButtonText('Cancel')
+            .onClick(() => {
+                this.resolved = true;
+                this.close();
+            });
+
+        new ButtonComponent(buttonRow)
+            .setButtonText('Save')
+            .setCta()
+            .onClick(() => {
+                if (this.resolved) return;
+                this.resolved = true;
+                const patch = this.buildPatch();
+                this.close();
+                void this.onSave(patch);
+            });
+    }
+
+    private buildPatch(): StateUpdatePatch {
+        const patch: StateUpdatePatch = {};
+        const trimmedName = this.nameValue.trim();
+        if (trimmedName && trimmedName !== (this.state.name || '')) {
+            patch.name = trimmedName;
+        }
+        const trimmedDesc = this.descriptionValue;
+        if (trimmedDesc !== (this.state.description || '')) {
+            patch.description = trimmedDesc;
+        }
+        return patch;
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}
+
+/**
+ * Confirmation modal for permanent state deletion.
+ * Mirrors WorkspaceDeleteConfirmModal in WorkspacesTab.ts.
+ */
+class StateDeleteConfirmModal extends Modal {
+    private resolved = false;
+
+    constructor(
+        app: App,
+        private readonly stateName: string,
+        private readonly onResolve: (confirmed: boolean) => void
+    ) {
+        super(app);
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+
+        contentEl.createEl('h2', { text: 'Delete state?' });
+        contentEl.createEl('p', {
+            text: `Delete state "${this.stateName}"? This cannot be undone.`,
+            cls: 'setting-item-description'
+        });
+
+        const buttonRow = contentEl.createDiv('modal-button-container');
+
+        new ButtonComponent(buttonRow)
+            .setButtonText('Cancel')
+            .onClick(() => {
+                this.resolve(false);
+                this.close();
+            });
+
+        new ButtonComponent(buttonRow)
+            .setButtonText('Delete')
+            .setWarning()
+            .onClick(() => {
+                this.resolve(true);
+                this.close();
+            });
+    }
+
+    onClose(): void {
+        this.resolve(false);
+        this.contentEl.empty();
+    }
+
+    private resolve(confirmed: boolean): void {
+        if (this.resolved) return;
+        this.resolved = true;
+        this.onResolve(confirmed);
+    }
+}

--- a/src/components/workspace/WorkspaceDetailRenderer.ts
+++ b/src/components/workspace/WorkspaceDetailRenderer.ts
@@ -3,7 +3,7 @@
  * Extracted from WorkspacesTab to keep the tab under 600 lines.
  */
 
-import { ButtonComponent, Component, DropdownComponent, Notice, TextAreaComponent, TextComponent } from 'obsidian';
+import { App, ButtonComponent, Component, DropdownComponent, Notice, TextAreaComponent, TextComponent } from 'obsidian';
 import { BreadcrumbNav, BreadcrumbNavItem } from '../../settings/components/BreadcrumbNav';
 import { WorkspaceFormRenderer } from './WorkspaceFormRenderer';
 import { CardItem } from '../CardManager';
@@ -14,6 +14,7 @@ import type { CreateTaskData, TaskListOptions, UpdateTaskData } from '../../agen
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
 import type { TaskMetadata, TaskPriority, TaskStatus } from '../../database/repositories/interfaces/ITaskRepository';
 import type { PaginatedResult } from '../../types/pagination/PaginationTypes';
+import { StatesSectionRenderer, StatesSectionService } from './StatesSectionRenderer';
 
 type ProjectStatus = ProjectMetadata['status'];
 
@@ -72,10 +73,19 @@ export interface DetailCallbacks {
     onRefreshProjects: () => Promise<void>;
     onOpenProjectDetail: (project: ProjectMetadata) => void;
     safeRegisterDomEvent: <K extends keyof HTMLElementEventMap>(el: HTMLElement, eventName: K, handler: (event: HTMLElementEventMap[K]) => void) => void;
+    /**
+     * Resolves the service used by the States section. Returns null when the
+     * service is unavailable (e.g., MemoryService not yet initialized) so the
+     * section can render a placeholder.
+     */
+    getStatesService: () => Promise<StatesSectionService | null>;
+    /** Provides the Obsidian App instance for the States section's modals. */
+    getApp: () => App;
 }
 
 export class WorkspaceDetailRenderer {
     private formRenderer?: WorkspaceFormRenderer;
+    private statesRenderer?: StatesSectionRenderer;
     private component?: Component;
 
     constructor(component?: Component) {
@@ -155,6 +165,7 @@ export class WorkspaceDetailRenderer {
         this.formRenderer.render(formContainer);
 
         this.renderProjectsSection(container, workspace, callbacks);
+        this.renderStatesSection(container, workspace, callbacks);
 
         const actions = container.createDiv('nexus-form-actions');
 
@@ -207,6 +218,60 @@ export class WorkspaceDetailRenderer {
             .onClick(() => {
                 callbacks.onNavigateProjects();
             });
+    }
+
+    private renderStatesSection(
+        container: HTMLElement,
+        workspace: Partial<ProjectWorkspace>,
+        callbacks: DetailCallbacks
+    ): void {
+        const sectionHost = container.createDiv();
+
+        if (!workspace.id) {
+            const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
+            section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
+            section.createEl('p', {
+                text: 'Save this workspace before managing states.',
+                cls: 'nexus-form-hint'
+            });
+            return;
+        }
+
+        const workspaceId = workspace.id;
+
+        // Render an initial placeholder so the section is visible while the
+        // service resolves; the StatesSectionRenderer will replace it when
+        // the service is ready (or render an error if not).
+        const placeholder = sectionHost.createDiv('nexus-form-section nexus-states-section');
+        placeholder.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
+        placeholder.createEl('p', {
+            text: 'Loading states section...',
+            cls: 'nexus-loading-message'
+        });
+
+        void callbacks.getStatesService().then((service) => {
+            sectionHost.empty();
+            if (!service) {
+                const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
+                section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
+                section.createEl('p', {
+                    text: 'States service is unavailable.',
+                    cls: 'nexus-form-hint'
+                });
+                return;
+            }
+            this.statesRenderer = new StatesSectionRenderer(callbacks.getApp(), service, this.component);
+            this.statesRenderer.render(sectionHost, workspaceId);
+        }).catch((error) => {
+            console.error('[WorkspaceDetailRenderer] Failed to resolve states service:', error);
+            sectionHost.empty();
+            const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
+            section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
+            section.createEl('p', {
+                text: 'Failed to load states section.',
+                cls: 'nexus-form-hint nexus-states-error'
+            });
+        });
     }
 
     renderProjects(

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -1088,6 +1088,19 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.stateRepo.saveState(workspaceId, sessionId, state);
   };
 
+  updateState = async (
+    id: string,
+    updates: {
+      name?: string;
+      description?: string;
+      tags?: string[];
+      content?: unknown;
+    }
+  ): Promise<void> => {
+    await this.ensureInitialized();
+    return this.stateRepo.updateState(id, updates);
+  };
+
   deleteState = async (id: string): Promise<void> => {
     await this.ensureInitialized();
     return this.stateRepo.delete(id);

--- a/src/database/interfaces/IStorageAdapter.ts
+++ b/src/database/interfaces/IStorageAdapter.ts
@@ -306,6 +306,23 @@ export interface IStorageAdapter {
   ): Promise<string>;
 
   /**
+   * Update an existing state's metadata or content.
+   * Only fields present in `updates` are mutated; omitted fields are unchanged.
+   *
+   * @param id - State ID
+   * @param updates - Partial state fields to mutate (name, description, tags, content)
+   */
+  updateState(
+    id: string,
+    updates: {
+      name?: string;
+      description?: string;
+      tags?: string[];
+      content?: unknown;
+    }
+  ): Promise<void>;
+
+  /**
    * Delete a state
    *
    * @param id - State ID

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -208,6 +208,33 @@ export interface StateDeletedEvent extends BaseStorageEvent {
   stateId: string;
 }
 
+/**
+ * Event: State updated
+ *
+ * Records a partial update to an existing state's metadata or content.
+ * Only the fields present in `data` are mutated; omitted fields are unchanged.
+ * Replay folds successive updates on top of the original state_saved event.
+ */
+export interface StateUpdatedEvent extends BaseStorageEvent {
+  type: 'state_updated';
+  /** Parent workspace ID */
+  workspaceId: string;
+  /** Parent session ID */
+  sessionId: string;
+  /** Target state ID */
+  stateId: string;
+  data: {
+    /** Updated state name */
+    name?: string;
+    /** Updated description */
+    description?: string;
+    /** Updated tags (replaces the prior tag list) */
+    tags?: string[];
+    /** Updated JSON-serialized state content (replaces the prior content) */
+    stateJson?: string;
+  };
+}
+
 // ============================================================================
 // Trace Events
 // ============================================================================
@@ -680,6 +707,7 @@ export type WorkspaceEvent =
   | SessionCreatedEvent
   | SessionUpdatedEvent
   | StateSavedEvent
+  | StateUpdatedEvent
   | StateDeletedEvent
   | TraceAddedEvent;
 
@@ -729,6 +757,7 @@ export function isWorkspaceEvent(event: StorageEvent): event is WorkspaceEvent {
     'session_created',
     'session_updated',
     'state_saved',
+    'state_updated',
     'state_deleted',
     'trace_added',
   ].includes(event.type);
@@ -797,6 +826,7 @@ export function isUpdateEvent(event: StorageEvent): boolean {
   return [
     'workspace_updated',
     'session_updated',
+    'state_updated',
     'conversation_updated',
     'message_updated',
     'branch_message_updated',

--- a/src/database/repositories/StateRepository.ts
+++ b/src/database/repositories/StateRepository.ts
@@ -21,11 +21,13 @@
 import { BaseRepository, RepositoryDependencies, DatabaseRow } from './base/BaseRepository';
 import {
   IStateRepository,
-  SaveStateData
+  SaveStateData,
+  UpdateStateData
 } from './interfaces/IStateRepository';
 import { StateMetadata, StateData } from '../../types/storage/HybridStorageTypes';
 import {
   StateSavedEvent,
+  StateUpdatedEvent,
   StateDeletedEvent
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
@@ -203,23 +205,29 @@ export class StateRepository
       return null;
     }
 
-    // Read full state from JSONL file
+    // Read full state from JSONL file. Fold subsequent state_updated events
+    // over the original state_saved event so callers see the latest content.
     try {
-      const events = await this.jsonlWriter.readEvents<StateSavedEvent>(
+      const events = await this.jsonlWriter.readEvents<StateSavedEvent | StateUpdatedEvent>(
         this.jsonlPath(metadata.workspaceId)
       );
 
-      // Find the state saved event for this ID
-      const stateEvent = events.find(
-        e => e.type === 'state_saved' && e.data.id === id
+      const savedEvent = events.find(
+        (e): e is StateSavedEvent => e.type === 'state_saved' && e.data.id === id
       );
 
-      if (!stateEvent) {
+      if (!savedEvent) {
         this.logError('getStateData', `State event not found in JSONL: ${id}`);
         return null;
       }
 
-      const content = this.parseJsonValue<unknown>(stateEvent.data.stateJson);
+      let content = this.parseJsonValue<unknown>(savedEvent.data.stateJson);
+
+      for (const event of events) {
+        if (event.type === 'state_updated' && event.stateId === id && event.data.stateJson !== undefined) {
+          content = this.parseJsonValue<unknown>(event.data.stateJson);
+        }
+      }
 
       const stateData: StateData = {
         ...metadata,
@@ -299,6 +307,78 @@ export class StateRepository
       return id;
     } catch (error) {
       this.logError('saveState', error);
+      throw error;
+    }
+  }
+
+  async updateState(id: string, updates: UpdateStateData): Promise<void> {
+    if (
+      updates.name === undefined &&
+      updates.description === undefined &&
+      updates.tags === undefined &&
+      updates.content === undefined
+    ) {
+      return;
+    }
+
+    try {
+      await this.transaction(async () => {
+        const metadata = await this.getById(id);
+        if (!metadata) {
+          throw new Error(`State not found: ${id}`);
+        }
+
+        const eventData: StateUpdatedEvent['data'] = {};
+        if (updates.name !== undefined) eventData.name = updates.name;
+        if (updates.description !== undefined) eventData.description = updates.description;
+        if (updates.tags !== undefined) eventData.tags = updates.tags;
+        if (updates.content !== undefined) {
+          eventData.stateJson = JSON.stringify(updates.content);
+        }
+
+        await this.writeEvent<StateUpdatedEvent>(
+          this.jsonlPath(metadata.workspaceId),
+          {
+            type: 'state_updated',
+            workspaceId: metadata.workspaceId,
+            sessionId: metadata.sessionId,
+            stateId: id,
+            data: eventData
+          }
+        );
+
+        const setClauses: string[] = [];
+        const params: QueryParams = [];
+        if (updates.name !== undefined) {
+          setClauses.push('name = ?');
+          params.push(updates.name);
+        }
+        if (updates.description !== undefined) {
+          setClauses.push('description = ?');
+          params.push(updates.description);
+        }
+        if (updates.tags !== undefined) {
+          setClauses.push('tagsJson = ?');
+          params.push(JSON.stringify(updates.tags));
+        }
+
+        if (setClauses.length > 0) {
+          params.push(id);
+          await this.sqliteCache.run(
+            `UPDATE states SET ${setClauses.join(', ')} WHERE id = ?`,
+            params
+          );
+        }
+
+        // Invalidate content cache so the next getStateData re-reads the
+        // folded JSONL (state_saved + state_updated events).
+        this.stateContentCache.delete(id);
+      });
+
+      this.invalidateCache();
+      this.log('updateState', { id, fields: Object.keys(updates) });
+    } catch (error) {
+      this.logError('updateState', error);
       throw error;
     }
   }

--- a/src/database/repositories/interfaces/IStateRepository.ts
+++ b/src/database/repositories/interfaces/IStateRepository.ts
@@ -27,6 +27,18 @@ export interface SaveStateData {
 }
 
 /**
+ * Partial mutations allowed on an existing state. Only fields present here
+ * are mutable; the original `created` timestamp, `id`, `workspaceId`, and
+ * `sessionId` remain immutable.
+ */
+export interface UpdateStateData {
+  name?: string;
+  description?: string;
+  tags?: string[];
+  content?: unknown;
+}
+
+/**
  * State repository interface
  */
 export interface IStateRepository extends IRepository<StateMetadata> {
@@ -65,6 +77,17 @@ export interface IStateRepository extends IRepository<StateMetadata> {
     sessionId: string,
     data: SaveStateData
   ): Promise<string>;
+
+  /**
+   * Update an existing state's metadata or content.
+   * Writes a state_updated event to the workspace JSONL and patches the
+   * SQLite cache. Only fields present in `updates` are mutated.
+   *
+   * @param id - State ID
+   * @param updates - Partial fields to mutate
+   * @throws Error if the state does not exist
+   */
+  updateState(id: string, updates: UpdateStateData): Promise<void>;
 
   /**
    * Count states for a workspace or session

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -13,6 +13,7 @@ import {
   SessionCreatedEvent,
   SessionUpdatedEvent,
   StateSavedEvent,
+  StateUpdatedEvent,
   StateDeletedEvent,
   TraceAddedEvent,
 } from '../interfaces/StorageEvents';
@@ -55,6 +56,9 @@ export class WorkspaceEventApplier {
         break;
       case 'state_saved':
         await this.applyStateSaved(event);
+        break;
+      case 'state_updated':
+        await this.applyStateUpdated(event);
         break;
       case 'state_deleted':
         await this.applyStateDeleted(event);
@@ -191,6 +195,38 @@ export class WorkspaceEventApplier {
         event.data.tags ? JSON.stringify(event.data.tags) : null
       ]
     );
+  }
+
+  private async applyStateUpdated(event: StateUpdatedEvent): Promise<void> {
+    if (!event.stateId) {
+      return;
+    }
+
+    const updates: string[] = [];
+    const values: unknown[] = [];
+
+    if (event.data.name !== undefined) {
+      updates.push('name = ?');
+      values.push(event.data.name);
+    }
+    if (event.data.description !== undefined) {
+      updates.push('description = ?');
+      values.push(event.data.description);
+    }
+    if (event.data.tags !== undefined) {
+      updates.push('tagsJson = ?');
+      values.push(JSON.stringify(event.data.tags));
+    }
+    // stateJson lives in JSONL only (not in the SQLite states table), so no
+    // SQLite column update is needed when only content changes.
+
+    if (updates.length > 0) {
+      values.push(event.stateId);
+      await this.sqliteCache.run(
+        `UPDATE states SET ${updates.join(', ')} WHERE id = ?`,
+        values
+      );
+    }
   }
 
   private async applyStateDeleted(event: StateDeletedEvent): Promise<void> {

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -565,6 +565,20 @@ export class WorkspaceService {
     return this.stateService.getStateByNameOrId(workspaceId, sessionId, identifier);
   }
 
+  async updateState(
+    workspaceId: string,
+    sessionId: string,
+    stateId: string,
+    updates: {
+      name?: string;
+      description?: string;
+      tags?: string[];
+      content?: unknown;
+    }
+  ): Promise<void> {
+    return this.stateService.updateState(workspaceId, sessionId, stateId, updates);
+  }
+
   // ============================================================================
   // Workspace Query Methods (kept — workspace-level concerns)
   // ============================================================================

--- a/src/services/workspace/WorkspaceStateService.ts
+++ b/src/services/workspace/WorkspaceStateService.ts
@@ -9,7 +9,7 @@ import { MemoryTrace, StateData } from '../../types/storage/StorageTypes';
 import * as HybridTypes from '../../types/storage/HybridStorageTypes';
 import { TraceMetadata } from '../../database/types/memory/MemoryTypes';
 import { WorkspaceState } from '../../database/types/session/SessionTypes';
-import { StorageAdapterOrGetter, resolveAdapter, withReadableBackend } from '../helpers/DualBackendExecutor';
+import { StorageAdapterOrGetter, resolveAdapter, withReadableBackend, withDualBackend } from '../helpers/DualBackendExecutor';
 
 /**
  * Dependencies injected from WorkspaceService to avoid circular references.
@@ -285,6 +285,53 @@ export class WorkspaceStateService {
         return states.find(
           state => state.name?.toLowerCase() === identifier.toLowerCase()
         ) || null;
+      }
+    );
+  }
+
+  /**
+   * Update an existing state's metadata or content. Only the fields present
+   * in `updates` are mutated; omitted fields are left unchanged.
+   *
+   * @param workspaceId - Parent workspace ID (used by legacy fallback lookup)
+   * @param sessionId - Parent session ID (used by legacy fallback lookup)
+   * @param stateId - State ID
+   * @param updates - Partial fields to mutate (name, description, tags, content)
+   */
+  async updateState(
+    workspaceId: string,
+    sessionId: string,
+    stateId: string,
+    updates: {
+      name?: string;
+      description?: string;
+      tags?: string[];
+      content?: unknown;
+    }
+  ): Promise<void> {
+    return withDualBackend(
+      this.storageAdapterOrGetter,
+      async (adapter) => {
+        await adapter.updateState(stateId, updates);
+        await adapter.updateWorkspace(workspaceId, { lastAccessed: Date.now() });
+      },
+      async () => {
+        const workspace = await this.fileSystem.readWorkspace(workspaceId);
+        if (!workspace || !workspace.sessions[sessionId] || !workspace.sessions[sessionId].states[stateId]) {
+          throw new Error(`State not found: ${stateId}`);
+        }
+        const existing = workspace.sessions[sessionId].states[stateId];
+        const next: StateData = { ...existing };
+        if (updates.name !== undefined) next.name = updates.name;
+        if (updates.description !== undefined) next.description = updates.description;
+        if (updates.tags !== undefined) next.tags = updates.tags;
+        if (updates.content !== undefined) {
+          next.state = this.coerceWorkspaceState(updates.content);
+        }
+        workspace.sessions[sessionId].states[stateId] = next;
+        workspace.lastAccessed = Date.now();
+        await this.fileSystem.writeWorkspace(workspaceId, workspace);
+        await this.indexManager.updateWorkspaceInIndex(workspace);
       }
     );
   }

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -17,6 +17,7 @@ import { FilePickerRenderer } from '../../components/workspace/FilePickerRendere
 import { WorkspaceListRenderer } from '../../components/workspace/WorkspaceListRenderer';
 import { WorkspaceDetailRenderer, DetailCallbacks } from '../../components/workspace/WorkspaceDetailRenderer';
 import { ProjectsManagerView } from '../../components/workspace/ProjectsManagerView';
+import { StatesSectionService, StateSummary } from '../../components/workspace/StatesSectionRenderer';
 import { ProjectWorkspace } from '../../database/workspace-types';
 import { WorkspaceService, type WorkspaceChangeEvent } from '../../services/WorkspaceService';
 import { CustomPromptStorageService } from '../../agents/promptManager/services/CustomPromptStorageService';
@@ -26,6 +27,7 @@ import type { ServiceManager } from '../../core/ServiceManager';
 import type { WorkflowRunService } from '../../services/workflows/WorkflowRunService';
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
 import type { ExternalSyncEvent, HybridStorageAdapter } from '../../database/adapters/HybridStorageAdapter';
+import type { MemoryService } from '../../agents/memoryManager/services/MemoryService';
 
 export interface WorkspacesTabServices {
     app: App;
@@ -385,8 +387,88 @@ export class WorkspacesTab {
             getTaskService: () => this.projectsManager.getTaskService(),
             onRefreshProjects: () => this.projectsManager.refreshProjects(),
             onOpenProjectDetail: (project) => { void this.openProjectDetailAndRender(project); },
-            safeRegisterDomEvent: (el, eventName, handler) => this.safeRegisterDomEvent(el, eventName, handler)
+            safeRegisterDomEvent: (el, eventName, handler) => this.safeRegisterDomEvent(el, eventName, handler),
+            getStatesService: () => this.getStatesService(),
+            getApp: () => this.services.app
         };
+    }
+
+    /**
+     * Build the StatesSectionService implementation by composing MemoryService
+     * (read + update path) and HybridStorageAdapter (delete path).
+     *
+     * Backend contracts (issue #215, backend-coder confirmed):
+     * - Read: MemoryService.getStates(workspaceId) returns workspace-scoped
+     *   states across all sessions, with full snapshot under `item.state`.
+     *   Archive flag lives at `item.state.state.metadata.isArchived`.
+     * - Update: MemoryService.updateState(workspaceId, sessionId, stateId,
+     *   {name?, description?, tags?, state?}) routes through the adapter via
+     *   state_updated JSONL events + SQLite patch.
+     * - Archive: same updateState call with a full snapshot whose
+     *   `state.metadata.isArchived` is toggled.
+     * - Delete: HybridStorageAdapter.deleteState(stateId) directly.
+     */
+    private async getStatesService(): Promise<StatesSectionService | null> {
+        if (!this.services.serviceManager) return null;
+
+        try {
+            const [memoryService, adapter] = await Promise.all([
+                this.services.serviceManager.getService<MemoryService>('memoryService'),
+                this.services.serviceManager.getService<HybridStorageAdapter>('hybridStorageAdapter')
+            ]);
+            if (!memoryService || !adapter) return null;
+
+            const readArchiveFlag = (item: { state?: { state?: { metadata?: Record<string, unknown> } } }): boolean | undefined => {
+                const flag = item.state?.state?.metadata?.isArchived;
+                return typeof flag === 'boolean' ? flag : undefined;
+            };
+
+            return {
+                listStates: async (workspaceId, includeArchived) => {
+                    const result = await memoryService.getStates(workspaceId);
+                    const items: StateSummary[] = result.items.map(item => ({
+                        id: item.id,
+                        name: item.name,
+                        description: item.description,
+                        sessionId: item.sessionId,
+                        workspaceId: item.workspaceId,
+                        created: item.created,
+                        tags: item.tags,
+                        isArchived: readArchiveFlag(item)
+                    }));
+                    return includeArchived
+                        ? items
+                        : items.filter(item => !item.isArchived);
+                },
+                updateState: async (workspaceId, sessionId, stateId, patch) => {
+                    await memoryService.updateState(workspaceId, sessionId, stateId, patch);
+                },
+                archiveState: async (workspaceId, sessionId, stateId, restore) => {
+                    const existing = await memoryService.getState(workspaceId, sessionId, stateId);
+                    if (!existing) {
+                        throw new Error('State not found');
+                    }
+                    const nextInner = {
+                        workspace: existing.state?.workspace,
+                        recentTraces: existing.state?.recentTraces ?? [],
+                        contextFiles: existing.state?.contextFiles ?? [],
+                        metadata: {
+                            ...(existing.state?.metadata ?? {}),
+                            isArchived: !restore
+                        }
+                    };
+                    await memoryService.updateState(workspaceId, sessionId, stateId, {
+                        state: { ...existing, state: nextInner }
+                    });
+                },
+                deleteState: async (_workspaceId, _sessionId, stateId) => {
+                    await adapter.deleteState(stateId);
+                }
+            };
+        } catch (error) {
+            console.error('[WorkspacesTab] Failed to resolve states service:', error);
+            return null;
+        }
     }
 
     // --- Navigation ---

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-05-22T15:21:49.121Z
+ * Generated: 2026-05-26T18:42:39.780Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-05-26T18:42:39.780Z
+ * Generated: 2026-05-26T19:28:55.874Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/styles.css
+++ b/styles.css
@@ -8328,3 +8328,141 @@ body.is-mobile .nexus-task-board-shell {
         flex-direction: column;
     }
 }
+
+/* ============================================================
+   States section (workspace detail → States)
+   ============================================================ */
+
+.nexus-states-section {
+    /* inherits .nexus-form-section spacing/borders */
+}
+
+.nexus-states-toolbar {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-m);
+    flex-wrap: wrap;
+}
+
+.nexus-states-archived-toggle {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-s);
+}
+
+.nexus-states-toolbar-label {
+    font-size: var(--font-ui-small);
+    color: var(--text-muted);
+}
+
+.nexus-states-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-s);
+}
+
+.nexus-states-row {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-m);
+    padding: var(--space-m);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    background: var(--background-secondary);
+}
+
+.nexus-states-row--archived {
+    opacity: 0.65;
+}
+
+.nexus-states-row-main {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xxs);
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.nexus-states-row-title {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-s);
+    font-size: var(--font-ui-medium);
+    font-weight: var(--font-semibold);
+    color: var(--text-normal);
+    overflow-wrap: anywhere;
+}
+
+.nexus-states-archived-badge {
+    font-size: var(--font-ui-smaller);
+    font-weight: var(--font-normal);
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px var(--space-xs);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    background: var(--background-primary);
+}
+
+.nexus-states-row-meta {
+    font-size: var(--font-ui-smaller);
+    color: var(--text-muted);
+}
+
+.nexus-states-row-description {
+    font-size: var(--font-ui-small);
+    color: var(--text-normal);
+    overflow-wrap: anywhere;
+}
+
+.nexus-states-row-actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-xs);
+    flex: 0 0 auto;
+}
+
+.nexus-states-action-btn {
+    /* clickable-icon supplies most styling; only tweak hit target */
+    padding: var(--space-xs);
+}
+
+.nexus-states-delete-btn:hover {
+    color: var(--text-error);
+}
+
+.nexus-states-error {
+    color: var(--text-error);
+}
+
+/* State edit modal */
+
+.nexus-state-edit-modal h2 {
+    margin-top: 0;
+}
+
+.nexus-state-edit-label {
+    display: block;
+    margin-top: var(--space-m);
+    margin-bottom: var(--space-xs);
+    font-size: var(--font-ui-small);
+    font-weight: var(--font-semibold);
+    color: var(--text-normal);
+}
+
+.nexus-state-edit-input {
+    width: 100%;
+}
+
+.nexus-state-edit-textarea {
+    width: 100%;
+    min-height: 96px;
+    resize: vertical;
+}

--- a/tests/helpers/mockFactories.ts
+++ b/tests/helpers/mockFactories.ts
@@ -51,6 +51,8 @@ interface MockStorageAdapter {
   addTrace: MockFn<[], Promise<string>>;
   getTraces: MockFn<[], Promise<Record<string, unknown>>>;
   saveState: MockFn<[], Promise<string>>;
+  updateState: MockFn;
+  deleteState: MockFn;
   getState: MockFn<[], Promise<unknown>>;
   getStates: MockFn<[], Promise<Record<string, unknown>>>;
   getConversations: MockFn<[], Promise<Record<string, unknown>>>;
@@ -174,6 +176,8 @@ export function createMockAdapter(ready: boolean): MockStorageAdapter {
     addTrace: jest.fn().mockResolvedValue('trace-new'),
     getTraces: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
     saveState: jest.fn().mockResolvedValue('state-new'),
+    updateState: jest.fn(),
+    deleteState: jest.fn(),
     getState: jest.fn().mockResolvedValue(null),
     getStates: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
     getConversations: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),

--- a/tests/unit/ArchiveStateTool.test.ts
+++ b/tests/unit/ArchiveStateTool.test.ts
@@ -1,0 +1,208 @@
+import { ArchiveStateTool } from '../../src/agents/memoryManager/tools/states/archiveState';
+import type { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import type { WorkspaceState } from '../../src/database/types/session/SessionTypes';
+
+interface StateListItem {
+  id: string;
+  name: string;
+  sessionId?: string;
+  state?: WorkspaceState;
+}
+
+function buildWorkspaceState(overrides: Partial<WorkspaceState> = {}): WorkspaceState {
+  return {
+    id: 'state-1',
+    sessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    name: 'Checkpoint',
+    description: 'A snapshot',
+    created: 100,
+    state: {
+      workspace: null,
+      recentTraces: [],
+      contextFiles: [],
+      metadata: {}
+    },
+    ...overrides
+  } as WorkspaceState;
+}
+
+function buildAgentMocks(opts: {
+  listItems: StateListItem[];
+  getStateResult: WorkspaceState | null;
+  updateState?: jest.Mock;
+}): {
+  agent: MemoryManagerAgent;
+  memoryService: {
+    getStates: jest.Mock;
+    getState: jest.Mock;
+    updateState: jest.Mock;
+  };
+  workspaceService: { getWorkspaceByNameOrId: jest.Mock };
+} {
+  const memoryService = {
+    getStates: jest.fn().mockResolvedValue({
+      items: opts.listItems,
+      page: 0,
+      pageSize: opts.listItems.length || 10,
+      totalItems: opts.listItems.length,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPreviousPage: false
+    }),
+    getState: jest.fn().mockResolvedValue(opts.getStateResult),
+    updateState: opts.updateState ?? jest.fn().mockResolvedValue(undefined)
+  };
+  const workspaceService = {
+    getWorkspaceByNameOrId: jest.fn().mockResolvedValue({ id: 'workspace-1', name: 'Workspace Name' })
+  };
+  const agent = {
+    getMemoryServiceAsync: jest.fn().mockResolvedValue(memoryService),
+    getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService)
+  } as unknown as MemoryManagerAgent;
+  return { agent, memoryService, workspaceService };
+}
+
+function archiveContext() {
+  return {
+    workspaceId: 'Workspace Name',
+    sessionId: 'session-1',
+    memory: 'Testing archive.',
+    goal: 'Verify archive round-trip.'
+  };
+}
+
+describe('ArchiveStateTool', () => {
+  it('archives an un-archived state by toggling metadata.isArchived to true', async () => {
+    const listItems: StateListItem[] = [{ id: 'state-1', name: 'Checkpoint', sessionId: 'session-1' }];
+    const existing = buildWorkspaceState();
+    const { agent, memoryService } = buildAgentMocks({ listItems, getStateResult: existing });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Checkpoint' });
+
+    expect(result.success).toBe(true);
+    expect(memoryService.updateState).toHaveBeenCalledTimes(1);
+    const updateCall = memoryService.updateState.mock.calls[0];
+    expect(updateCall[0]).toBe('workspace-1');
+    expect(updateCall[1]).toBe('session-1');
+    expect(updateCall[2]).toBe('state-1');
+    const passedNextState = updateCall[3].state as WorkspaceState;
+    expect(passedNextState.state?.metadata?.isArchived).toBe(true);
+  });
+
+  it('preserves tags and snapshot fields when archiving a TAGGED state (B1 regression guard)', async () => {
+    // This is the B1 skeleton-corruption guard: archiveState must read the REAL
+    // snapshot via getState and preserve every existing field. Before the fix,
+    // a skeleton WorkspaceState was constructed and tags/conversationContext/
+    // activeTask/activeFiles/nextSteps were clobbered.
+    const listItems: StateListItem[] = [{ id: 'state-1', name: 'Tagged Checkpoint', sessionId: 'session-1' }];
+    const existing = buildWorkspaceState({
+      name: 'Tagged Checkpoint',
+      tags: ['important', 'milestone'],
+      state: {
+        workspace: { id: 'workspace-1' } as unknown as WorkspaceState['state']['workspace'],
+        recentTraces: [{ id: 'trace-1' }] as unknown as WorkspaceState['state']['recentTraces'],
+        contextFiles: ['notes/Plan.md'] as unknown as WorkspaceState['state']['contextFiles'],
+        metadata: {
+          tags: ['important', 'milestone'],
+          conversationContext: 'Discussing Q3 roadmap',
+          activeTask: 'Finalize plan',
+          activeFiles: ['notes/Plan.md'],
+          nextSteps: ['Ship by Friday']
+        } as unknown as WorkspaceState['state']['metadata']
+      }
+    });
+    const { agent, memoryService } = buildAgentMocks({ listItems, getStateResult: existing });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Tagged Checkpoint' });
+
+    expect(result.success).toBe(true);
+    const passedNextState = memoryService.updateState.mock.calls[0][3].state as WorkspaceState;
+    // isArchived flipped
+    expect(passedNextState.state?.metadata?.isArchived).toBe(true);
+    // Top-level tags survive
+    expect(passedNextState.tags).toEqual(['important', 'milestone']);
+    // Nested metadata survives (this is what skeleton-corruption clobbered)
+    const md = passedNextState.state?.metadata as Record<string, unknown>;
+    expect(md.tags).toEqual(['important', 'milestone']);
+    expect(md.conversationContext).toBe('Discussing Q3 roadmap');
+    expect(md.activeTask).toBe('Finalize plan');
+    expect(md.activeFiles).toEqual(['notes/Plan.md']);
+    expect(md.nextSteps).toEqual(['Ship by Friday']);
+    // Snapshot sub-fields survive
+    expect(passedNextState.state?.recentTraces).toEqual([{ id: 'trace-1' }]);
+    expect(passedNextState.state?.contextFiles).toEqual(['notes/Plan.md']);
+  });
+
+  it('restores an archived state by toggling metadata.isArchived to false, preserving tags', async () => {
+    const listItems: StateListItem[] = [{ id: 'state-1', name: 'Tagged Checkpoint', sessionId: 'session-1' }];
+    const existing = buildWorkspaceState({
+      tags: ['important'],
+      state: {
+        workspace: null,
+        recentTraces: [],
+        contextFiles: [],
+        metadata: {
+          tags: ['important'],
+          isArchived: true
+        } as unknown as WorkspaceState['state']['metadata']
+      }
+    });
+    const { agent, memoryService } = buildAgentMocks({ listItems, getStateResult: existing });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Tagged Checkpoint', restore: true });
+
+    expect(result.success).toBe(true);
+    const passedNextState = memoryService.updateState.mock.calls[0][3].state as WorkspaceState;
+    expect(passedNextState.state?.metadata?.isArchived).toBe(false);
+    expect(passedNextState.tags).toEqual(['important']);
+    expect((passedNextState.state?.metadata as Record<string, unknown>).tags).toEqual(['important']);
+  });
+
+  it('returns a clear error when the named state is not found', async () => {
+    const { agent, memoryService } = buildAgentMocks({ listItems: [], getStateResult: null });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Nonexistent' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/State "Nonexistent" not found/);
+    expect(memoryService.updateState).not.toHaveBeenCalled();
+  });
+
+  it('rejects restore=true on a state that is not archived', async () => {
+    const listItems: StateListItem[] = [{ id: 'state-1', name: 'Checkpoint', sessionId: 'session-1' }];
+    const existing = buildWorkspaceState();
+    const { agent, memoryService } = buildAgentMocks({ listItems, getStateResult: existing });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Checkpoint', restore: true });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/is not archived/);
+    expect(memoryService.updateState).not.toHaveBeenCalled();
+  });
+
+  it('rejects archive on a state that is already archived (idempotency guard)', async () => {
+    const listItems: StateListItem[] = [{ id: 'state-1', name: 'Checkpoint', sessionId: 'session-1' }];
+    const existing = buildWorkspaceState({
+      state: {
+        workspace: null,
+        recentTraces: [],
+        contextFiles: [],
+        metadata: { isArchived: true } as unknown as WorkspaceState['state']['metadata']
+      }
+    });
+    const { agent, memoryService } = buildAgentMocks({ listItems, getStateResult: existing });
+
+    const tool = new ArchiveStateTool(agent);
+    const result = await tool.execute({ context: archiveContext(), name: 'Checkpoint' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/is already archived/);
+    expect(memoryService.updateState).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/MemoryServiceDeleteState.test.ts
+++ b/tests/unit/MemoryServiceDeleteState.test.ts
@@ -1,0 +1,41 @@
+import { MemoryService } from '../../src/agents/memoryManager/services/MemoryService';
+import type { Plugin } from 'obsidian';
+import type { WorkspaceService } from '../../src/services/WorkspaceService';
+import type { IStorageAdapter } from '../../src/database/interfaces/IStorageAdapter';
+
+/**
+ * Defensive guard: MemoryService.deleteState must route through
+ * IStorageAdapter.deleteState on the hybrid backend.
+ *
+ * Pre-fix (PR #216 M1), this method did a workspace round-trip
+ * (getWorkspace + mutate workspace.sessions[sid].states[stateId] +
+ * updateWorkspace), which silently no-ops on the hybrid backend because
+ * states are first-class rows in the states table, not nested under
+ * workspace.sessions. This test exists to catch any hand-edit that
+ * reintroduces that pattern.
+ */
+describe('MemoryService.deleteState (hybrid-backend routing)', () => {
+  it('routes through adapter.deleteState(stateId) when the storage adapter is ready', async () => {
+    const deleteStateMock = jest.fn().mockResolvedValue(undefined);
+    const adapter = {
+      isReady: () => true,
+      deleteState: deleteStateMock
+    } as unknown as IStorageAdapter;
+
+    // workspaceService should NEVER be called on the hybrid path — if it is,
+    // we've reintroduced the broken workspace round-trip.
+    const getWorkspace = jest.fn();
+    const updateWorkspace = jest.fn();
+    const workspaceService = { getWorkspace, updateWorkspace } as unknown as WorkspaceService;
+
+    const plugin = {} as unknown as Plugin;
+    const service = new MemoryService(plugin, workspaceService, adapter);
+
+    await service.deleteState('workspace-1', 'session-1', 'state-1');
+
+    expect(deleteStateMock).toHaveBeenCalledTimes(1);
+    expect(deleteStateMock).toHaveBeenCalledWith('state-1');
+    expect(getWorkspace).not.toHaveBeenCalled();
+    expect(updateWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/StateRepository.test.ts
+++ b/tests/unit/StateRepository.test.ts
@@ -1,0 +1,170 @@
+import { StateRepository } from '../../src/database/repositories/StateRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import type {
+  StateSavedEvent,
+  StateUpdatedEvent
+} from '../../src/database/interfaces/StorageEvents';
+
+type AnyStateEvent = StateSavedEvent | StateUpdatedEvent;
+
+function createMockDeps(events: AnyStateEvent[] = []): RepositoryDependencies {
+  return {
+    sqliteCache: {
+      queryOne: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      run: jest.fn(),
+      transaction: jest.fn((fn: () => Promise<unknown>) => fn())
+    } as never,
+    jsonlWriter: {
+      appendEvent: jest.fn().mockImplementation((_path: string, ev: AnyStateEvent) => ({
+        ...ev,
+        id: 'evt-x',
+        timestamp: Date.now(),
+        deviceId: 'dev-1'
+      })),
+      readEvents: jest.fn().mockResolvedValue(events)
+    } as never,
+    queryCache: {
+      cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+      invalidateByType: jest.fn(),
+      invalidateById: jest.fn(),
+      invalidate: jest.fn()
+    } as never
+  };
+}
+
+function stateMetadataRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'state-1',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    name: 'Checkpoint',
+    description: 'A checkpoint',
+    created: 100,
+    tagsJson: null,
+    ...overrides
+  };
+}
+
+function savedEvent(stateId: string, content: unknown, overrides: Partial<StateSavedEvent> = {}): StateSavedEvent {
+  return {
+    id: `evt-saved-${stateId}`,
+    type: 'state_saved',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    timestamp: 1,
+    deviceId: 'dev-1',
+    data: {
+      id: stateId,
+      name: 'Checkpoint',
+      description: 'A checkpoint',
+      created: 100,
+      stateJson: JSON.stringify(content),
+      tags: undefined
+    },
+    ...overrides
+  } as StateSavedEvent;
+}
+
+function updatedEvent(stateId: string, content: unknown, timestamp = 2, overrides: Partial<StateUpdatedEvent> = {}): StateUpdatedEvent {
+  return {
+    id: `evt-updated-${stateId}-${timestamp}`,
+    type: 'state_updated',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    stateId,
+    timestamp,
+    deviceId: 'dev-1',
+    data: {
+      stateJson: JSON.stringify(content)
+    },
+    ...overrides
+  } as StateUpdatedEvent;
+}
+
+describe('StateRepository.getStateData event-folding', () => {
+  it('folds a single state_updated event over state_saved (returns updated content)', async () => {
+    const events: AnyStateEvent[] = [
+      savedEvent('state-1', { value: 'original' }),
+      updatedEvent('state-1', { value: 'updated-once' }, 2)
+    ];
+    const deps = createMockDeps(events);
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue(stateMetadataRow());
+
+    const repo = new StateRepository(deps);
+    const result = await repo.getStateData('state-1');
+
+    expect(result?.content).toEqual({ value: 'updated-once' });
+    expect(deps.jsonlWriter.readEvents).toHaveBeenCalledWith('workspaces/ws_ws-1.jsonl');
+  });
+
+  it('returns the LATEST content when N×state_updated events are folded in order', async () => {
+    const events: AnyStateEvent[] = [
+      savedEvent('state-1', { value: 'original' }),
+      updatedEvent('state-1', { value: 'second' }, 2),
+      updatedEvent('state-1', { value: 'third' }, 3),
+      updatedEvent('state-1', { value: 'latest' }, 4)
+    ];
+    const deps = createMockDeps(events);
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue(stateMetadataRow());
+
+    const repo = new StateRepository(deps);
+    const result = await repo.getStateData('state-1');
+
+    expect(result?.content).toEqual({ value: 'latest' });
+  });
+
+  it('skips state_updated events targeting a different stateId in the same JSONL (cross-stateId isolation)', async () => {
+    const events: AnyStateEvent[] = [
+      savedEvent('state-1', { value: 'state1-original' }),
+      // Updates for a SIBLING state in the same workspace JSONL must not bleed in
+      updatedEvent('state-2', { value: 'state2-update' }, 2),
+      updatedEvent('state-2', { value: 'state2-later-update' }, 3)
+    ];
+    const deps = createMockDeps(events);
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue(stateMetadataRow());
+
+    const repo = new StateRepository(deps);
+    const result = await repo.getStateData('state-1');
+
+    expect(result?.content).toEqual({ value: 'state1-original' });
+  });
+
+  it('leaves content unchanged when a state_updated event has no stateJson (metadata-only update)', async () => {
+    const metadataOnlyUpdate = updatedEvent('state-1', undefined, 2);
+    // Remove stateJson to simulate metadata-only (name/description/tags only) update
+    (metadataOnlyUpdate.data as { stateJson?: string }).stateJson = undefined;
+    metadataOnlyUpdate.data.name = 'Renamed';
+
+    const events: AnyStateEvent[] = [
+      savedEvent('state-1', { value: 'original' }),
+      metadataOnlyUpdate
+    ];
+    const deps = createMockDeps(events);
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue(stateMetadataRow());
+
+    const repo = new StateRepository(deps);
+    const result = await repo.getStateData('state-1');
+
+    expect(result?.content).toEqual({ value: 'original' });
+  });
+
+  it('returns null via the metadata-not-found gate when the SQLite row is absent (delete tombstone)', async () => {
+    // After state_deleted runs through WorkspaceEventApplier.applyStateDeleted, the
+    // SQLite row is DELETEd. The next getStateData call hits the !metadata branch
+    // and returns null BEFORE the fold loop is reached.
+    const events: AnyStateEvent[] = [
+      savedEvent('state-1', { value: 'original' }),
+      updatedEvent('state-1', { value: 'updated' }, 2)
+    ];
+    const deps = createMockDeps(events);
+    (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue(null);
+
+    const repo = new StateRepository(deps);
+    const result = await repo.getStateData('state-1');
+
+    expect(result).toBeNull();
+    // Fold loop should never run when metadata is absent
+    expect(deps.jsonlWriter.readEvents).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #215 — adds the missing state-management CLI surface and a parallel UI in Settings.

**AI surface (CRUA, mirrors workspace tools):**
- `memory update-state` — rename / edit description / replace tags
- `memory archive-state [--restore]` — soft-archive + restore, mirroring `archive-workspace`
- **No `delete-state` tool** — by design, the AI cannot delete states. Deletion is UI-only.

**UI surface (Settings → Workspaces → workspace detail):**
- New "States" section under the existing Projects section
- List states with show-archived toggle
- Edit modal (name + description)
- Archive / Restore (reversible)
- Delete with confirmation modal (humans can destroy; mirrors `WorkspaceDeleteConfirmModal`)

## Bonus: latent bug fix

While tracing the service layer, found that `MemoryService.updateState` was silently no-op'ing on the hybrid (SQL/IndexedDB) backend — production default since v5.8.12. It read `workspace.sessions[].states[]` which is empty on hybrid (states are first-class table rows). The storage layer is extended in this PR to fix it:

- New `StateUpdatedEvent` (mirrors `state_deleted` shape)
- `IStorageAdapter.updateState` + `IStateRepository.updateState` + `UpdateStateData`
- `StateRepository.updateState` (UPDATE + event-folding in `getStateData` for replay correctness)
- `HybridStorageAdapter.updateState` delegation
- `WorkspaceEventApplier.applyStateUpdated` handler
- `WorkspaceService.updateState` facade
- `WorkspaceStateService.updateState` with dual-backend support
- `MemoryService.updateState` rewritten to route through the adapter

Any other caller of `MemoryService.updateState` now actually persists changes.

## Test plan

- [x] `npm test` — 2756 / 2771 pass (15 pre-existing skips, 0 regressions)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean (esbuild + connector regen)
- [x] `npx eslint` on touched files — clean
- [ ] Manual: create a state, archive it via UI, restore it
- [ ] Manual: edit state name + description via UI
- [ ] Manual: delete state via UI (confirm modal gates correctly)
- [ ] Manual: call `memory archive-state` and `memory update-state` from MCP
- [ ] Manual: confirm `memory list-states --include-archived` surfaces archived states

🤖 Generated with [Claude Code](https://claude.com/claude-code)