### PR TITLE
fix(memoryManager): surface isArchived from getStates for tagged states

### DIFF
--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -552,7 +552,7 @@ export class MemoryService {
       async (adapter) => {
         const result = await adapter.getStates(workspaceId, sessionId, options);
         const convertedItems: StateItem[] = await Promise.all(result.items.map(async stateMeta => {
-          const fullState = stateMeta.tags ? null : await adapter.getState(stateMeta.id);
+          const fullState = await adapter.getState(stateMeta.id);
           const tags = stateMeta.tags || this.extractStateTagsFromContent(fullState?.content);
           return {
             id: stateMeta.id,

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-05-26T19:28:55.874Z
+ * Generated: 2026-05-26T20:02:11.686Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/unit/MemoryServiceGetStates.test.ts
+++ b/tests/unit/MemoryServiceGetStates.test.ts
@@ -1,0 +1,107 @@
+import { MemoryService } from '../../src/agents/memoryManager/services/MemoryService';
+import type { Plugin } from 'obsidian';
+import type { WorkspaceService } from '../../src/services/WorkspaceService';
+import type { IStorageAdapter } from '../../src/database/interfaces/IStorageAdapter';
+
+/**
+ * Defensive guard: MemoryService.getStates must surface `isArchived` for
+ * tagged states by reading full JSONL content via adapter.getState — NOT
+ * by short-circuiting on the SQLite metadata fast-path when `stateMeta.tags`
+ * is cached.
+ *
+ * Pre-fix (PR #216 read-path follow-up), MemoryService.ts:555 had:
+ *   const fullState = stateMeta.tags ? null : await adapter.getState(stateMeta.id);
+ *
+ * For tagged states, this skipped the content fetch — `state.metadata.isArchived`
+ * never surfaced, so both the workspace-settings states UI filter and the
+ * LLM-facing listStates filter (listStates.ts:106) treated archived tagged
+ * states as visible. The archive icon would write state_updated correctly but
+ * the next read returned a skeleton without isArchived.
+ *
+ * Proper long-term fix is to denormalize isArchived into SQLite metadata
+ * (v13 migration) so the fast-path can return a complete view without the
+ * JSONL round-trip. Tracked as a separate follow-up.
+ */
+describe('MemoryService.getStates (isArchived surfacing for tagged states)', () => {
+  const taggedArchivedStateMeta = {
+    id: 'state-tagged-archived',
+    name: 'Tagged Archived State',
+    description: 'A state with tags that has been archived',
+    sessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    created: 1717000000000,
+    tags: ['draft', 'review']
+  };
+
+  const taggedArchivedContent = {
+    id: 'state-tagged-archived',
+    name: 'Tagged Archived State',
+    workspaceId: 'workspace-1',
+    sessionId: 'session-1',
+    created: 1717000000000,
+    state: {
+      workspace: null,
+      recentTraces: [],
+      contextFiles: [],
+      metadata: {
+        tags: ['draft', 'review'],
+        isArchived: true
+      }
+    }
+  };
+
+  function buildService(adapterOverrides: Partial<IStorageAdapter>): MemoryService {
+    const adapter = {
+      isReady: () => true,
+      getStates: jest.fn().mockResolvedValue({
+        items: [taggedArchivedStateMeta],
+        total: 1,
+        page: 0,
+        pageSize: 50,
+        hasMore: false
+      }),
+      getState: jest.fn().mockResolvedValue({ content: taggedArchivedContent }),
+      ...adapterOverrides
+    } as unknown as IStorageAdapter;
+
+    const workspaceService = {
+      getWorkspace: jest.fn()
+    } as unknown as WorkspaceService;
+
+    const plugin = {} as unknown as Plugin;
+    return new MemoryService(plugin, workspaceService, adapter);
+  }
+
+  it('surfaces state.metadata.isArchived for tagged states by reading full content', async () => {
+    const getStateMock = jest.fn().mockResolvedValue({ content: taggedArchivedContent });
+    const service = buildService({ getState: getStateMock });
+
+    const result = await service.getStates('workspace-1');
+
+    expect(getStateMock).toHaveBeenCalledWith('state-tagged-archived');
+
+    const returned = result.items.find((s) => s.id === 'state-tagged-archived');
+    expect(returned).toBeDefined();
+    const metadata = returned?.state?.state?.metadata as { isArchived?: boolean; tags?: unknown } | undefined;
+    expect(metadata?.isArchived).toBe(true);
+  });
+
+  it('preserves the cached tags from SQLite metadata when content is fetched', async () => {
+    const service = buildService({});
+
+    const result = await service.getStates('workspace-1');
+    const returned = result.items.find((s) => s.id === 'state-tagged-archived');
+
+    expect(returned?.tags).toEqual(['draft', 'review']);
+  });
+
+  it('calls adapter.getState for tagged states (no shortcut)', async () => {
+    const getStateMock = jest.fn().mockResolvedValue({ content: taggedArchivedContent });
+    const service = buildService({ getState: getStateMock });
+
+    await service.getStates('workspace-1');
+
+    expect(getStateMock).toHaveBeenCalledTimes(1);
+    expect(getStateMock).toHaveBeenCalledWith('state-tagged-archived');
+  });
+});


### PR DESCRIPTION
## Summary

Bug found while manually testing PR #216 (issue #215): clicking the archive icon on a state in the workspace-settings UI did not remove it from the list, and the refresh button had no effect.

Root cause is a SQLite-metadata fast-path in `MemoryService.getStates` at line 555 — when `stateMeta.tags` was cached, the JSONL content fetch was skipped, and the skeleton return path never surfaced `state.metadata.isArchived` to consumers. This affected **both** the UI list filter **and** the AI-facing `listStates` tool filter at `listStates.ts:106`, partially breaking the AI-archive-only read contract from #215.

Fix is surgical (1 line): drop the `stateMeta.tags ? null :` shortcut so `adapter.getState` always runs. Line 556's tag-extraction OR-short-circuits when `stateMeta.tags` is set, so behavior on the untagged path is unchanged. Tool filter inherits the fix automatically (reads `state.state?.metadata?.isArchived` from the same items).

Manual-tested in Obsidian — archive icon now removes tagged states from the list immediately.

## Test plan
- [x] New: `MemoryServiceGetStates.test.ts` — 3 regression tests (tagged-archived isArchived surfacing, tags preservation, no-shortcut assertion).
- [x] `npm run build` clean (lint + tsc + esbuild + connector regen).
- [x] `npm test` — 220/222 suites, 2792/2809 tests pass (2 pre-existing flakes unrelated).
- [x] Manual test in Obsidian: archive a tagged state → row disappears from list; refresh works; AI listStates respects archive on tagged states.

## Follow-up tech debt (not blocking)
Proper long-term fix is denormalizing `is_archived` into SQLite states metadata so the fast-path can return a complete view (~80-120 LoC, v12→v13 migration). The shortcut existed for perf — denormalization restores it without correctness cost. Will file as a separate issue post-merge.

Follow-up to #215 manual-test finding (do not auto-close — #215 has further verification still pending after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)