### PR TITLE
feat(workspaces): Wave 3 PR1 — BoxedSection + ConfirmModal foundation

### DIFF
--- a/src/components/workspace/StatesSectionRenderer.ts
+++ b/src/components/workspace/StatesSectionRenderer.ts
@@ -16,6 +16,8 @@
  */
 
 import { App, ButtonComponent, Component, Modal, Notice, TextAreaComponent, TextComponent, ToggleComponent, setIcon } from 'obsidian';
+import { BoxedSection } from '../../settings/components/BoxedSection';
+import { ConfirmModal } from '../../settings/components/ConfirmModal';
 
 /**
  * State summary shown in the list. Matches the projection returned by
@@ -76,38 +78,46 @@ export class StatesSectionRenderer {
         this.workspaceId = workspaceId;
         container.empty();
 
-        const section = container.createDiv('nexus-form-section nexus-states-section');
-        section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
-
         if (!workspaceId) {
-            section.createEl('p', {
-                text: 'Save this workspace before managing states.',
-                cls: 'nexus-form-hint'
-            });
+            new BoxedSection(container, {
+                title: 'States',
+                unbounded: true,
+                body: (body) => {
+                    body.createEl('p', {
+                        text: 'Save this workspace before managing states.',
+                        cls: 'nexus-form-hint'
+                    });
+                }
+            }, this.component);
             return;
         }
 
-        section.createEl('p', {
-            text: 'Snapshots of workspace context that can be resumed later. Edit, archive, or delete states here.',
-            cls: 'nexus-form-hint'
-        });
+        new BoxedSection(container, {
+            title: 'States',
+            unbounded: true,
+            toolbar: (toolbar) => {
+                const archivedLabel = toolbar.createDiv('nexus-states-archived-toggle');
+                archivedLabel.createSpan({ text: 'Show archived', cls: 'nexus-states-toolbar-label' });
+                new ToggleComponent(archivedLabel)
+                    .setValue(this.includeArchived)
+                    .onChange((value) => {
+                        this.includeArchived = value;
+                        void this.loadAndRender();
+                    });
 
-        // Toolbar: archived toggle + refresh
-        const toolbar = section.createDiv('nexus-states-toolbar');
-        const archivedLabel = toolbar.createDiv('nexus-states-archived-toggle');
-        archivedLabel.createSpan({ text: 'Show archived', cls: 'nexus-states-toolbar-label' });
-        new ToggleComponent(archivedLabel)
-            .setValue(this.includeArchived)
-            .onChange((value) => {
-                this.includeArchived = value;
-                void this.loadAndRender();
-            });
+                new ButtonComponent(toolbar)
+                    .setButtonText('Refresh')
+                    .onClick(() => { void this.loadAndRender(); });
+            },
+            body: (body) => {
+                body.createEl('p', {
+                    text: 'Snapshots of workspace context that can be resumed later. Edit, archive, or delete states here.',
+                    cls: 'nexus-form-hint'
+                });
+                this.listContainer = body.createDiv('nexus-states-list');
+            }
+        }, this.component);
 
-        new ButtonComponent(toolbar)
-            .setButtonText('Refresh')
-            .onClick(() => { void this.loadAndRender(); });
-
-        this.listContainer = section.createDiv('nexus-states-list');
         void this.loadAndRender();
     }
 
@@ -258,8 +268,16 @@ export class StatesSectionRenderer {
             new Notice('Cannot archive state: missing sessionId');
             return;
         }
+        const restore = !!state.isArchived;
+
+        // Confirm on archive (going to archived); restore is a one-click reversal,
+        // no confirmation needed.
+        if (!restore) {
+            const confirmed = await this.confirmArchive(state.name || 'Untitled state');
+            if (!confirmed) return;
+        }
+
         try {
-            const restore = !!state.isArchived;
             await this.service.archiveState(this.workspaceId, sessionId, state.id, restore);
             new Notice(restore ? 'State restored' : 'State archived');
             await this.loadAndRender();
@@ -267,6 +285,23 @@ export class StatesSectionRenderer {
             console.error('[StatesSectionRenderer] Failed to archive state:', error);
             new Notice('Failed to archive state');
         }
+    }
+
+    private confirmArchive(stateName: string): Promise<boolean> {
+        return new Promise<boolean>((resolve) => {
+            let confirmed = false;
+            const modal = new ConfirmModal(this.app, {
+                variant: 'archive',
+                title: 'Archive state?',
+                body: `Archive state "${stateName}"? You can restore it later from this list.`,
+                onConfirm: () => { confirmed = true; }
+            });
+            modal.onClose = () => {
+                modal.contentEl.empty();
+                resolve(confirmed);
+            };
+            modal.open();
+        });
     }
 
     private async confirmAndDelete(state: StateSummary): Promise<void> {

--- a/src/components/workspace/WorkspaceDetailRenderer.ts
+++ b/src/components/workspace/WorkspaceDetailRenderer.ts
@@ -4,6 +4,8 @@
  */
 
 import { App, ButtonComponent, Component, DropdownComponent, Notice, TextAreaComponent, TextComponent } from 'obsidian';
+import { BoxedSection } from '../../settings/components/BoxedSection';
+import { ConfirmModal } from '../../settings/components/ConfirmModal';
 import { BreadcrumbNav, BreadcrumbNavItem } from '../../settings/components/BreadcrumbNav';
 import { WorkspaceFormRenderer } from './WorkspaceFormRenderer';
 import { CardItem } from '../CardManager';
@@ -92,37 +94,22 @@ export class WorkspaceDetailRenderer {
         this.component = component;
     }
 
-    private async confirmDangerousAction(message: string): Promise<boolean> {
+    private async confirmDangerousAction(app: App, message: string): Promise<boolean> {
         return await new Promise<boolean>((resolve) => {
-            const overlay = window.activeDocument.body.createDiv('modal-container');
-            const modal = overlay.createDiv('modal nexus-workspace-confirm-modal');
-            const content = modal.createDiv('modal-content');
-
-            content.createEl('h2', { text: 'Confirm action' });
-            content.createEl('p', { text: message });
-
-            const buttons = content.createDiv('modal-button-container');
-            const cancelButton = buttons.createEl('button', {
-                text: 'Cancel',
-                cls: 'mod-cancel'
-            });
-            const confirmButton = buttons.createEl('button', {
-                text: 'Delete',
-                cls: 'mod-warning'
-            });
-
-            const cleanup = (result: boolean) => {
-                overlay.remove();
-                resolve(result);
-            };
-
-            cancelButton.addEventListener('click', () => cleanup(false));
-            confirmButton.addEventListener('click', () => cleanup(true));
-            overlay.addEventListener('click', (event) => {
-                if (event.target === overlay) {
-                    cleanup(false);
+            let confirmed = false;
+            const modal = new ConfirmModal(app, {
+                variant: 'delete',
+                title: 'Confirm delete',
+                body: message,
+                onConfirm: () => {
+                    confirmed = true;
                 }
             });
+            modal.onClose = () => {
+                modal.contentEl.empty();
+                resolve(confirmed);
+            };
+            modal.open();
         });
     }
 
@@ -197,27 +184,30 @@ export class WorkspaceDetailRenderer {
         workspace: Partial<ProjectWorkspace>,
         callbacks: DetailCallbacks
     ): void {
-        const section = container.createDiv('nexus-form-section');
-        section.createEl('h4', { text: 'Projects', cls: 'nexus-section-header' });
+        new BoxedSection(container, {
+            title: 'Projects',
+            unbounded: true,
+            body: (body) => {
+                if (!workspace.id) {
+                    body.createEl('p', {
+                        text: 'Save this workspace before managing projects and tasks.',
+                        cls: 'nexus-form-hint'
+                    });
+                    return;
+                }
 
-        if (!workspace.id) {
-            section.createEl('p', {
-                text: 'Save this workspace before managing projects and tasks.',
-                cls: 'nexus-form-hint'
-            });
-            return;
-        }
+                body.createEl('p', {
+                    text: 'Manage workspace projects and project tasks using the same settings navigation pattern as workflows.',
+                    cls: 'nexus-form-hint'
+                });
 
-        section.createEl('p', {
-            text: 'Manage workspace projects and project tasks using the same settings navigation pattern as workflows.',
-            cls: 'nexus-form-hint'
-        });
-
-        new ButtonComponent(section)
-            .setButtonText('Manage projects')
-            .onClick(() => {
-                callbacks.onNavigateProjects();
-            });
+                new ButtonComponent(body)
+                    .setButtonText('Manage projects')
+                    .onClick(() => {
+                        callbacks.onNavigateProjects();
+                    });
+            }
+        }, this.component);
     }
 
     private renderStatesSection(
@@ -228,12 +218,16 @@ export class WorkspaceDetailRenderer {
         const sectionHost = container.createDiv();
 
         if (!workspace.id) {
-            const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
-            section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
-            section.createEl('p', {
-                text: 'Save this workspace before managing states.',
-                cls: 'nexus-form-hint'
-            });
+            new BoxedSection(sectionHost, {
+                title: 'States',
+                unbounded: true,
+                body: (body) => {
+                    body.createEl('p', {
+                        text: 'Save this workspace before managing states.',
+                        cls: 'nexus-form-hint'
+                    });
+                }
+            }, this.component);
             return;
         }
 
@@ -242,22 +236,30 @@ export class WorkspaceDetailRenderer {
         // Render an initial placeholder so the section is visible while the
         // service resolves; the StatesSectionRenderer will replace it when
         // the service is ready (or render an error if not).
-        const placeholder = sectionHost.createDiv('nexus-form-section nexus-states-section');
-        placeholder.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
-        placeholder.createEl('p', {
-            text: 'Loading states section...',
-            cls: 'nexus-loading-message'
-        });
+        new BoxedSection(sectionHost, {
+            title: 'States',
+            unbounded: true,
+            body: (body) => {
+                body.createEl('p', {
+                    text: 'Loading states section...',
+                    cls: 'nexus-loading-message'
+                });
+            }
+        }, this.component);
 
         void callbacks.getStatesService().then((service) => {
             sectionHost.empty();
             if (!service) {
-                const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
-                section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
-                section.createEl('p', {
-                    text: 'States service is unavailable.',
-                    cls: 'nexus-form-hint'
-                });
+                new BoxedSection(sectionHost, {
+                    title: 'States',
+                    unbounded: true,
+                    body: (body) => {
+                        body.createEl('p', {
+                            text: 'States service is unavailable.',
+                            cls: 'nexus-form-hint'
+                        });
+                    }
+                }, this.component);
                 return;
             }
             this.statesRenderer = new StatesSectionRenderer(callbacks.getApp(), service, this.component);
@@ -265,12 +267,16 @@ export class WorkspaceDetailRenderer {
         }).catch((error) => {
             console.error('[WorkspaceDetailRenderer] Failed to resolve states service:', error);
             sectionHost.empty();
-            const section = sectionHost.createDiv('nexus-form-section nexus-states-section');
-            section.createEl('h4', { text: 'States', cls: 'nexus-section-header' });
-            section.createEl('p', {
-                text: 'Failed to load states section.',
-                cls: 'nexus-form-hint nexus-states-error'
-            });
+            new BoxedSection(sectionHost, {
+                title: 'States',
+                unbounded: true,
+                body: (body) => {
+                    body.createEl('p', {
+                        text: 'Failed to load states section.',
+                        cls: 'nexus-form-hint nexus-states-error'
+                    });
+                }
+            }, this.component);
         });
     }
 
@@ -695,7 +701,7 @@ export class WorkspaceDetailRenderer {
     }
 
     private async deleteProject(projectId: string, callbacks: DetailCallbacks): Promise<void> {
-        const confirmed = await this.confirmDangerousAction('Delete this project and all its tasks? This cannot be undone.');
+        const confirmed = await this.confirmDangerousAction(callbacks.getApp(), 'Delete this project and all its tasks? This cannot be undone.');
         if (!confirmed) return;
 
         const taskService = await callbacks.getTaskService();
@@ -716,7 +722,7 @@ export class WorkspaceDetailRenderer {
     }
 
     private async deleteTask(taskId: string, callbacks: DetailCallbacks): Promise<void> {
-        const confirmed = await this.confirmDangerousAction('Delete this task? This cannot be undone.');
+        const confirmed = await this.confirmDangerousAction(callbacks.getApp(), 'Delete this task? This cannot be undone.');
         if (!confirmed) return;
 
         const taskService = await callbacks.getTaskService();

--- a/src/components/workspace/WorkspaceFormRenderer.ts
+++ b/src/components/workspace/WorkspaceFormRenderer.ts
@@ -1,4 +1,5 @@
 import { DropdownComponent, TextComponent, TextAreaComponent, ButtonComponent } from 'obsidian';
+import { BoxedSection } from '../../settings/components/BoxedSection';
 import { ProjectWorkspace } from '../../database/workspace-types';
 import type { WorkspaceWorkflow } from '../../database/types/workspace/WorkspaceTypes';
 import { CustomPrompt } from '../../types/mcp/CustomPromptTypes';
@@ -52,37 +53,40 @@ export class WorkspaceFormRenderer {
    * Render Basic Info section
    */
   private renderBasicInfoSection(container: HTMLElement): void {
-    const section = container.createDiv('nexus-form-section');
-    section.createEl('h4', { text: 'Basic info', cls: 'nexus-section-header' });
+    new BoxedSection(container, {
+      title: 'Basic info',
+      unbounded: true,
+      body: (body) => {
+        // Name field
+        const nameField = body.createDiv('nexus-form-field');
+        nameField.createEl('label', { text: 'Name', cls: 'nexus-form-label' });
+        const nameInput = new TextComponent(nameField);
+        nameInput.setPlaceholder('My workspace');
+        nameInput.setValue(this.formData.name || '');
+        nameInput.onChange((value) => {
+          this.formData.name = value;
+        });
 
-    // Name field
-    const nameField = section.createDiv('nexus-form-field');
-    nameField.createEl('label', { text: 'Name', cls: 'nexus-form-label' });
-    const nameInput = new TextComponent(nameField);
-    nameInput.setPlaceholder('My workspace');
-    nameInput.setValue(this.formData.name || '');
-    nameInput.onChange((value) => {
-      this.formData.name = value;
-    });
+        // Description field
+        const descField = body.createDiv('nexus-form-field');
+        descField.createEl('label', { text: 'Description', cls: 'nexus-form-label' });
+        const descInput = new TextAreaComponent(descField);
+        descInput.setPlaceholder('Brief description of this workspace...');
+        descInput.setValue(this.formData.description || '');
+        descInput.onChange((value) => {
+          this.formData.description = value;
+        });
 
-    // Description field
-    const descField = section.createDiv('nexus-form-field');
-    descField.createEl('label', { text: 'Description', cls: 'nexus-form-label' });
-    const descInput = new TextAreaComponent(descField);
-    descInput.setPlaceholder('Brief description of this workspace...');
-    descInput.setValue(this.formData.description || '');
-    descInput.onChange((value) => {
-      this.formData.description = value;
-    });
-
-    // Root Folder field
-    const folderField = section.createDiv('nexus-form-field');
-    folderField.createEl('label', { text: 'Root folder', cls: 'nexus-form-label' });
-    const folderInput = new TextComponent(folderField);
-    folderInput.setPlaceholder('/');
-    folderInput.setValue(this.formData.rootFolder || '/');
-    folderInput.onChange((value) => {
-      this.formData.rootFolder = value;
+        // Root Folder field
+        const folderField = body.createDiv('nexus-form-field');
+        folderField.createEl('label', { text: 'Root folder', cls: 'nexus-form-label' });
+        const folderInput = new TextComponent(folderField);
+        folderInput.setPlaceholder('/');
+        folderInput.setValue(this.formData.rootFolder || '/');
+        folderInput.onChange((value) => {
+          this.formData.rootFolder = value;
+        });
+      }
     });
   }
 
@@ -90,9 +94,6 @@ export class WorkspaceFormRenderer {
    * Render Context section
    */
   private renderContextSection(container: HTMLElement): void {
-    const section = container.createDiv('nexus-form-section');
-    section.createEl('h4', { text: 'Context', cls: 'nexus-section-header' });
-
     // Ensure context exists
     if (!this.formData.context) {
       this.formData.context = {
@@ -103,42 +104,45 @@ export class WorkspaceFormRenderer {
       };
     }
 
-    // Purpose field
-    const purposeField = section.createDiv('nexus-form-field');
-    purposeField.createEl('label', { text: 'Purpose', cls: 'nexus-form-label' });
-    const purposeInput = new TextComponent(purposeField);
-    purposeInput.setPlaceholder('What is this workspace for?');
-    purposeInput.setValue(this.formData.context?.purpose || '');
-    purposeInput.onChange((value) => {
-      if (this.formData.context) {
-        this.formData.context.purpose = value;
+    new BoxedSection(container, {
+      title: 'Context',
+      unbounded: true,
+      body: (body) => {
+        // Purpose field
+        const purposeField = body.createDiv('nexus-form-field');
+        purposeField.createEl('label', { text: 'Purpose', cls: 'nexus-form-label' });
+        const purposeInput = new TextComponent(purposeField);
+        purposeInput.setPlaceholder('What is this workspace for?');
+        purposeInput.setValue(this.formData.context?.purpose || '');
+        purposeInput.onChange((value) => {
+          if (this.formData.context) {
+            this.formData.context.purpose = value;
+          }
+        });
+
+        // Preferences field
+        const prefsField = body.createDiv('nexus-form-field');
+        prefsField.createEl('label', { text: 'Preferences', cls: 'nexus-form-label' });
+        const prefsInput = new TextAreaComponent(prefsField);
+        prefsInput.setPlaceholder('Guidelines: tone, focus areas, constraints...');
+        prefsInput.setValue(this.formData.context?.preferences || '');
+        prefsInput.onChange((value) => {
+          if (this.formData.context) {
+            this.formData.context.preferences = value;
+          }
+        });
+        prefsInput.inputEl.rows = 3;
+
+        // Workflows section (nested subsection — stays inline)
+        this.renderWorkflowsSection(body);
       }
     });
-
-    // Preferences field
-    const prefsField = section.createDiv('nexus-form-field');
-    prefsField.createEl('label', { text: 'Preferences', cls: 'nexus-form-label' });
-    const prefsInput = new TextAreaComponent(prefsField);
-    prefsInput.setPlaceholder('Guidelines: tone, focus areas, constraints...');
-    prefsInput.setValue(this.formData.context?.preferences || '');
-    prefsInput.onChange((value) => {
-      if (this.formData.context) {
-        this.formData.context.preferences = value;
-      }
-    });
-    prefsInput.inputEl.rows = 3;
-
-    // Workflows section
-    this.renderWorkflowsSection(section);
   }
 
   /**
    * Render Agent & Files section
    */
   private renderAgentFilesSection(container: HTMLElement): void {
-    const section = container.createDiv('nexus-form-section');
-    section.createEl('h4', { text: 'Agent & files', cls: 'nexus-section-header' });
-
     // Ensure context exists
     if (!this.formData.context) {
       this.formData.context = {
@@ -149,40 +153,46 @@ export class WorkspaceFormRenderer {
       };
     }
 
-    // Dedicated Agent field
-    const agentField = section.createDiv('nexus-form-field');
-    agentField.createEl('label', { text: 'Dedicated agent', cls: 'nexus-form-label' });
+    new BoxedSection(container, {
+      title: 'Agent & files',
+      unbounded: true,
+      body: (body) => {
+        // Dedicated Agent field
+        const agentField = body.createDiv('nexus-form-field');
+        agentField.createEl('label', { text: 'Dedicated agent', cls: 'nexus-form-label' });
 
-    const dropdownContainer = agentField.createDiv('nexus-dropdown-container');
-    const dropdown = new DropdownComponent(dropdownContainer);
+        const dropdownContainer = agentField.createDiv('nexus-dropdown-container');
+        const dropdown = new DropdownComponent(dropdownContainer);
 
-    dropdown.addOption('', 'None');
-    this.availableAgents.forEach(agent => {
-      dropdown.addOption(agent.id, agent.name);
-    });
+        dropdown.addOption('', 'None');
+        this.availableAgents.forEach(agent => {
+          dropdown.addOption(agent.id, agent.name);
+        });
 
-    // Use top-level dedicatedAgentId field (matches backend MCP implementation)
-    // Field can contain either ID or name - find matching agent by either
-    const workspaceWithId = this.formData as ProjectWorkspace & { dedicatedAgentId?: string };
-    const dedicatedId = workspaceWithId.dedicatedAgentId || '';
+        // Use top-level dedicatedAgentId field (matches backend MCP implementation)
+        // Field can contain either ID or name - find matching agent by either
+        const workspaceWithId = this.formData as ProjectWorkspace & { dedicatedAgentId?: string };
+        const dedicatedId = workspaceWithId.dedicatedAgentId || '';
 
-    // Try to find agent by ID first, then by name
-    const matchingAgent = this.availableAgents.find(a => a.id === dedicatedId || a.name === dedicatedId);
-    const dropdownValue = matchingAgent?.id || '';
-    dropdown.setValue(dropdownValue);
+        // Try to find agent by ID first, then by name
+        const matchingAgent = this.availableAgents.find(a => a.id === dedicatedId || a.name === dedicatedId);
+        const dropdownValue = matchingAgent?.id || '';
+        dropdown.setValue(dropdownValue);
 
-    dropdown.onChange((value) => {
-      // Set top-level dedicatedAgentId field (string: ID or name)
-      const workspaceWithId = this.formData as ProjectWorkspace & { dedicatedAgentId?: string };
-      if (value) {
-        workspaceWithId.dedicatedAgentId = value;
-      } else {
-        delete workspaceWithId.dedicatedAgentId;
+        dropdown.onChange((value) => {
+          // Set top-level dedicatedAgentId field (string: ID or name)
+          const workspaceWithId = this.formData as ProjectWorkspace & { dedicatedAgentId?: string };
+          if (value) {
+            workspaceWithId.dedicatedAgentId = value;
+          } else {
+            delete workspaceWithId.dedicatedAgentId;
+          }
+        });
+
+        // Key Files subsection (nested — stays inline)
+        this.renderKeyFilesSection(body);
       }
     });
-
-    // Key Files section
-    this.renderKeyFilesSection(section);
   }
 
   /**

--- a/src/settings/components/BoxedSection.ts
+++ b/src/settings/components/BoxedSection.ts
@@ -1,0 +1,102 @@
+/**
+ * BoxedSection — Boxed section primitive with sticky header + scrollable body
+ * + optional toolbar + optional accent action button.
+ *
+ * Visual contract: docs/mockups/workspace-tab-redesign-v3-subpages.html
+ * (`.ws-section` family).
+ *
+ * Pure DOM + Obsidian-safe — no Node.js imports. Mobile-compatible.
+ */
+
+import { Component } from 'obsidian';
+
+export interface BoxedSectionConfig {
+    /** Section title text. */
+    title: string;
+    /**
+     * Optional explicit id for the title element. When set, the wrapping
+     * `<section>` receives `aria-labelledby=<titleId>` for screen readers.
+     */
+    titleId?: string;
+    /**
+     * Toolbar render callback. Receives the toolbar host element so callers
+     * can append filter/sort/toggle affordances. Mounted in the header right
+     * cluster, before the optional action button.
+     */
+    toolbar?: (toolbar: HTMLElement) => void;
+    /** Accent action button label (e.g., "+ New project"). */
+    actionLabel?: string;
+    /** Click handler for the accent action button. Ignored unless actionLabel is set. */
+    onAction?: () => void;
+    /** Body render callback. Receives the scrollable body element. */
+    body: (body: HTMLElement) => void;
+    /**
+     * When true, body has `max-height: none` (no internal scroll — content
+     * flows naturally). Use for form-field sections + lists that own their
+     * own scroll context.
+     */
+    unbounded?: boolean;
+}
+
+export class BoxedSection {
+    private readonly sectionEl: HTMLElement;
+    private readonly bodyEl: HTMLElement;
+
+    constructor(container: HTMLElement, config: BoxedSectionConfig, component?: Component) {
+        this.sectionEl = container.createEl('section', { cls: 'ws-section' });
+        if (config.titleId) {
+            this.sectionEl.setAttribute('aria-labelledby', config.titleId);
+        }
+
+        const header = this.sectionEl.createDiv('ws-section-header');
+        const titleEl = header.createEl('h3', {
+            text: config.title,
+            cls: 'ws-section-title'
+        });
+        if (config.titleId) {
+            titleEl.id = config.titleId;
+        }
+
+        const hasToolbar = !!config.toolbar;
+        const hasAction = !!config.actionLabel && !!config.onAction;
+        if (hasToolbar || hasAction) {
+            const toolbar = header.createDiv('ws-section-toolbar');
+            if (config.toolbar) {
+                config.toolbar(toolbar);
+            }
+            if (hasAction) {
+                const button = toolbar.createEl('button', {
+                    text: config.actionLabel,
+                    cls: 'ws-section-action',
+                    attr: { type: 'button' }
+                });
+                const handler = () => { config.onAction?.(); };
+                if (component) {
+                    component.registerDomEvent(button, 'click', handler);
+                } else {
+                    button.addEventListener('click', handler);
+                }
+            }
+        }
+
+        this.bodyEl = this.sectionEl.createDiv('ws-section-body');
+        if (config.unbounded) {
+            this.bodyEl.addClass('is-unbounded');
+        }
+
+        config.body(this.bodyEl);
+    }
+
+    /**
+     * Returns the scrollable body element for late re-renders.
+     * Callers should `body.empty()` before re-rendering content.
+     */
+    getBody(): HTMLElement {
+        return this.bodyEl;
+    }
+
+    /** Returns the outer `<section>` element. */
+    getElement(): HTMLElement {
+        return this.sectionEl;
+    }
+}

--- a/src/settings/components/ConfirmModal.ts
+++ b/src/settings/components/ConfirmModal.ts
@@ -1,0 +1,71 @@
+/**
+ * ConfirmModal — Variant-aware confirmation modal.
+ *
+ * Replaces ad-hoc inline modals (e.g., WorkspaceDetailRenderer.confirmDangerousAction)
+ * with a single primitive whose copy + CTA scales by variant.
+ *
+ * Pure DOM + Obsidian Modal — no Node.js imports. Mobile-compatible.
+ */
+
+import { App, ButtonComponent, Modal } from 'obsidian';
+
+export type ConfirmVariant = 'delete' | 'remove' | 'archive';
+
+export interface ConfirmModalConfig {
+    variant: ConfirmVariant;
+    title: string;
+    body: string;
+    /** Optional CTA label override. Defaults from variant. */
+    ctaLabel?: string;
+    /** Invoked when user confirms. May return a Promise; modal closes after resolve. */
+    onConfirm: () => void | Promise<void>;
+}
+
+const DEFAULT_CTA: Record<ConfirmVariant, string> = {
+    delete: 'Delete',
+    remove: 'Remove',
+    archive: 'Archive'
+};
+
+export class ConfirmModal extends Modal {
+    private readonly config: ConfirmModalConfig;
+
+    constructor(app: App, config: ConfirmModalConfig) {
+        super(app);
+        this.config = config;
+    }
+
+    onOpen(): void {
+        const { contentEl } = this;
+        contentEl.empty();
+        contentEl.addClass('nexus-confirm-modal');
+        contentEl.addClass(`nexus-confirm-modal--${this.config.variant}`);
+
+        contentEl.createEl('h2', { text: this.config.title });
+        contentEl.createEl('p', { text: this.config.body });
+
+        const buttons = contentEl.createDiv('modal-button-container');
+
+        new ButtonComponent(buttons)
+            .setButtonText('Cancel')
+            .onClick(() => this.close());
+
+        const ctaLabel = this.config.ctaLabel ?? DEFAULT_CTA[this.config.variant];
+        const cta = new ButtonComponent(buttons).setButtonText(ctaLabel);
+
+        // Destructive variants get the warning styling; archive is reversible.
+        if (this.config.variant === 'delete' || this.config.variant === 'remove') {
+            cta.setWarning();
+        } else {
+            cta.setCta();
+        }
+
+        cta.onClick(() => {
+            void Promise.resolve(this.config.onConfirm()).finally(() => this.close());
+        });
+    }
+
+    onClose(): void {
+        this.contentEl.empty();
+    }
+}

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -9,9 +9,10 @@
  * - FilePickerRenderer (file picker)
  */
 
-import { App, Notice, Component, Modal, ButtonComponent } from 'obsidian';
+import { App, Notice, Component } from 'obsidian';
 import { SettingsRouter } from '../SettingsRouter';
 import { BreadcrumbNav, BreadcrumbNavItem } from '../components/BreadcrumbNav';
+import { ConfirmModal } from '../components/ConfirmModal';
 import { WorkflowEditorRenderer, Workflow } from '../../components/workspace/WorkflowEditorRenderer';
 import { FilePickerRenderer } from '../../components/workspace/FilePickerRenderer';
 import { WorkspaceListRenderer } from '../../components/workspace/WorkspaceListRenderer';
@@ -563,11 +564,17 @@ export class WorkspacesTab {
 
     private async confirmDeleteWorkspace(workspaceName = this.currentWorkspace?.name || 'Workspace'): Promise<boolean> {
         return new Promise<boolean>((resolve) => {
-            const modal = new WorkspaceDeleteConfirmModal(
-                this.services.app,
-                workspaceName,
-                resolve
-            );
+            let confirmed = false;
+            const modal = new ConfirmModal(this.services.app, {
+                variant: 'delete',
+                title: 'Delete workspace?',
+                body: `Delete workspace "${workspaceName}"? This cannot be undone.`,
+                onConfirm: () => { confirmed = true; }
+            });
+            modal.onClose = () => {
+                modal.contentEl.empty();
+                resolve(confirmed);
+            };
             modal.open();
         });
     }
@@ -852,53 +859,3 @@ export class WorkspacesTab {
     }
 }
 
-class WorkspaceDeleteConfirmModal extends Modal {
-    private resolved = false;
-
-    constructor(
-        app: App,
-        private readonly workspaceName: string,
-        private readonly onResolve: (confirmed: boolean) => void
-    ) {
-        super(app);
-    }
-
-    onOpen(): void {
-        const { contentEl } = this;
-        contentEl.empty();
-
-        contentEl.createEl('h2', { text: 'Delete workspace?' });
-        contentEl.createEl('p', {
-            text: `Delete workspace "${this.workspaceName}"? This cannot be undone.`,
-            cls: 'setting-item-description'
-        });
-
-        const buttonRow = contentEl.createDiv('modal-button-container');
-
-        new ButtonComponent(buttonRow)
-            .setButtonText('Cancel')
-            .onClick(() => {
-                this.resolve(false);
-                this.close();
-            });
-
-        new ButtonComponent(buttonRow)
-            .setButtonText('Delete')
-            .setWarning()
-            .onClick(() => {
-                this.resolve(true);
-                this.close();
-            });
-    }
-
-    onClose(): void {
-        this.resolve(false);
-        this.contentEl.empty();
-    }
-
-    private resolve(confirmed: boolean): void {
-        if (this.resolved) return;
-        this.resolved = true;
-        this.onResolve(confirmed);
-    }
-}

--- a/styles.css
+++ b/styles.css
@@ -5042,7 +5042,7 @@ body.is-mobile .message-action-btn.message-branch-next {
     flex-wrap: wrap;
     gap: 8px;
     margin-bottom: 12px;
-    font-size: var(--font-ui-small);
+    font-size: 13px;
 }
 
 .nexus-breadcrumb .nexus-breadcrumb-link {
@@ -8465,4 +8465,130 @@ body.is-mobile .nexus-task-board-shell {
     width: 100%;
     min-height: 96px;
     resize: vertical;
+}
+
+/* =====================================================================
+ * Workspace settings — boxed section primitive (.ws-section family)
+ *
+ * Mockup: docs/mockups/workspace-tab-redesign-v3-subpages.html
+ * Used by: src/settings/components/BoxedSection.ts
+ * Sticky header + scrollable body (default max-height: 320px;
+ * pass `unbounded: true` to BoxedSection to remove the cap).
+ * ===================================================================== */
+
+.ws-section {
+    margin-top: 16px;
+    background: var(--background-secondary);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.ws-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--background-modifier-border);
+    background: var(--background-secondary);
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+
+.ws-section-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-normal);
+    margin: 0;
+}
+
+.ws-section-action {
+    appearance: none;
+    background: var(--interactive-accent);
+    color: var(--text-on-accent);
+    border: 1px solid var(--interactive-accent);
+    padding: 4px 10px;
+    font-size: 12px;
+    font-family: inherit;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 4px;
+    line-height: 1.3;
+}
+
+.ws-section-action:hover {
+    background: var(--interactive-accent-hover);
+    border-color: var(--interactive-accent-hover);
+}
+
+.ws-section-body {
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 0 16px;
+}
+
+.ws-section-body.is-unbounded {
+    max-height: none;
+}
+
+.ws-section-body::-webkit-scrollbar {
+    width: 10px;
+}
+
+.ws-section-body::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-border);
+    border-radius: 5px;
+    border: 2px solid var(--background-secondary);
+}
+
+.ws-section-body::-webkit-scrollbar-thumb:hover {
+    background: var(--background-modifier-border-hover);
+}
+
+/* Toolbar cluster — filter / sort / toggle / inline +action slot */
+.ws-section-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ws-section-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--text-muted);
+    cursor: pointer;
+    user-select: none;
+}
+
+.ws-section-toggle input[type="checkbox"] {
+    accent-color: var(--interactive-accent);
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    cursor: pointer;
+}
+
+.ws-section-toggle:hover {
+    color: var(--text-normal);
+}
+
+.ws-section-select {
+    appearance: none;
+    background: transparent;
+    color: var(--text-muted);
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 4px;
+    padding: 2px 8px;
+    font: inherit;
+    font-size: 12px;
+    cursor: pointer;
+}
+
+.ws-section-select:hover {
+    color: var(--text-normal);
+    border-color: var(--background-modifier-border-hover);
 }

--- a/tests/unit/BoxedSection.test.ts
+++ b/tests/unit/BoxedSection.test.ts
@@ -1,0 +1,329 @@
+/**
+ * BoxedSection Unit Tests
+ *
+ * Verifies the boxed-section primitive renders the .ws-section header/body/
+ * optional toolbar + action structure, respects unbounded, wires accessibility
+ * (aria-labelledby), and routes the action click through registerDomEvent
+ * when a Component is provided.
+ */
+
+import { BoxedSection } from '../../src/settings/components/BoxedSection';
+import { Component } from 'obsidian';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+type MockElement = {
+  tagName: string;
+  className: string;
+  id: string;
+  createEl: jest.Mock<MockElement, [string, unknown?]>;
+  createDiv: jest.Mock<MockElement, [string | { cls?: string }?]>;
+  createSpan: jest.Mock<MockElement, [{ cls?: string; text?: string }?]>;
+  addClass: jest.Mock<void, [string]>;
+  setAttribute: jest.Mock<void, [string, string]>;
+  addEventListener: jest.Mock<void, [string, () => void]>;
+  empty: jest.Mock<void, []>;
+  remove: jest.Mock<void, []>;
+  textContent: string;
+  _children: MockElement[];
+};
+
+function createMockContainer(): MockElement {
+  const createElement = (cls?: string): MockElement => {
+    const el: MockElement = {
+      tagName: 'DIV',
+      className: cls || '',
+      id: '',
+      addClass: jest.fn(),
+      setAttribute: jest.fn(),
+      createEl: jest.fn((tag?: string, opts?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+        const child = createElement(opts?.cls || '');
+        child.tagName = (tag || 'DIV').toUpperCase();
+        if (opts?.text) child.textContent = opts.text;
+        el._children.push(child);
+        return child;
+      }),
+      createDiv: jest.fn((cls2?: string | { cls?: string }) => {
+        const c = typeof cls2 === 'string' ? cls2 : cls2?.cls || '';
+        const child = createElement(c);
+        el._children.push(child);
+        return child;
+      }),
+      createSpan: jest.fn((opts?: { cls?: string; text?: string }) => {
+        const child = createElement(opts?.cls || '');
+        if (opts?.text) child.textContent = opts.text;
+        el._children.push(child);
+        return child;
+      }),
+      addEventListener: jest.fn(),
+      empty: jest.fn(),
+      remove: jest.fn(),
+      textContent: '',
+      _children: [],
+    };
+    return el;
+  };
+  return createElement('');
+}
+
+function getFirstChild(el: MockElement): MockElement {
+  const child = el._children[0];
+  if (!child) throw new Error('Expected child element not found');
+  return child;
+}
+
+// ============================================================================
+// BoxedSection Tests
+// ============================================================================
+
+describe('BoxedSection', () => {
+
+  describe('rendering', () => {
+    it('should create a <section> with class ws-section', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      expect(container.createEl).toHaveBeenCalledWith('section', { cls: 'ws-section' });
+    });
+
+    it('should create header with ws-section-header class', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      expect(section.createDiv).toHaveBeenCalledWith('ws-section-header');
+    });
+
+    it('should create h3 title with the provided text', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Projects',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const header = getFirstChild(section);
+      expect(header.createEl).toHaveBeenCalledWith('h3', expect.objectContaining({
+        text: 'Projects',
+        cls: 'ws-section-title'
+      }));
+    });
+
+    it('should create body with ws-section-body class', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      expect(section.createDiv).toHaveBeenCalledWith('ws-section-body');
+    });
+
+    it('should add is-unbounded class on body when unbounded=true', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        unbounded: true,
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      // section._children = [header, body]
+      const body = section._children[1];
+      expect(body?.addClass).toHaveBeenCalledWith('is-unbounded');
+    });
+
+    it('should NOT add is-unbounded class when unbounded is omitted', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const body = section._children[1];
+      expect(body?.addClass).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('aria-labelledby', () => {
+    it('should set aria-labelledby on section + id on title when titleId provided', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'States',
+        titleId: 'states-section-title',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      expect(section.setAttribute).toHaveBeenCalledWith('aria-labelledby', 'states-section-title');
+
+      const header = getFirstChild(section);
+      const title = getFirstChild(header);
+      expect(title.id).toBe('states-section-title');
+    });
+
+    it('should not set aria-labelledby when titleId omitted', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      expect(section.setAttribute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('body callback', () => {
+    it('should invoke body callback with the scrollable body element', () => {
+      const container = createMockContainer();
+      const bodyCallback = jest.fn();
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: bodyCallback
+      });
+
+      expect(bodyCallback).toHaveBeenCalledTimes(1);
+      const section = getFirstChild(container);
+      const bodyEl = section._children[1];
+      expect(bodyCallback).toHaveBeenCalledWith(bodyEl);
+    });
+
+    it('getBody() should return the same body element passed to callback', () => {
+      const container = createMockContainer();
+      let bodyFromCallback: HTMLElement | null = null;
+
+      const sec = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: (b) => { bodyFromCallback = b; }
+      });
+
+      expect(sec.getBody()).toBe(bodyFromCallback);
+    });
+  });
+
+  describe('toolbar + action', () => {
+    it('should invoke toolbar callback with the toolbar host element', () => {
+      const container = createMockContainer();
+      const toolbarCallback = jest.fn();
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        toolbar: toolbarCallback,
+        body: () => { /* no-op */ }
+      });
+
+      expect(toolbarCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should create accent action button with actionLabel text', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Projects',
+        actionLabel: '+ New project',
+        onAction: jest.fn(),
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const header = getFirstChild(section);
+      // Header creates a toolbar (createDiv 'ws-section-toolbar'), which then creates the action button.
+      expect(header.createDiv).toHaveBeenCalledWith('ws-section-toolbar');
+    });
+
+    it('should NOT create toolbar when neither toolbar callback nor actionLabel/onAction set', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const header = getFirstChild(section);
+      // Header only ever calls createEl('h3') for the title — no createDiv('ws-section-toolbar')
+      const toolbarCalls = header.createDiv.mock.calls.filter(c => c[0] === 'ws-section-toolbar');
+      expect(toolbarCalls.length).toBe(0);
+    });
+
+    it('should NOT create action button when actionLabel is set but onAction is missing', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        actionLabel: '+ Add',
+        // onAction intentionally missing
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const header = getFirstChild(section);
+      const toolbarCalls = header.createDiv.mock.calls.filter(c => c[0] === 'ws-section-toolbar');
+      expect(toolbarCalls.length).toBe(0);
+    });
+
+    it('should wire onAction via component.registerDomEvent when component provided', () => {
+      const container = createMockContainer();
+      const onAction = jest.fn();
+      const component = new Component();
+      const registerSpy = jest.spyOn(component, 'registerDomEvent');
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Projects',
+        actionLabel: '+ New project',
+        onAction,
+        body: () => { /* no-op */ }
+      }, component);
+
+      expect(registerSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'click',
+        expect.any(Function)
+      );
+    });
+
+    it('should fall back to addEventListener when no component provided', () => {
+      const container = createMockContainer();
+      const onAction = jest.fn();
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Projects',
+        actionLabel: '+ New project',
+        onAction,
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      const header = getFirstChild(section);
+      // Toolbar is created (createDiv 'ws-section-toolbar') as the 2nd createDiv call after the action button button createEl call.
+      // The action button is created inside the toolbar via toolbar.createEl('button', ...). The handler is registered via addEventListener.
+      const toolbar = header._children.find(c => c.className === 'ws-section-toolbar');
+      expect(toolbar).toBeTruthy();
+      if (!toolbar) return;
+      const actionButton = toolbar._children[0];
+      expect(actionButton?.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    });
+  });
+
+  describe('getElement', () => {
+    it('should return the outer section element', () => {
+      const container = createMockContainer();
+      const sec = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'Test',
+        body: () => { /* no-op */ }
+      });
+
+      const section = getFirstChild(container);
+      expect(sec.getElement()).toBe(section);
+    });
+  });
+});

--- a/tests/unit/BoxedSectionStructure.test.ts
+++ b/tests/unit/BoxedSectionStructure.test.ts
@@ -1,0 +1,319 @@
+/**
+ * BoxedSection Structural Deepening Tests
+ *
+ * Complements tests/unit/BoxedSection.test.ts (smoke coverage frontend-coder
+ * shipped) by asserting:
+ *   1. DOM nesting: action button lives inside the toolbar div (not loose
+ *      in header), and the toolbar lives inside the header.
+ *   2. No inline style.position / style.maxHeight on any element — sticky
+ *      positioning and the 320px max-height must come from styles.css per
+ *      the project's "no inline styles" non-negotiable in CLAUDE.md.
+ *   3. getBody() / getElement() return stable references across calls.
+ *   4. Late-render re-use pattern (caller .empty() + repopulate) doesn't
+ *      disturb the BoxedSection's body reference.
+ *
+ * Uses the same _children-tracking mock pattern frontend-coder established
+ * in BoxedSection.test.ts so structural assertions are observable.
+ */
+
+import { BoxedSection } from '../../src/settings/components/BoxedSection';
+import { Component } from 'obsidian';
+
+type MockElement = {
+  tagName: string;
+  className: string;
+  id: string;
+  style: Record<string, string>;
+  createEl: jest.Mock<MockElement, [string, unknown?]>;
+  createDiv: jest.Mock<MockElement, [string | { cls?: string }?]>;
+  createSpan: jest.Mock<MockElement, [{ cls?: string; text?: string }?]>;
+  addClass: jest.Mock<void, [string]>;
+  setAttribute: jest.Mock<void, [string, string]>;
+  addEventListener: jest.Mock<void, [string, () => void]>;
+  empty: jest.Mock<void, []>;
+  remove: jest.Mock<void, []>;
+  textContent: string;
+  _children: MockElement[];
+};
+
+function createMockContainer(): MockElement {
+  const createElement = (cls?: string): MockElement => {
+    const el: MockElement = {
+      tagName: 'DIV',
+      className: cls || '',
+      id: '',
+      style: {},
+      addClass: jest.fn(),
+      setAttribute: jest.fn(),
+      createEl: jest.fn((tag?: string, opts?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+        const child = createElement(opts?.cls || '');
+        child.tagName = (tag || 'DIV').toUpperCase();
+        if (opts?.text) child.textContent = opts.text;
+        el._children.push(child);
+        return child;
+      }),
+      createDiv: jest.fn((cls2?: string | { cls?: string }) => {
+        const c = typeof cls2 === 'string' ? cls2 : cls2?.cls || '';
+        const child = createElement(c);
+        el._children.push(child);
+        return child;
+      }),
+      createSpan: jest.fn((opts?: { cls?: string; text?: string }) => {
+        const child = createElement(opts?.cls || '');
+        if (opts?.text) child.textContent = opts.text;
+        el._children.push(child);
+        return child;
+      }),
+      addEventListener: jest.fn(),
+      empty: jest.fn(),
+      remove: jest.fn(),
+      textContent: '',
+      _children: [],
+    };
+    return el;
+  };
+  return createElement('');
+}
+
+function firstChild(el: MockElement): MockElement {
+  const child = el._children[0];
+  if (!child) throw new Error('Expected child not found');
+  return child;
+}
+
+describe('BoxedSection structural deepening', () => {
+  describe('Toolbar / action nesting (header.toolbar.action, not header.action)', () => {
+    it('places .ws-section-toolbar as a child of .ws-section-header (not of <section>)', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        toolbar: (tb) => { tb.createSpan({ text: 'tb' }); },
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      // section._children = [header, body]; toolbar must NOT appear here.
+      const headerIdx = section._children.findIndex(c => c.className === 'ws-section-header');
+      const bodyIdx = section._children.findIndex(c => c.className === 'ws-section-body');
+      const toolbarAtSectionLevel = section._children.find(c => c.className === 'ws-section-toolbar');
+      expect(headerIdx).toBeGreaterThanOrEqual(0);
+      expect(bodyIdx).toBeGreaterThanOrEqual(0);
+      expect(toolbarAtSectionLevel).toBeUndefined();
+
+      const header = section._children[headerIdx];
+      const toolbar = header._children.find(c => c.className === 'ws-section-toolbar');
+      expect(toolbar).toBeDefined();
+    });
+
+    it('places .ws-section-action button as a child of .ws-section-toolbar (not of header)', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        actionLabel: '+ New thing',
+        onAction: () => { void 0; },
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const header = section._children.find(c => c.className === 'ws-section-header');
+      const toolbar = header?._children.find(c => c.className === 'ws-section-toolbar');
+      expect(toolbar).toBeDefined();
+
+      // Header should NOT have a direct action button child — must be under toolbar.
+      const actionAtHeaderLevel = header?._children.find(c => c.className === 'ws-section-action');
+      expect(actionAtHeaderLevel).toBeUndefined();
+
+      const action = toolbar?._children.find(c => c.className === 'ws-section-action');
+      expect(action).toBeDefined();
+      expect(action?.tagName).toBe('BUTTON');
+      expect(action?.textContent).toBe('+ New thing');
+    });
+
+    it('does NOT create a toolbar when neither toolbar callback nor action are set', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const header = section._children.find(c => c.className === 'ws-section-header');
+      const toolbar = header?._children.find(c => c.className === 'ws-section-toolbar');
+      expect(toolbar).toBeUndefined();
+    });
+
+    it('creates the toolbar even with toolbar-only (no action)', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        toolbar: (tb) => { tb.createSpan({ text: 'just-toolbar' }); },
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const header = section._children.find(c => c.className === 'ws-section-header');
+      const toolbar = header?._children.find(c => c.className === 'ws-section-toolbar');
+      expect(toolbar).toBeDefined();
+      // No action button created
+      const action = toolbar?._children.find(c => c.className === 'ws-section-action');
+      expect(action).toBeUndefined();
+    });
+  });
+
+  describe('No inline style leakage (CLAUDE.md non-negotiable)', () => {
+    it('does NOT touch section.style (sticky positioning comes from styles.css)', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        actionLabel: 'X',
+        onAction: () => { void 0; },
+        body: (b) => { b.createDiv('content'); }
+      });
+
+      const section = firstChild(container);
+      // style object must remain empty — no inline mutations
+      expect(Object.keys(section.style)).toHaveLength(0);
+    });
+
+    it('does NOT touch header.style', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const header = section._children.find(c => c.className === 'ws-section-header');
+      expect(Object.keys(header?.style ?? {})).toHaveLength(0);
+    });
+
+    it('does NOT touch body.style (max-height comes from styles.css)', () => {
+      const container = createMockContainer();
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        unbounded: true,
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const body = section._children.find(c => c.className === 'ws-section-body');
+      expect(Object.keys(body?.style ?? {})).toHaveLength(0);
+    });
+  });
+
+  describe('getBody() / getElement() identity stability', () => {
+    it('getBody() returns the same reference across multiple calls', () => {
+      const container = createMockContainer();
+      const section = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: () => { void 0; }
+      });
+
+      const a = section.getBody();
+      const b = section.getBody();
+      const c = section.getBody();
+
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+    });
+
+    it('getElement() returns the same reference across multiple calls', () => {
+      const container = createMockContainer();
+      const section = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: () => { void 0; }
+      });
+
+      expect(section.getElement()).toBe(section.getElement());
+    });
+
+    it('getBody() returns the same element passed to the body callback', () => {
+      const container = createMockContainer();
+      let bodyFromCallback: HTMLElement | undefined;
+      const section = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: (b) => { bodyFromCallback = b; }
+      });
+
+      expect(section.getBody()).toBe(bodyFromCallback);
+    });
+
+    it('getElement() returns the section element appended to the container', () => {
+      const container = createMockContainer();
+      const section = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: () => { void 0; }
+      });
+
+      expect(section.getElement()).toBe(container._children[0]);
+    });
+  });
+
+  describe('Late-render pattern (getBody().empty() + repopulate)', () => {
+    it('does not invalidate the body reference after caller invokes .empty()', () => {
+      const container = createMockContainer();
+      const section = new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        body: (b) => { b.createDiv('first-render'); }
+      });
+
+      const bodyBefore = section.getBody();
+      bodyBefore.empty();
+      // Caller pattern: re-populate after empty
+      (bodyBefore as unknown as MockElement).createDiv('second-render');
+
+      const bodyAfter = section.getBody();
+      expect(bodyAfter).toBe(bodyBefore);
+      // .empty was invoked on the same node
+      expect((bodyBefore as unknown as MockElement).empty).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Component-scoped event registration target', () => {
+    it('wires the action button click via component.registerDomEvent (not addEventListener) when component provided', () => {
+      const container = createMockContainer();
+      const component = new Component();
+      const registerSpy = jest.spyOn(component, 'registerDomEvent');
+      const handler = jest.fn();
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        actionLabel: 'Go',
+        onAction: handler,
+        body: () => { void 0; }
+      }, component);
+
+      expect(registerSpy).toHaveBeenCalledTimes(1);
+      const [el, type] = registerSpy.mock.calls[0];
+      expect(type).toBe('click');
+      // The element passed in MUST be the action button (className ws-section-action).
+      expect((el as unknown as MockElement).className).toBe('ws-section-action');
+      expect((el as unknown as MockElement).tagName).toBe('BUTTON');
+      // NOTE: The Obsidian mock's registerDomEvent internally calls
+      // el.addEventListener for cleanup tracking. The contract we're testing
+      // is "BoxedSection routes through component.registerDomEvent" — verified
+      // above. Direct el.addEventListener calls are an implementation detail
+      // of the mock, not BoxedSection itself.
+    });
+
+    it('falls back to addEventListener when NO component provided', () => {
+      const container = createMockContainer();
+      const handler = jest.fn();
+
+      new BoxedSection(container as unknown as HTMLElement, {
+        title: 'T',
+        actionLabel: 'Go',
+        onAction: handler,
+        body: () => { void 0; }
+      });
+
+      const section = firstChild(container);
+      const header = section._children.find(c => c.className === 'ws-section-header');
+      const toolbar = header?._children.find(c => c.className === 'ws-section-toolbar');
+      const action = toolbar?._children.find(c => c.className === 'ws-section-action');
+      expect(action?.addEventListener).toHaveBeenCalledTimes(1);
+      const [type] = (action?.addEventListener as jest.Mock).mock.calls[0];
+      expect(type).toBe('click');
+    });
+  });
+});

--- a/tests/unit/ConfirmModal.test.ts
+++ b/tests/unit/ConfirmModal.test.ts
@@ -1,0 +1,268 @@
+/**
+ * ConfirmModal Unit Tests
+ *
+ * Verifies variant-aware copy emission, default CTA labels per variant,
+ * onConfirm callback wiring, and Modal lifecycle compliance.
+ */
+
+import { ConfirmModal } from '../../src/settings/components/ConfirmModal';
+import { App, ButtonComponent } from 'obsidian';
+
+describe('ConfirmModal', () => {
+  const app = {} as App;
+
+  describe('variant copy + structure', () => {
+    it('should emit h2 + p with config title + body when opened', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'delete',
+        title: 'Delete workspace?',
+        body: 'Delete workspace "Demo"? This cannot be undone.',
+        onConfirm: jest.fn()
+      });
+
+      const createElSpy = jest.spyOn(modal.contentEl, 'createEl');
+      modal.open();
+
+      expect(createElSpy).toHaveBeenCalledWith('h2', { text: 'Delete workspace?' });
+      expect(createElSpy).toHaveBeenCalledWith('p', { text: 'Delete workspace "Demo"? This cannot be undone.' });
+    });
+
+    it('should add nexus-confirm-modal and variant class to contentEl', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'archive',
+        title: 'Archive state?',
+        body: 'Archive state "Snapshot 1"?',
+        onConfirm: jest.fn()
+      });
+
+      const addClassSpy = jest.spyOn(modal.contentEl, 'addClass');
+      modal.open();
+
+      expect(addClassSpy).toHaveBeenCalledWith('nexus-confirm-modal');
+      expect(addClassSpy).toHaveBeenCalledWith('nexus-confirm-modal--archive');
+    });
+  });
+
+  describe('default CTA labels per variant', () => {
+    it.each<['delete' | 'remove' | 'archive', string]>([
+      ['delete', 'Delete'],
+      ['remove', 'Remove'],
+      ['archive', 'Archive'],
+    ])('variant=%s should default CTA label to %s', (variant, expectedLabel) => {
+      const setButtonTextCalls: string[] = [];
+      const origSetButtonText = ButtonComponent.prototype.setButtonText;
+      ButtonComponent.prototype.setButtonText = function (label: string) {
+        setButtonTextCalls.push(label);
+        return origSetButtonText.call(this, label);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant,
+          title: 'Title',
+          body: 'Body',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        expect(setButtonTextCalls).toContain(expectedLabel);
+      } finally {
+        ButtonComponent.prototype.setButtonText = origSetButtonText;
+      }
+    });
+  });
+
+  describe('CTA wiring', () => {
+    it('should call onConfirm when CTA is clicked', () => {
+      const onConfirm = jest.fn();
+      const modal = new ConfirmModal(app, {
+        variant: 'delete',
+        title: 'Delete?',
+        body: 'Confirm?',
+        onConfirm
+      });
+
+      // Spy on ButtonComponent.onClick BEFORE open
+      const onClickCalls: Array<() => void> = [];
+      const origOnClick = ButtonComponent.prototype.onClick;
+      ButtonComponent.prototype.onClick = function (cb: () => void) {
+        onClickCalls.push(cb);
+        return origOnClick.call(this, cb);
+      };
+
+      try {
+        modal.open();
+
+        // 2 ButtonComponents constructed inside ConfirmModal.onOpen:
+        // [0] Cancel, [1] CTA
+        expect(onClickCalls.length).toBeGreaterThanOrEqual(2);
+        const ctaCb = onClickCalls[onClickCalls.length - 1];
+        if (ctaCb) ctaCb();
+
+        // onConfirm is invoked synchronously; modal.close() runs after.
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+      } finally {
+        ButtonComponent.prototype.onClick = origOnClick;
+      }
+    });
+
+    it('should NOT call onConfirm when Cancel is clicked', () => {
+      const onConfirm = jest.fn();
+      const modal = new ConfirmModal(app, {
+        variant: 'delete',
+        title: 'Delete?',
+        body: 'Confirm?',
+        onConfirm
+      });
+
+      const onClickCalls: Array<() => void> = [];
+      const origOnClick = ButtonComponent.prototype.onClick;
+      ButtonComponent.prototype.onClick = function (cb: () => void) {
+        onClickCalls.push(cb);
+        return origOnClick.call(this, cb);
+      };
+
+      try {
+        modal.open();
+        // Click Cancel (first button registered)
+        const cancelCb = onClickCalls[0];
+        if (cancelCb) cancelCb();
+
+        expect(onConfirm).not.toHaveBeenCalled();
+      } finally {
+        ButtonComponent.prototype.onClick = origOnClick;
+      }
+    });
+  });
+
+  describe('CTA styling per variant', () => {
+    it('delete variant should call setWarning on CTA', () => {
+      const setWarningCalls: number[] = [];
+      const origSetWarning = ButtonComponent.prototype.setWarning;
+      ButtonComponent.prototype.setWarning = function () {
+        setWarningCalls.push(1);
+        return origSetWarning.call(this);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'delete',
+          title: 'Delete?',
+          body: 'Confirm?',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        expect(setWarningCalls.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        ButtonComponent.prototype.setWarning = origSetWarning;
+      }
+    });
+
+    it('remove variant should call setWarning on CTA', () => {
+      const setWarningCalls: number[] = [];
+      const origSetWarning = ButtonComponent.prototype.setWarning;
+      ButtonComponent.prototype.setWarning = function () {
+        setWarningCalls.push(1);
+        return origSetWarning.call(this);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'remove',
+          title: 'Remove?',
+          body: 'Confirm?',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        expect(setWarningCalls.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        ButtonComponent.prototype.setWarning = origSetWarning;
+      }
+    });
+
+    it('archive variant should call setCta on CTA (not setWarning)', () => {
+      const setCtaCalls: number[] = [];
+      const setWarningCalls: number[] = [];
+      const origSetCta = ButtonComponent.prototype.setCta;
+      const origSetWarning = ButtonComponent.prototype.setWarning;
+      ButtonComponent.prototype.setCta = function () {
+        setCtaCalls.push(1);
+        return origSetCta.call(this);
+      };
+      ButtonComponent.prototype.setWarning = function () {
+        setWarningCalls.push(1);
+        return origSetWarning.call(this);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'archive',
+          title: 'Archive?',
+          body: 'Confirm?',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        expect(setCtaCalls.length).toBeGreaterThanOrEqual(1);
+        expect(setWarningCalls.length).toBe(0);
+      } finally {
+        ButtonComponent.prototype.setCta = origSetCta;
+        ButtonComponent.prototype.setWarning = origSetWarning;
+      }
+    });
+  });
+
+  describe('CTA label override', () => {
+    it('should honor ctaLabel override when provided', () => {
+      const setButtonTextCalls: string[] = [];
+      const origSetButtonText = ButtonComponent.prototype.setButtonText;
+      ButtonComponent.prototype.setButtonText = function (label: string) {
+        setButtonTextCalls.push(label);
+        return origSetButtonText.call(this, label);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'delete',
+          title: 'Custom?',
+          body: 'Confirm?',
+          ctaLabel: 'Yes, delete it',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        // Should include the override label
+        expect(setButtonTextCalls).toContain('Yes, delete it');
+        // Should NOT include the default 'Delete' label
+        expect(setButtonTextCalls).not.toContain('Delete');
+      } finally {
+        ButtonComponent.prototype.setButtonText = origSetButtonText;
+      }
+    });
+
+    it('should use default label when ctaLabel omitted', () => {
+      const setButtonTextCalls: string[] = [];
+      const origSetButtonText = ButtonComponent.prototype.setButtonText;
+      ButtonComponent.prototype.setButtonText = function (label: string) {
+        setButtonTextCalls.push(label);
+        return origSetButtonText.call(this, label);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'archive',
+          title: 'Archive?',
+          body: 'Confirm?',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        expect(setButtonTextCalls).toContain('Archive');
+      } finally {
+        ButtonComponent.prototype.setButtonText = origSetButtonText;
+      }
+    });
+  });
+});

--- a/tests/unit/ConfirmModalA11y.test.ts
+++ b/tests/unit/ConfirmModalA11y.test.ts
@@ -1,0 +1,167 @@
+/**
+ * ConfirmModal A11y Characterization Tests
+ *
+ * Documents the current accessibility surface of ConfirmModal and flags
+ * gaps that warrant a follow-up issue.
+ *
+ * What ConfirmModal DOES today (verified):
+ *   - Extends Obsidian's Modal base class — inherits role="dialog" via
+ *     Obsidian-managed modalEl (cannot be asserted directly in jsdom; this
+ *     test asserts the structural primitives our code creates).
+ *   - Creates an h2 title element inside contentEl.
+ *   - Creates a p body element inside contentEl.
+ *   - Variant-class added to contentEl for CSS targeting.
+ *
+ * What ConfirmModal does NOT do today (gap — flagged for follow-up):
+ *   - Does NOT set aria-label / aria-labelledby on modalEl or contentEl
+ *     (i.e., the title h2 has no id, so it cannot be referenced by aria
+ *     attributes).
+ *   - Does NOT set aria-describedby on the body p (so screen readers will
+ *     reach the body text only via focus traversal, not via the dialog's
+ *     accessible description).
+ *
+ * RECOMMENDATION (deferred to follow-up issue):
+ *   In a future PR, ConfirmModal.onOpen should:
+ *     1. Generate a stable id for the h2 (e.g., `nexus-confirm-title-${rand}`).
+ *     2. Generate a stable id for the body p.
+ *     3. Set this.titleEl.id / modalEl.setAttribute('aria-labelledby', titleId).
+ *     4. Set modalEl.setAttribute('aria-describedby', bodyId).
+ *   This is non-trivial because Obsidian's Modal already manages modalEl and
+ *   we'd need to verify titleEl vs modalEl semantics. PR1 ships with the
+ *   default Obsidian Modal a11y posture.
+ */
+
+import { App, ButtonComponent } from 'obsidian';
+import { ConfirmModal } from '../../src/settings/components/ConfirmModal';
+
+describe('ConfirmModal a11y characterization', () => {
+  const app = {} as App;
+
+  describe('Modal lifecycle inheritance', () => {
+    it('extends Obsidian Modal (inherits role=dialog from base class)', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'delete',
+        title: 'T',
+        body: 'B',
+        onConfirm: jest.fn()
+      });
+
+      // The Modal base class manages modalEl + role=dialog at runtime.
+      // In our jsdom Obsidian mock, modalEl exists as a div placeholder.
+      expect(modal.modalEl).toBeDefined();
+      expect(modal.contentEl).toBeDefined();
+      // titleEl is set up by Modal — currently unused by ConfirmModal's body.
+      expect(modal.titleEl).toBeDefined();
+    });
+  });
+
+  describe('Heading structure (assertive screen-reader anchor)', () => {
+    it('emits h2 with config.title text inside contentEl on open', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'delete',
+        title: 'Delete workspace?',
+        body: 'B',
+        onConfirm: jest.fn()
+      });
+
+      const createElSpy = jest.spyOn(modal.contentEl, 'createEl');
+      modal.open();
+
+      expect(createElSpy).toHaveBeenCalledWith('h2', { text: 'Delete workspace?' });
+    });
+
+    it('emits p with config.body text inside contentEl on open', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'remove',
+        title: 'T',
+        body: 'This action cannot be undone.',
+        onConfirm: jest.fn()
+      });
+
+      const createElSpy = jest.spyOn(modal.contentEl, 'createEl');
+      modal.open();
+
+      expect(createElSpy).toHaveBeenCalledWith('p', { text: 'This action cannot be undone.' });
+    });
+  });
+
+  describe('Documented a11y gap — flagged for follow-up issue', () => {
+    /**
+     * These assertions DOCUMENT the current state of the code so future
+     * a11y improvements have a falsifiable baseline. When ConfirmModal
+     * gains explicit aria-labelledby/aria-describedby wiring, these tests
+     * should be FLIPPED to assert the positive behavior.
+     */
+    it('GAP: does not set an id on the title h2 (no aria-labelledby anchor)', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'archive',
+        title: 'Archive state?',
+        body: 'B',
+        onConfirm: jest.fn()
+      });
+
+      const createElCalls: Array<{ tag: string; options?: { text?: string; attr?: Record<string, string> } }> = [];
+      const origCreateEl = modal.contentEl.createEl.bind(modal.contentEl);
+      modal.contentEl.createEl = jest.fn((tag: string, options?: { text?: string; attr?: Record<string, string> }) => {
+        createElCalls.push({ tag, options });
+        return origCreateEl(tag as never, options as never);
+      }) as never;
+
+      modal.open();
+
+      const h2Call = createElCalls.find((c) => c.tag === 'h2');
+      expect(h2Call).toBeDefined();
+      // Document: no `attr: { id: ... }` is passed today.
+      expect(h2Call?.options?.attr).toBeUndefined();
+    });
+
+    it('GAP: does not set an id on the body p (no aria-describedby anchor)', () => {
+      const modal = new ConfirmModal(app, {
+        variant: 'archive',
+        title: 'T',
+        body: 'This action is reversible.',
+        onConfirm: jest.fn()
+      });
+
+      const createElCalls: Array<{ tag: string; options?: { text?: string; attr?: Record<string, string> } }> = [];
+      const origCreateEl = modal.contentEl.createEl.bind(modal.contentEl);
+      modal.contentEl.createEl = jest.fn((tag: string, options?: { text?: string; attr?: Record<string, string> }) => {
+        createElCalls.push({ tag, options });
+        return origCreateEl(tag as never, options as never);
+      }) as never;
+
+      modal.open();
+
+      const pCall = createElCalls.find((c) => c.tag === 'p');
+      expect(pCall).toBeDefined();
+      // Document: no `attr: { id: ... }` is passed today.
+      expect(pCall?.options?.attr).toBeUndefined();
+    });
+  });
+
+  describe('Keyboard accessibility — Cancel button presence', () => {
+    it('emits a Cancel ButtonComponent so users can dismiss without confirming', () => {
+      const buttonLabels: string[] = [];
+      const origSetButtonText = ButtonComponent.prototype.setButtonText;
+      ButtonComponent.prototype.setButtonText = function (label: string) {
+        buttonLabels.push(label);
+        return origSetButtonText.call(this, label);
+      };
+
+      try {
+        const modal = new ConfirmModal(app, {
+          variant: 'delete',
+          title: 'T',
+          body: 'B',
+          onConfirm: jest.fn()
+        });
+        modal.open();
+
+        // Cancel is the first button registered (so it's reachable via Tab).
+        expect(buttonLabels[0]).toBe('Cancel');
+      } finally {
+        ButtonComponent.prototype.setButtonText = origSetButtonText;
+      }
+    });
+  });
+});

--- a/tests/unit/ConfirmModalCallSites.integration.test.ts
+++ b/tests/unit/ConfirmModalCallSites.integration.test.ts
@@ -1,0 +1,351 @@
+/**
+ * ConfirmModal Call-Site Integration Tests
+ *
+ * Asserts that the 3 in-scope PR1 call sites invoke `new ConfirmModal(app, config)`
+ * with the right variant/title/body/onConfirm shape, and that the surrounding
+ * `await confirm...` promise resolves correctly based on the user's choice.
+ *
+ * Strategy: jest.mock the ConfirmModal module with a spy class that captures
+ * constructor args + exposes synthetic open/close/confirm hooks. This isolates
+ * each call site from real Modal DOM rendering and lets us assert on:
+ *   1. The config passed to `new ConfirmModal(...)` per call site.
+ *   2. The async promise resolution path:
+ *        - user clicks CTA  → onConfirm() fires → onClose() resolves with `true`
+ *        - user clicks Cancel → onClose() resolves with `false`
+ *
+ * Coverage:
+ *   - WorkspacesTab.confirmDeleteWorkspace (variant=delete)
+ *   - WorkspaceDetailRenderer.confirmDangerousAction (variant=delete, uniform per CODE decision)
+ *   - StatesSectionRenderer.confirmArchive (variant=archive, reversible accent)
+ */
+
+import { App, Component, createMockElement } from 'obsidian';
+
+// --- Spy class that replaces ConfirmModal ---
+// Captures (app, config) per construction; exposes the captured instances so
+// tests can synthetically fire onConfirm() then onClose() to drive the
+// resolve(true | false) path each call site wraps around.
+
+interface CapturedConfirmModal {
+  app: unknown;
+  config: {
+    variant: 'delete' | 'remove' | 'archive';
+    title: string;
+    body: string;
+    ctaLabel?: string;
+    onConfirm: () => void | Promise<void>;
+  };
+  onClose: () => void;
+  open: () => void;
+  contentEl: HTMLElement;
+}
+
+const capturedInstances: CapturedConfirmModal[] = [];
+
+jest.mock('../../src/settings/components/ConfirmModal', () => {
+  return {
+    ConfirmModal: jest.fn().mockImplementation(function (
+      this: CapturedConfirmModal,
+      app: unknown,
+      config: CapturedConfirmModal['config']
+    ) {
+      this.app = app;
+      this.config = config;
+      this.contentEl = createMockElement('div');
+      // onClose is assigned by the call site after construction
+      // (see WorkspacesTab.confirmDeleteWorkspace + sibling closures).
+      this.onClose = () => { void 0; };
+      this.open = () => { void 0; };
+      capturedInstances.push(this);
+      return this;
+    })
+  };
+});
+
+// Imports MUST come after jest.mock for hoisting to take effect.
+import { WorkspacesTab } from '../../src/settings/tabs/WorkspacesTab';
+import { WorkspaceDetailRenderer } from '../../src/components/workspace/WorkspaceDetailRenderer';
+import { StatesSectionRenderer, StatesSectionService } from '../../src/components/workspace/StatesSectionRenderer';
+import { SettingsRouter } from '../../src/settings/SettingsRouter';
+
+/**
+ * Test-only surface for invoking the private confirm helpers without dragging
+ * in the full renderer machinery. Mirrors the established pattern in
+ * tests/unit/WorkspacesTab.test.ts.
+ */
+interface TestableWorkspacesTab {
+  currentWorkspace: { id: string; name: string } | null;
+  confirmDeleteWorkspace(workspaceName?: string): Promise<boolean>;
+}
+
+interface TestableDetailRenderer {
+  confirmDangerousAction(app: App, message: string): Promise<boolean>;
+}
+
+interface TestableStatesRenderer {
+  confirmArchive(stateName: string): Promise<boolean>;
+}
+
+function makeStatesService(): jest.Mocked<StatesSectionService> {
+  return {
+    listStates: jest.fn().mockResolvedValue([]),
+    updateState: jest.fn().mockResolvedValue(undefined),
+    archiveState: jest.fn().mockResolvedValue(undefined),
+    deleteState: jest.fn().mockResolvedValue(undefined)
+  } as unknown as jest.Mocked<StatesSectionService>;
+}
+
+/** Drive the spy modal through a successful CTA-click cycle. */
+function clickCta(instance: CapturedConfirmModal): void {
+  // Call site closure flips `confirmed = true` in onConfirm.
+  void Promise.resolve(instance.config.onConfirm());
+  // Then the modal closes — which fires onClose, which resolves the outer promise.
+  instance.onClose();
+}
+
+/** Drive the spy modal through a Cancel-click cycle (no onConfirm fire). */
+function clickCancel(instance: CapturedConfirmModal): void {
+  // Cancel skips onConfirm. The wrapping promise still resolves via onClose.
+  instance.onClose();
+}
+
+describe('ConfirmModal call-site integration', () => {
+  beforeEach(() => {
+    capturedInstances.length = 0;
+  });
+
+  describe('WorkspacesTab.confirmDeleteWorkspace (variant=delete)', () => {
+    function createTab(): TestableWorkspacesTab {
+      const container = createMockElement('div');
+      const router = new SettingsRouter();
+      const tab = new WorkspacesTab(container, router, {
+        app: new App(),
+        prefetchedWorkspaces: [],
+        workspaceService: undefined
+      });
+      return tab as unknown as TestableWorkspacesTab;
+    }
+
+    it('constructs ConfirmModal with variant=delete + workspace-named copy', async () => {
+      const tab = createTab();
+      tab.currentWorkspace = { id: 'ws-1', name: 'Acme Q2 launch' };
+
+      const pending = tab.confirmDeleteWorkspace();
+      // Give the microtask queue a tick so the modal is constructed + opened.
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(1);
+      const inst = capturedInstances[0];
+      expect(inst.config.variant).toBe('delete');
+      expect(inst.config.title).toBe('Delete workspace?');
+      expect(inst.config.body).toBe('Delete workspace "Acme Q2 launch"? This cannot be undone.');
+
+      // Resolve the dangling promise so the test cleanup doesn't leak.
+      clickCancel(inst);
+      await expect(pending).resolves.toBe(false);
+    });
+
+    it('honors explicit workspaceName arg over currentWorkspace.name', async () => {
+      const tab = createTab();
+      tab.currentWorkspace = { id: 'ws-1', name: 'Other' };
+
+      const pending = tab.confirmDeleteWorkspace('Override name');
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(1);
+      expect(capturedInstances[0].config.body).toContain('"Override name"');
+
+      clickCancel(capturedInstances[0]);
+      await pending;
+    });
+
+    it('falls back to "Workspace" when no name available', async () => {
+      const tab = createTab();
+      tab.currentWorkspace = null;
+
+      const pending = tab.confirmDeleteWorkspace();
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(1);
+      expect(capturedInstances[0].config.body).toContain('"Workspace"');
+
+      clickCancel(capturedInstances[0]);
+      await pending;
+    });
+
+    it('resolves true when user confirms (CTA click → onConfirm → onClose)', async () => {
+      const tab = createTab();
+      tab.currentWorkspace = { id: 'ws-1', name: 'Demo' };
+
+      const pending = tab.confirmDeleteWorkspace();
+      await Promise.resolve();
+
+      clickCta(capturedInstances[0]);
+      await expect(pending).resolves.toBe(true);
+    });
+
+    it('resolves false when user cancels (onClose without onConfirm)', async () => {
+      const tab = createTab();
+      tab.currentWorkspace = { id: 'ws-1', name: 'Demo' };
+
+      const pending = tab.confirmDeleteWorkspace();
+      await Promise.resolve();
+
+      clickCancel(capturedInstances[0]);
+      await expect(pending).resolves.toBe(false);
+    });
+  });
+
+  describe('WorkspaceDetailRenderer.confirmDangerousAction (variant=delete uniform)', () => {
+    /**
+     * Frontend-coder's CODE decision: confirmDangerousAction always uses
+     * variant=delete (uniform), regardless of the calling action (project
+     * delete vs task delete). Both invoke this single helper; per-call-site
+     * variant semantics are deferred to PR2/PR3.
+     */
+    function createRenderer(): TestableDetailRenderer {
+      const renderer = new WorkspaceDetailRenderer(new Component());
+      return renderer as unknown as TestableDetailRenderer;
+    }
+
+    it('constructs ConfirmModal with variant=delete + caller-supplied message', async () => {
+      const renderer = createRenderer();
+      const app = new App();
+
+      const pending = renderer.confirmDangerousAction(
+        app,
+        'Delete this project and all its tasks? This cannot be undone.'
+      );
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(1);
+      const inst = capturedInstances[0];
+      expect(inst.config.variant).toBe('delete');
+      expect(inst.config.title).toBe('Confirm delete');
+      expect(inst.config.body).toBe('Delete this project and all its tasks? This cannot be undone.');
+      expect(inst.app).toBe(app);
+
+      clickCancel(inst);
+      await pending;
+    });
+
+    it('uses the same variant=delete for the task-deletion message', async () => {
+      const renderer = createRenderer();
+      const app = new App();
+
+      const pending = renderer.confirmDangerousAction(
+        app,
+        'Delete this task? This cannot be undone.'
+      );
+      await Promise.resolve();
+
+      // CODE decision documented in commit body: "variant=delete uniform"
+      expect(capturedInstances[0].config.variant).toBe('delete');
+      expect(capturedInstances[0].config.body).toBe('Delete this task? This cannot be undone.');
+
+      clickCancel(capturedInstances[0]);
+      await pending;
+    });
+
+    it('resolves true on confirm and false on cancel', async () => {
+      const renderer = createRenderer();
+      const app = new App();
+
+      const confirmPending = renderer.confirmDangerousAction(app, 'msg-1');
+      await Promise.resolve();
+      clickCta(capturedInstances[0]);
+      await expect(confirmPending).resolves.toBe(true);
+
+      capturedInstances.length = 0;
+
+      const cancelPending = renderer.confirmDangerousAction(app, 'msg-2');
+      await Promise.resolve();
+      clickCancel(capturedInstances[0]);
+      await expect(cancelPending).resolves.toBe(false);
+    });
+  });
+
+  describe('StatesSectionRenderer.confirmArchive (variant=archive)', () => {
+    function createRenderer(): {
+      renderer: TestableStatesRenderer;
+      service: jest.Mocked<StatesSectionService>;
+    } {
+      const service = makeStatesService();
+      const renderer = new StatesSectionRenderer(new App(), service);
+      return { renderer: renderer as unknown as TestableStatesRenderer, service };
+    }
+
+    it('constructs ConfirmModal with variant=archive + reversible-action copy', async () => {
+      const { renderer } = createRenderer();
+
+      const pending = renderer.confirmArchive('Pre-launch snapshot');
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(1);
+      const inst = capturedInstances[0];
+      expect(inst.config.variant).toBe('archive');
+      expect(inst.config.title).toBe('Archive state?');
+      // Copy must communicate reversibility — flagged by mockup as the
+      // distinguishing trait of archive vs delete.
+      expect(inst.config.body).toContain('Pre-launch snapshot');
+      expect(inst.config.body).toContain('You can restore it later');
+
+      clickCancel(inst);
+      await pending;
+    });
+
+    it('resolves true on confirm (archive flow proceeds)', async () => {
+      const { renderer } = createRenderer();
+
+      const pending = renderer.confirmArchive('S1');
+      await Promise.resolve();
+      clickCta(capturedInstances[0]);
+
+      await expect(pending).resolves.toBe(true);
+    });
+
+    it('resolves false on cancel (archive flow aborts)', async () => {
+      const { renderer } = createRenderer();
+
+      const pending = renderer.confirmArchive('S1');
+      await Promise.resolve();
+      clickCancel(capturedInstances[0]);
+
+      await expect(pending).resolves.toBe(false);
+    });
+  });
+
+  describe('Cross-site invariants', () => {
+    it('PR1 wires NO ConfirmModal call site to variant=remove (deferred to PR2)', async () => {
+      // Triple-touch every PR1 call site; assert none of them use 'remove'.
+      // PR2 will introduce 'remove' for key-files row removal (out of PR1 scope).
+      const tab = new WorkspacesTab(createMockElement('div'), new SettingsRouter(), {
+        app: new App(),
+        prefetchedWorkspaces: [],
+        workspaceService: undefined
+      }) as unknown as TestableWorkspacesTab;
+      tab.currentWorkspace = { id: 'ws-1', name: 'X' };
+      const p1 = tab.confirmDeleteWorkspace();
+      await Promise.resolve();
+      clickCancel(capturedInstances[0]);
+      await p1;
+
+      const detail = new WorkspaceDetailRenderer() as unknown as TestableDetailRenderer;
+      const p2 = detail.confirmDangerousAction(new App(), 'x');
+      await Promise.resolve();
+      clickCancel(capturedInstances[1]);
+      await p2;
+
+      const service = makeStatesService();
+      const states = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      const p3 = states.confirmArchive('s');
+      await Promise.resolve();
+      clickCancel(capturedInstances[2]);
+      await p3;
+
+      const variants = capturedInstances.map((i) => i.config.variant);
+      expect(variants).toEqual(['delete', 'delete', 'archive']);
+      expect(variants).not.toContain('remove');
+    });
+  });
+});

--- a/tests/unit/StatesSectionRendererPort.test.ts
+++ b/tests/unit/StatesSectionRendererPort.test.ts
@@ -1,0 +1,283 @@
+/**
+ * StatesSectionRenderer Port Regression Tests
+ *
+ * Asserts that the PR1 BoxedSection shell port preserved the load-bearing
+ * service-call shape from PR #216 / v5.9.7:
+ *   - listStates(workspaceId, includeArchived) is called with both branches
+ *     of the Show archived toggle.
+ *   - Archive callback flow: ConfirmModal accept → archiveState(workspaceId,
+ *     sessionId, stateId, restore=false) → list refresh.
+ *   - Restore flow skips the confirm modal entirely (one-click reversal).
+ *
+ * The v5.9.7 archive-visibility fix lives in MemoryService.getStates (covered
+ * by tests/unit/MemoryServiceGetStates.test.ts). This file covers the
+ * renderer-side contract: that the renderer continues to delegate to the
+ * StatesSectionService unchanged, so the v5.9.7 fix surfaces through the UI.
+ */
+
+import { App, Component, createMockElement } from 'obsidian';
+
+// Mock ConfirmModal so we can drive the archive confirm flow synthetically
+// without rendering a real modal.
+interface CapturedConfirmModal {
+  app: unknown;
+  config: {
+    variant: 'delete' | 'remove' | 'archive';
+    title: string;
+    body: string;
+    onConfirm: () => void | Promise<void>;
+  };
+  onClose: () => void;
+  open: () => void;
+  contentEl: HTMLElement;
+}
+
+const capturedInstances: CapturedConfirmModal[] = [];
+
+jest.mock('../../src/settings/components/ConfirmModal', () => ({
+  ConfirmModal: jest.fn().mockImplementation(function (
+    this: CapturedConfirmModal,
+    app: unknown,
+    config: CapturedConfirmModal['config']
+  ) {
+    this.app = app;
+    this.config = config;
+    this.contentEl = createMockElement('div');
+    this.onClose = () => { void 0; };
+    this.open = () => { void 0; };
+    capturedInstances.push(this);
+    return this;
+  })
+}));
+
+import { StatesSectionRenderer, StatesSectionService, StateSummary } from '../../src/components/workspace/StatesSectionRenderer';
+
+interface TestableStatesRenderer {
+  workspaceId?: string;
+  includeArchived: boolean;
+  cachedStates: StateSummary[];
+  listContainer?: HTMLElement;
+  // private methods exposed for direct invocation
+  toggleArchive(state: StateSummary): Promise<void>;
+  confirmAndDelete(state: StateSummary): Promise<void>;
+  // loadAndRender is private but visible via cast
+  loadAndRender(): Promise<void>;
+}
+
+function makeService(overrides: Partial<jest.Mocked<StatesSectionService>> = {}): jest.Mocked<StatesSectionService> {
+  return {
+    listStates: jest.fn().mockResolvedValue([]),
+    updateState: jest.fn().mockResolvedValue(undefined),
+    archiveState: jest.fn().mockResolvedValue(undefined),
+    deleteState: jest.fn().mockResolvedValue(undefined),
+    ...overrides
+  } as unknown as jest.Mocked<StatesSectionService>;
+}
+
+function makeState(overrides: Partial<StateSummary> = {}): StateSummary {
+  return {
+    id: 'state-1',
+    name: 'Snapshot',
+    sessionId: 'sess-1',
+    workspaceId: 'ws-1',
+    created: 1_700_000_000_000,
+    isArchived: false,
+    ...overrides
+  };
+}
+
+/** Drive the spy modal through a successful CTA-click cycle. */
+function clickCta(instance: CapturedConfirmModal): void {
+  void Promise.resolve(instance.config.onConfirm());
+  instance.onClose();
+}
+
+describe('StatesSectionRenderer port regression', () => {
+  beforeEach(() => {
+    capturedInstances.length = 0;
+  });
+
+  describe('render() — BoxedSection shell + workspaceId branch', () => {
+    it('renders a "save first" hint inside BoxedSection when workspaceId is undefined', () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service);
+      const container = createMockElement('div');
+
+      renderer.render(container, undefined);
+
+      // BoxedSection emits a <section class="ws-section"> outer element.
+      const section = container.querySelector('section.ws-section');
+      expect(section).not.toBeNull();
+      // Should NOT call listStates when there is no workspace yet.
+      expect(service.listStates).not.toHaveBeenCalled();
+    });
+
+    it('calls listStates(workspaceId, includeArchived=false) on initial render', async () => {
+      const service = makeService({
+        listStates: jest.fn().mockResolvedValue([]) as jest.Mocked<StatesSectionService>['listStates']
+      });
+      const renderer = new StatesSectionRenderer(new App(), service);
+      const container = createMockElement('div');
+
+      renderer.render(container, 'ws-42');
+      // loadAndRender is fire-and-forget — yield to let it run.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(service.listStates).toHaveBeenCalledWith('ws-42', false);
+    });
+  });
+
+  describe('Show archived toggle — both branches of the v5.9.7 fix', () => {
+    it('calls listStates with includeArchived=false when toggle is OFF (default)', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+      renderer.includeArchived = false;
+
+      await renderer.loadAndRender();
+
+      expect(service.listStates).toHaveBeenCalledWith('ws-1', false);
+    });
+
+    it('calls listStates with includeArchived=true when toggle is ON', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+      renderer.includeArchived = true;
+
+      await renderer.loadAndRender();
+
+      expect(service.listStates).toHaveBeenCalledWith('ws-1', true);
+    });
+
+    it('surfaces archived states from the service unchanged (v5.9.7 contract)', async () => {
+      // PR #218 fix guarantees getStates returns isArchived for tagged states.
+      // The renderer must pass that through to its render path verbatim.
+      const archivedState = makeState({
+        id: 's-archived',
+        name: 'Tagged snapshot',
+        isArchived: true,
+        tags: ['my-tag']
+      });
+      const service = makeService({
+        listStates: jest.fn().mockResolvedValue([archivedState]) as jest.Mocked<StatesSectionService>['listStates']
+      });
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+      renderer.includeArchived = true;
+
+      await renderer.loadAndRender();
+
+      expect(renderer.cachedStates).toHaveLength(1);
+      expect(renderer.cachedStates[0].isArchived).toBe(true);
+      expect(renderer.cachedStates[0].name).toBe('Tagged snapshot');
+    });
+  });
+
+  describe('Archive flow — ConfirmModal accept → archiveState → refresh', () => {
+    it('calls archiveState(workspaceId, sessionId, stateId, restore=false) after user confirms', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+
+      const state = makeState({ id: 's-1', sessionId: 'sess-1', isArchived: false });
+      const pending = renderer.toggleArchive(state);
+
+      // ConfirmModal mock captured; simulate user click on CTA.
+      await Promise.resolve();
+      expect(capturedInstances).toHaveLength(1);
+      expect(capturedInstances[0].config.variant).toBe('archive');
+      clickCta(capturedInstances[0]);
+
+      await pending;
+
+      expect(service.archiveState).toHaveBeenCalledWith('ws-1', 'sess-1', 's-1', false);
+      // After archive, the list refreshes via loadAndRender → listStates.
+      expect(service.listStates).toHaveBeenCalled();
+    });
+
+    it('does NOT call archiveState when user cancels the confirm modal', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+
+      const state = makeState({ id: 's-1', sessionId: 'sess-1', isArchived: false });
+      const pending = renderer.toggleArchive(state);
+
+      await Promise.resolve();
+      // Cancel: close without invoking onConfirm.
+      capturedInstances[0].onClose();
+
+      await pending;
+
+      expect(service.archiveState).not.toHaveBeenCalled();
+    });
+
+    it('SKIPS the confirm modal for restore (one-click reversal) and calls archiveState with restore=true', async () => {
+      // Per CODE intent: restore is reversible-of-reversible, so no confirm
+      // gate — the user gets immediate restoration.
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+
+      const archived = makeState({ id: 's-archived', sessionId: 'sess-1', isArchived: true });
+      await renderer.toggleArchive(archived);
+
+      expect(capturedInstances).toHaveLength(0);
+      expect(service.archiveState).toHaveBeenCalledWith('ws-1', 'sess-1', 's-archived', true);
+    });
+
+    it('shows a Notice and does not call archiveState when sessionId is missing', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+
+      const broken = makeState({ id: 's-1', sessionId: undefined });
+      await renderer.toggleArchive(broken);
+
+      expect(service.archiveState).not.toHaveBeenCalled();
+      expect(capturedInstances).toHaveLength(0);
+    });
+  });
+
+  describe('Delete flow — uses internal StateDeleteConfirmModal (NOT new ConfirmModal)', () => {
+    /**
+     * NOTE: The delete-state path still uses StateDeleteConfirmModal (the
+     * pre-existing internal Modal subclass), NOT the new ConfirmModal
+     * primitive. This is intentional for PR1 — the delete sweep is deferred
+     * to a follow-up PR (out of scope per the commit body's "Out of scope"
+     * list). We assert here that the delete path does NOT trigger our
+     * captured ConfirmModal mock; if a future PR sweeps it, this test will
+     * fail and signal the call-site count needs updating.
+     */
+    it('does NOT construct the shared ConfirmModal for delete (uses StateDeleteConfirmModal)', async () => {
+      const service = makeService();
+      const renderer = new StatesSectionRenderer(new App(), service) as unknown as TestableStatesRenderer;
+      renderer.workspaceId = 'ws-1';
+      renderer.listContainer = createMockElement('div');
+
+      const state = makeState({ id: 's-1', sessionId: 'sess-1' });
+      // Fire-and-forget — the internal StateDeleteConfirmModal is not part
+      // of our jest.mock, so the call dispatches into the real (mocked)
+      // Modal base class. We only care that our shared ConfirmModal mock is
+      // NOT touched.
+      const pending = renderer.confirmAndDelete(state);
+      await Promise.resolve();
+
+      expect(capturedInstances).toHaveLength(0);
+
+      // Cleanup: don't leave the promise dangling (StateDeleteConfirmModal's
+      // resolver wires via constructor callback, won't fire here, so we
+      // simply don't await pending — the test scope ends and Jest discards).
+      void pending;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR1 of Wave 3 (Workspaces tab redesign). Foundation slice: extracts shared UI primitives, ports the workspace detail/states surfaces to use them, and sweeps the confirm dialog across 3 destructive-action call sites. Visual contract anchored by `docs/mockups/workspace-tab-redesign-v3-subpages.html` (v3.1, blessed 2026-05-26). Plan: `docs/plans/workspace-tab-redesign-plan.md`.

- **New primitives**: `BoxedSection` (sticky-header + scrollable-body shell with config object + `getBody()` accessor) and `ConfirmModal` (variant: delete/remove/archive — only delete/archive wired in PR1).
- **Port**: `WorkspaceDetailRenderer.renderDetail`, `WorkspaceFormRenderer`, and `StatesSectionRenderer` ported to BoxedSection. StatesSection port is byte-identical preservation of the v5.9.7 archive-visibility chain (PR #218 / `eae5f507`).
- **Sweep**: ConfirmModal across 3 call sites — `WorkspacesTab.confirmDeleteWorkspace` (variant=delete), `WorkspaceDetailRenderer.confirmDangerousAction` (variant=delete uniform per implementation decision), `StatesSectionRenderer` archive flow (variant=archive). `StateDeleteConfirmModal` sweep is **explicitly deferred to PR2** and locked in by a characterization test.
- **CSS**: `.ws-section` family + `.ws-section-toolbar` family + breadcrumb font-size fix at `styles.css:5045`.
- **Tests**: +1120 LoC across 4 new test files (42 tests, all passing). Full suite **2863 passed / 17 skipped**, build + lint clean.

**Out of scope** for PR1 (follow in subsequent PRs): row primitives + checkbox sweep (PR2), TaskDetail + Dependencies/Linked notes (PR3), WorkflowEditor + FilePicker + mobile breakpoint (PR4).

**Read 2 scope expansion**: `WorkspaceFormRenderer.ts` was added mid-implementation because its confirm-delete shared `confirmDangerousAction`. Plan §Components Affected amended in-flight.

## Test plan
- [x] `npm run build` clean
- [x] `npm run test` — 2863 / 17 skipped / 0 failed
- [x] PR #218 v5.9.7 archive-visibility chain preserved (verified through both Show-archived toggle branches in `StatesSectionRendererPort.test.ts`)
- [x] No inline style leakage on new primitives (`.ws-section` + `.ws-section-toolbar` family lives in `styles.css`)
- [ ] **Manual**: open Settings → Workspaces → select workspace → verify Projects/States/Workflows/Key files sections render with sticky headers + scroll
- [ ] **Manual**: trigger delete on a workspace, project, key file → verify ConfirmModal renders with correct variant copy
- [ ] **Manual**: archive a state → verify variant=archive ConfirmModal renders and Show archived toggle behavior unchanged from v5.9.7
- [ ] **Manual** (mobile): defer to PR4 — mobile breakpoint not in PR1 scope

## Follow-ups (not blocking this PR)
- ConfirmModal a11y wiring (`aria-labelledby` / `aria-describedby`) — 2 characterization tests in `ConfirmModalA11y.test.ts` already gate the gap; flip to positive assertions when the work lands. Will file as standalone issue or bundle with #217 polish.
- `StateDeleteConfirmModal` sweep → PR2 scope; characterization test will fail-loud when the sweep lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)