### PR TITLE
Add Claude Opus 4.8 model definitions

### DIFF
--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -1,6 +1,6 @@
 /**
  * Anthropic Model Specifications
- * Updated April 2026 with Claude Opus 4.7
+ * Updated May 2026 with Claude Opus 4.8
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -15,6 +15,24 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     maxTokens: 64000,
     inputCostPerMillion: 1.00,
     outputCostPerMillion: 5.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Claude Opus 4.8
+  {
+    provider: 'anthropic',
+    name: 'Claude Opus 4.8',
+    apiName: 'claude-opus-4-8',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -1,7 +1,7 @@
 /**
  * OpenRouter Model Specifications
  * OpenRouter provides access to multiple providers through a unified API
- * Updated April 2026 with GPT-5.5, Claude Sonnet 4.6, and Gemini 3.1 models
+ * Updated May 2026 with Claude Opus 4.8
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -109,6 +109,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     provider: 'openrouter',
     name: 'Claude Opus 4.7 (1M)',
     apiName: 'anthropic/claude-opus-4.7',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'Claude Opus 4.8',
+    apiName: 'anthropic/claude-opus-4.8',
     contextWindow: 1000000,
     maxTokens: 128000,
     inputCostPerMillion: 5.00,

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -1,5 +1,41 @@
 import { ModelRegistry, DEFAULT_MODELS } from '../../src/services/llm/adapters/ModelRegistry';
 
+describe('ModelRegistry Claude Opus 4.8 models', () => {
+  it('registers Claude Opus 4.8 for Anthropic', () => {
+    expect(ModelRegistry.findModel('anthropic', 'claude-opus-4-8')).toEqual(expect.objectContaining({
+      name: 'Claude Opus 4.8',
+      contextWindow: 1000000,
+      maxTokens: 128000,
+      inputCostPerMillion: 5,
+      outputCostPerMillion: 25,
+      capabilities: expect.objectContaining({
+        supportsJSON: true,
+        supportsImages: true,
+        supportsFunctions: true,
+        supportsStreaming: true,
+        supportsThinking: true
+      })
+    }));
+  });
+
+  it('registers Claude Opus 4.8 for OpenRouter with the provider namespace', () => {
+    expect(ModelRegistry.findModel('openrouter', 'anthropic/claude-opus-4.8')).toEqual(expect.objectContaining({
+      name: 'Claude Opus 4.8',
+      contextWindow: 1000000,
+      maxTokens: 128000,
+      inputCostPerMillion: 5,
+      outputCostPerMillion: 25,
+      capabilities: expect.objectContaining({
+        supportsJSON: true,
+        supportsImages: true,
+        supportsFunctions: true,
+        supportsStreaming: true,
+        supportsThinking: true
+      })
+    }));
+  });
+});
+
 describe('ModelRegistry GPT-5.5 models', () => {
   it('registers GPT-5.5 and GPT-5.5 Pro for OpenAI', () => {
     expect(ModelRegistry.findModel('openai', 'gpt-5.5')).toEqual(expect.objectContaining({


### PR DESCRIPTION
## Summary
- add Claude Opus 4.8 for Anthropic
- add Claude Opus 4.8 for OpenRouter
- cover both registry entries in ModelRegistry tests

## Verification
- npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand
- npm run build
- RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=anthropic/claude-opus-4.8 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
- direct Anthropic API smoke call for claude-opus-4-8 returned OK