### PR TITLE
Add Codex app MCP setup

### DIFF
--- a/src/settings/tabs/GetStartedTab.ts
+++ b/src/settings/tabs/GetStartedTab.ts
@@ -15,8 +15,14 @@ import { getPrimaryServerKey } from '../../constants/branding';
 import { ConfigStatus, getClaudeDesktopConfigPath, getConfigStatus } from '../getStartedStatus';
 import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
 import { CONNECTOR_JS_CONTENT } from '../../utils/connectorContent';
+import {
+    appendCodexMcpTomlSnippet,
+    buildCodexMcpTomlSnippet,
+    hasCodexMcpServerConfig
+} from '../../utils/codexMcpConfig';
 
 type GetStartedView = 'paths' | 'internal-chat' | 'mcp-setup';
+type CodexConfigStatus = 'no-config-file' | 'nexus-configured' | 'config-exists';
 type DesktopModuleMap = {
     child_process: typeof import('child_process');
     fs: typeof import('fs');
@@ -225,7 +231,7 @@ export class GetStartedTab {
             this.services.component
         );
 
-        this.container.createEl('h3', { text: 'Claude Desktop setup' });
+        this.container.createEl('h3', { text: 'MCP integration setup' });
 
         // MCP setup requires Node.js modules (path, fs, child_process) — desktop only
         if (!Platform.isDesktop) {
@@ -235,6 +241,8 @@ export class GetStartedTab {
             });
             return;
         }
+
+        this.container.createEl('h4', { text: 'Claude Desktop' });
 
         // Check for Node.js availability
         const nodePath = this.resolveNodePath();
@@ -370,8 +378,110 @@ export class GetStartedTab {
             }
         }
 
+        this.renderCodexSetupSection();
+
         // Always show manual copy-paste section as fallback
         this.renderManualConfigSection(configPath);
+    }
+
+    private renderCodexSetupSection(): void {
+        this.container.createEl('hr', { cls: 'nexus-divider' });
+
+        const section = this.container.createDiv('nexus-codex-config');
+        section.createEl('h4', { text: 'Codex' });
+
+        const nodeFs = this.loadDesktopModule('fs');
+        const pathMod = this.loadDesktopModule('path');
+        const configPath = this.getCodexConfigPath(pathMod);
+        const nodePath = this.resolveNodePath();
+        const configStatus = this.getCodexConfigStatus(nodeFs, configPath);
+
+        const row = section.createDiv('nexus-mcp-row');
+        const statusText = this.getCodexStatusText(configStatus);
+        row.createEl('span', {
+            text: statusText,
+            cls: configStatus === 'nexus-configured'
+                ? 'nexus-mcp-status nexus-mcp-success'
+                : 'nexus-mcp-status'
+        });
+
+        const actions = row.createDiv('nexus-mcp-actions');
+        const component = this.services.component;
+
+        if (configStatus === 'nexus-configured') {
+            const openBtn = actions.createEl('button', { text: 'Open config' });
+            const openHandler = () => this.openConfigFile(configPath);
+            if (component) {
+                component.registerDomEvent(openBtn, 'click', openHandler);
+            }
+
+            const revealBtn = actions.createEl('button', { text: this.getRevealButtonText() });
+            const revealHandler = () => this.revealInFolder(configPath);
+            if (component) {
+                component.registerDomEvent(revealBtn, 'click', revealHandler);
+            }
+
+            section.createEl('p', {
+                text: 'Restart codex or start a new session if Nexus does not appear.',
+                cls: 'nexus-mcp-help'
+            });
+        } else {
+            const addBtn = actions.createEl('button', { text: 'Add Nexus', cls: 'mod-cta' });
+            const addHandler = () => {
+                this.autoConfigureCodex();
+            };
+            if (component) {
+                component.registerDomEvent(addBtn, 'click', addHandler);
+            }
+
+            if (!nodePath) {
+                addBtn.disabled = true;
+            }
+
+            section.createEl('p', {
+                text: 'This updates the config file directly; no terminal window opens.',
+                cls: 'nexus-mcp-help'
+            });
+        }
+
+        this.renderCodexManualConfig(section, configPath);
+    }
+
+    private renderCodexManualConfig(section: HTMLElement, configPath: string): void {
+        const manualSection = section.createDiv('nexus-manual-config');
+        manualSection.createEl('p', {
+            text: 'Manual configuration:',
+            cls: 'setting-item-description'
+        });
+
+        const configToml = this.getCodexConfigToml();
+        const codeBlock = manualSection.createEl('pre', { cls: 'nexus-config-code' });
+        codeBlock.createEl('code', { text: configToml });
+
+        const copyBtn = manualSection.createEl('button', { text: 'Copy configuration', cls: 'mod-cta' });
+        const copyHandler = async () => {
+            try {
+                await navigator.clipboard.writeText(configToml);
+                copyBtn.textContent = 'Copied!';
+                window.setTimeout(() => {
+                    copyBtn.textContent = 'Copy configuration';
+                }, 2000);
+            } catch {
+                new Notice('Failed to copy to clipboard');
+            }
+        };
+        const component = this.services.component;
+        if (component) {
+            component.registerDomEvent(copyBtn, 'click', copyHandler);
+        }
+
+        const pathInfo = manualSection.createDiv('nexus-config-path');
+        pathInfo.createEl('span', { text: 'Config file location: ', cls: 'setting-item-description' });
+        const pathLink = pathInfo.createEl('a', { text: configPath, href: '#' });
+        const pathHandler = () => this.revealInFolder(configPath);
+        if (component) {
+            component.registerDomEvent(pathLink, 'click', pathHandler);
+        }
     }
 
     /**
@@ -477,6 +587,63 @@ export class GetStartedTab {
         return typeof maybeConfig.mcpServers === 'object' && maybeConfig.mcpServers !== null;
     }
 
+    private getCodexConfigPath(pathMod: DesktopModuleMap['path']): string {
+        const codexHome = process.env.CODEX_HOME || pathMod.join(this.getUserHome(), '.codex');
+        return pathMod.normalize(pathMod.join(codexHome, 'config.toml'));
+    }
+
+    private getUserHome(): string {
+        if (Platform.isWin) {
+            return process.env.USERPROFILE || process.env.HOME || '';
+        }
+
+        return process.env.HOME || '';
+    }
+
+    private getCodexConfigStatus(
+        nodeFs: DesktopModuleMap['fs'],
+        configPath: string
+    ): CodexConfigStatus {
+        if (!nodeFs.existsSync(configPath)) {
+            return 'no-config-file';
+        }
+
+        try {
+            const content = nodeFs.readFileSync(configPath, 'utf-8');
+            const serverKey = getPrimaryServerKey(this.services.app.vault.getName());
+
+            if (hasCodexMcpServerConfig(content, serverKey)) {
+                return 'nexus-configured';
+            }
+        } catch (error) {
+            console.error('[GetStartedTab] Error reading Codex config:', error);
+        }
+
+        return 'config-exists';
+    }
+
+    private getCodexStatusText(configStatus: CodexConfigStatus): string {
+        if (configStatus === 'nexus-configured') {
+            return '✓ connected';
+        }
+
+        if (configStatus === 'no-config-file') {
+            return 'Ready to configure';
+        }
+
+        return 'Codex config found';
+    }
+
+    private getCodexConfigToml(): string {
+        const pathMod = this.loadDesktopModule('path');
+        const vaultName = this.services.app.vault.getName();
+        const serverKey = getPrimaryServerKey(vaultName);
+        const connectorPath = pathMod.normalize(pathMod.join(this.services.pluginPath, 'connector.js'));
+        const nodePath = this.resolveNodePath() || 'node';
+
+        return buildCodexMcpTomlSnippet(serverKey, nodePath, [connectorPath]);
+    }
+
     /**
      * Generate the configuration JSON string
      */
@@ -565,6 +732,53 @@ export class GetStartedTab {
         } catch (error) {
             console.error('[GetStartedTab] Error auto-configuring:', error);
             new Notice(`Failed to configure: ${(error as Error).message}`);
+        }
+    }
+
+    private autoConfigureCodex(): void {
+        const nodeFs = this.loadDesktopModule('fs');
+        const pathMod = this.loadDesktopModule('path');
+
+        try {
+            const nodePath = this.resolveNodePath();
+
+            if (!nodePath) {
+                new Notice('Node.js not found. Please install Node.js and try again.');
+                return;
+            }
+
+            const vaultName = this.services.app.vault.getName();
+            const serverKey = getPrimaryServerKey(vaultName);
+            const connectorPath = this.ensureConnectorFile(nodeFs, pathMod);
+            const configPath = this.getCodexConfigPath(pathMod);
+            const configDir = pathMod.dirname(configPath);
+            const configToml = buildCodexMcpTomlSnippet(serverKey, nodePath, [connectorPath]);
+
+            if (!nodeFs.existsSync(configDir)) {
+                nodeFs.mkdirSync(configDir, { recursive: true });
+            }
+
+            if (!nodeFs.existsSync(configPath)) {
+                nodeFs.writeFileSync(configPath, `${configToml}\n`, 'utf-8');
+                new Notice('Nexus connector added to the app config. Restart the app or start a new session if needed.');
+                this.render();
+                return;
+            }
+
+            const existingContent = nodeFs.readFileSync(configPath, 'utf-8');
+            if (hasCodexMcpServerConfig(existingContent, serverKey)) {
+                new Notice('Nexus is already configured in the app config.');
+                this.render();
+                return;
+            }
+
+            const updatedContent = appendCodexMcpTomlSnippet(existingContent, configToml);
+            nodeFs.writeFileSync(configPath, updatedContent, 'utf-8');
+            new Notice('Nexus connector added to the app config. Restart the app or start a new session if needed.');
+            this.render();
+        } catch (error) {
+            console.error('[GetStartedTab] Error auto-configuring Codex:', error);
+            new Notice(`Failed to configure Codex: ${(error as Error).message}`);
         }
     }
 

--- a/src/utils/codexMcpConfig.ts
+++ b/src/utils/codexMcpConfig.ts
@@ -1,0 +1,59 @@
+export function buildCodexMcpTomlSnippet(
+    serverKey: string,
+    command: string,
+    args: string[]
+): string {
+    const escapedArgs = args
+        .map((arg) => `"${escapeTomlBasicString(arg)}"`)
+        .join(', ');
+
+    return [
+        `[mcp_servers.${formatTomlKey(serverKey)}]`,
+        `command = "${escapeTomlBasicString(command)}"`,
+        `args = [${escapedArgs}]`
+    ].join('\n');
+}
+
+export function hasCodexMcpServerConfig(content: string, serverKey: string): boolean {
+    const tablePattern = new RegExp(
+        `^\\s*\\[\\s*mcp_servers\\s*\\.\\s*(?:${escapeRegExp(serverKey)}|"${escapeRegExp(escapeTomlBasicString(serverKey))}")\\s*\\]\\s*$`,
+        'm'
+    );
+
+    return tablePattern.test(content);
+}
+
+export function appendCodexMcpTomlSnippet(content: string, snippet: string): string {
+    const trimmedSnippet = snippet.trim();
+    if (!content.trim()) {
+        return `${trimmedSnippet}\n`;
+    }
+
+    const separator = content.endsWith('\n') ? '\n' : '\n\n';
+    return `${content}${separator}${trimmedSnippet}\n`;
+}
+
+const BACKSPACE = String.fromCharCode(8);
+
+function formatTomlKey(key: string): string {
+    if (/^[A-Za-z0-9_-]+$/.test(key)) {
+        return key;
+    }
+
+    return `"${escapeTomlBasicString(key)}"`;
+}
+
+function escapeTomlBasicString(value: string): string {
+    return value
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(new RegExp(BACKSPACE, 'g'), '\\b')
+        .replace(/\t/g, '\\t')
+        .replace(/\n/g, '\\n')
+        .replace(/\f/g, '\\f')
+        .replace(/\r/g, '\\r');
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/unit/codexMcpConfig.test.ts
+++ b/tests/unit/codexMcpConfig.test.ts
@@ -1,0 +1,64 @@
+import {
+  appendCodexMcpTomlSnippet,
+  buildCodexMcpTomlSnippet,
+  hasCodexMcpServerConfig
+} from '../../src/utils/codexMcpConfig';
+
+describe('codexMcpConfig', () => {
+  it('builds a Codex MCP server TOML snippet', () => {
+    expect(buildCodexMcpTomlSnippet(
+      'nexus-test-vault',
+      '/opt/homebrew/bin/node',
+      ['/Users/test/Vault/.obsidian/plugins/nexus/connector.js']
+    )).toBe([
+      '[mcp_servers.nexus-test-vault]',
+      'command = "/opt/homebrew/bin/node"',
+      'args = ["/Users/test/Vault/.obsidian/plugins/nexus/connector.js"]'
+    ].join('\n'));
+  });
+
+  it('quotes server keys that are not valid bare TOML keys', () => {
+    expect(buildCodexMcpTomlSnippet(
+      'nexus test',
+      'C:\\Program Files\\nodejs\\node.exe',
+      ['C:\\Vault "A"\\.obsidian\\plugins\\nexus\\connector.js']
+    )).toBe([
+      '[mcp_servers."nexus test"]',
+      'command = "C:\\\\Program Files\\\\nodejs\\\\node.exe"',
+      'args = ["C:\\\\Vault \\"A\\"\\\\.obsidian\\\\plugins\\\\nexus\\\\connector.js"]'
+    ].join('\n'));
+  });
+
+  it('detects existing bare and quoted Codex MCP server tables', () => {
+    expect(hasCodexMcpServerConfig(
+      '[mcp_servers.nexus-test-vault]\ncommand = "node"\n',
+      'nexus-test-vault'
+    )).toBe(true);
+
+    expect(hasCodexMcpServerConfig(
+      '[mcp_servers."nexus test"]\ncommand = "node"\n',
+      'nexus test'
+    )).toBe(true);
+  });
+
+  it('does not match tool sub-tables without the server table', () => {
+    expect(hasCodexMcpServerConfig(
+      '[mcp_servers.nexus-test-vault.tools.toolManager_getTools]\napproval_mode = "approve"\n',
+      'nexus-test-vault'
+    )).toBe(false);
+  });
+
+  it('appends a Codex MCP snippet without overwriting existing config', () => {
+    expect(appendCodexMcpTomlSnippet(
+      'model = "gpt-5.5"\n',
+      '[mcp_servers.nexus]\ncommand = "node"\nargs = ["connector.js"]'
+    )).toBe('model = "gpt-5.5"\n\n[mcp_servers.nexus]\ncommand = "node"\nargs = ["connector.js"]\n');
+  });
+
+  it('creates a snippet-only config for an empty file', () => {
+    expect(appendCodexMcpTomlSnippet(
+      '',
+      '[mcp_servers.nexus]\ncommand = "node"\nargs = ["connector.js"]'
+    )).toBe('[mcp_servers.nexus]\ncommand = "node"\nargs = ["connector.js"]\n');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Codex section to the MCP integration setup screen
- write Nexus MCP server config directly to the Codex app config file at CODEX_HOME/config.toml or ~/.codex/config.toml
- add TOML snippet generation, detection, and append helpers with focused tests

## Validation
- npx jest tests/unit/codexMcpConfig.test.ts --runInBand
- npm run build

## Manual test
- Verified in a test vault that the Codex setup button adds Nexus to the Codex app config successfully.