### PR TITLE
feat(apps): Data Analysis app — runPython sandbox + lossless spreadsheet round-trip (desktop-only)

### DIFF
--- a/docs/plans/sandboxed-code-execution-app-plan.md
+++ b/docs/plans/sandboxed-code-execution-app-plan.md
@@ -1,0 +1,378 @@
+# Sandboxed Data Analysis App — Implementation Plan
+
+**Status**: Proposed (design blessed, pre-implementation)
+**Branch**: `claude/nexus-sandboxed-execution-SjoDA`
+**Author**: design session 2026-05-31
+**Type**: New app agent (`src/agents/apps/dataAnalysis/`) — **desktop-only**
+
+---
+
+## 1. Goal
+
+A **Data Analysis app**: the user (or the AI) writes **Python** that runs against
+**CSV and Excel (`.xlsx`)** data from the vault, using the real **pandas** stack,
+inside a sandbox that **cannot break out** — no host filesystem, no network, no
+Obsidian API, no process spawning. Data goes *in*, a bounded result comes *out*.
+
+Canonical flows:
+- "What's the average spend by category in `budget.csv`?"
+- "In `Q3.xlsx`, pivot revenue by region and month."
+- "Reconcile `a.csv` and `b.csv` — which IDs are missing from each?"
+
+Ships as an **app agent** (`BaseAppAgent`), toggleable from Apps settings,
+registered through the existing `AppManager` → `registerDynamicAgent` →
+ToolManager flow like `ComposerAgent`/`WebToolsAgent`.
+
+### Platform: desktop-only (decided 2026-05-31)
+
+Precedent exists — ingestion, composer, and web-tools are already desktop-only.
+This unlocks Pyodide/pandas without the mobile-weight risk (§3). The app must
+**not register or load anything on mobile**; tools guard with `isDesktop()`
+(as `webTools/.../captureToMarkdown.ts:48` does), and all Pyodide imports are
+lazy so module init never touches Node/heavy code on a phone.
+
+### Non-goals
+
+- **No vault API inside the sandbox.** The guest never touches `vault.*`. The
+  *host* reads the file and writes its bytes into the sandbox's in-memory FS.
+- **No network inside the sandbox.** Network globals are scrubbed before any
+  user code runs (§4).
+- **No "call other Nexus tools" bridge.** Pure analysis. Compose with other
+  agents at the edges (read → analyze → present).
+- **No *user-driven* runtime package installation.** A fixed, preloaded package
+  set: `pandas` + `numpy` (+ `python-dateutil`/`pytz`/`six` deps) loaded via
+  `loadPackage`, plus `openpyxl` + `et_xmlfile` installed once at startup via
+  `micropip` (+ `packaging`) — see Phase 0 findings: openpyxl is pure-Python and
+  not in the Pyodide distribution. No *user* `micropip`/`loadPackage` at runtime.
+
+---
+
+> **Phase 0 spike (2026-05-31): GO.** Validated with Pyodide 0.29.4 / pandas 2.3.3 /
+> openpyxl 3.1.5 — network-scrub lockdown blocks `js.fetch`, MEMFS isolates the host
+> disk, real `read_csv` + `read_excel` round-trip works, marshalling + 1500-row cap
+> work, ~21MB first-load, ~3.3s cold-start, and **fully offline vendoring** confirmed
+> (CDN was blocked; sourced from npm + GitHub release + PyPI). Full results:
+> `docs/plans/spike-findings-pyodide-2026-05-31.md`. Remaining checks are
+> Electron-worker-specific (terminate-timeout, memory cap, no-Node-in-worker).
+
+## 2. Engine decision: Pyodide + pandas
+
+### How we got here (recorded so review doesn't relitigate)
+
+1. **Native Electron execution** (`eval`/`vm`/`Function`) — rejected: runs in the
+   plugin's own realm → instant total breakout; Node's `vm` is explicitly not a
+   security boundary; all `undefined` on mobile.
+2. **QuickJS-in-WASM + JS libs (Arquero/SheetJS)** — strong: caged-by-default,
+   light (~1MB), mobile-safe. Rejected as primary **because** the app is now
+   framed as *data analysis* with Excel, and pandas' ergonomics/robustness for
+   messy real-world spreadsheets decisively beat a hand-assembled JS dataframe
+   stack — and desktop-only removes QuickJS's mobile/weight advantages.
+3. **Pyodide + pandas** — chosen: the gold-standard data stack, first-class
+   `read_csv`/`read_excel`, and (given desktop-only) its weight is acceptable.
+
+| | QuickJS + JS libs | **Pyodide + pandas (chosen)** |
+|---|---|---|
+| Excel (.xlsx) | inject SheetJS (~800KB) | `pandas.read_excel` + openpyxl — first-class |
+| Dataframes/pivot/join | Arquero (pure-JS) | pandas — gold standard, AI writes it fluently |
+| Sandbox posture | caged by default | **caged by configuration** — must lock down (§4) |
+| One-time download | ~1MB | **~20–25MB** (core + pandas/numpy/openpyxl), cached |
+| Cold start | ms | **seconds** (runtime init + imports) |
+| Mobile | fine | heavy/risky → **desktop-only** |
+
+### ⚠️ The critical caveat: Pyodide is NOT sandboxed by default
+
+Unlike QuickJS, Pyodide exposes a **`js` bridge** — Python can do
+`import js; js.fetch(...)` and reach the host JS global scope. So isolation is
+something we **build**, not something we get for free. §4 is therefore the most
+important part of this plan; if it's done wrong, there is no sandbox.
+
+---
+
+## 3. WASM/asset delivery
+
+Pyodide is not a single `.wasm` — it's `pyodide.asm.js` + `pyodide.asm.wasm` +
+`python_stdlib.zip` + package wheels (pandas, numpy, openpyxl). It's designed to
+load these from an `indexURL`.
+
+**Build:** the Pyodide loader glue stays small in `main.js` (the heavy wasm/wheels
+are never bundled, so the 5MB `main.js` ceiling is unaffected). `.wasm` loader is
+already `file` in `esbuild.config.mjs:70`.
+
+**Delivery (desktop-only → network-at-first-use is acceptable):**
+- **v1 — lazy CDN load.** On first use, `loadPyodide({ indexURL: <jsDelivr,
+  pinned version> })` and `loadPackage(['pandas','openpyxl'])`. Show a one-time
+  "Setting up the Python data environment… (~20MB, happens once)" `Notice`,
+  modeled on `WasmEnsurer`'s UX. Rely on Electron HTTP cache for subsequent runs.
+- **v2 (follow-up) — vendor locally.** Use `desktopRequire('node:fs')` to cache
+  the Pyodide files + wheels into `{plugin.manifest.dir}/pyodide/` on first run,
+  then point `indexURL` at the local folder for offline/repeatable loads —
+  the spirit of `WasmEnsurer` (check-exists → download-if-missing) extended to a
+  directory of assets.
+
+> **Spike item:** confirm the cleanest local-`indexURL` strategy in Electron
+> (file:// vs reading bytes via fs and feeding the worker). v1 CDN load is the
+> de-risking baseline; v2 is an enhancement, not a blocker.
+
+---
+
+## 4. Sandboxing Pyodide — the lockdown recipe
+
+Because Pyodide isn't caged by default, confinement is an explicit construction:
+
+1. **Run Pyodide in a dedicated Web Worker.** Separate realm, no DOM, and in
+   Electron Workers have **no Node integration by default**
+   (`nodeIntegrationInWorker` is off) — so no `require`, no `fs`,
+   no `child_process` reachable from the worker.
+2. **In-memory FS only.** Pyodide's default FS is MEMFS (in-memory), isolated
+   from real disk. We **never mount NODEFS**. The host writes input bytes via
+   `pyodide.FS.writeFile('/data/input.xlsx', bytes)`; Python file I/O stays
+   inside the virtual FS. `open('/etc/passwd')` hits the VFS, not the disk.
+3. **Scrub network globals after load, before user code.** Pyodide needs `fetch`
+   during *load* (to pull packages). Immediately after `loadPackage` and before
+   running any untrusted code, null out the worker's network surface:
+   `self.fetch = self.XMLHttpRequest = self.WebSocket = self.importScripts =
+   undefined`. Then `import js; js.fetch` resolves to `undefined` — no
+   exfiltration path. (Also why runtime `loadPackage` is disallowed — it would
+   need the very `fetch` we removed.)
+4. **Timeout = `worker.terminate()`.** A runaway loop is killed deterministically
+   by tearing down the worker (cleaner than an interrupt handler). The next run
+   spins a fresh worker.
+5. **Memory ceiling.** Configure a max WASM memory on the Pyodide Emscripten
+   module so a memory bomb throws rather than growing unbounded. (Pyodide's hard
+   cap is imperfect — document the residual risk; the worker teardown is the
+   backstop.)
+6. **Bounded I/O.** Input size cap (§6) before injection; output row cap (§6) on
+   the returned value.
+
+This is "caged by configuration" done deliberately — the worker boundary + no
+Node + scrubbed network + MEMFS-only is the sandbox.
+
+---
+
+## 5. Architecture & data flow
+
+```
+User: "average spend by category in budget.csv"
+        │
+        ▼
+runAnalysis tool (TRUSTED HOST, desktop-only)
+  1. isDesktop() guard
+  2. resolve inputPath via existing ContentManager + isValidPath()
+  3. read file bytes in the host (vault stays host-side)
+  4. ensure Pyodide worker is up (lazy first-use load + scrub, §3/§4)
+  5. FS.writeFile('/data/<name>', bytes)  — inject data, not capability
+  6. runPythonAsync(userCode) with a worker.terminate() timeout
+  7. marshal result → enforce maxRows cap (§6) → JSON
+        │
+        ▼
+Pyodide worker (UNTRUSTED GUEST) — no Node, no network, MEMFS-only
+  import pandas as pd
+  df = pd.read_csv('/data/budget.csv')      # or read_excel for .xlsx
+  result = df.groupby('category')['amount'].mean().reset_index()
+  result.to_dict(orient='records')           # → host
+        │
+        ▼
+CommonResult { success, data: [...≤1500 rows...], logs, stats }
+```
+
+The guest's entire view of the world: the bytes the host placed in `/data/`,
+the preloaded pandas/numpy/openpyxl, and a captured stdout. No vault, no
+network, no host filesystem.
+
+### File layout (mirrors `ComposerAgent`)
+
+```
+src/agents/apps/dataAnalysis/
+  DataAnalysisAgent.ts          # BaseAppAgent; manifest (no creds); registers tools; desktop-only
+  types.ts
+  tools/
+    runAnalysis.ts              # extends BaseTool; isDesktop() guard
+    listCapabilities.ts         # (optional) advertise pandas/read_excel etc. to the AI
+  services/
+    PyodideSandbox.ts           # worker lifecycle, lockdown (§4), FS injection, marshalling
+    pyodide.worker.ts           # the Web Worker entry: loadPyodide + scrub + run
+    PyodideEnsurer.ts           # (v2) local vendoring of pyodide assets, WasmEnsurer-style
+```
+
+### Registration (one line + standard app wiring)
+
+- `AppManager.getBuiltInAppRegistry()` (`src/services/apps/AppManager.ts:~229`):
+  ```ts
+  if (isDesktop()) registry.set('data-analysis', () => new DataAnalysisAgent());
+  ```
+- Flows through `AgentRegistrationService` Phase 3 → `syncToolManagerAgent` →
+  `registerDynamicAgent`. Manifest declares **no credentials**.
+
+---
+
+## 6. Input & output caps
+
+**Output row cap (your 1500-row guardrail).** JSONSchema validates inputs, not
+computed outputs, so this is a **host-side guardrail on the returned value**,
+documented in the tool description so the AI knows the rule up front:
+- `maxRows` param, default **1500** (overridable to a hard ceiling).
+- After the guest returns, if the result is a row collection > `maxRows` →
+  **reject** with: *"Result has 8,432 rows (max 1500). Aggregate
+  (groupby/pivot/describe) or add a filter/limit and re-run."*
+- The error returns to the AI, which rewrites toward a **summary** — pushing
+  every query toward aggregation instead of dumping rows into chat context.
+
+**Input size cap.** A large file still has to fit the memory budget even if the
+output is one number. Enforce a max input-bytes limit (e.g. ~10MB, configurable)
+before injecting into the worker FS; reject oversized inputs with guidance to
+pre-filter.
+
+**Output persistence (optional).** Since the guest can't touch the vault, an
+optional `outputPath` lets the **host** read a result back out of the worker FS
+(or take the returned table) and write it to the vault post-run — enabling
+"analyze the sheet **and save a report**" without granting the guest vault access.
+
+---
+
+## 7. `runAnalysis` tool contract
+
+**Params** (`getMergedSchema` over common context fields):
+| field | type | notes |
+|---|---|---|
+| `code` | string (required) | Python. Returns a JSON-serializable value (e.g. `df...to_dict('records')`). |
+| `inputs` | `{ name: path }` map (optional) | host reads each via `isValidPath` + ContentManager, writes to `/data/<name>` in the worker FS. Supports multi-file (joins/reconcile). |
+| `maxRows` | number (default 1500, hard max e.g. 10000) | output row guardrail (§6). |
+| `maxInputBytes` | number (default ~10MB) | input size guardrail (§6). |
+| `timeoutMs` | number (default ~5000, hard max ~30000) | worker-terminate budget. |
+| `outputPath` | string (optional) | host writes the result/produced file to the vault post-run. |
+
+**Result** (`CommonResult`):
+```jsonc
+{
+  "success": true,
+  "data": [ /* ≤ maxRows records, or a scalar/object */ ],
+  "logs": ["...captured Python stdout..."],
+  "stats": { "durationMs": 820, "rowsReturned": 12, "loadedFromCache": true }
+}
+```
+On error/timeout/OOM/over-cap: `{ success: false, error: "<message + Python traceback>" }`.
+
+**`getStatusLabel`**: `verbs('Analyzing data', 'Analyzed data', 'Analysis failed')`.
+
+---
+
+## 8. Threat model & confinement
+
+| Vector | Mitigation |
+|---|---|
+| Read host filesystem | Worker has no Node; Pyodide FS is MEMFS-only; never mount NODEFS. |
+| Path traversal on input | host validates `inputPath` via `isValidPath()` before read; guest can't request paths. |
+| Network exfiltration (`import js; js.fetch`) | `fetch`/`XHR`/`WebSocket`/`importScripts` scrubbed from worker scope after load, before user code. |
+| Spawn processes | no `child_process` reachable in a no-Node worker. |
+| Runaway loop hangs UI | runs off the main thread; `worker.terminate()` at `timeoutMs`. |
+| Memory bomb | max WASM memory configured; worker teardown as backstop. |
+| Host-scope escape via `js` bridge | network scrubbed; no vault/Obsidian objects ever passed into the worker. |
+| Output context blow-up | `maxRows` cap + input-bytes cap + truncation flags. |
+| Mobile crash from heavy/Node code | desktop-only registration + `isDesktop()` guard + lazy imports. |
+
+**Residual risks to document:** Pyodide's memory hard-cap is imperfect (teardown
+is the backstop); CPU is bounded by wall-clock, not a fair scheduler; the `js`
+bridge lockdown must be audited on every Pyodide version bump (a new global could
+reintroduce a network path) — pin the version and re-verify the scrub on upgrade.
+
+---
+
+## 9. Implementation phases
+
+**Phase 0 — Spike (de-risk before committing):**
+- Stand up Pyodide in a Web Worker; `loadPackage(['pandas','openpyxl'])`; run
+  `read_csv` and `read_excel` on injected bytes; prove `worker.terminate()`
+  timeout; **prove the network scrub** (assert `import js; js.fetch` is dead).
+  **Measure** first-load download size + cold-start time + warm-run time. Gate
+  the rest on this.
+
+**Phase 1 — Sandbox service:** `PyodideSandbox.ts` + `pyodide.worker.ts` —
+lifecycle, lockdown (§4), FS injection, stdout capture, result marshalling,
+traceback surfacing. Unit-tested.
+
+**Phase 2 — Delivery:** v1 lazy CDN load with one-time Notice; confirm `main.js`
+delta is small. (v2 local vendoring deferred.)
+
+**Phase 3 — App + tool:** `DataAnalysisAgent` + `runAnalysis` (+ optional
+`listCapabilities`), desktop-only registration, `inputs` host-read wiring,
+`maxRows`/`maxInputBytes`/`outputPath` enforcement.
+
+**Phase 4 — Tests & docs:** sandbox-escape tests (no network, no NODEFS,
+traversal rejected, terminate kills loops), pandas CSV+Excel integration,
+row-cap + input-cap behavior, desktop-only guard. Changelog + app doc.
+
+---
+
+## 10. Open questions for review
+
+1. **Delivery UX** — is a ~20MB one-time CDN download (cached) acceptable for
+   v1, or is local vendoring (v2) needed up front for offline users?
+2. **Default caps** — `maxRows` 1500 / `timeoutMs` 5000 / `maxInputBytes` 10MB —
+   tune?
+3. **Package set** — pandas + numpy + openpyxl for v1. Add anything (e.g.
+   `python-dateutil` is a pandas dep already; `xlrd` for legacy `.xls`)?
+4. **Result conventions** — require user code to return a JSON-serializable value
+   explicitly, or auto-`to_dict`/`json.dumps` a trailing DataFrame?
+5. **Worker reuse** — keep a warm worker between runs (fast, but state could leak
+   between analyses) vs fresh worker per run (clean, slower)? Leaning fresh-per-run
+   for isolation, with the Pyodide *runtime* cached.
+
+---
+
+## 11. Why this fits Nexus
+
+- **App, not base tool** — toggleable, dynamically registered, desktop-only like
+  existing heavy apps; zero base-tool changes.
+- **Reuses patterns** — `BaseAppAgent`/`BaseTool`, `isValidPath`, the
+  `WasmEnsurer`/`desktopRequire` lazy-asset ethos, and the existing iframe/worker
+  isolation precedent (transformers.js, `esbuild.config.mjs:93`).
+- **Honestly sandboxed** — confinement is explicit and audited (worker + no Node
+  + scrubbed network + MEMFS-only), not assumed. The vault is never exposed to
+  the guest; the host mediates all I/O at the edges.
+- **Real analysis power** — pandas + Excel, with a row-cap guardrail that keeps
+  results summary-shaped and context-cheap.
+
+---
+
+## 12. Audit response (2026-05-31)
+
+An adversarial audit reviewed the implementation. **Fixed in code** (host-side,
+unit-tested):
+- **Concurrency (was HIGH):** runs are now serialized through a queue — Pyodide
+  isn't reentrant and the worker is reused; a timeout terminating the worker can
+  no longer corrupt or hang a concurrent run.
+- **Partial-install gate (was HIGH):** bootstrap now always runs the idempotent,
+  per-file ensurer, so an interrupted download can't pass a `pyodide.js`-only
+  presence check then fail at load.
+- **Row-cap bypass (was HIGH):** added a universal serialized-byte output budget
+  (default 512KB) on top of the row cap, so `{rows:[...]}` / `to_dict()` shapes
+  can't dump unbounded data.
+- **Marshalling (was HIGH):** results are now serialized **in Python** with a
+  numpy/pandas/datetime-aware encoder (NaN→null, int64→number, Timestamp→iso),
+  validated against those cases in a spike — no more BigInt throws or silent
+  corruption.
+- **Mediums:** index-prefixed input filenames (no silent overwrite on name
+  collision), blob-URL revoked after init (not synchronously), worker init
+  listener leak fixed, `/data` cleared per run, capability list derived from one
+  constant.
+
+**Security posture — the honest version (was the BLOCKER).** Pyodide is *not*
+caged by default. The lockdown was hardened from a 4-name denylist to a
+realm-wide scrub (delete network globals across `self`/`globalThis`/the prototype
+chain + drop Python network modules). **But in-realm scrubbing cannot stop a
+determined attacker re-deriving globals via `Function("return this")()`.** So the
+accepted threat model is:
+
+> **Prevent the AI's analysis code from *accidentally/incidentally* reaching the
+> network or vault — not run hostile third-party code.**
+
+For "run untrusted code safely" you'd need an OS/process sandbox, which is a
+different, much larger project. The realm scrub + no-Node-worker + MEMFS-only +
+terminate-timeout is strong *defense-in-depth* for the accidental-egress model,
+and must still be **pen-tested in a real Electron worker** (the `Function`-ctor,
+captured-reference, `sendBeacon`, dynamic-`import()` vectors) before any
+"sandboxed" claim is made in user-facing copy.
+
+**Still pending (needs a real Obsidian desktop build):** the four Electron
+runtime items (no-Node-in-worker, terminate-timeout, file:// importScripts +
+local indexURL load, live asset download) plus the security pen-test above.

--- a/docs/plans/spike-findings-hucre-2026-05-31.md
+++ b/docs/plans/spike-findings-hucre-2026-05-31.md
@@ -1,0 +1,76 @@
+# Spike Findings — `hucre` as the lossless xlsx write-back engine (2026-05-31)
+
+Companion to `docs/plans/spreadsheet-mirror-versioning-plan.md` (§3.5, §11 S2).
+Spike run headless in Node 22 against `hucre@0.6.0` in a throwaway dir (the repo
+`package.json`/lock were **not** touched).
+
+## Verdict: GO — with hucre vendored as a runtime asset (not bundled into main.js)
+
+## 1. Bundle size (measured via esbuild, minified, `--platform=browser`)
+
+| Entry | Minified | Gzip |
+|---|---|---|
+| `hucre/xlsx` (only what we need) | **308,714 B (~302 KB)** | 84,982 B |
+| `hucre` (full) | 416,245 B | 118,180 B |
+
+Current `main.js` = 4,776,436 B → **headroom to 5,000,000 B is only 223,564 B (~218 KB).**
+The xlsx-only entry (302 KB) **exceeds headroom by ~85 KB**, so it **cannot be
+bundled into main.js**. In a single-file Obsidian CJS build even a dynamic
+`import()` is inlined, so lazy-import does NOT help.
+
+**Decision: vendor hucre as a runtime asset**, the same pattern the Data Analysis
+app uses for Pyodide (`PyodideEnsurer`/`PyodideAssets`): ship/load the prebuilt
+`hucre/xlsx` bundle as a separate file loaded at runtime (desktop-gated). Cost in
+main.js ≈ 0. Package facts: MIT, **zero runtime deps**, ESM, `unpackedSize`
+2.79 MB (all formats — irrelevant once we vendor only the xlsx bundle).
+
+## 2. Lossless preservation — EMPIRICALLY VALIDATED
+
+Test: created a workbook with `writeXlsx`, injected a sentinel unmanaged part
+`xl/charts/chart1.xml` via jszip (stand-in for a chart/drawing), then
+`openXlsx → edit a data cell (100→999) → saveXlsx`, and re-inspected:
+
+```
+_rawEntries has chart part?      true
+chart part preserved byte-identical: true
+data cell EMEA amount now:        999  (expected 999)
+VERDICT: PASS — lossless edit + chart preserved
+```
+
+Mechanism (confirmed in the type defs and at runtime):
+- `openXlsx(bytes) → RoundtripWorkbook` carries **`_rawEntries: Map<path, bytes>`**
+  (every original ZIP part) + **`_modifiedParts: Set<path>`** + original
+  `_contentTypes`/`_rootRels` + a `hasMacros` flag.
+- `saveXlsx(wb)` regenerates **only** the parts in `_modifiedParts`; everything
+  else is written back from `_rawEntries` **byte-for-byte**. Charts/images/pivots/
+  drawings survive because we never rebuild them.
+
+## 3. API notes for the write-back implementation
+
+- Public surface: `import { openXlsx, saveXlsx, readXlsx, writeXlsx } from 'hucre/xlsx'`.
+- `openXlsx`/`saveXlsx` take/return `Uint8Array` → trivial to wire to vault binary
+  read/write host-side.
+- **Important: editing `sheet.rows[r][c]` does NOT auto-mark the part dirty.** The
+  write-back must explicitly `wb._modifiedParts.add('xl/worksheets/sheetN.xml')`
+  for each sheet it changed. This fits our delta model (we already know which
+  sheets/cells changed) but must be done deliberately.
+- **VBA/macros**: `hasMacros` true → output is XLSM content types; save with
+  `.xlsm`. The guard/write path must honor the original extension.
+- Runs headless in Node 22 (CompressionStream) → write-back is **unit-testable
+  without Electron**.
+
+## 4. Still open (needs real workbooks / Electron, not blocking the GO)
+
+- **Enumerate the 8/135 unsupported features** and confirm the pre-scan guard
+  (plan §6) refuses them rather than dropping silently. (This spike validated the
+  *preservation* path for an unmanaged part; it did not enumerate the gaps.)
+- Real-world fidelity pass on actual chart/pivot/conditional-formatting workbooks.
+- Confirm the vendored-asset load path works in the Electron renderer (mirrors the
+  Pyodide-asset Electron caveat).
+- Pin `hucre` at a known version (pre-1.0; expect API churn).
+
+## Reproduction
+
+Throwaway dir, `npm i hucre@0.6.0`; esbuild the `hucre/xlsx` entry minified for
+size; round-trip script uses `writeXlsx` + jszip-injected sentinel part +
+`openXlsx`/`saveXlsx`/`readXlsx`. (Scripts not committed — gitignored spike dir.)

--- a/docs/plans/spike-findings-pyodide-2026-05-31.md
+++ b/docs/plans/spike-findings-pyodide-2026-05-31.md
@@ -1,0 +1,135 @@
+# Phase 0 Spike Findings — Pyodide Data Analysis App
+
+**Date**: 2026-05-31
+**Branch**: `claude/nexus-sandboxed-execution-SjoDA`
+**Pyodide version**: 0.29.4 (Python 3.13, `pandas` 2.3.3, `numpy` 2.2.5, `openpyxl` 3.1.5)
+**Where run**: Node 22 (headless Linux container). See "Validity & caveats" for what this
+does and does NOT prove vs. a real Electron Web Worker.
+
+**Verdict: GO.** Every high-risk item the spike was meant to kill came back green —
+the security lockdown holds, real pandas + Excel work, delivery is ~21MB and works
+fully offline. Remaining unknowns are browser-worker-specific and low-risk.
+
+---
+
+## 1. What was validated (results)
+
+### Security lockdown — the crux (core spike)
+The make-or-break for Pyodide is that it is **not** caged by default (the `js`
+bridge proxies the host global scope). The planned mitigation — scrub network
+globals after load, before user code — was tested directly:
+
+| Check | Result |
+|---|---|
+| Python sees `js.fetch` **before** scrub | `REACHABLE` |
+| Python sees `js.fetch` **after** scrubbing host `fetch`/`XHR`/`WebSocket` | `undefined` — **BLOCKED ✓** |
+| Guest reads real host disk (`/home/user/nexus/package.json`) via `os.path.exists` | `isolated` — **no leak ✓** (default FS is in-memory MEMFS) |
+| 8,432-row result vs `maxRows=1500` guardrail | **REJECTED ✓** with the aggregate-or-limit message |
+| 3-row result vs cap | passed ✓ |
+
+→ The "worker + no Node + scrubbed network + MEMFS-only" lockdown is mechanically sound.
+
+### Real pandas + Excel (pandas spike)
+| Step | Result | Time |
+|---|---|---|
+| `pd.read_csv` (injected bytes) + `groupby` + `pivot_table` | correct output | ~2.9s (first pandas call, includes import warmup) |
+| **`pd.read_excel` round-trip** (pandas writes `.xlsx` via openpyxl, reads it back) | correct revenue-by-product | **~0.5s** |
+| DataFrame → JS records marshalling (`.to_dict('records')` → `.toJs`) | `rows=6`, clean JS objects | **7ms** |
+
+→ The exact `runAnalysis` data path — host injects bytes into MEMFS → pandas reads →
+compute → marshal JSON back — works end to end for **both CSV and Excel**.
+
+### Timings (Node; treat as ballpark for Electron)
+| Phase | Time |
+|---|---|
+| Core runtime cold-start | ~1.7s |
+| `loadPackage(pandas + numpy + deps)` from local | ~1.1s |
+| `micropip` install openpyxl from local | ~0.4s |
+| **Total cold-start w/ pandas + Excel ready** | **~3.3s** |
+| Warm re-run (runtime hot) | 7–9ms |
+
+→ Confirms the "seconds of cold-start" assumption. Mitigation: load lazily on first
+use behind a one-time Notice; keep the runtime warm across runs.
+
+---
+
+## 2. Delivery — measured sizes, and a correction
+
+Real, measured first-load footprint (none of this touches the 5MB `main.js` —
+delivered out-of-band exactly like `sqlite3.wasm`):
+
+| Asset | Size |
+|---|---|
+| Core: `pyodide.asm.wasm` | 8.6 MB |
+| Core: `python_stdlib.zip` | 2.4 MB |
+| Core: `pyodide.asm.js` + loader | ~1.1 MB |
+| `pandas` wheel | 4.3 MB |
+| `numpy` wheel | 2.7 MB |
+| `python-dateutil` + `pytz` + `six` | ~0.7 MB |
+| `micropip` + `packaging` | ~0.2 MB |
+| `openpyxl` + `et_xmlfile` | ~0.27 MB |
+| **Total first-load** | **≈ 21 MB** (matches the plan's ~20–25MB estimate) |
+
+**Correction to the plan's package set:** `openpyxl` (and its dep `et_xmlfile`) are
+**not** in the Pyodide distribution — they're pure-Python, installed via **`micropip`**.
+So Excel support requires shipping/availability of **`micropip` + `packaging` +
+`openpyxl` + `et_xmlfile`** in addition to `pandas`. The plan's "package set" and
+"delivery" sections are updated accordingly.
+
+**Offline vendoring is proven.** In this sandbox the jsDelivr CDN was blocked
+(`host_not_allowed`), so all assets were sourced **without the CDN**:
+- Core runtime: the `pyodide` **npm package** (13 MB) — bundles wasm + stdlib + loader.
+- Compiled wheels (pandas/numpy/…): the **GitHub release tarball** `pyodide-0.29.4.tar.bz2`.
+- Pure-Python wheels (openpyxl/et_xmlfile): **PyPI** (`files.pythonhosted.org`).
+
+This directly validates the plan's **§3 v2 local-vendoring** delivery path: we can
+ship/cache a curated wheel set into the plugin folder and run **100% offline** via a
+local `indexURL` — a stronger story than CDN-only. In the user's real Obsidian
+environment the CDN is normally reachable for the simpler v1 lazy-load path.
+
+---
+
+## 3. Validity & caveats — what still needs an Electron check
+
+This spike ran in **Node**, which is itself not a sandbox (Node has `fs`/`require`).
+What it proves is the **mechanisms**, which are environment-independent:
+- the `js`-bridge network scrub kills the network capability ✓
+- MEMFS does not expose real disk by default ✓
+- the inject → compute → marshal → row-cap data-flow is correct for CSV **and** Excel ✓
+- delivery sizes/timings and offline vendoring ✓
+
+**Still to validate in a real Electron/browser Web Worker (low risk, but required
+before shipping):**
+1. **Worker isolation in Electron** — confirm a Worker has no Node integration
+   (`nodeIntegrationInWorker` off) so `require`/`fs`/`child_process` are truly absent.
+2. **`worker.terminate()` timeout** — kill a runaway `while True:` deterministically
+   (can't terminate the main-thread runtime in a Node CLI; this is the proper mechanism).
+3. **Memory hard-cap** — configure max WASM memory so a memory bomb throws; confirm
+   teardown is a clean backstop.
+4. **Local `indexURL` wiring in Electron** — serve the vendored wheels to the worker
+   (file:// vs feeding bytes); confirm offline load.
+
+---
+
+## 4. Plan deltas applied
+
+- §2/§9: cold-start measured (~3.3s with pandas+Excel); warm runs <10ms.
+- §3: real sizes (~21MB); openpyxl/et_xmlfile need micropip+packaging; offline
+  vendoring confirmed; CDN (v1) vs local-vendor (v2) both viable.
+- Open questions: default caps confirmed reasonable; package set finalized as
+  `pandas, numpy, (deps), micropip, packaging, openpyxl, et_xmlfile`.
+- Remaining Phase-0 follow-ups narrowed to the four Electron-worker items above.
+
+## 5. Reproduction
+The spike scripts are **not committed** (`docs/plans/*` is gitignored for non-`.md`
+files). To reproduce in a scratch dir:
+1. `npm i pyodide@0.29.4` (core runtime + loader, ~13MB).
+2. Compiled wheels (pandas/numpy/deps/micropip/packaging): extract from the GitHub
+   release tarball `pyodide-0.29.4.tar.bz2` into the package dir.
+3. Pure-Python wheels (openpyxl/et_xmlfile): download from PyPI.
+4. In Node: `loadPyodide()` → `loadPackage(['pandas','micropip'])` →
+   `micropip.install(['emfs:/…openpyxl…whl'], false)`; inject CSV/XLSX bytes via
+   `pyodide.FS.writeFile`; run pandas; assert the network scrub
+   (`import js; js.fetch` → `undefined`) and the Python marshaller (NaN→null,
+   datetime→iso, int64→number). All asset filenames/URLs are pinned in
+   `src/agents/apps/dataAnalysis/services/PyodideEnsurer.ts`.

--- a/docs/plans/spreadsheet-mirror-manual-test.md
+++ b/docs/plans/spreadsheet-mirror-manual-test.md
@@ -45,20 +45,34 @@ in the vault. Ask the AI (or call the tool) `mirrorWorkbook { path: "budget.xlsx
   `.part0/.part1/…` with contiguous row ranges.
 - Re-running mirror on the unchanged file reports `regenerated: false`.
 
-## 4. Edit + write back
+## 4. Edit → AUTOMATIC write-back
 
-Edit a **data** cell in a `.partN.csv` (e.g. change an amount). Then
-`applyToWorkbook { path: "budget.xlsx", dryRun: true }` → review the summary
-(`cellsApplied`, sample before→after, `cellsBlocked`). Then run without `dryRun`.
+The round-trip is **automatic**: editing any mirror `.partN.csv` triggers a
+debounced (~1.5s) write-back to the source `.xlsx` — no explicit tool call needed.
+Edit a CSV two ways:
+
+- **With pandas (code edits the CSV):** `runAnalysis` with `outputPath` pointing at
+  a mirror shard and a `.csv` extension, e.g.
+  `inputs:{data:"Nexus/spreadsheets/budget/Data.part0.csv"}`,
+  `outputPath:"Nexus/spreadsheets/budget/Data.part0.csv"`, code that returns a list
+  of rows/records (`df.to_dict("records")`). The result is written as CSV.
+- **With CRUD:** `contentManager replace/insert` on the `.partN.csv` text.
+
+Either way, ~1.5s after the edit settles:
 
 **Expect:**
-- The `.xlsx` updates with your value, and — critically — **the chart and all
-  formatting survive** when you open it in Excel. (This is the whole point of
-  hucre vs openpyxl.)
-- A snapshot appears under `spreadsheets/budget/_archive/<ts>/`.
-- The mirror re-projects (manifest `sourceHash` changes; CSVs reflect the new state).
-- ❗ Open the file in Excel and confirm formulas downstream of your edit
-  **recalculate** (hucre writes values, Excel recalcs on open).
+- A Notice: "Synced N change(s) to budget.xlsx …".
+- The `.xlsx` updates, and — critically — **the chart and all formatting survive**
+  when you open it in Excel (the whole point of hucre vs openpyxl).
+- A snapshot under `spreadsheets/budget/_archive/<ts>/`.
+- The mirror re-projects (manifest `sourceHash` changes) **without looping**
+  (the watcher suppresses its own re-projection writes).
+- ❗ In Excel, confirm formulas downstream of your edit **recalculate** (hucre
+  writes values; Excel recalcs on open).
+
+`applyToWorkbook` still exists for a **manual/preview** path — call it with
+`dryRun: true` to see the change set, or `force: true` to override the divergence
+guard — but you don't need it for the normal flow.
 
 ## 5. Guard checks
 

--- a/docs/plans/spreadsheet-mirror-manual-test.md
+++ b/docs/plans/spreadsheet-mirror-manual-test.md
@@ -16,7 +16,7 @@ Copy `main.js` + `manifest.json` + `styles.css` into
 ## 1. Enable the app
 
 Settings → **Apps** → enable **Data Analysis** (desktop-only). It exposes four
-tools: `runAnalysis`, `listCapabilities`, **`mirrorWorkbook`**, **`applyToWorkbook`**.
+tools: `runPython`, `listCapabilities`, **`mirrorWorkbook`**, **`applyToWorkbook`**.
 
 ## 2. First-run engine download (the riskiest new path)
 
@@ -51,7 +51,7 @@ The round-trip is **automatic**: editing any mirror `.partN.csv` triggers a
 debounced (~1.5s) write-back to the source `.xlsx` — no explicit tool call needed.
 Edit a CSV two ways:
 
-- **With pandas (code edits the CSV):** `runAnalysis` with `outputPath` pointing at
+- **With pandas (code edits the CSV):** `runPython` with `outputPath` pointing at
   a mirror shard and a `.csv` extension, e.g.
   `inputs:{data:"Nexus/spreadsheets/budget/Data.part0.csv"}`,
   `outputPath:"Nexus/spreadsheets/budget/Data.part0.csv"`, code that returns a list

--- a/docs/plans/spreadsheet-mirror-manual-test.md
+++ b/docs/plans/spreadsheet-mirror-manual-test.md
@@ -1,0 +1,90 @@
+# Spreadsheet Mirror + Write-back — Manual Test Guide (Obsidian desktop)
+
+What to run once the branch is built/deployed into a real Obsidian desktop vault.
+Everything below the unit layer (hucre download + Blob-import, real `.xlsx`
+parsing, vault binary write) is **first-run validation** — it has not executed
+outside the headless test container.
+
+## 0. Build + deploy
+
+```
+npm run build          # main.js ~4.79MB (<5MB); hucre is NOT bundled
+```
+Copy `main.js` + `manifest.json` + `styles.css` into
+`<vault>/.obsidian/plugins/nexus/` (or `npm run deploy`). Reload Obsidian.
+
+## 1. Enable the app
+
+Settings → **Apps** → enable **Data Analysis** (desktop-only). It exposes four
+tools: `runAnalysis`, `listCapabilities`, **`mirrorWorkbook`**, **`applyToWorkbook`**.
+
+## 2. First-run engine download (the riskiest new path)
+
+The first `mirrorWorkbook`/`applyToWorkbook` call triggers a one-time download of
+the hucre engine (~300 KB) from esm.sh into
+`.obsidian/plugins/nexus/hucre/hucre-xlsx.mjs`, then loads it via a Blob-URL ESM
+import. **Verify:**
+- A Notice "Setting up the spreadsheet engine — downloading once…" appears, then
+  "Spreadsheet engine ready."
+- The file lands in the `hucre/` folder and is ~300 KB.
+- ❗ If the load fails, the likely culprits are (a) esm.sh `?bundle` not producing a
+  self-contained file, or (b) Electron CSP blocking the Blob import. Fallbacks:
+  pre-vendor the file manually, or switch the load to `file://` import.
+
+## 3. Mirror a workbook
+
+Put a real `budget.xlsx` (multiple sheets, some **formulas**, ideally a **chart**)
+in the vault. Ask the AI (or call the tool) `mirrorWorkbook { path: "budget.xlsx" }`.
+
+**Expect:** `<Nexus root>/spreadsheets/budget/` containing `manifest.json` and
+`<Sheet>.part0.csv` per sheet. Check:
+- Sheet order + `rowCount`/`colCount` look right.
+- `manifest.sheets[].formulaCells` is **non-empty** for sheets with formulas
+  (this proves the XML formula-scan works → the write-back guard is active).
+- A large sheet (>`maxShardBytes`, default per Settings → Data) splits into
+  `.part0/.part1/…` with contiguous row ranges.
+- Re-running mirror on the unchanged file reports `regenerated: false`.
+
+## 4. Edit + write back
+
+Edit a **data** cell in a `.partN.csv` (e.g. change an amount). Then
+`applyToWorkbook { path: "budget.xlsx", dryRun: true }` → review the summary
+(`cellsApplied`, sample before→after, `cellsBlocked`). Then run without `dryRun`.
+
+**Expect:**
+- The `.xlsx` updates with your value, and — critically — **the chart and all
+  formatting survive** when you open it in Excel. (This is the whole point of
+  hucre vs openpyxl.)
+- A snapshot appears under `spreadsheets/budget/_archive/<ts>/`.
+- The mirror re-projects (manifest `sourceHash` changes; CSVs reflect the new state).
+- ❗ Open the file in Excel and confirm formulas downstream of your edit
+  **recalculate** (hucre writes values, Excel recalcs on open).
+
+## 5. Guard checks
+
+- **Formula guard:** edit a cell that `manifest.formulaCells` lists → `applyToWorkbook`
+  should report it under `cellsBlocked`/`blockedFormulaCells` and NOT overwrite it.
+- **Divergence guard:** edit `budget.xlsx` directly in Excel after mirroring, then
+  `applyToWorkbook` → expect `reason: "divergence"` (refused). `force: true` overrides.
+- **No-op:** apply with no CSV edits → `reason: "no-changes"`.
+
+## 6. Known gaps to watch (from the plan §11/§12)
+
+- **Sheet→worksheet-part mapping** is the sorted-Nth `sheetN.xml` approximation.
+  On a multi-sheet workbook, confirm edits land on the RIGHT sheet and the right
+  sheet's formulas are detected. If not, the precise fix is workbook-rels mapping.
+- **`.xlsm`/macros:** a macro workbook should keep working; confirm the write-back
+  doesn't corrupt it (hucre flags `hasMacros`).
+- **hucre's 8/135 unsupported features:** if a workbook uses one, the write-back may
+  not round-trip it — the plan calls for a pre-scan refusal (not yet implemented).
+  For now, eyeball exotic workbooks after write-back.
+
+## 7. What's already proven (don't re-test)
+
+Headless unit tests cover: CSV (de)serialization + sharding, mirror generation
+(idempotency, stale-shard cleanup sparing `_archive/`, name collisions), the diff
++ formula-guard + coercion, the write-back orchestration (apply/dryRun/divergence/
+no-op/snapshot/re-project), the formula-cell XML scan, and hucre's byte-intact
+preservation of an unmanaged part (spike S2). The manual pass is specifically about
+the **Electron-bound edges**: engine download/load, real `.xlsx` fidelity, and the
+vault binary write.

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -137,6 +137,15 @@ TypeScript over `hucre`**, *outside* Pyodide:
 We **do not need openpyxl in this flow** (it stays in the existing Data Analysis
 app for pandas xlsx reads). No Python on the write path, no formula engine.
 
+**Spike-validated (2026-05-31, `docs/plans/spike-findings-hucre-2026-05-31.md`):**
+lossless preservation proven empirically — an unmanaged ZIP part (chart stand-in)
+survived a data-cell edit byte-for-byte via `openXlsx`/`saveXlsx` (`_rawEntries` +
+`_modifiedParts` model). Runs headless in Node 22 → unit-testable without Electron.
+**Bundle: the `hucre/xlsx` entry is 302 KB minified vs only ~218 KB main.js
+headroom → it must be VENDORED as a runtime asset** (PyodideEnsurer pattern),
+costing ~0 in main.js. Write-back must explicitly mark `_modifiedParts` per edited
+sheet (cell edits don't auto-dirty), and honor `hasMacros`→`.xlsm`.
+
 ### 3.6 Data flow
 
 ```
@@ -268,13 +277,13 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
 - **Phase 0 — Spikes (gate the effort):**
   - **S1**: Extract `SnapshotArchiveService` from `SkillWriteService`; assert
     byte-identical archive output (no Skills behavior change).
-  - **S2 (hucre evaluation)**: load a formula-bearing, multi-sheet, **chart- and
-    pivot-bearing** workbook; apply a value edit to a data cell; save; confirm
-    (a) charts/images/pivots/formatting **survive byte-intact**, (b) formulas stay
-    live, (c) **enumerate the 8/135 unsupported features** and confirm the
-    pre-scan flags them, (d) **bundle-size impact vs the main.js <5MB budget**
-    (hucre is zero-dep/tree-shakeable but must be measured), (e) round-trip on
-    real-world workbooks. Pin the version (pre-1.0).
+  - **S2 (hucre evaluation) — partially DONE 2026-05-31**
+    (`spike-findings-hucre-2026-05-31.md`): ✅ byte-intact preservation of an
+    unmanaged part through a data-cell edit; ✅ bundle measured (302 KB xlsx-only
+    → **vendor as runtime asset**, not in main.js); ✅ headless API confirmed.
+    **Remaining**: enumerate the 8/135 unsupported features + confirm the §6
+    pre-scan refuses them; real-world chart/pivot/conditional-format fidelity
+    pass; Electron asset-load path; pin the (pre-1.0) version.
 - **Phase 1** — Mirror generation (hucre read → sharded values-CSV + manifest).
 - **Phase 2** — Lossless write-back (`applyToWorkbook`) — hucre apply, formula
   guard, `dryRun`, snapshot-then-replace, re-projection.
@@ -290,7 +299,9 @@ audit/restore for a path that hasn't proven out in Obsidian.
   gate adoption on spike S2, keep `@protobi/exceljs` as fallback.
 - **Silent loss on an unsupported feature** if the §6 pre-scan misses one of
   hucre's 8 gaps — spike S2 must enumerate them.
-- **Bundle budget** — must measure hucre's footprint against main.js <5MB.
+- **Bundle budget** — measured (S2): `hucre/xlsx` is 302 KB vs ~218 KB headroom,
+  so it is **vendored as a runtime asset**, not bundled. Residual: confirm the
+  Electron asset-load path (same caveat as Pyodide assets).
 - **Divergence corruption** if the §7 conflict guard is skipped.
 - **Scope creep** — three independently useful pieces (SnapshotArchiveService,
   event log, mirror+apply). Phase-0 spikes gate Phases 1–4.

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -291,6 +291,17 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
     pre-scan refuses them; real-world chart/pivot/conditional-format fidelity
     pass; Electron asset-load path; pin the (pre-1.0) version.
 - **Phase 1** — Mirror generation (hucre read → sharded values-CSV + manifest).
+  - **Core DONE 2026-05-31** (`src/agents/apps/dataAnalysis/spreadsheet/`,
+    11 tests in `SpreadsheetMirror.test.ts`): pure projection — RFC-4180 `csv.ts`,
+    byte-budget `shard.ts`, `WorkbookMirrorService` (idempotent via `sourceHash`,
+    stale-shard cleanup that spares `_archive/`, sheet-name collision
+    disambiguation), the `XlsxSource` seam + `HucreXlsxSource` value mapping
+    (loader-injected, unit-tested with a fake module), and the pinned
+    `HucreAssets` manifest. main.js unchanged — hucre is not bundled.
+  - **Remaining (Electron-bound)**: the `HucreEnsurer` fetch/load mechanics
+    (download the vendored `hucre/xlsx` bundle + `import(file://…)`), real
+    formula-cell detection via `openXlsx` cell inspection, and the
+    `mirrorWorkbook` tool wiring into the Data Analysis app.
 - **Phase 2** — Lossless write-back (`applyToWorkbook`) — hucre apply, formula
   guard, `dryRun`, snapshot-then-replace, re-projection.
 - **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore UI (§8).

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -1,0 +1,248 @@
+# Spreadsheet Mirror + Versioning — Implementation Plan
+
+Status: DRAFT (design, pre-spike). Owner: TBD. Created 2026-05-31.
+Companion to `docs/plans/sandboxed-code-execution-app-plan.md` (the Data Analysis app this builds on).
+
+## 1. Goal
+
+Let the AI clean / normalize / pattern-edit spreadsheet data on a plain-text
+surface, and have those edits flow back into the real `.xlsx` **without
+destroying the things CSV can't represent** (formulas, number formats, multi-sheet
+structure). Add CRUA-faithful version history so every edit is reversible and
+queryable.
+
+The workflow we're enabling, end to end:
+
+1. AI reads a spreadsheet (already works — Data Analysis app).
+2. AI cleans / normalizes a cell range or pattern match in pandas.
+3. Edits are applied back to the workbook **as deltas**, preserving untouched
+   formulas/formatting.
+4. Every apply leaves a restore point + an audit trail.
+
+### Non-goals
+
+- Not a live two-way Excel sync. The mirror is generated/regenerated; Excel is
+  not assumed to be edited concurrently (see §7 conflict policy).
+- Not preserving charts/images/pivots/VBA through a write-back (openpyxl drops
+  them — see §6). We **detect and refuse** rather than silently destroy.
+- Not mobile. The xlsx legs are desktop-only (Pyodide/openpyxl), same gate as
+  the Data Analysis app.
+
+## 2. What we already have (de-risking)
+
+- **openpyxl + et_xmlfile are already vendored** by `PyodideEnsurer.ts` (fetched
+  as wheels, offline micropip-installed from the local `indexUrl`). The xlsx
+  read/write engine is in the runtime today — **zero new asset work.**
+- **Pyodide + pandas** loaded offline from a `file://` indexURL.
+- The network-scrubbed worker already has a micropip-init allowlist
+  (`pyodideWorkerSource.ts`) that closes after package install.
+- **`archiveThenReplace`** (version-in-place snapshot) exists in
+  `SkillWriteService` — the primitive we'll extract (§4).
+- **Hybrid JSONL→SQLite** storage with per-entity event tables (states, tasks) —
+  the pattern the event log reuses (§5).
+
+## 3. Architecture
+
+### 3.1 Folder-per-workbook mirror
+
+One workbook → one mirror folder (multi-sheet forces a container):
+
+```
+budget.xlsx                          ← the real artifact, RETAINED as fidelity anchor
+<mirror-root>/budget/
+  manifest.json                      ← sheet order, source hash, per-cell type sidecar
+  Sheet1.csv                         ← values only — the AI's edit + analysis surface
+  Sheet2.csv
+  _archive/
+    Sheet1.<ts>.csv                  ← snapshots (shared SnapshotArchiveService, §4)
+```
+
+- `manifest.json` is load-bearing: CSV files are an unordered set, so it records
+  **sheet order**, the **source `.xlsx` content hash** (divergence detection, §7),
+  and a lightweight **per-cell type sidecar** for fidelity (§6.3).
+- **Mirror-root location**: default to a hidden plugin-data subfolder (avoids
+  vault clutter and Excel-opens-the-csv confusion); configurable. Decision
+  deferred to spike — see §10 Q1.
+
+### 3.2 The CSV is the value surface; the xlsx is the formula store
+
+This is the core decision and it resolves the "can we keep formulas in the CSV?"
+question. **No** — a single CSV grid can hold either the formula text or the
+computed value per cell, never both, and the formula text isn't analyzable. So:
+
+- **CSV = values only** → the AI can analyze/normalize numerically.
+- **Original `.xlsx` = formula/format store** → retained, never thrown away.
+- **Sync = delta-apply**: only the cells the AI *changed* are written into the
+  original workbook. Untouched cells (including all formulas/formatting) are
+  preserved automatically because openpyxl rewrites them verbatim on save.
+
+Cells the AI changed get the new literal value (correct — a normalized constant
+overwrites whatever was there). Cells it didn't touch keep their formula.
+
+### 3.3 Data flow
+
+```
+xlsx ──openpyxl(read)──▶ values CSVs + manifest (mirror)        [generate/refresh]
+CSVs ──AI edits (CRUD / Data Analysis app)──▶ edited CSVs        [edit]
+edited CSVs ─diff vs mirror─▶ changed-cell set                   [diff]
+changed-cell set ──openpyxl(load original, set cells, save)──▶ xlsx   [sync / write-back]
+                  + snapshot prior xlsx + CSV  (§4)
+                  + append spreadsheet_edit events (§5)
+```
+
+The **single guarded boundary** is the sync step. Everything funnels through it,
+and it's where all the guardrails (§6) live.
+
+## 4. DRY archive — extract `SnapshotArchiveService`
+
+The repo has **three distinct things named "archive"** (verified by grep):
+
+| Flavor | Semantics | Where today | Convention |
+|---|---|---|---|
+| Soft-archive **flag** | reversible `isArchived` status, entity stays | states/workspaces/prompts/tasks/skills (99 refs) | a flag, not files |
+| **Relocate**-archive | **moves** note/folder out | `StorageManager.archive` tool | `.archive/<ts>/<path>` |
+| **Version-in-place** | **copies** prior bytes, live file stays | `SkillWriteService.archiveThenReplace` | `_archive/<name>.<ts>` |
+
+- The **soft-flag** archive is a repository/event convention, not extractable
+  code — do NOT unify it (would be the wrong abstraction; cf. the CLAUDE.md
+  ToolManager-bridge pin: don't extract speculatively).
+- **Spreadsheet versioning needs version-in-place** (the live CSV/xlsx stays;
+  snapshot the prior state). That's the `archiveThenReplace` semantics.
+
+**The DRY move** (triggered now because spreadsheets are the *second* consumer):
+
+1. Extract a shared `SnapshotArchiveService` from `SkillWriteService`:
+   `archiveCopy(path, { archiveDir, timestampFn, hashFn })` — copies current
+   bytes to a timestamped archive destination, ensures the dir.
+2. Optionally expose `archiveMove(path, ...)` over the same primitive so
+   `StorageManager.archive` *could* share the dir/timestamp helper — but keep
+   each consumer's **convention** (`.archive/<ts>/` vs `_archive/<name>.<ts>`),
+   since those paths are observable behavior. Move-vs-copy stays explicit.
+3. Rewire Skills to the shared service with **no behavior change** (Phase 0
+   spike asserts byte-identical archive output).
+
+## 5. Versioning — snapshot + event log (complementary, not redundant)
+
+Two layers, both CRUA-faithful (archive = soft/reversible; nothing auto-hard-deletes):
+
+- **Snapshot archive** (`SnapshotArchiveService`, §4): coarse, byte-exact restore
+  points of the prior xlsx (and/or CSV) before each apply. Restore = un-archive.
+- **Event log**: fine-grained `spreadsheet_edit` events
+  `{ workbook, sheet, range|pattern, before, after, ts, hash }`.
+  - **JSONL = source of truth** (append-only, matches tasks/states).
+  - **Mirrored into a new SQLite table** for query ("every edit to Sheet1 this
+    week"). This is a **v14 migration + one table** — not new infrastructure.
+
+Snapshot answers "put it back"; event log answers "what changed and when".
+
+## 6. Fidelity findings + guardrails (from research, 2026-05-31)
+
+### 6.1 What openpyxl load→save preserves
+Cell values, **formulas** (default; `data_only=False`), styles, number formats,
+comments, hyperlinks, sheet dimensions/properties. → delta-apply is safe for these.
+
+### 6.2 What openpyxl load→save **destroys** — HARD GUARDRAIL
+**Charts, images, shapes** are dropped on save. Pivot tables, rich text
+(unless `rich_text=True`), and VBA (unless `keep_vba=True`, and then not editable)
+are also lossy. → **Pre-scan the original workbook before write-back**
+(`ws._charts`, `ws._images`, `wb.vba_archive`, pivot caches). If any are present,
+**refuse the silent write-back** and require explicit `acknowledgeLossy: true`
+(or write to a new file). We never silently destroy a user's charts.
+
+### 6.3 Type fidelity (CSV round-trip)
+pandas/CSV coerces types (leading-zero ZIPs, dates, big ints, NaN). Mitigations:
+- Mirror generation records each cell's **original type** in the manifest sidecar.
+- On apply, a changed cell is written **preserving the original cell's data type
+  where the new value is compatible** (e.g. keep a ZIP as text), else inferred.
+- Spike to validate (§10 Q2).
+
+### 6.4 Recalc staleness
+openpyxl writes values but does **not** evaluate formulas, so a formula
+downstream of an edited cell holds a stale cached result. Mitigation: set
+`workbook.calculation.fullCalcOnLoad = True` on save → Excel recomputes on open.
+
+## 7. Sync / conflict policy
+
+- Mirror carries the **source `.xlsx` hash** in its manifest.
+- Before generating/refreshing the mirror or applying a write-back, compare the
+  current xlsx hash to the stored one.
+  - Match → safe to proceed.
+  - Mismatch (user edited the xlsx in Excel since last mirror) → **do not blind
+    last-writer-wins**. Surface the divergence; offer re-mirror (discard CSV
+    edits) or refuse pending user choice. Spreadsheets are higher-stakes than
+    the Skills mirror, so default to **warn + require explicit resolution**.
+- One writer at a time through the sync boundary (serialize, like `runAnalysis`).
+
+## 8. Tool contracts (draft)
+
+Likely additive to the Data Analysis app (desktop-only), final shape TBD:
+
+- `mirrorWorkbook({ path })` → generates/refreshes the folder-per-workbook mirror;
+  returns sheet list + manifest summary. Idempotent (hash-gated).
+- `applyToWorkbook({ workbook, sheets?, dryRun?, overwrite?, acknowledgeLossy? })`
+  → diffs edited CSVs vs mirror, delta-applies to the retained xlsx via openpyxl,
+  snapshots + logs events. `dryRun` returns the change summary (cells changed,
+  before→after samples, lossy-content warnings) without writing.
+- History/restore surfaced via existing CRUA patterns + the event log.
+
+`dryRun` default-on for the first apply of a session is under consideration
+(overwriting a workbook is hard to reverse).
+
+## 9. Platform
+
+Desktop-only for all xlsx legs (Pyodide/openpyxl). The values-CSV editing surface
+could be cross-platform via CRUD, but mirror generation and write-back are gated
+behind `isDesktop()`, consistent with the Data Analysis app.
+
+## 10. Open questions for review
+
+- **Q1 — Mirror location**: hidden plugin-data subfolder (clean, but invisible to
+  the user) vs co-located beside the xlsx (visible/syncable, but clutters the
+  vault and risks the user opening the CSV by mistake). Lean: plugin-data,
+  configurable.
+- **Q2 — Type fidelity depth**: is the per-cell type sidecar enough, or do we need
+  a richer typed-cell manifest? Spike with a ZIP/date/bigint-heavy sheet.
+- **Q3 — Lossy-content default**: refuse-by-default vs write-to-copy-by-default
+  when charts/images/pivots are present.
+- **Q4 — Event-log granularity**: per-cell events (precise, verbose) vs
+  per-range/per-operation events (compact, coarser audit).
+- **Q5 — Restore UX**: reuse the States-style management UI, or a dedicated
+  spreadsheet-history view?
+
+## 11. Implementation phases
+
+- **Phase 0 — Spikes (gate the whole effort):**
+  - **S1**: Extract `SnapshotArchiveService` from `SkillWriteService`; assert
+    byte-identical archive output (no Skills behavior change).
+  - **S2**: openpyxl-in-Pyodide round-trip — load a formula-bearing, multi-sheet,
+    formatted workbook; delta-apply a value edit to a formula's dependency cell;
+    save; confirm (a) untouched formulas/formats survive, (b) charts/images
+    detection works, (c) `fullCalcOnLoad` triggers recalc, (d) type fidelity on
+    ZIP/date/bigint cells.
+- **Phase 1** — Mirror generation + manifest + values-CSV (`mirrorWorkbook`).
+- **Phase 2** — Delta-apply write-back (`applyToWorkbook`) with `dryRun`, lossy
+  guardrails, `fullCalcOnLoad`, snapshot-then-replace.
+- **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore surface.
+- **Phase 4** — Conflict/divergence policy (§7) + settings/UI.
+
+Event-log and conflict policy are deferred behind a working write-back so we
+don't build audit/restore for a path that hasn't proven out in Obsidian.
+
+## 12. Risks
+
+- **Silent fidelity loss** if the lossy-content guardrail (§6.2) is incomplete —
+  highest-severity risk; must be spike-validated against real workbooks.
+- **Divergence corruption** if conflict policy (§7) is skipped — blind
+  last-writer-wins could clobber Excel edits.
+- **Scope creep** — this is a subsystem (3 independently useful pieces:
+  SnapshotArchiveService, event log, mirror+apply). Phase 0 spikes must pass
+  before committing to Phases 1-4.
+- **Verified by unit/spike only** until manually exercised in Obsidian desktop
+  (same caveat as the Data Analysis app's Electron-runtime items).
+
+## Sources (fidelity research)
+
+- [openpyxl tutorial — what is preserved/lost on save](https://openpyxl.readthedocs.io/en/3.1/tutorial.html)
+- [openpyxl users — keeping style/format when editing](https://groups.google.com/g/openpyxl-users/c/eZ2HfCLPrJo)
+- [openpyxl data_only / cached formula values](https://groups.google.com/g/openpyxl-users/c/TWbBZjLj8Q0)
+- [openpyxl workbook.properties — CalcProperties / fullCalcOnLoad](https://openpyxl.readthedocs.io/en/3.1/api/openpyxl.workbook.properties.html)

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -304,6 +304,19 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
     `mirrorWorkbook` tool wiring into the Data Analysis app.
 - **Phase 2** — Lossless write-back (`applyToWorkbook`) — hucre apply, formula
   guard, `dryRun`, snapshot-then-replace, re-projection.
+  - **Core DONE 2026-05-31** (6 tests in `SpreadsheetWriteBack.test.ts`):
+    `csv.ts` gains RFC-4180 `parseCsv` + `cellToRaw`; `diff.ts` (cell diff on the
+    unquoted string form, A1 refs, formula-cell partition, original-type
+    coercion); `WorkbookWriteBackService` orchestrates read-original → divergence
+    guard → diff edited shards → formula guard → dryRun/no-op → snapshot via
+    `SnapshotArchiveService` → hucre apply → re-project. `HucreXlsxWriter` encodes
+    the spike's `_modifiedParts` marking behind an injected module (unit-tested
+    with a JSON-as-xlsx fake so the real orchestration runs end-to-end). The
+    actual `.xlsx` binary write to the vault is returned to the caller
+    (Electron `writeBinary`).
+  - **Remaining (Electron-bound)**: precise sheet→worksheet-part mapping via
+    workbook rels (currently best-effort sorted-Nth), the vault binary write +
+    `.xlsm` handling, and `applyToWorkbook` tool wiring.
 - **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore UI (§8).
 - **Phase 4** — Conflict/divergence policy (§7) + settings.
 

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -298,10 +298,13 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
     disambiguation), the `XlsxSource` seam + `HucreXlsxSource` value mapping
     (loader-injected, unit-tested with a fake module), and the pinned
     `HucreAssets` manifest. main.js unchanged — hucre is not bundled.
-  - **Remaining (Electron-bound)**: the `HucreEnsurer` fetch/load mechanics
-    (download the vendored `hucre/xlsx` bundle + `import(file://…)`), real
-    formula-cell detection via `openXlsx` cell inspection, and the
-    `mirrorWorkbook` tool wiring into the Data Analysis app.
+  - **Integration DONE 2026-05-31**: `HucreEnsurer` (download esm.sh `?bundle` →
+    `hucre/` folder → Blob-URL ESM import, cached); real formula-cell detection
+    via worksheet-XML scan in `HucreXlsxSource` (guard now active); `mirrorWorkbook`
+    tool wired into the Data Analysis app (desktop-gated, vault binary read,
+    `resolveVaultRoot`+`maxShardBytes` from runtime ctx). Build clean; hucre NOT
+    bundled (main.js +15 KB tool code only). **Needs first-run Electron validation —
+    see `spreadsheet-mirror-manual-test.md`.**
 - **Phase 2** — Lossless write-back (`applyToWorkbook`) — hucre apply, formula
   guard, `dryRun`, snapshot-then-replace, re-projection.
   - **Core DONE 2026-05-31** (6 tests in `SpreadsheetWriteBack.test.ts`):
@@ -314,9 +317,10 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
     with a JSON-as-xlsx fake so the real orchestration runs end-to-end). The
     actual `.xlsx` binary write to the vault is returned to the caller
     (Electron `writeBinary`).
-  - **Remaining (Electron-bound)**: precise sheet→worksheet-part mapping via
-    workbook rels (currently best-effort sorted-Nth), the vault binary write +
-    `.xlsm` handling, and `applyToWorkbook` tool wiring.
+  - **Integration DONE 2026-05-31**: `applyToWorkbook` tool wired (dryRun/force,
+    vault `writeBinary` of the new `.xlsx`, snapshot + re-project). Remaining to
+    validate in Electron: precise sheet→worksheet-part mapping via workbook rels
+    (currently best-effort sorted-Nth) and `.xlsm` round-trip — see manual-test doc.
 - **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore UI (§8).
 - **Phase 4** — Conflict/divergence policy (§7) + settings.
 

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -275,8 +275,14 @@ the pandas analysis is desktop-only. v1 gates the whole feature behind
 ## 11. Implementation phases
 
 - **Phase 0 — Spikes (gate the effort):**
-  - **S1**: Extract `SnapshotArchiveService` from `SkillWriteService`; assert
-    byte-identical archive output (no Skills behavior change).
+  - **S1 — DONE 2026-05-31**: Extracted `SnapshotArchiveService`
+    (`src/services/storage/SnapshotArchiveService.ts`) — the generic version-in-place
+    snapshot primitive (timestamp + same-instant disambiguation + skip-`_`/`.` tree
+    copy). `SkillWriteService.archiveThenReplace` now delegates to it, keeping the
+    SKILL.md gate + `null` contract. No-behavior-change proven: the existing
+    `SkillWriteService.test.ts` stays green; +4 direct tests in
+    `SnapshotArchiveService.test.ts`. Full Skills+archive sweep 127/127, build+lint
+    clean, main.js unchanged.
   - **S2 (hucre evaluation) — partially DONE 2026-05-31**
     (`spike-findings-hucre-2026-05-31.md`): ✅ byte-intact preservation of an
     unmanaged part through a data-cell edit; ✅ bundle measured (302 KB xlsx-only

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -1,97 +1,156 @@
 # Spreadsheet Mirror + Versioning — Implementation Plan
 
-Status: DRAFT (design, pre-spike). Owner: TBD. Created 2026-05-31.
+Status: DRAFT (design complete, pre-spike). Owner: TBD. Created 2026-05-31.
 Companion to `docs/plans/sandboxed-code-execution-app-plan.md` (the Data Analysis app this builds on).
+
+> Design decisions below were worked through and locked 2026-05-31. The only
+> remaining gates are the Phase-0 spikes (§11).
 
 ## 1. Goal
 
 Let the AI clean / normalize / pattern-edit spreadsheet data on a plain-text
-surface, and have those edits flow back into the real `.xlsx` **without
-destroying the things CSV can't represent** (formulas, number formats, multi-sheet
-structure). Add CRUA-faithful version history so every edit is reversible and
-queryable.
+surface, and have those edits flow back into the real `.xlsx` **losslessly** —
+preserving formulas, formatting, **and charts/images/pivots**. Add CRUA-faithful
+version history so every edit is reversible and queryable.
 
-The workflow we're enabling, end to end:
+End-to-end workflow:
 
 1. AI reads a spreadsheet (already works — Data Analysis app).
-2. AI cleans / normalizes a cell range or pattern match in pandas.
-3. Edits are applied back to the workbook **as deltas**, preserving untouched
-   formulas/formatting.
-4. Every apply leaves a restore point + an audit trail.
+2. AI cleans / normalizes a cell range or pattern match in pandas (optionally via
+   a reusable **Skill**).
+3. Changed cells are applied back to the workbook **as deltas**, leaving every
+   untouched part — including charts — byte-intact.
+4. Every apply leaves a restore point + an audit trail; the mirror is re-projected
+   from the updated workbook.
 
 ### Non-goals
 
-- Not a live two-way Excel sync. The mirror is generated/regenerated; Excel is
-  not assumed to be edited concurrently (see §7 conflict policy).
-- Not preserving charts/images/pivots/VBA through a write-back (openpyxl drops
-  them — see §6). We **detect and refuse** rather than silently destroy.
-- Not mobile. The xlsx legs are desktop-only (Pyodide/openpyxl), same gate as
-  the Data Analysis app.
+- **No formula engine.** We never evaluate or flatten Excel formulas (§3.4).
+- **No chart *creation*** from scratch — only **preservation** of existing charts
+  through edits (the engine, §3.5, gives us this).
+- **No PNG/visibility extraction** of charts — the user views charts in Excel;
+  the AI doesn't need them rendered. (Considered and dropped.)
+- Not a live two-way Excel sync — the mirror is a generated projection (§3.3),
+  with a divergence guard (§7), not a concurrently-edited store.
+- **v1 desktop-only** (the pandas analysis is Pyodide/desktop). Note the
+  mirror+write-back legs are pure TS and *could* go mobile later (§9).
 
 ## 2. What we already have (de-risking)
 
-- **openpyxl + et_xmlfile are already vendored** by `PyodideEnsurer.ts` (fetched
-  as wheels, offline micropip-installed from the local `indexUrl`). The xlsx
-  read/write engine is in the runtime today — **zero new asset work.**
-- **Pyodide + pandas** loaded offline from a `file://` indexURL.
-- The network-scrubbed worker already has a micropip-init allowlist
-  (`pyodideWorkerSource.ts`) that closes after package install.
-- **`archiveThenReplace`** (version-in-place snapshot) exists in
-  `SkillWriteService` — the primitive we'll extract (§4).
-- **Hybrid JSONL→SQLite** storage with per-entity event tables (states, tasks) —
-  the pattern the event log reuses (§5).
+- **Vault-root synced folder + resolver**: `storage.rootPath` (default `Nexus`,
+  renameable in Settings → Data) resolved via `resolveVaultRoot(settings)`
+  (`VaultRootResolver.ts`). Skills already mirror under it. Hands back
+  `maxShardBytes` — our file-size cap is already a configured storage concern.
+- **Pyodide + pandas** (Data Analysis app) for the analysis/cleaning compute.
+- **`archiveThenReplace`** (version-in-place snapshot) in `SkillWriteService` —
+  the primitive we extract (§4).
+- **Hybrid JSONL→SQLite** storage with per-entity event tables (states, tasks) +
+  **sharding** precedent (`shard_cursors`, v12) — the pattern the event log and
+  the CSV sharding reuse (§3.2, §5).
+- **App settings-section framework** (`AppCustomSection` + `SkillsSectionRenderer`,
+  `BoxedSection`, `ConfirmModal`) — the UI we recycle for history/restore (§8).
 
 ## 3. Architecture
 
-### 3.1 Folder-per-workbook mirror
+### 3.1 Location & layout (Q1 — LOCKED)
 
-One workbook → one mirror folder (multi-sheet forces a container):
-
-```
-budget.xlsx                          ← the real artifact, RETAINED as fidelity anchor
-<mirror-root>/budget/
-  manifest.json                      ← sheet order, source hash, per-cell type sidecar
-  Sheet1.csv                         ← values only — the AI's edit + analysis surface
-  Sheet2.csv
-  _archive/
-    Sheet1.<ts>.csv                  ← snapshots (shared SnapshotArchiveService, §4)
-```
-
-- `manifest.json` is load-bearing: CSV files are an unordered set, so it records
-  **sheet order**, the **source `.xlsx` content hash** (divergence detection, §7),
-  and a lightweight **per-cell type sidecar** for fidelity (§6.3).
-- **Mirror-root location**: default to a hidden plugin-data subfolder (avoids
-  vault clutter and Excel-opens-the-csv confusion); configurable. Decision
-  deferred to spike — see §10 Q1.
-
-### 3.2 The CSV is the value surface; the xlsx is the formula store
-
-This is the core decision and it resolves the "can we keep formulas in the CSV?"
-question. **No** — a single CSV grid can hold either the formula text or the
-computed value per cell, never both, and the formula text isn't analyzable. So:
-
-- **CSV = values only** → the AI can analyze/normalize numerically.
-- **Original `.xlsx` = formula/format store** → retained, never thrown away.
-- **Sync = delta-apply**: only the cells the AI *changed* are written into the
-  original workbook. Untouched cells (including all formulas/formatting) are
-  preserved automatically because openpyxl rewrites them verbatim on save.
-
-Cells the AI changed get the new literal value (correct — a normalized constant
-overwrites whatever was there). Cells it didn't touch keep their formula.
-
-### 3.3 Data flow
+Mirrors live under the **resolved Nexus root**, a sibling of `skills/`/`data/`/
+`guides/`, so they inherit the user's rename, the sync guarantee (non-hidden vault
+folder), and path validation:
 
 ```
-xlsx ──openpyxl(read)──▶ values CSVs + manifest (mirror)        [generate/refresh]
-CSVs ──AI edits (CRUD / Data Analysis app)──▶ edited CSVs        [edit]
-edited CSVs ─diff vs mirror─▶ changed-cell set                   [diff]
-changed-cell set ──openpyxl(load original, set cells, save)──▶ xlsx   [sync / write-back]
-                  + snapshot prior xlsx + CSV  (§4)
-                  + append spreadsheet_edit events (§5)
+<resolveVaultRoot(settings).resolvedPath>/        ← e.g. "Nexus/" (renameable, synced)
+  spreadsheets/
+    budget/
+      manifest.json            ← sheet order, source-xlsx hash, shard index, formula-cell map
+      Sheet1.part0.csv         ← values only — the AI's edit + analysis surface
+      Sheet1.part1.csv         ← sharded to maxShardBytes (the 5MB cap)
+      Sheet2.part0.csv
+      _archive/
+        Sheet1.part0.<ts>.csv  ← value-level snapshots (SnapshotArchiveService, §4)
 ```
 
-The **single guarded boundary** is the sync step. Everything funnels through it,
-and it's where all the guardrails (§6) live.
+### 3.2 5MB-per-file cap → sharded CSVs (LOCKED)
+
+A sheet can exceed the cap, so each sheet's CSV **shards to `maxShardBytes`**
+(reusing the existing storage sharding discipline). `manifest.json` is the **shard
+index**: sheet order, per-shard row ranges, reassembly order, and the source hash.
+The event-log JSONL shards the same way as it grows.
+
+### 3.3 The CSV is a *projection*; the xlsx is the source of truth (LOCKED)
+
+The mirror is **not** a parallel store — it's a regenerated view:
+
+```
+edit CSV ──apply (changed cells)──▶ xlsx (source of truth) ──re-project──▶ fresh CSV mirror
+```
+
+After every write-back we re-project the CSVs from the updated workbook, so the
+mirror always reflects canonical state. Because the projection is small + sharded
+(<cap), **we snapshot the CSV projection, not the big xlsx** (value-level restore,
+§5) — the user's own file backups/sync cover byte-exact xlsx history.
+
+### 3.4 Formulas: never evaluated, never flattened (LOCKED — single mode)
+
+Two non-overlapping worlds, no toggle, no engine:
+
+- **Excel formulas stay live in the xlsx** → Excel recomputes them on open. We
+  never read, evaluate, or replace them.
+- **The AI computes what *it* needs in pandas** (optionally a saved **Skill**),
+  writing results as literal values into **data** cells.
+
+Implications:
+- **Formula-cell write guard**: by default the write-back **does not overwrite
+  formula cells** — it warns if an edit targets one. Existing formulas survive
+  automatically.
+- **Projection labels formula cells** (in `manifest.json`) as "formula output —
+  recompute from inputs if you need the current value; the cached value may be
+  stale until Excel reopens." No staleness handling beyond the label.
+- **Skills synergy**: a user's standard cleaning/analysis lives as a reusable,
+  versioned pandas Skill — computation moves out of brittle Excel formulas into
+  inspectable scripts.
+
+### 3.5 Write-back engine: `hucre` (LOCKED — research 2026-05-31)
+
+Every full read-modify-write library (openpyxl, ExcelJS, SheetJS) rebuilds the
+file from an incomplete object model and **drops charts/images/pivots**. We need
+surgical editing (touch only changed cells, leave everything else byte-intact).
+Rather than hand-roll OOXML zip surgery, we adopt **[`hucre`](https://github.com/productdevbook/hucre)**:
+
+- **MIT, zero dependencies, pure TypeScript, ESM.**
+- Round-trips **charts, images, pivots, VBA, themes, slicers, timelines** —
+  "open, modify, save — without losing charts." Covers 127/135 tracked features.
+- Runs in **browsers / Web Workers / Electron renderer** (`CompressionStream` +
+  pure-TS fallback; no Node APIs).
+- **Actively maintained**: v0.6.0 (2026-05-28), 1.4k stars, 7 releases.
+- Fallback if the spike finds gaps: **`@protobi/exceljs`** (chart/pivot-preserving
+  ExcelJS fork).
+
+**Architectural consequence — write-back leaves the sandbox.** The write-back is
+deterministic file manipulation with no untrusted code, so it runs **host-side in
+TypeScript over `hucre`**, *outside* Pyodide:
+
+- **hucre (host, TS)** → reads xlsx → sheet values (mirror gen) **and** applies
+  changed cells back losslessly.
+- **Pyodide/pandas (sandbox)** → purely the analysis compute on CSV values.
+
+We **do not need openpyxl in this flow** (it stays in the existing Data Analysis
+app for pandas xlsx reads). No Python on the write path, no formula engine.
+
+### 3.6 Data flow
+
+```
+xlsx ──hucre.read (TS host)──▶ values CSVs (sharded) + manifest      [generate/refresh]
+CSVs ──AI edits (CRUD / Data Analysis pandas / Skill)──▶ edited CSVs [edit]
+edited CSVs ─diff vs mirror─▶ changed data-cell set                 [diff]
+changed set ──hucre.apply changed cells, save (TS host)──▶ xlsx      [write-back, lossless]
+            + formula-cell write guard (§3.4)
+            + snapshot prior CSV shards (§4/§5)
+            + append spreadsheet_edit event (§5)
+            + re-project CSVs from updated xlsx (§3.3)
+```
+
+The **single guarded boundary** is the write-back step; all guardrails (§6) live there.
 
 ## 4. DRY archive — extract `SnapshotArchiveService`
 
@@ -103,146 +162,143 @@ The repo has **three distinct things named "archive"** (verified by grep):
 | **Relocate**-archive | **moves** note/folder out | `StorageManager.archive` tool | `.archive/<ts>/<path>` |
 | **Version-in-place** | **copies** prior bytes, live file stays | `SkillWriteService.archiveThenReplace` | `_archive/<name>.<ts>` |
 
-- The **soft-flag** archive is a repository/event convention, not extractable
-  code — do NOT unify it (would be the wrong abstraction; cf. the CLAUDE.md
-  ToolManager-bridge pin: don't extract speculatively).
-- **Spreadsheet versioning needs version-in-place** (the live CSV/xlsx stays;
-  snapshot the prior state). That's the `archiveThenReplace` semantics.
+- The **soft-flag** archive is a repository/event convention, not extractable code
+  — do NOT unify it (wrong abstraction; cf. the CLAUDE.md ToolManager-bridge pin).
+- **Spreadsheet versioning needs version-in-place** — the `archiveThenReplace`
+  semantics.
 
-**The DRY move** (triggered now because spreadsheets are the *second* consumer):
+**The DRY move** (triggered now — spreadsheets are the *second* consumer):
 
-1. Extract a shared `SnapshotArchiveService` from `SkillWriteService`:
-   `archiveCopy(path, { archiveDir, timestampFn, hashFn })` — copies current
-   bytes to a timestamped archive destination, ensures the dir.
-2. Optionally expose `archiveMove(path, ...)` over the same primitive so
-   `StorageManager.archive` *could* share the dir/timestamp helper — but keep
-   each consumer's **convention** (`.archive/<ts>/` vs `_archive/<name>.<ts>`),
-   since those paths are observable behavior. Move-vs-copy stays explicit.
-3. Rewire Skills to the shared service with **no behavior change** (Phase 0
-   spike asserts byte-identical archive output).
+1. Extract `SnapshotArchiveService` from `SkillWriteService`:
+   `archiveCopy(path, { archiveDir, timestampFn, hashFn })`.
+2. Optionally expose `archiveMove(...)` over the same primitive so
+   `StorageManager.archive` can share the dir/timestamp helper — but keep each
+   consumer's **convention** (move-vs-copy and path stay explicit; observable).
+3. Rewire Skills to the shared service with **no behavior change** (spike S1
+   asserts byte-identical output).
 
-## 5. Versioning — snapshot + event log (complementary, not redundant)
+## 5. Versioning — snapshot + event log
 
-Two layers, both CRUA-faithful (archive = soft/reversible; nothing auto-hard-deletes):
+Both CRUA-faithful (archive = soft/reversible; nothing auto-hard-deletes):
 
-- **Snapshot archive** (`SnapshotArchiveService`, §4): coarse, byte-exact restore
-  points of the prior xlsx (and/or CSV) before each apply. Restore = un-archive.
-- **Event log**: fine-grained `spreadsheet_edit` events
-  `{ workbook, sheet, range|pattern, before, after, ts, hash }`.
-  - **JSONL = source of truth** (append-only, matches tasks/states).
-  - **Mirrored into a new SQLite table** for query ("every edit to Sheet1 this
-    week"). This is a **v14 migration + one table** — not new infrastructure.
+- **Snapshot archive** (`SnapshotArchiveService`, §4): **value-level**, the prior
+  **CSV shards** before each apply (Q-resolved: always under the cap, diffable;
+  not byte-exact xlsx). Restore = un-archive.
+- **Event log** (Q4 — per-operation, LOCKED): one `spreadsheet_edit` event per
+  logical edit — `{ workbook, sheet, range|pattern, opSummary, cellsChanged,
+  sample[], ts, hash }` — **not** per-cell (avoids the 5000-cell explosion;
+  snapshots give exact restore). JSONL = source of truth (sharded), mirrored into
+  a **new SQLite table (v14 migration)** for query.
 
 Snapshot answers "put it back"; event log answers "what changed and when".
 
-## 6. Fidelity findings + guardrails (from research, 2026-05-31)
+## 6. Guardrails (at the write-back boundary)
 
-### 6.1 What openpyxl load→save preserves
-Cell values, **formulas** (default; `data_only=False`), styles, number formats,
-comments, hyperlinks, sheet dimensions/properties. → delta-apply is safe for these.
-
-### 6.2 What openpyxl load→save **destroys** — HARD GUARDRAIL
-**Charts, images, shapes** are dropped on save. Pivot tables, rich text
-(unless `rich_text=True`), and VBA (unless `keep_vba=True`, and then not editable)
-are also lossy. → **Pre-scan the original workbook before write-back**
-(`ws._charts`, `ws._images`, `wb.vba_archive`, pivot caches). If any are present,
-**refuse the silent write-back** and require explicit `acknowledgeLossy: true`
-(or write to a new file). We never silently destroy a user's charts.
-
-### 6.3 Type fidelity (CSV round-trip)
-pandas/CSV coerces types (leading-zero ZIPs, dates, big ints, NaN). Mitigations:
-- Mirror generation records each cell's **original type** in the manifest sidecar.
-- On apply, a changed cell is written **preserving the original cell's data type
-  where the new value is compatible** (e.g. keep a ZIP as text), else inferred.
-- Spike to validate (§10 Q2).
-
-### 6.4 Recalc staleness
-openpyxl writes values but does **not** evaluate formulas, so a formula
-downstream of an edited cell holds a stale cached result. Mitigation: set
-`workbook.calculation.fullCalcOnLoad = True` on save → Excel recomputes on open.
+- **Unsupported-feature pre-scan**: hucre covers 127/135 features. Before
+  write-back, detect any part hucre can't round-trip (the 8 gaps — spike S2
+  enumerates them) and **refuse rather than silently lose**. (Charts/images/pivots
+  are *supported*, so unlike the openpyxl path there is no chart guard needed.)
+- **Formula-cell write guard** (§3.4): don't overwrite formula cells by default.
+- **Divergence guard** (§7): source-hash mismatch blocks blind overwrite.
+- **`dryRun`**: returns the change summary (cells changed, before→after samples,
+  any refused/unsupported parts) without writing.
+- **Serialize** write-backs (one at a time), like `runAnalysis`.
 
 ## 7. Sync / conflict policy
 
-- Mirror carries the **source `.xlsx` hash** in its manifest.
-- Before generating/refreshing the mirror or applying a write-back, compare the
-  current xlsx hash to the stored one.
-  - Match → safe to proceed.
-  - Mismatch (user edited the xlsx in Excel since last mirror) → **do not blind
-    last-writer-wins**. Surface the divergence; offer re-mirror (discard CSV
-    edits) or refuse pending user choice. Spreadsheets are higher-stakes than
-    the Skills mirror, so default to **warn + require explicit resolution**.
-- One writer at a time through the sync boundary (serialize, like `runAnalysis`).
+- `manifest.json` carries the **source `.xlsx` hash**.
+- Before mirror-refresh or write-back, compare current xlsx hash to stored:
+  - Match → proceed.
+  - Mismatch (user edited the xlsx in Excel since last mirror) → **no blind
+    last-writer-wins**: surface the divergence; offer re-mirror (discard CSV
+    edits) or refuse pending the user's choice. Default **warn + require explicit
+    resolution** (spreadsheets are higher-stakes than the Skills mirror).
 
-## 8. Tool contracts (draft)
+## 8. UI — reuse, don't rebuild (Q5 — LOCKED)
 
-Likely additive to the Data Analysis app (desktop-only), final shape TBD:
+History/restore recycles the existing app-settings stack, ~no net-new components:
 
-- `mirrorWorkbook({ path })` → generates/refreshes the folder-per-workbook mirror;
-  returns sheet list + manifest summary. Idempotent (hash-gated).
-- `applyToWorkbook({ workbook, sheets?, dryRun?, overwrite?, acknowledgeLossy? })`
-  → diffs edited CSVs vs mirror, delta-applies to the retained xlsx via openpyxl,
-  snapshots + logs events. `dryRun` returns the change summary (cells changed,
-  before→after samples, lossy-content warnings) without writing.
-- History/restore surfaced via existing CRUA patterns + the event log.
+- **`AppCustomSection`** hook — the Skills app's settings-section mount; Data
+  Analysis app reuses it.
+- **`StatesSectionRenderer`** — already "a list of snapshots with restore/
+  archive/delete"; model `SpreadsheetHistorySectionRenderer` on it.
+- **`BoxedSection`** container + **`ConfirmModal`** (`confirmDangerousAction`,
+  `variant=delete`/`archive`) for restore/delete confirmation.
+- Backed by **`SnapshotArchiveService`** (§4) + the event log (§5).
+
+## 9. Tool contracts (draft)
+
+Additive to the Data Analysis app (desktop-gated for v1):
+
+- `mirrorWorkbook({ path })` → hucre-reads the xlsx, writes sharded values-CSVs +
+  manifest. Idempotent (hash-gated). Returns sheet/shard summary.
+- `applyToWorkbook({ workbook, sheets?, dryRun?, overwrite? })` → diffs edited
+  CSVs vs mirror, hucre-applies changed **data** cells (formula-cell guard),
+  snapshots prior shards, logs the op event, re-projects the mirror. `dryRun`
+  returns the summary without writing.
+- History/restore via the §8 UI + event log.
 
 `dryRun` default-on for the first apply of a session is under consideration
 (overwriting a workbook is hard to reverse).
 
-## 9. Platform
+Note: the mirror + write-back legs are pure TS (hucre) and mobile-capable; only
+the pandas analysis is desktop-only. v1 gates the whole feature behind
+`isDesktop()` for consistency; revisit a mobile editing surface later.
 
-Desktop-only for all xlsx legs (Pyodide/openpyxl). The values-CSV editing surface
-could be cross-platform via CRUD, but mirror generation and write-back are gated
-behind `isDesktop()`, consistent with the Data Analysis app.
+## 10. Resolved decisions (was "open questions")
 
-## 10. Open questions for review
-
-- **Q1 — Mirror location**: hidden plugin-data subfolder (clean, but invisible to
-  the user) vs co-located beside the xlsx (visible/syncable, but clutters the
-  vault and risks the user opening the CSV by mistake). Lean: plugin-data,
-  configurable.
-- **Q2 — Type fidelity depth**: is the per-cell type sidecar enough, or do we need
-  a richer typed-cell manifest? Spike with a ZIP/date/bigint-heavy sheet.
-- **Q3 — Lossy-content default**: refuse-by-default vs write-to-copy-by-default
-  when charts/images/pivots are present.
-- **Q4 — Event-log granularity**: per-cell events (precise, verbose) vs
-  per-range/per-operation events (compact, coarser audit).
-- **Q5 — Restore UX**: reuse the States-style management UI, or a dedicated
-  spreadsheet-history view?
+- **Q1 location** → `<root>/spreadsheets/<workbook>/` via `resolveVaultRoot`,
+  sharded to `maxShardBytes`. ✅
+- **Q2 type fidelity** → mostly dissolves: delta-apply only touches changed cells,
+  so the **retained xlsx is the type store**; only *new* cells need inference. No
+  rich typed manifest — a light formula-cell + new-cell-type map suffices. ✅
+- **Q3 lossy content** → solved by engine choice: **hucre preserves** charts/
+  images/pivots, so no refuse-on-charts. Guard only the 8 genuinely-unsupported
+  features (§6). ✅
+- **Q4 event-log granularity** → **per-operation** events + snapshots for exact
+  restore. ✅
+- **Q5 restore UX** → **reuse** the States-section stack via `AppCustomSection`. ✅
+- **Formula handling** → no engine, no flatten; preserve live + formula-cell
+  guard + label; AI/Skills recompute. ✅
+- **Engine** → **hucre** (host-side TS), fallback `@protobi/exceljs`. ✅
+- **PNG extraction** → dropped. ✅
 
 ## 11. Implementation phases
 
-- **Phase 0 — Spikes (gate the whole effort):**
+- **Phase 0 — Spikes (gate the effort):**
   - **S1**: Extract `SnapshotArchiveService` from `SkillWriteService`; assert
     byte-identical archive output (no Skills behavior change).
-  - **S2**: openpyxl-in-Pyodide round-trip — load a formula-bearing, multi-sheet,
-    formatted workbook; delta-apply a value edit to a formula's dependency cell;
-    save; confirm (a) untouched formulas/formats survive, (b) charts/images
-    detection works, (c) `fullCalcOnLoad` triggers recalc, (d) type fidelity on
-    ZIP/date/bigint cells.
-- **Phase 1** — Mirror generation + manifest + values-CSV (`mirrorWorkbook`).
-- **Phase 2** — Delta-apply write-back (`applyToWorkbook`) with `dryRun`, lossy
-  guardrails, `fullCalcOnLoad`, snapshot-then-replace.
-- **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore surface.
-- **Phase 4** — Conflict/divergence policy (§7) + settings/UI.
+  - **S2 (hucre evaluation)**: load a formula-bearing, multi-sheet, **chart- and
+    pivot-bearing** workbook; apply a value edit to a data cell; save; confirm
+    (a) charts/images/pivots/formatting **survive byte-intact**, (b) formulas stay
+    live, (c) **enumerate the 8/135 unsupported features** and confirm the
+    pre-scan flags them, (d) **bundle-size impact vs the main.js <5MB budget**
+    (hucre is zero-dep/tree-shakeable but must be measured), (e) round-trip on
+    real-world workbooks. Pin the version (pre-1.0).
+- **Phase 1** — Mirror generation (hucre read → sharded values-CSV + manifest).
+- **Phase 2** — Lossless write-back (`applyToWorkbook`) — hucre apply, formula
+  guard, `dryRun`, snapshot-then-replace, re-projection.
+- **Phase 3** — Event log (JSONL + v14 SQLite table) + history/restore UI (§8).
+- **Phase 4** — Conflict/divergence policy (§7) + settings.
 
-Event-log and conflict policy are deferred behind a working write-back so we
-don't build audit/restore for a path that hasn't proven out in Obsidian.
+Event-log/conflict/UI are deferred behind a working write-back so we don't build
+audit/restore for a path that hasn't proven out in Obsidian.
 
 ## 12. Risks
 
-- **Silent fidelity loss** if the lossy-content guardrail (§6.2) is incomplete —
-  highest-severity risk; must be spike-validated against real workbooks.
-- **Divergence corruption** if conflict policy (§7) is skipped — blind
-  last-writer-wins could clobber Excel edits.
-- **Scope creep** — this is a subsystem (3 independently useful pieces:
-  SnapshotArchiveService, event log, mirror+apply). Phase 0 spikes must pass
-  before committing to Phases 1-4.
-- **Verified by unit/spike only** until manually exercised in Obsidian desktop
-  (same caveat as the Data Analysis app's Electron-runtime items).
+- **`hucre` is pre-1.0 (v0.6.0)** — API churn + maturity risk; pin the version,
+  gate adoption on spike S2, keep `@protobi/exceljs` as fallback.
+- **Silent loss on an unsupported feature** if the §6 pre-scan misses one of
+  hucre's 8 gaps — spike S2 must enumerate them.
+- **Bundle budget** — must measure hucre's footprint against main.js <5MB.
+- **Divergence corruption** if the §7 conflict guard is skipped.
+- **Scope creep** — three independently useful pieces (SnapshotArchiveService,
+  event log, mirror+apply). Phase-0 spikes gate Phases 1–4.
+- **Verified by unit/spike only** until manually exercised in Obsidian desktop.
 
-## Sources (fidelity research)
+## Sources (research, 2026-05-31)
 
-- [openpyxl tutorial — what is preserved/lost on save](https://openpyxl.readthedocs.io/en/3.1/tutorial.html)
-- [openpyxl users — keeping style/format when editing](https://groups.google.com/g/openpyxl-users/c/eZ2HfCLPrJo)
-- [openpyxl data_only / cached formula values](https://groups.google.com/g/openpyxl-users/c/TWbBZjLj8Q0)
-- [openpyxl workbook.properties — CalcProperties / fullCalcOnLoad](https://openpyxl.readthedocs.io/en/3.1/api/openpyxl.workbook.properties.html)
+- [hucre — zero-dep TS spreadsheet engine, chart round-trip](https://github.com/productdevbook/hucre)
+- [xlsx-populate — surgical XML editing (unmaintained since 2019)](https://github.com/dtjohnson/xlsx-populate)
+- [ExcelJS #2607 — charts dropped on round-trip](https://github.com/exceljs/exceljs/issues/2607)
+- [openpyxl tutorial — charts/images lost on save](https://openpyxl.readthedocs.io/en/stable/tutorial.html)

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -85,7 +85,7 @@ explicit AI tool call. A debounced (`~1.5s`) vault `modify` watcher
 write-back when a shard changes; it suppresses its own re-projection writes
 (syncing flag + cooldown) so there's no loop. `applyToWorkbook` remains as a
 manual `dryRun`/`force` path. The AI edits the CSV either with **pandas**
-(`runAnalysis` `outputPath` ending `.csv` → tabular result written as CSV) or
+(`runPython` `outputPath` ending `.csv` → tabular result written as CSV) or
 with **ContentManager CRUD**. `mirrorWorkbook` is still the explicit "start
 working on this workbook" step. `manifest.sourcePath` records the `.xlsx` so the
 watcher can locate it.
@@ -224,7 +224,7 @@ Snapshot answers "put it back"; event log answers "what changed and when".
 - **Divergence guard** (§7): source-hash mismatch blocks blind overwrite.
 - **`dryRun`**: returns the change summary (cells changed, before→after samples,
   any refused/unsupported parts) without writing.
-- **Serialize** write-backs (one at a time), like `runAnalysis`.
+- **Serialize** write-backs (one at a time), like `runPython`.
 
 ## 7. Sync / conflict policy
 

--- a/docs/plans/spreadsheet-mirror-versioning-plan.md
+++ b/docs/plans/spreadsheet-mirror-versioning-plan.md
@@ -77,6 +77,19 @@ A sheet can exceed the cap, so each sheet's CSV **shards to `maxShardBytes`**
 index**: sheet order, per-shard row ranges, reassembly order, and the source hash.
 The event-log JSONL shards the same way as it grows.
 
+### 3.2b Trigger model: AUTOMATIC write-back (decided 2026-05-31)
+
+User decision: the round-trip runs **automatically** on CSV save, not via an
+explicit AI tool call. A debounced (`~1.5s`) vault `modify` watcher
+(`SpreadsheetAutoSync`) scoped to `<root>/spreadsheets/*/*.csv` runs the
+write-back when a shard changes; it suppresses its own re-projection writes
+(syncing flag + cooldown) so there's no loop. `applyToWorkbook` remains as a
+manual `dryRun`/`force` path. The AI edits the CSV either with **pandas**
+(`runAnalysis` `outputPath` ending `.csv` → tabular result written as CSV) or
+with **ContentManager CRUD**. `mirrorWorkbook` is still the explicit "start
+working on this workbook" step. `manifest.sourcePath` records the `.xlsx` so the
+watcher can locate it.
+
 ### 3.3 The CSV is a *projection*; the xlsx is the source of truth (LOCKED)
 
 The mirror is **not** a parallel store — it's a regenerated view:

--- a/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
+++ b/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
@@ -11,7 +11,7 @@
 
 import { BaseAppAgent } from '../BaseAppAgent';
 import { AppManifest } from '../../../types/apps/AppTypes';
-import { RunAnalysisTool } from './tools/runAnalysis';
+import { RunPythonTool } from './tools/runPython';
 import { ListCapabilitiesTool } from './tools/listCapabilities';
 import { MirrorWorkbookTool } from './tools/mirrorWorkbook';
 import { ApplyToWorkbookTool } from './tools/applyToWorkbook';
@@ -40,7 +40,7 @@ const DATA_ANALYSIS_MANIFEST: AppManifest = {
   credentials: [],
   validation: { mode: 'none' },
   tools: [
-    { slug: 'runAnalysis', description: 'Run pandas/Python on CSV/XLSX inputs and return a bounded result' },
+    { slug: 'runPython', description: 'Run pandas/Python on CSV/XLSX inputs and return a bounded result' },
     { slug: 'listCapabilities', description: 'List the available Python packages and supported input formats' },
     { slug: 'mirrorWorkbook', description: 'Project an .xlsx into editable CSV shards under <root>/spreadsheets/' },
     { slug: 'applyToWorkbook', description: 'Apply CSV edits back into the .xlsx losslessly (charts/formulas preserved)' },
@@ -55,7 +55,7 @@ export class DataAnalysisAgent extends BaseAppAgent {
 
   constructor() {
     super(DATA_ANALYSIS_MANIFEST);
-    this.registerTool(new RunAnalysisTool(this));
+    this.registerTool(new RunPythonTool(this));
     this.registerTool(new ListCapabilitiesTool(this));
     this.registerTool(new MirrorWorkbookTool(this));
     this.registerTool(new ApplyToWorkbookTool(this));

--- a/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
+++ b/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
@@ -1,0 +1,68 @@
+/**
+ * DataAnalysisAgent — desktop-only app for running Python (pandas) against
+ * vault CSV/Excel data inside a sandboxed, network-isolated Pyodide worker.
+ *
+ * Registered in: AppManager.getBuiltInAppRegistry() (desktop only).
+ * Exported from: src/agents/apps/index.ts
+ *
+ * The heavy Pyodide runtime is created lazily on first use and torn down on
+ * unload. No external API keys required.
+ */
+
+import { BaseAppAgent } from '../BaseAppAgent';
+import { AppManifest } from '../../../types/apps/AppTypes';
+import { RunAnalysisTool } from './tools/runAnalysis';
+import { ListCapabilitiesTool } from './tools/listCapabilities';
+import { IAnalysisSandbox } from './types';
+import { PyodideSandbox } from './services/PyodideSandbox';
+
+const DATA_ANALYSIS_MANIFEST: AppManifest = {
+  id: 'data-analysis',
+  name: 'Data Analysis',
+  description:
+    'Run Python (pandas) on vault CSV/Excel data in an isolated runtime (off-thread, ' +
+    'no Node, in-memory filesystem). Best-effort isolation that blocks accidental network/vault ' +
+    'access — not a hard sandbox for hostile code. Desktop only.',
+  version: '0.1.0',
+  author: 'Nexus',
+  credentials: [],
+  validation: { mode: 'none' },
+  tools: [
+    { slug: 'runAnalysis', description: 'Run pandas/Python on CSV/XLSX inputs and return a bounded result' },
+    { slug: 'listCapabilities', description: 'List the available Python packages and supported input formats' },
+  ],
+};
+
+export class DataAnalysisAgent extends BaseAppAgent {
+  private sandbox: IAnalysisSandbox | null = null;
+
+  constructor() {
+    super(DATA_ANALYSIS_MANIFEST);
+    this.registerTool(new RunAnalysisTool(this));
+    this.registerTool(new ListCapabilitiesTool(this));
+  }
+
+  /** Lazily create + initialize the desktop-only Pyodide sandbox. */
+  async getSandbox(): Promise<IAnalysisSandbox> {
+    if (!this.sandbox) {
+      const app = this.getApp();
+      if (!app) {
+        throw new Error('Obsidian app is not available.');
+      }
+      this.sandbox = new PyodideSandbox(app);
+    }
+    await this.sandbox.ensureReady();
+    return this.sandbox;
+  }
+
+  /** Test seam: inject a fake sandbox to exercise the tool without Pyodide. */
+  setSandbox(sandbox: IAnalysisSandbox): void {
+    this.sandbox = sandbox;
+  }
+
+  onunload(): void {
+    this.sandbox?.dispose();
+    this.sandbox = null;
+    super.onunload();
+  }
+}

--- a/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
+++ b/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
@@ -13,8 +13,13 @@ import { BaseAppAgent } from '../BaseAppAgent';
 import { AppManifest } from '../../../types/apps/AppTypes';
 import { RunAnalysisTool } from './tools/runAnalysis';
 import { ListCapabilitiesTool } from './tools/listCapabilities';
+import { MirrorWorkbookTool } from './tools/mirrorWorkbook';
+import { ApplyToWorkbookTool } from './tools/applyToWorkbook';
 import { IAnalysisSandbox } from './types';
 import { PyodideSandbox } from './services/PyodideSandbox';
+import { HucreEnsurer } from './services/HucreEnsurer';
+import type { HucreModule } from './spreadsheet/HucreModule';
+import { resolveVaultRoot } from '../../../database/storage/VaultRootResolver';
 
 const DATA_ANALYSIS_MANIFEST: AppManifest = {
   id: 'data-analysis',
@@ -30,16 +35,44 @@ const DATA_ANALYSIS_MANIFEST: AppManifest = {
   tools: [
     { slug: 'runAnalysis', description: 'Run pandas/Python on CSV/XLSX inputs and return a bounded result' },
     { slug: 'listCapabilities', description: 'List the available Python packages and supported input formats' },
+    { slug: 'mirrorWorkbook', description: 'Project an .xlsx into editable CSV shards under <root>/spreadsheets/' },
+    { slug: 'applyToWorkbook', description: 'Apply CSV edits back into the .xlsx losslessly (charts/formulas preserved)' },
   ],
 };
 
 export class DataAnalysisAgent extends BaseAppAgent {
   private sandbox: IAnalysisSandbox | null = null;
+  private hucre: HucreEnsurer | null = null;
 
   constructor() {
     super(DATA_ANALYSIS_MANIFEST);
     this.registerTool(new RunAnalysisTool(this));
     this.registerTool(new ListCapabilitiesTool(this));
+    this.registerTool(new MirrorWorkbookTool(this));
+    this.registerTool(new ApplyToWorkbookTool(this));
+  }
+
+  /** Lazily vendor + load the hucre xlsx engine (desktop-only runtime asset). */
+  async getHucreModule(): Promise<HucreModule> {
+    const app = this.getApp();
+    if (!app) {
+      throw new Error('Obsidian app is not available.');
+    }
+    if (!this.hucre) {
+      this.hucre = new HucreEnsurer(app);
+    }
+    return this.hucre.loadModule();
+  }
+
+  /**
+   * Resolved mirror storage settings: the synced Nexus root (renameable in
+   * Settings → Data) and the per-file shard cap. Falls back to defaults when the
+   * runtime context isn't wired.
+   */
+  getMirrorStorage(): { root: string; maxShardBytes: number } {
+    const settings = this.getRuntimeContext()?.getSettings();
+    const resolution = resolveVaultRoot({ storage: settings?.storage });
+    return { root: resolution.resolvedPath, maxShardBytes: resolution.maxShardBytes };
   }
 
   /** Lazily create + initialize the desktop-only Pyodide sandbox. */

--- a/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
+++ b/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
@@ -20,6 +20,7 @@ import { PyodideSandbox } from './services/PyodideSandbox';
 import { HucreEnsurer } from './services/HucreEnsurer';
 import type { HucreModule } from './spreadsheet/HucreModule';
 import { resolveVaultRoot } from '../../../database/storage/VaultRootResolver';
+import { isDesktop } from '../../../utils/platform';
 import { SpreadsheetAutoSync } from './spreadsheet/SpreadsheetAutoSync';
 import { WorkbookMirrorService } from './spreadsheet/WorkbookMirrorService';
 import { WorkbookWriteBackService } from './spreadsheet/WorkbookWriteBackService';
@@ -29,7 +30,7 @@ import { SnapshotArchiveService } from '../../../services/storage/SnapshotArchiv
 import { App, EventRef, Notice, normalizePath } from 'obsidian';
 
 const DATA_ANALYSIS_MANIFEST: AppManifest = {
-  id: 'data-analysis',
+  id: 'data',
   name: 'Data Analysis',
   description:
     'Run Python (pandas) on vault CSV/Excel data in an isolated runtime (off-thread, ' +
@@ -105,7 +106,9 @@ export class DataAnalysisAgent extends BaseAppAgent {
   /** Start the auto-sync vault watcher once the App is injected (desktop). */
   setApp(app: App): void {
     super.setApp(app);
-    if (this.vaultModifyRef) {
+    // Auto-sync is desktop-only (hucre write-back) and needs a real vault event
+    // bus — guard both so non-desktop and test/mocked vaults are no-ops.
+    if (this.vaultModifyRef || !isDesktop() || typeof app.vault?.on !== 'function') {
       return;
     }
     this.autoSync = new SpreadsheetAutoSync({

--- a/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
+++ b/src/agents/apps/dataAnalysis/DataAnalysisAgent.ts
@@ -20,6 +20,13 @@ import { PyodideSandbox } from './services/PyodideSandbox';
 import { HucreEnsurer } from './services/HucreEnsurer';
 import type { HucreModule } from './spreadsheet/HucreModule';
 import { resolveVaultRoot } from '../../../database/storage/VaultRootResolver';
+import { SpreadsheetAutoSync } from './spreadsheet/SpreadsheetAutoSync';
+import { WorkbookMirrorService } from './spreadsheet/WorkbookMirrorService';
+import { WorkbookWriteBackService } from './spreadsheet/WorkbookWriteBackService';
+import { HucreXlsxSource } from './spreadsheet/HucreXlsxSource';
+import { HucreXlsxWriter } from './spreadsheet/HucreXlsxWriter';
+import { SnapshotArchiveService } from '../../../services/storage/SnapshotArchiveService';
+import { App, EventRef, Notice, normalizePath } from 'obsidian';
 
 const DATA_ANALYSIS_MANIFEST: AppManifest = {
   id: 'data-analysis',
@@ -43,6 +50,8 @@ const DATA_ANALYSIS_MANIFEST: AppManifest = {
 export class DataAnalysisAgent extends BaseAppAgent {
   private sandbox: IAnalysisSandbox | null = null;
   private hucre: HucreEnsurer | null = null;
+  private autoSync: SpreadsheetAutoSync | null = null;
+  private vaultModifyRef: EventRef | null = null;
 
   constructor() {
     super(DATA_ANALYSIS_MANIFEST);
@@ -93,7 +102,71 @@ export class DataAnalysisAgent extends BaseAppAgent {
     this.sandbox = sandbox;
   }
 
+  /** Start the auto-sync vault watcher once the App is injected (desktop). */
+  setApp(app: App): void {
+    super.setApp(app);
+    if (this.vaultModifyRef) {
+      return;
+    }
+    this.autoSync = new SpreadsheetAutoSync({
+      getRoot: () => this.getMirrorStorage().root,
+      sync: (workbookId) => this.syncWorkbook(workbookId),
+    });
+    this.vaultModifyRef = app.vault.on('modify', (file) => this.autoSync?.notifyModified(file.path));
+  }
+
+  /**
+   * Auto write-back for one mirrored workbook: read the manifest for its source
+   * `.xlsx`, apply the edited CSV shards back losslessly, and persist. Triggered
+   * (debounced) by the vault watcher when a mirror shard changes; a no-op when
+   * there's no manifest or nothing actually changed.
+   */
+  private async syncWorkbook(workbookId: string): Promise<void> {
+    const app = this.getApp();
+    const vault = this.getVault();
+    if (!app || !vault) {
+      return;
+    }
+    const { root, maxShardBytes } = this.getMirrorStorage();
+    const mirror = new WorkbookMirrorService(vault.adapter);
+    const manifest = await mirror.readManifest({ root, workbookId, maxShardBytes });
+    if (!manifest || !manifest.sourcePath) {
+      return;
+    }
+
+    let buffer: ArrayBuffer;
+    try {
+      buffer = await vault.adapter.readBinary(normalizePath(manifest.sourcePath));
+    } catch {
+      return; // source moved/deleted — skip silently
+    }
+
+    const mod = await this.getHucreModule();
+    const writeBack = new WorkbookWriteBackService(
+      vault.adapter,
+      new HucreXlsxSource(() => Promise.resolve(mod)),
+      new HucreXlsxWriter(() => Promise.resolve(mod)),
+      mirror,
+      new SnapshotArchiveService(vault.adapter)
+    );
+
+    const target = { root, workbookId, maxShardBytes, sourcePath: manifest.sourcePath };
+    const result = await writeBack.apply(target, new Uint8Array(buffer));
+
+    if (result.applied && result.newBytes) {
+      await vault.adapter.writeBinary(normalizePath(manifest.sourcePath), result.newBytes.slice().buffer);
+      const blocked = result.summary.cellsBlocked > 0 ? `, ${result.summary.cellsBlocked} formula cell(s) skipped` : '';
+      new Notice(`Synced ${result.summary.cellsApplied} change(s) to ${manifest.sourcePath}${blocked}.`, 4000);
+    }
+  }
+
   onunload(): void {
+    if (this.vaultModifyRef) {
+      this.getApp()?.vault.offref(this.vaultModifyRef);
+      this.vaultModifyRef = null;
+    }
+    this.autoSync?.dispose();
+    this.autoSync = null;
     this.sandbox?.dispose();
     this.sandbox = null;
     super.onunload();

--- a/src/agents/apps/dataAnalysis/services/HucreEnsurer.ts
+++ b/src/agents/apps/dataAnalysis/services/HucreEnsurer.ts
@@ -1,0 +1,124 @@
+/**
+ * HucreEnsurer — vendors the `hucre/xlsx` engine into the plugin's `hucre`
+ * folder on first use and loads it at runtime, mirroring {@link PyodideEnsurer}.
+ *
+ * Why vendored (not bundled): the xlsx entry is ~302 KB minified, over main.js's
+ * ~218 KB headroom against the 5 MB ceiling (spike S2). It is downloaded once
+ * (dependency-bundled ESM from esm.sh) and loaded locally thereafter.
+ *
+ * Load mechanism: the vendored file is read as text and imported via a Blob URL
+ * (`import(blob:…)`), the same realm trick the Pyodide worker uses — this dodges
+ * esbuild's static `import()` resolution (so hucre never enters the bundle) and
+ * avoids `file://`/CSP quirks in the Electron renderer.
+ *
+ * ⚠️ PENDING Electron validation: the download URL shape and the Blob-import load
+ * path must be exercised in a real Obsidian desktop build (not runnable headless).
+ */
+
+import { App, FileSystemAdapter, Notice, requestUrl } from 'obsidian';
+import { HUCRE_XLSX_ASSET } from '../spreadsheet/HucreAssets';
+import type { HucreModule } from '../spreadsheet/HucreModule';
+
+const KNOWN_PLUGIN_FOLDERS = ['nexus', 'claudesidian-mcp'] as const;
+
+function getFsAdapter(app: App): FileSystemAdapter {
+  const adapter = app.vault.adapter;
+  if (!(adapter instanceof FileSystemAdapter)) {
+    throw new Error('Spreadsheet sync requires a desktop filesystem vault.');
+  }
+  return adapter;
+}
+
+async function detectPluginFolder(app: App): Promise<string> {
+  const configDir = app.vault.configDir;
+  for (const folder of KNOWN_PLUGIN_FOLDERS) {
+    if (await app.vault.adapter.exists(`${configDir}/plugins/${folder}/manifest.json`)) {
+      return folder;
+    }
+  }
+  return KNOWN_PLUGIN_FOLDERS[0];
+}
+
+/** Vault-relative path to the vendored hucre file. */
+export async function resolveHucreAssetPath(app: App): Promise<string> {
+  const folder = await detectPluginFolder(app);
+  return `${app.vault.configDir}/plugins/${folder}/hucre/${HUCRE_XLSX_ASSET.file}`;
+}
+
+export class HucreEnsurer {
+  private cached: HucreModule | null = null;
+
+  constructor(private readonly app: App) {}
+
+  /** Ensure the vendored bundle is present (download once if missing). */
+  async ensure(): Promise<{ ok: boolean; error?: string }> {
+    const adapter = getFsAdapter(this.app);
+    const path = await resolveHucreAssetPath(this.app);
+
+    if (await this.isPresent(path)) {
+      return { ok: true };
+    }
+
+    const dir = path.slice(0, path.lastIndexOf('/'));
+    if (!(await adapter.exists(dir))) {
+      await adapter.mkdir(dir);
+    }
+
+    const notice = new Notice('Setting up the spreadsheet engine — downloading once…', 0);
+    try {
+      const res = await requestUrl({ url: HUCRE_XLSX_ASSET.url, method: 'GET' });
+      if (res.status !== 200 || res.arrayBuffer.byteLength < HUCRE_XLSX_ASSET.minBytes) {
+        notice.hide();
+        return { ok: false, error: `Failed to download the spreadsheet engine (HTTP ${res.status}).` };
+      }
+      await adapter.writeBinary(path, res.arrayBuffer);
+      notice.hide();
+      new Notice('Spreadsheet engine ready.', 3000);
+      return { ok: true };
+    } catch (error) {
+      notice.hide();
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  /** Ensure + load the hucre module (cached after first load). */
+  async loadModule(): Promise<HucreModule> {
+    if (this.cached) {
+      return this.cached;
+    }
+    const ensured = await this.ensure();
+    if (!ensured.ok) {
+      throw new Error(ensured.error ?? 'Spreadsheet engine unavailable.');
+    }
+
+    const path = await resolveHucreAssetPath(this.app);
+    const code = await this.app.vault.adapter.read(path);
+
+    const url = URL.createObjectURL(new Blob([code], { type: 'text/javascript' }));
+    try {
+      // Function-wrapped native dynamic import so esbuild does not statically
+      // resolve/bundle it (hucre must stay a runtime asset, never in main.js).
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const importEsm = new Function('u', 'return import(u);') as (u: string) => Promise<Record<string, unknown>>;
+      const mod = await importEsm(url);
+      const openXlsx = mod.openXlsx as HucreModule['openXlsx'] | undefined;
+      const saveXlsx = mod.saveXlsx as HucreModule['saveXlsx'] | undefined;
+      if (typeof openXlsx !== 'function' || typeof saveXlsx !== 'function') {
+        throw new Error('Vendored hucre bundle is missing openXlsx/saveXlsx.');
+      }
+      this.cached = { openXlsx, saveXlsx };
+      return this.cached;
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  private async isPresent(path: string): Promise<boolean> {
+    const adapter = getFsAdapter(this.app);
+    if (!(await adapter.exists(path))) {
+      return false;
+    }
+    const stat = await adapter.stat(path);
+    return !!stat && stat.size >= HUCRE_XLSX_ASSET.minBytes;
+  }
+}

--- a/src/agents/apps/dataAnalysis/services/PyodideAssets.ts
+++ b/src/agents/apps/dataAnalysis/services/PyodideAssets.ts
@@ -1,0 +1,92 @@
+/**
+ * Resolves the vendored Pyodide asset directory inside the plugin folder.
+ *
+ * Delivery follows the SQLite `WasmEnsurer` ethos: the heavy runtime + wheels
+ * live next to main.js (never bundled into it) and are loaded at runtime. The
+ * worker loads Pyodide from a local file:// indexURL so execution is offline.
+ *
+ * Desktop-only — requires a FileSystemAdapter.
+ *
+ * ⚠️ PENDING Electron validation: file:// URL shape for importScripts/indexURL,
+ * and auto-download of missing assets (currently presence is required).
+ */
+
+import { App, FileSystemAdapter } from 'obsidian';
+
+const KNOWN_PLUGIN_FOLDERS = ['nexus', 'claudesidian-mcp'];
+const MICROPIP_WHEEL_RE = /^(openpyxl|et_xmlfile)-.*\.whl$/;
+
+export interface PyodideAssetInfo {
+  /** file:// URL to the pyodide asset directory, trailing slash included. */
+  indexUrl: string;
+  /** Exact wheel filenames to install via micropip (pure-Python, not in dist). */
+  micropipWheels: string[];
+}
+
+function getFsAdapter(app: App): FileSystemAdapter {
+  const adapter = app.vault.adapter;
+  if (!(adapter instanceof FileSystemAdapter)) {
+    throw new Error('Data Analysis requires a desktop filesystem vault.');
+  }
+  return adapter;
+}
+
+async function detectPluginFolder(app: App, adapter: FileSystemAdapter): Promise<string> {
+  const configDir = app.vault.configDir;
+  for (const folder of KNOWN_PLUGIN_FOLDERS) {
+    // Detect by the always-present manifest.json so the write target resolves
+    // even before the pyodide assets have been vendored.
+    if (await adapter.exists(`${configDir}/plugins/${folder}/manifest.json`)) {
+      return folder;
+    }
+  }
+  return KNOWN_PLUGIN_FOLDERS[0];
+}
+
+/** Vault-relative path to the pyodide asset directory (the download target). */
+export async function resolvePyodideDirVaultPath(app: App): Promise<string> {
+  const adapter = getFsAdapter(app);
+  const folder = await detectPluginFolder(app, adapter);
+  return `${app.vault.configDir}/plugins/${folder}/pyodide`;
+}
+
+/** True when the Pyodide runtime has been vendored into the plugin folder. */
+export async function pyodideAssetsPresent(app: App): Promise<boolean> {
+  let adapter: FileSystemAdapter;
+  try {
+    adapter = getFsAdapter(app);
+  } catch {
+    return false;
+  }
+  const configDir = app.vault.configDir;
+  for (const folder of KNOWN_PLUGIN_FOLDERS) {
+    if (await adapter.exists(`${configDir}/plugins/${folder}/pyodide/pyodide.js`)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function resolvePyodideAssets(app: App): Promise<PyodideAssetInfo> {
+  const adapter = getFsAdapter(app);
+  const configDir = app.vault.configDir;
+  const folder = await detectPluginFolder(app, adapter);
+  const dir = `${configDir}/plugins/${folder}/pyodide`;
+
+  const listing = await adapter
+    .list(dir)
+    .catch(() => ({ files: [] as string[], folders: [] as string[] }));
+  const micropipWheels = (listing.files || [])
+    .map((p) => p.split('/').pop() || '')
+    .filter((name) => MICROPIP_WHEEL_RE.test(name));
+
+  const absDir = `${adapter.getBasePath()}/${dir}`;
+  return { indexUrl: `${toFileUrl(absDir)}/`, micropipWheels };
+}
+
+/** Minimal absolute-path → file:// URL. Encodes spaces; handles Windows drives. */
+function toFileUrl(absPath: string): string {
+  let p = absPath.replace(/\\/g, '/');
+  if (!p.startsWith('/')) p = `/${p}`; // Windows "C:/..." -> "/C:/..."
+  return `file://${p.replace(/ /g, '%20')}`;
+}

--- a/src/agents/apps/dataAnalysis/services/PyodideEnsurer.ts
+++ b/src/agents/apps/dataAnalysis/services/PyodideEnsurer.ts
@@ -1,0 +1,155 @@
+/**
+ * PyodideEnsurer — vendors the Pyodide runtime + pandas/Excel wheels into the
+ * plugin's "pyodide" folder on first use, mirroring the SQLite WasmEnsurer.
+ *
+ * Why vendored (not bundled): the ~21MB of wasm + wheels must never enter
+ * main.js (5MB ceiling). They are downloaded once and loaded locally so the
+ * sandbox runs offline thereafter.
+ *
+ * Asset sources (pinned to PYODIDE_VERSION):
+ *   - core runtime + compiled wheels (pandas/numpy/…): the Pyodide jsDelivr CDN
+ *   - openpyxl + et_xmlfile (pure-Python, not in the Pyodide dist): PyPI
+ * All filenames/URLs were validated in the Phase 0 spike.
+ *
+ * ⚠️ PENDING Electron validation: the actual network download path (requestUrl
+ * + adapter.writeBinary) must be exercised in a real Obsidian desktop build.
+ * The pinned manifest is unit-tested; the download mechanics are not runnable
+ * in the headless test container.
+ */
+
+import { App, Notice, requestUrl } from 'obsidian';
+
+export const PYODIDE_VERSION = '0.29.4';
+const CDN_BASE = `https://cdn.jsdelivr.net/pyodide/v${PYODIDE_VERSION}/full/`;
+
+export interface AssetSpec {
+  /** Filename written into the pyodide dir. */
+  file: string;
+  /** Absolute download URL. */
+  url: string;
+  /** Reject downloads smaller than this (guards against HTML error pages). */
+  minBytes: number;
+}
+
+/** Fixed-name core runtime files (resolved against the CDN). */
+const CORE_FILES = [
+  'pyodide.js',
+  'pyodide.asm.js',
+  'pyodide.asm.wasm',
+  'python_stdlib.zip',
+  'pyodide-lock.json',
+];
+
+/** Compiled wheels loaded via loadPackage — exact lock filenames for this version. */
+const COMPILED_WHEELS = [
+  'pandas-2.3.3-cp313-cp313-pyemscripten_2025_0_wasm32.whl',
+  'numpy-2.2.5-cp313-cp313-pyemscripten_2025_0_wasm32.whl',
+  'python_dateutil-2.9.0.post0-py2.py3-none-any.whl',
+  'pytz-2025.2-py2.py3-none-any.whl',
+  'six-1.17.0-py2.py3-none-any.whl',
+  'micropip-0.11.1-py3-none-any.whl',
+  'packaging-26.2-py3-none-any.whl',
+];
+
+/** Pure-Python wheels installed via micropip — sourced from PyPI (not in the dist). */
+const PYPI_WHEELS: AssetSpec[] = [
+  {
+    file: 'openpyxl-3.1.5-py2.py3-none-any.whl',
+    url: 'https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl',
+    minBytes: 100_000,
+  },
+  {
+    file: 'et_xmlfile-2.0.0-py3-none-any.whl',
+    url: 'https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl',
+    minBytes: 5_000,
+  },
+];
+
+/** The complete, deterministic set of files the sandbox needs on disk. */
+export function buildPyodideAssetManifest(): AssetSpec[] {
+  const fromCdn = (file: string, minBytes: number): AssetSpec => ({ file, url: CDN_BASE + file, minBytes });
+  return [
+    ...CORE_FILES.map((f) => fromCdn(f, 1_000)),
+    ...COMPILED_WHEELS.map((f) => fromCdn(f, 5_000)),
+    ...PYPI_WHEELS,
+  ];
+}
+
+export interface EnsureResult {
+  ok: boolean;
+  downloaded: number;
+  error?: string;
+}
+
+export class PyodideEnsurer {
+  constructor(private readonly app: App) {}
+
+  /**
+   * Ensure every manifest asset is present (and non-truncated) in `targetDir`.
+   * Downloads only what's missing. Idempotent.
+   */
+  async ensureAssets(targetDir: string): Promise<EnsureResult> {
+    const adapter = this.app.vault.adapter;
+    const manifest = buildPyodideAssetManifest();
+
+    const missing: AssetSpec[] = [];
+    for (const asset of manifest) {
+      if (!(await this.isPresent(`${targetDir}/${asset.file}`, asset.minBytes))) {
+        missing.push(asset);
+      }
+    }
+    if (missing.length === 0) {
+      return { ok: true, downloaded: 0 };
+    }
+
+    if (!(await adapter.exists(targetDir))) {
+      await adapter.mkdir(targetDir);
+    }
+
+    const notice = new Notice(
+      `Setting up the Python data environment — downloading ${missing.length} files ` +
+        `(~21MB, one time only)…`,
+      0
+    );
+    let downloaded = 0;
+    try {
+      for (const asset of missing) {
+        const data = await this.download(asset);
+        if (!data) {
+          notice.hide();
+          return { ok: false, downloaded, error: `Failed to download ${asset.file}` };
+        }
+        await adapter.writeBinary(`${targetDir}/${asset.file}`, data);
+        downloaded++;
+      }
+      notice.hide();
+      new Notice('Python data environment ready.', 3000);
+      return { ok: true, downloaded };
+    } catch (error) {
+      notice.hide();
+      return { ok: false, downloaded, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  private async isPresent(path: string, minBytes: number): Promise<boolean> {
+    const adapter = this.app.vault.adapter;
+    if (!(await adapter.exists(path))) {
+      return false;
+    }
+    const stat = await adapter.stat(path);
+    return !!stat && stat.size >= minBytes;
+  }
+
+  private async download(asset: AssetSpec): Promise<ArrayBuffer | null> {
+    try {
+      const res = await requestUrl({ url: asset.url, method: 'GET' });
+      if (res.status !== 200) {
+        return null;
+      }
+      const buffer = res.arrayBuffer;
+      return buffer.byteLength >= asset.minBytes ? buffer : null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/agents/apps/dataAnalysis/services/PyodideSandbox.ts
+++ b/src/agents/apps/dataAnalysis/services/PyodideSandbox.ts
@@ -1,0 +1,200 @@
+/**
+ * PyodideSandbox — runs Python (pandas) in a locked-down Web Worker.
+ *
+ * Isolation (plan §4): dedicated Worker with no Node integration, MEMFS-only FS,
+ * the network surface scrubbed after load (see pyodideWorkerSource), and runaway
+ * code killed deterministically by worker.terminate(). Desktop-only.
+ *
+ * Runs are SERIALIZED: Pyodide's runPythonAsync is not reentrant and the worker
+ * is reused, so a queue guarantees one analysis at a time. A timeout terminates
+ * the worker and rejects the in-flight run; queued runs re-bootstrap on their turn.
+ *
+ * ⚠️ PENDING Electron runtime validation: Blob-worker creation, file://
+ * importScripts of the vendored pyodide.js, local indexURL load, and the
+ * terminate-timeout path must be verified in a real Obsidian desktop build.
+ * The data-flow, marshalling, and network-scrub mechanics were validated in the
+ * Phase 0 spike (docs/plans/spike-findings-pyodide-2026-05-31.md).
+ */
+
+import { App } from 'obsidian';
+import {
+  IAnalysisSandbox,
+  SandboxRunRequest,
+  SandboxRunResult,
+  PYODIDE_PACKAGES,
+} from '../types';
+import { resolvePyodideAssets, pyodideAssetsPresent, resolvePyodideDirVaultPath } from './PyodideAssets';
+import { buildPyodideWorkerSource } from './pyodideWorkerSource';
+import { PyodideEnsurer } from './PyodideEnsurer';
+
+interface WorkerMessage {
+  type?: string;
+  id?: number;
+  success?: boolean;
+  data?: unknown;
+  logs?: string[];
+  error?: string;
+  stats?: { durationMs: number };
+}
+
+export class PyodideSandbox implements IAnalysisSandbox {
+  private readonly app: App;
+  private worker: Worker | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private blobUrl: string | null = null;
+  private seq = 0;
+  /** Tail of the run queue — serializes runs over the single reused worker. */
+  private tail: Promise<unknown> = Promise.resolve();
+
+  constructor(app: App) {
+    this.app = app;
+  }
+
+  ensureReady(): Promise<void> {
+    if (!this.readyPromise) {
+      this.readyPromise = this.bootstrap().catch((err) => {
+        // allow a later retry to re-bootstrap
+        this.readyPromise = null;
+        throw err;
+      });
+    }
+    return this.readyPromise;
+  }
+
+  private async bootstrap(): Promise<void> {
+    // First use / partial install: the ensurer is idempotent and per-file, so
+    // run it unconditionally to recover from an interrupted prior download.
+    const targetDir = await resolvePyodideDirVaultPath(this.app);
+    const ensured = await new PyodideEnsurer(this.app).ensureAssets(targetDir);
+    if (!ensured.ok || !(await pyodideAssetsPresent(this.app))) {
+      throw new Error(
+        `The Python data environment could not be installed${ensured.error ? `: ${ensured.error}` : ''}. ` +
+          'Check your internet connection and try again.'
+      );
+    }
+
+    const assets = await resolvePyodideAssets(this.app);
+    const source = buildPyodideWorkerSource({
+      indexUrl: assets.indexUrl,
+      loadPackages: [...PYODIDE_PACKAGES],
+      micropipWheels: assets.micropipWheels,
+    });
+
+    this.blobUrl = URL.createObjectURL(new Blob([source], { type: 'application/javascript' }));
+    const worker = new Worker(this.blobUrl);
+    this.worker = worker;
+
+    await new Promise<void>((resolve, reject) => {
+      let done = false;
+      const cleanup = () => {
+        done = true;
+        worker.removeEventListener('message', onMsg);
+        worker.removeEventListener('error', onErr);
+        this.revokeBlobUrl();
+      };
+      const onMsg = (ev: MessageEvent<WorkerMessage>) => {
+        const d = ev.data || {};
+        if (d.type === 'ready') {
+          cleanup();
+          resolve();
+        } else if (d.type === 'init-error') {
+          cleanup();
+          reject(new Error(d.error || 'Pyodide failed to initialize.'));
+        }
+      };
+      const onErr = (e: ErrorEvent) => {
+        if (done) return;
+        cleanup();
+        reject(new Error(`Sandbox worker error: ${e.message}`));
+      };
+      worker.addEventListener('message', onMsg);
+      worker.addEventListener('error', onErr);
+      worker.postMessage({ type: 'init' });
+    });
+  }
+
+  run(request: SandboxRunRequest): Promise<SandboxRunResult> {
+    // Chain onto the queue so only one run executes at a time, regardless of
+    // whether the previous one resolved or rejected.
+    const turn = this.tail.then(
+      () => this.execOne(request),
+      () => this.execOne(request)
+    );
+    this.tail = turn.catch(() => undefined);
+    return turn;
+  }
+
+  private async execOne(request: SandboxRunRequest): Promise<SandboxRunResult> {
+    try {
+      await this.ensureReady();
+    } catch (err) {
+      return { success: false, error: err instanceof Error ? err.message : String(err) };
+    }
+    const worker = this.worker;
+    if (!worker) {
+      return { success: false, error: 'Sandbox worker is not available.' };
+    }
+    const id = ++this.seq;
+
+    return new Promise<SandboxRunResult>((resolve) => {
+      let settled = false;
+      const finish = (r: SandboxRunResult) => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timer);
+        worker.removeEventListener('message', onMsg);
+        resolve(r);
+      };
+
+      const onMsg = (ev: MessageEvent<WorkerMessage>) => {
+        const d = ev.data || {};
+        if (d.type === 'result' && d.id === id) {
+          finish({ success: !!d.success, data: d.data, logs: d.logs, error: d.error, stats: d.stats });
+        }
+      };
+
+      const timer = window.setTimeout(() => {
+        // runaway code: terminating the worker is the only deterministic stop.
+        // Safe because runs are serialized — no other run is using this worker.
+        this.hardReset();
+        finish({
+          success: false,
+          error: `Analysis exceeded ${request.timeoutMs}ms and was terminated. Reduce the work or add a limit.`,
+        });
+      }, request.timeoutMs);
+
+      worker.addEventListener('message', onMsg);
+      worker.postMessage(
+        {
+          type: 'run',
+          id,
+          code: request.code,
+          files: request.files.map((f) => ({
+            varName: f.varName,
+            sandboxPath: f.sandboxPath,
+            bytes: f.bytes,
+          })),
+        },
+        request.files.map((f) => f.bytes.buffer)
+      );
+    });
+  }
+
+  private revokeBlobUrl(): void {
+    if (this.blobUrl) {
+      URL.revokeObjectURL(this.blobUrl);
+      this.blobUrl = null;
+    }
+  }
+
+  private hardReset(): void {
+    this.worker?.terminate();
+    this.worker = null;
+    this.readyPromise = null;
+    this.revokeBlobUrl();
+  }
+
+  dispose(): void {
+    this.hardReset();
+  }
+}

--- a/src/agents/apps/dataAnalysis/services/guards.ts
+++ b/src/agents/apps/dataAnalysis/services/guards.ts
@@ -1,0 +1,130 @@
+/**
+ * Pure host-side guardrails for the Data Analysis app.
+ *
+ * No Obsidian / Pyodide dependencies here — these are deterministic functions
+ * that bound the tool's inputs and outputs, and are fully unit-tested.
+ */
+
+import { DATA_ANALYSIS_DEFAULTS } from '../types';
+import { isValidPath } from '../../../../utils/pathUtils';
+
+export interface RowCapOutcome {
+  ok: boolean;
+  rowCount: number | null;
+  error?: string;
+}
+
+/**
+ * Count the "rows" of a marshalled result. An array of records is the canonical
+ * row collection; anything else (scalar, single object) is uncapped.
+ */
+export function countResultRows(data: unknown): number | null {
+  return Array.isArray(data) ? data.length : null;
+}
+
+/**
+ * The 1500-row guardrail. JSONSchema can't validate a computed output, so this
+ * runs host-side on the returned value and nudges callers toward aggregation.
+ */
+export function enforceRowCap(data: unknown, maxRows: number): RowCapOutcome {
+  const rowCount = countResultRows(data);
+  if (rowCount !== null && rowCount > maxRows) {
+    return {
+      ok: false,
+      rowCount,
+      error:
+        `Result has ${rowCount.toLocaleString()} rows (max ${maxRows.toLocaleString()}). ` +
+        `Aggregate (groupby/pivot/describe) or add a filter/limit and re-run.`,
+    };
+  }
+  return { ok: true, rowCount };
+}
+
+export interface OutputBudgetOutcome {
+  ok: boolean;
+  bytes: number;
+  error?: string;
+}
+
+/**
+ * Universal output backstop. The row cap only bounds top-level arrays — a
+ * `{rows: [...]}` or `df.to_dict()` shape would otherwise dump unbounded data
+ * into context. This caps the serialized size of ANY result shape.
+ */
+export function enforceOutputBudget(data: unknown, maxBytes: number): OutputBudgetOutcome {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(data) ?? 'null';
+  } catch {
+    return { ok: false, bytes: 0, error: 'Result is not JSON-serializable.' };
+  }
+  const bytes = serialized.length;
+  if (bytes > maxBytes) {
+    return {
+      ok: false,
+      bytes,
+      error:
+        `Result is ${Math.round(bytes / 1024).toLocaleString()}KB ` +
+        `(max ${Math.round(maxBytes / 1024).toLocaleString()}KB). ` +
+        `Aggregate or reduce the columns/rows returned and re-run.`,
+    };
+  }
+  return { ok: true, bytes };
+}
+
+export function clampMaxRows(requested: number | undefined): number {
+  const { maxRows, maxRowsHardCap } = DATA_ANALYSIS_DEFAULTS;
+  return isPositive(requested) ? Math.min(Math.floor(requested), maxRowsHardCap) : maxRows;
+}
+
+export function clampOutputBytes(requested: number | undefined): number {
+  const { maxOutputBytes, maxOutputBytesHardCap } = DATA_ANALYSIS_DEFAULTS;
+  return isPositive(requested) ? Math.min(Math.floor(requested), maxOutputBytesHardCap) : maxOutputBytes;
+}
+
+export function clampInputBytes(requested: number | undefined): number {
+  const { maxInputBytes, maxInputBytesHardCap } = DATA_ANALYSIS_DEFAULTS;
+  return isPositive(requested) ? Math.min(Math.floor(requested), maxInputBytesHardCap) : maxInputBytes;
+}
+
+export function clampTimeout(requested: number | undefined): number {
+  const { timeoutMs, timeoutHardCapMs } = DATA_ANALYSIS_DEFAULTS;
+  return isPositive(requested) ? Math.min(Math.floor(requested), timeoutHardCapMs) : timeoutMs;
+}
+
+function isPositive(n: number | undefined): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n >= 1;
+}
+
+export interface InputValidation {
+  ok: boolean;
+  error?: string;
+}
+
+/** Reject traversal / absolute / illegal input paths before the host reads them. */
+export function validateInputPath(path: string): InputValidation {
+  if (!isValidPath(path)) {
+    return {
+      ok: false,
+      error: `Invalid input path: "${path}" — must be vault-relative, no ".." or absolute paths`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Derive the in-sandbox filename for an input. Keeps the source extension so the
+ * user's choice of `pd.read_csv` vs `pd.read_excel` lines up with the bytes.
+ */
+export function sandboxFileName(varName: string, sourcePath: string): string {
+  const lastSlash = sourcePath.lastIndexOf('/');
+  const dot = sourcePath.lastIndexOf('.');
+  const ext = dot > lastSlash ? sourcePath.slice(dot) : '';
+  const cleaned = varName.replace(/[^A-Za-z0-9_]/g, '_');
+  const safe = /[A-Za-z0-9]/.test(cleaned) ? cleaned : 'input';
+  return `${safe}${ext}`;
+}
+
+export function formatBytesMb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}

--- a/src/agents/apps/dataAnalysis/services/pyodideWorkerSource.ts
+++ b/src/agents/apps/dataAnalysis/services/pyodideWorkerSource.ts
@@ -1,0 +1,154 @@
+/**
+ * Builds the Web Worker source for the Pyodide sandbox.
+ *
+ * The worker runs entirely off the main thread with NO Node integration. It:
+ *   1. loads Pyodide + pandas from the local file:// indexURL (offline),
+ *   2. micropip-installs openpyxl (pure-Python, not in the Pyodide dist),
+ *   3. HARDENS the realm: deletes the network surface across self / globalThis /
+ *      the prototype chain and drops Python network modules (the lockdown,
+ *      plan §4) — best-effort in-realm defense; see the security note below,
+ *   4. on each run: clears MEMFS /data, injects fresh input bytes, exposes an
+ *      `inputs` path dict, executes user code, and marshals the result to JSON
+ *      *in Python* (NaN→null, datetime→iso, numpy/int64-safe — validated in the
+ *      marshal spike) so pandas output round-trips cleanly.
+ *
+ * ⚠️ SECURITY NOTE: in-realm scrubbing cannot defeat a determined adversary who
+ * re-derives globals via `Function("return this")()`. The intended threat model
+ * is "prevent the AI's analysis code from accidentally/incidentally reaching the
+ * network or vault", not "run hostile third-party code". A true boundary also
+ * requires the Electron worker having no Node integration + no granted network,
+ * which is PENDING Electron validation (terminate-timeout, file:// load too).
+ */
+
+/** Python defined once at init: a numpy/pandas/datetime-aware json.dumps. */
+const MARSHAL_PY = `import json, math, datetime
+def __nexus_default(o):
+    try:
+        import numpy as np
+        if isinstance(o, np.integer): return int(o)
+        if isinstance(o, np.floating):
+            f = float(o)
+            return f if math.isfinite(f) else None
+        if isinstance(o, np.ndarray): return o.tolist()
+    except Exception:
+        pass
+    if isinstance(o, (datetime.date, datetime.datetime)): return o.isoformat()
+    try:
+        import pandas as pd
+        if o is pd.NaT: return None
+    except Exception:
+        pass
+    return str(o)
+def __nexus_dumps(x):
+    return json.dumps(x, default=__nexus_default)`;
+
+/** Python run at init to drop in-Python network reach. */
+const DROP_NET_PY = `import sys
+for __m in list(sys.modules):
+    if __m == 'micropip' or __m == 'pyodide.http' or __m.startswith('pyodide_http'):
+        sys.modules.pop(__m, None)`;
+
+export interface WorkerBootstrapOptions {
+  /** file:// URL to the pyodide asset dir (trailing slash). */
+  indexUrl: string;
+  /** Compiled packages loaded via loadPackage. */
+  loadPackages: string[];
+  /** Exact wheel filenames installed via micropip from indexUrl. */
+  micropipWheels: string[];
+}
+
+export function buildPyodideWorkerSource(opts: WorkerBootstrapOptions): string {
+  return `'use strict';
+let pyodide = null;
+const INDEX_URL = ${JSON.stringify(opts.indexUrl)};
+const LOAD_PACKAGES = ${JSON.stringify(opts.loadPackages)};
+const MICROPIP_WHEELS = ${JSON.stringify(opts.micropipWheels)};
+
+// Best-effort realm hardening: remove the network surface from every reachable
+// global target. Runs AFTER load (which needs fetch) and BEFORE any user code.
+function __hardenRealm() {
+  const NAMES = ['fetch','XMLHttpRequest','WebSocket','EventSource','WebTransport',
+                 'Request','Response','Headers','importScripts','caches','indexedDB'];
+  const targets = [self, globalThis];
+  let p = Object.getPrototypeOf(self);
+  while (p && p !== Object.prototype) { targets.push(p); p = Object.getPrototypeOf(p); }
+  for (const t of targets) {
+    for (const n of NAMES) {
+      try { delete t[n]; } catch (e) { /* non-configurable */ }
+      try { Object.defineProperty(t, n, { value: undefined, configurable: false, writable: false }); } catch (e) { /* frozen */ }
+    }
+  }
+  try { if (self.navigator) self.navigator.sendBeacon = undefined; } catch (e) { /* readonly */ }
+}
+
+async function init() {
+  importScripts(INDEX_URL + 'pyodide.js');
+  pyodide = await self.loadPyodide({ indexURL: INDEX_URL });
+  await pyodide.loadPackage([...LOAD_PACKAGES, 'micropip']);
+  if (MICROPIP_WHEELS.length) {
+    const micropip = pyodide.pyimport('micropip');
+    await micropip.install(MICROPIP_WHEELS.map(function (w) { return INDEX_URL + w; }), false);
+  }
+  pyodide.runPython(${JSON.stringify(MARSHAL_PY)});
+  try { pyodide.runPython(${JSON.stringify(DROP_NET_PY)}); } catch (e) { /* best effort */ }
+  __hardenRealm();
+}
+
+const ready = init().then(function () { return { ok: true }; })
+  .catch(function (e) { return { ok: false, error: String((e && e.stack) || e) }; });
+
+// JSON.dumps may emit NaN/Infinity tokens (invalid JSON); coerce to null pre-parse.
+function __parseMarshalled(s) {
+  return JSON.parse(String(s).replace(/\\bNaN\\b/g, 'null').replace(/-?\\bInfinity\\b/g, 'null'));
+}
+
+self.onmessage = async function (ev) {
+  const msg = ev.data || {};
+
+  if (msg.type === 'init') {
+    const r = await ready;
+    self.postMessage(r.ok ? { type: 'ready' } : { type: 'init-error', error: r.error });
+    return;
+  }
+
+  if (msg.type === 'run') {
+    const r = await ready;
+    if (!r.ok) {
+      self.postMessage({ id: msg.id, type: 'result', success: false, error: 'Runtime failed to initialize: ' + r.error });
+      return;
+    }
+    const started = Date.now();
+    const logs = [];
+    let proxy = null;
+    try {
+      pyodide.setStdout({ batched: function (s) { logs.push(s); } });
+      pyodide.setStderr({ batched: function (s) { logs.push(s); } });
+
+      // Fresh MEMFS state per run (no data leak between analyses).
+      try { pyodide.runPython("import shutil; shutil.rmtree('/data', ignore_errors=True)"); } catch (e) { /* none yet */ }
+      pyodide.FS.mkdirTree('/data');
+
+      const inputs = {};
+      const files = msg.files || [];
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i];
+        pyodide.FS.writeFile(f.sandboxPath, f.bytes);
+        inputs[f.varName] = f.sandboxPath;
+      }
+      pyodide.globals.set('inputs', pyodide.toPy(inputs));
+
+      proxy = await pyodide.runPythonAsync(msg.code);
+      pyodide.globals.set('__nexus_result', proxy);
+      const jsonStr = pyodide.runPython('__nexus_dumps(__nexus_result)');
+      const data = __parseMarshalled(jsonStr);
+
+      self.postMessage({ id: msg.id, type: 'result', success: true, data: data, logs: logs, stats: { durationMs: Date.now() - started } });
+    } catch (e) {
+      self.postMessage({ id: msg.id, type: 'result', success: false, error: String((e && e.message) || e), logs: logs });
+    } finally {
+      try { if (proxy && typeof proxy.destroy === 'function') proxy.destroy(); } catch (e) { /* not a proxy */ }
+    }
+  }
+};
+`;
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreAssets.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreAssets.ts
@@ -1,0 +1,37 @@
+/**
+ * HucreAssets — vendors the `hucre/xlsx` engine as a runtime asset, mirroring
+ * {@link PyodideEnsurer}. hucre's xlsx entry is ~302 KB minified, which exceeds
+ * main.js's ~218 KB headroom against the 5 MB ceiling (measured in spike S2,
+ * docs/plans/spike-findings-hucre-2026-05-31.md), so it must NEVER be bundled —
+ * it is fetched once and loaded from the plugin's `hucre` folder thereafter.
+ *
+ * The asset is the dependency-bundled ESM build of the `hucre/xlsx` subpath
+ * (esm.sh resolves hucre's internal `./xlsx/*.mjs` parts into one file).
+ *
+ * ⚠️ PENDING Electron validation: the download (requestUrl) + the
+ * `import(file://…)` load path must be exercised in a real Obsidian desktop
+ * build. Only the pinned manifest below is unit-tested; the fetch/load mechanics
+ * are not runnable in the headless container.
+ */
+
+export const HUCRE_VERSION = '0.6.0';
+
+export interface HucreAssetSpec {
+  /** Filename written into the plugin's hucre dir. */
+  file: string;
+  /** Absolute download URL (dependency-bundled ESM of `hucre/xlsx`). */
+  url: string;
+  /** Reject downloads smaller than this (guards against HTML error pages). */
+  minBytes: number;
+}
+
+export const HUCRE_XLSX_ASSET: HucreAssetSpec = {
+  file: 'hucre-xlsx.mjs',
+  url: `https://esm.sh/hucre@${HUCRE_VERSION}/xlsx`,
+  minBytes: 50_000,
+};
+
+/** The complete, deterministic set of files the write-back/mirror engine needs. */
+export function buildHucreAssetManifest(): HucreAssetSpec[] {
+  return [HUCRE_XLSX_ASSET];
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreAssets.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreAssets.ts
@@ -27,7 +27,9 @@ export interface HucreAssetSpec {
 
 export const HUCRE_XLSX_ASSET: HucreAssetSpec = {
   file: 'hucre-xlsx.mjs',
-  url: `https://esm.sh/hucre@${HUCRE_VERSION}/xlsx`,
+  // `?bundle` inlines hucre's internal `./xlsx/*` parts into one self-contained
+  // ESM file so the vendored asset loads offline (no further network fetches).
+  url: `https://esm.sh/hucre@${HUCRE_VERSION}/xlsx?bundle&target=es2022`,
   minBytes: 50_000,
 };
 

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreModule.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreModule.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared shape of the `hucre/xlsx` round-trip module used by both the reader
+ * (HucreXlsxSource) and the writer (HucreXlsxWriter). hucre is loaded as a
+ * vendored runtime asset (see HucreEnsurer), so the module is injected.
+ *
+ * Matches the API verified in spike S2 (openXlsx → RoundtripWorkbook with
+ * `_rawEntries`/`_modifiedParts`; saveXlsx preserves unmodified parts).
+ */
+
+import type { CellValue } from './types';
+
+export interface HucreRoundtripWorkbook {
+  sheets: Array<{ name: string; rows: CellValue[][] }>;
+  /** Every original ZIP part, keyed by path (charts/images/pivots ride here). */
+  _rawEntries: Map<string, Uint8Array>;
+  /** Parts to regenerate on save; cell edits must add the sheet's part here. */
+  _modifiedParts: Set<string>;
+  /** True when the source carries VBA macros (xl/vbaProject.bin → `.xlsm`). */
+  hasMacros?: boolean;
+}
+
+export interface HucreModule {
+  openXlsx(bytes: Uint8Array): Promise<HucreRoundtripWorkbook>;
+  saveXlsx(workbook: HucreRoundtripWorkbook): Promise<Uint8Array>;
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxSource.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxSource.ts
@@ -1,0 +1,84 @@
+/**
+ * HucreXlsxSource — the {@link XlsxSource} backed by the `hucre` engine
+ * (lossless xlsx round-trip; see docs/plans/spike-findings-hucre-2026-05-31.md).
+ *
+ * hucre is VENDORED as a runtime asset (302 KB — too big for main.js's 5MB
+ * ceiling, see {@link HucreAssets}), so the module is injected via a loader
+ * rather than statically imported. This keeps the value-mapping logic here pure
+ * and unit-testable with a fake module, while the actual asset load is the only
+ * Electron-bound piece.
+ *
+ * ⚠️ formula-cell detection is best-effort here and refined in the Electron pass
+ * (openXlsx exposes cell-level formulas; the headless `readXlsx` returns values).
+ */
+
+import type { CellValue, ParsedSheet, ParsedWorkbook, XlsxSource } from './types';
+
+/** The shape of one sheet as hucre's reader yields it. */
+export interface HucreSheet {
+  name: string;
+  rows: unknown[][];
+}
+
+export interface HucreReadResult {
+  sheets: HucreSheet[];
+  hasMacros?: boolean;
+}
+
+/** The slice of `hucre/xlsx` we depend on (so it can be stubbed in tests). */
+export interface HucreXlsxModule {
+  readXlsx(bytes: Uint8Array): Promise<HucreReadResult>;
+}
+
+export class HucreXlsxSource implements XlsxSource {
+  constructor(private loadModule: () => Promise<HucreXlsxModule>) {}
+
+  async readWorkbook(bytes: Uint8Array): Promise<ParsedWorkbook> {
+    const mod = await this.loadModule();
+    const result = await mod.readXlsx(bytes);
+
+    const sheets: ParsedSheet[] = result.sheets.map((sheet) => ({
+      name: sheet.name,
+      rows: sheet.rows.map((row) => row.map(toCellValue)),
+      formulaCells: [],
+    }));
+
+    return {
+      sheets,
+      sourceHash: fnv1aHex(bytes),
+      hasMacros: result.hasMacros ?? false,
+    };
+  }
+}
+
+/** Coerce an arbitrary reader cell into a CSV-representable {@link CellValue}. */
+function toCellValue(value: unknown): CellValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  // Unexpected object-shaped cell: serialize rather than emit "[object Object]".
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+/** FNV-1a (32-bit) hex over raw bytes — fast, dependency-free content key. */
+export function fnv1aHex(bytes: Uint8Array): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    hash ^= bytes[i];
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxSource.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxSource.ts
@@ -2,53 +2,62 @@
  * HucreXlsxSource — the {@link XlsxSource} backed by the `hucre` engine
  * (lossless xlsx round-trip; see docs/plans/spike-findings-hucre-2026-05-31.md).
  *
- * hucre is VENDORED as a runtime asset (302 KB — too big for main.js's 5MB
- * ceiling, see {@link HucreAssets}), so the module is injected via a loader
- * rather than statically imported. This keeps the value-mapping logic here pure
- * and unit-testable with a fake module, while the actual asset load is the only
- * Electron-bound piece.
+ * Reads via `openXlsx` (the same RoundtripWorkbook the writer uses) so we get
+ * both the cell VALUES (for the CSV projection) and the raw worksheet XML — the
+ * latter lets us detect FORMULA cells (`<c r="B2"><f>…`) so the write-back's
+ * formula-cell guard is active. hucre is injected (it's a vendored runtime asset,
+ * not bundled — see HucreAssets), which also keeps this logic unit-testable.
  *
- * ⚠️ formula-cell detection is best-effort here and refined in the Electron pass
- * (openXlsx exposes cell-level formulas; the headless `readXlsx` returns values).
+ * ⚠️ PENDING Electron validation: the sheet-index → worksheet-part mapping is the
+ * sorted-Nth `xl/worksheets/sheetN.xml` approximation (precise mapping is via
+ * workbook rels). Verify against multi-sheet real workbooks.
  */
 
+import type { HucreModule } from './HucreModule';
 import type { CellValue, ParsedSheet, ParsedWorkbook, XlsxSource } from './types';
 
-/** The shape of one sheet as hucre's reader yields it. */
-export interface HucreSheet {
-  name: string;
-  rows: unknown[][];
-}
-
-export interface HucreReadResult {
-  sheets: HucreSheet[];
-  hasMacros?: boolean;
-}
-
-/** The slice of `hucre/xlsx` we depend on (so it can be stubbed in tests). */
-export interface HucreXlsxModule {
-  readXlsx(bytes: Uint8Array): Promise<HucreReadResult>;
-}
-
 export class HucreXlsxSource implements XlsxSource {
-  constructor(private loadModule: () => Promise<HucreXlsxModule>) {}
+  constructor(private loadModule: () => Promise<HucreModule>) {}
 
   async readWorkbook(bytes: Uint8Array): Promise<ParsedWorkbook> {
     const mod = await this.loadModule();
-    const result = await mod.readXlsx(bytes);
+    const wb = await mod.openXlsx(bytes);
 
-    const sheets: ParsedSheet[] = result.sheets.map((sheet) => ({
-      name: sheet.name,
-      rows: sheet.rows.map((row) => row.map(toCellValue)),
-      formulaCells: [],
-    }));
+    const worksheetParts = [...wb._rawEntries.keys()]
+      .filter((k) => /^xl\/worksheets\/sheet\d+\.xml$/.test(k))
+      .sort();
+
+    const sheets: ParsedSheet[] = wb.sheets.map((sheet, index) => {
+      const part = worksheetParts[index];
+      const xml = part ? wb._rawEntries.get(part) : undefined;
+      return {
+        name: sheet.name,
+        rows: sheet.rows.map((row) => row.map(toCellValue)),
+        formulaCells: xml ? formulaCellsFromXml(decodeUtf8(xml)) : [],
+      };
+    });
 
     return {
       sheets,
       sourceHash: fnv1aHex(bytes),
-      hasMacros: result.hasMacros ?? false,
+      hasMacros: wb.hasMacros ?? false,
     };
   }
+}
+
+/** A1 refs of cells holding a formula (`<c r="B2" …><f>…`). */
+export function formulaCellsFromXml(xml: string): string[] {
+  const refs: string[] = [];
+  const re = /<c\b[^>]*\br="([A-Z]+\d+)"[^>]*>\s*<f[\s>/]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml)) !== null) {
+    refs.push(m[1]);
+  }
+  return refs;
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes);
 }
 
 /** Coerce an arbitrary reader cell into a CSV-representable {@link CellValue}. */
@@ -65,7 +74,6 @@ function toCellValue(value: unknown): CellValue {
   if (typeof value === 'bigint') {
     return value.toString();
   }
-  // Unexpected object-shaped cell: serialize rather than emit "[object Object]".
   try {
     return JSON.stringify(value);
   } catch {

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxWriter.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxWriter.ts
@@ -17,21 +17,11 @@
  * parts) but may regenerate a sibling worksheet.
  */
 
-import type { CellValue, CellWrite, XlsxWriter } from './types';
-
-export interface HucreRoundtripWorkbook {
-  sheets: Array<{ name: string; rows: CellValue[][] }>;
-  _rawEntries: Map<string, Uint8Array>;
-  _modifiedParts: Set<string>;
-}
-
-export interface HucreApplyModule {
-  openXlsx(bytes: Uint8Array): Promise<HucreRoundtripWorkbook>;
-  saveXlsx(workbook: HucreRoundtripWorkbook): Promise<Uint8Array>;
-}
+import type { HucreModule, HucreRoundtripWorkbook } from './HucreModule';
+import type { CellWrite, XlsxWriter } from './types';
 
 export class HucreXlsxWriter implements XlsxWriter {
-  constructor(private loadModule: () => Promise<HucreApplyModule>) {}
+  constructor(private loadModule: () => Promise<HucreModule>) {}
 
   async applyCellWrites(sourceBytes: Uint8Array, writes: CellWrite[]): Promise<Uint8Array> {
     const mod = await this.loadModule();

--- a/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxWriter.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxWriter.ts
@@ -1,0 +1,77 @@
+/**
+ * HucreXlsxWriter — the {@link XlsxWriter} backed by `hucre`'s round-trip API.
+ *
+ * Per spike S2 (docs/plans/spike-findings-hucre-2026-05-31.md): `openXlsx`
+ * preserves every original ZIP part in `_rawEntries`; editing `sheet.rows[r][c]`
+ * does NOT auto-mark the part dirty, so we must explicitly add the changed
+ * sheet's worksheet part to `_modifiedParts`; `saveXlsx` then regenerates only
+ * those parts and writes the rest (charts/images/pivots) back byte-for-byte.
+ *
+ * The hucre module is INJECTED (it's a vendored runtime asset, not bundled — see
+ * HucreAssets), which also makes the apply orchestration unit-testable with a fake.
+ *
+ * ⚠️ PENDING Electron validation: the precise sheet→worksheet-part mapping
+ * (`xl/worksheets/sheetN.xml` via workbook rels) is approximated here as the
+ * sorted Nth worksheet part. Verify against multi-sheet real workbooks; until
+ * then over-marking is safe for cross-part fidelity (charts live in separate
+ * parts) but may regenerate a sibling worksheet.
+ */
+
+import type { CellValue, CellWrite, XlsxWriter } from './types';
+
+export interface HucreRoundtripWorkbook {
+  sheets: Array<{ name: string; rows: CellValue[][] }>;
+  _rawEntries: Map<string, Uint8Array>;
+  _modifiedParts: Set<string>;
+}
+
+export interface HucreApplyModule {
+  openXlsx(bytes: Uint8Array): Promise<HucreRoundtripWorkbook>;
+  saveXlsx(workbook: HucreRoundtripWorkbook): Promise<Uint8Array>;
+}
+
+export class HucreXlsxWriter implements XlsxWriter {
+  constructor(private loadModule: () => Promise<HucreApplyModule>) {}
+
+  async applyCellWrites(sourceBytes: Uint8Array, writes: CellWrite[]): Promise<Uint8Array> {
+    const mod = await this.loadModule();
+    const wb = await mod.openXlsx(sourceBytes);
+
+    const indexByName = new Map(wb.sheets.map((s, i) => [s.name, i]));
+    const touched = new Set<number>();
+
+    for (const write of writes) {
+      const idx = indexByName.get(write.sheet);
+      if (idx === undefined) {
+        continue;
+      }
+      const rows = wb.sheets[idx].rows;
+      while (rows.length <= write.row) {
+        rows.push([]);
+      }
+      const row = rows[write.row];
+      while (row.length <= write.col) {
+        row.push(null);
+      }
+      row[write.col] = write.value;
+      touched.add(idx);
+    }
+
+    for (const idx of touched) {
+      const part = HucreXlsxWriter.worksheetPart(wb, idx);
+      if (part) {
+        wb._modifiedParts.add(part);
+      }
+    }
+
+    return mod.saveXlsx(wb);
+  }
+
+  /** Best-effort sheet-index → worksheet part path (see ⚠️ note above). */
+  private static worksheetPart(wb: HucreRoundtripWorkbook, sheetIndex: number): string | null {
+    const parts = [...wb._rawEntries.keys()]
+      .filter((k) => /^xl\/worksheets\/sheet\d+\.xml$/.test(k))
+      .sort();
+    return parts[sheetIndex] ?? null;
+  }
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/SpreadsheetAutoSync.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/SpreadsheetAutoSync.ts
@@ -1,0 +1,119 @@
+/**
+ * SpreadsheetAutoSync — debounced, loop-safe scheduler that turns vault file
+ * changes under `<root>/spreadsheets/<id>/*.csv` into a write-back of that
+ * workbook. The actual sync work is injected (`sync`), so the scheduling logic
+ * (path filtering, debounce, self-write suppression) is pure + unit-testable;
+ * the agent wires `sync` to the hucre write-back and the vault `modify` event.
+ *
+ * Loop safety: the write-back re-projects the mirror (writes CSVs), which would
+ * re-fire `modify`. We ignore events for a workbook while its sync is running
+ * (catches the re-projection writes) and for a short cooldown afterward (catches
+ * trailing events). Because the debounce only fires after edits go quiet, a
+ * genuine concurrent edit mid-sync is a non-issue — and if one ever happened it
+ * stays in the CSV and is picked up by the next trigger.
+ */
+
+export type SyncFn = (workbookId: string) => Promise<void>;
+
+export interface AutoSyncOptions {
+  /** Current resolved vault root (e.g. `Nexus`). Read each event (rename-safe). */
+  getRoot: () => string;
+  sync: SyncFn;
+  /** Quiet period after the last edit before syncing. Default 1500ms. */
+  debounceMs?: number;
+  /** Window after a sync during which re-projection writes are ignored. Default 800ms. */
+  cooldownMs?: number;
+  setTimer?: (fn: () => void, ms: number) => number;
+  clearTimer?: (handle: number) => void;
+  now?: () => number;
+}
+
+export class SpreadsheetAutoSync {
+  private readonly debounceMs: number;
+  private readonly cooldownMs: number;
+  private readonly setTimer: (fn: () => void, ms: number) => number;
+  private readonly clearTimer: (handle: number) => void;
+  private readonly now: () => number;
+
+  private readonly timers = new Map<string, number>();
+  private readonly suppressedUntil = new Map<string, number>();
+  private readonly syncing = new Set<string>();
+
+  constructor(private readonly options: AutoSyncOptions) {
+    this.debounceMs = options.debounceMs ?? 1500;
+    this.cooldownMs = options.cooldownMs ?? 800;
+    this.setTimer = options.setTimer ?? ((fn, ms) => window.setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((h) => window.clearTimeout(h));
+    this.now = options.now ?? Date.now;
+  }
+
+  /** Call on every vault `modify`. No-op unless `path` is a mirror CSV shard. */
+  notifyModified(path: string): void {
+    const workbookId = this.workbookIdOf(path);
+    if (!workbookId) {
+      return;
+    }
+    if (this.syncing.has(workbookId)) {
+      return; // mid-sync — ignore (catches our own re-projection writes)
+    }
+    if (this.now() < (this.suppressedUntil.get(workbookId) ?? 0)) {
+      return; // cooldown — ignore trailing re-projection writes
+    }
+    this.schedule(workbookId);
+  }
+
+  private schedule(workbookId: string): void {
+    const existing = this.timers.get(workbookId);
+    if (existing) {
+      this.clearTimer(existing);
+    }
+    this.timers.set(workbookId, this.setTimer(() => void this.run(workbookId), this.debounceMs));
+  }
+
+  private async run(workbookId: string): Promise<void> {
+    this.timers.delete(workbookId);
+    if (this.syncing.has(workbookId)) {
+      return;
+    }
+    this.syncing.add(workbookId);
+    try {
+      await this.options.sync(workbookId);
+    } catch {
+      // Failures surface via the sync impl (Notice); don't crash the listener.
+    } finally {
+      this.syncing.delete(workbookId);
+      this.suppressedUntil.set(workbookId, this.now() + this.cooldownMs);
+    }
+  }
+
+  /** Map a vault path to its workbook id, or null if it isn't a mirror CSV shard. */
+  workbookIdOf(path: string): string | null {
+    const prefix = `${this.options.getRoot()}/spreadsheets/`;
+    const norm = path.replace(/^\/+/, '');
+    if (!norm.startsWith(prefix)) {
+      return null;
+    }
+    const rest = norm.slice(prefix.length);
+    const slash = rest.indexOf('/');
+    if (slash < 0) {
+      return null;
+    }
+    const workbookId = rest.slice(0, slash);
+    const relFile = rest.slice(slash + 1);
+    if (!relFile.endsWith('.csv')) {
+      return null; // ignore manifest.json and other files
+    }
+    if (relFile.startsWith('_archive/') || relFile.includes('/_archive/')) {
+      return null; // ignore snapshot shards
+    }
+    return workbookId;
+  }
+
+  /** Cancel any pending timers (call on unload). */
+  dispose(): void {
+    for (const handle of this.timers.values()) {
+      this.clearTimer(handle);
+    }
+    this.timers.clear();
+  }
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService.ts
@@ -32,6 +32,8 @@ export interface MirrorTarget {
   root: string;
   /** Workbook id (source basename without extension), e.g. `budget`. */
   workbookId: string;
+  /** Vault-relative path of the source `.xlsx` (recorded for auto-sync). */
+  sourcePath?: string;
   /** Per-file byte cap (e.g. `maxShardBytes`). */
   maxShardBytes: number;
   /** Clock injection for deterministic tests. Default {@link Date.now}. */
@@ -113,6 +115,7 @@ export class WorkbookMirrorService {
     const manifest: MirrorManifest = {
       schemaVersion: MIRROR_SCHEMA_VERSION,
       workbook: target.workbookId,
+      sourcePath: target.sourcePath ?? existing?.sourcePath ?? '',
       sourceHash: workbook.sourceHash,
       hasMacros: workbook.hasMacros ?? false,
       generatedAt: new Date((target.now ?? Date.now)()).toISOString(),

--- a/src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService.ts
@@ -1,0 +1,175 @@
+/**
+ * WorkbookMirrorService — generates/refreshes the folder-per-workbook CSV mirror
+ * (the AI's value surface) from a {@link ParsedWorkbook}.
+ *
+ * Layout (under the resolved Nexus root, synced + renameable):
+ *   <root>/spreadsheets/<workbookId>/
+ *     manifest.json          — sheet order, shard index (row ranges), source hash
+ *     <Sheet>.part<n>.csv     — values, sharded to maxShardBytes
+ *     _archive/…              — snapshots (SnapshotArchiveService, the write-back leg)
+ *
+ * This service is pure projection: it (re)writes the values-CSV view. It does NOT
+ * touch the source `.xlsx` (that's the write-back leg) and does NOT snapshot
+ * (that's `SnapshotArchiveService`). Generation is idempotent — if an existing
+ * manifest's `sourceHash` matches, it's a no-op.
+ *
+ * All I/O goes through Obsidian's {@link DataAdapter}; every path is normalized.
+ */
+
+import { normalizePath } from 'obsidian';
+import type { DataAdapter } from 'obsidian';
+import { shardSheet } from './shard';
+import {
+  MIRROR_SCHEMA_VERSION,
+  type MirrorManifest,
+  type ParsedWorkbook,
+  type SheetManifest,
+  type ShardEntry,
+} from './types';
+
+export interface MirrorTarget {
+  /** Resolved vault root, e.g. `Nexus` (from `resolveVaultRoot`). */
+  root: string;
+  /** Workbook id (source basename without extension), e.g. `budget`. */
+  workbookId: string;
+  /** Per-file byte cap (e.g. `maxShardBytes`). */
+  maxShardBytes: number;
+  /** Clock injection for deterministic tests. Default {@link Date.now}. */
+  now?: () => number;
+}
+
+export interface MirrorResult {
+  manifest: MirrorManifest;
+  /** False when an existing same-hash mirror let us skip the rewrite. */
+  regenerated: boolean;
+}
+
+export class WorkbookMirrorService {
+  constructor(private adapter: DataAdapter) {}
+
+  /** `<root>/spreadsheets/<workbookId>`. */
+  mirrorDir(target: MirrorTarget): string {
+    return normalizePath(`${target.root}/spreadsheets/${target.workbookId}`);
+  }
+
+  /** Read the existing manifest, or null when absent/unparseable. */
+  async readManifest(target: MirrorTarget): Promise<MirrorManifest | null> {
+    const path = normalizePath(`${this.mirrorDir(target)}/manifest.json`);
+    try {
+      if (!(await this.adapter.exists(path))) {
+        return null;
+      }
+      return JSON.parse(await this.adapter.read(path)) as MirrorManifest;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Generate (or refresh) the mirror. Idempotent: an existing manifest with the
+   * same `sourceHash` short-circuits to `regenerated: false`.
+   */
+  async generate(workbook: ParsedWorkbook, target: MirrorTarget): Promise<MirrorResult> {
+    const existing = await this.readManifest(target);
+    if (existing && existing.sourceHash === workbook.sourceHash) {
+      return { manifest: existing, regenerated: false };
+    }
+
+    const dir = this.mirrorDir(target);
+    await this.ensureFolder(dir);
+    await this.clearShardCsvs(dir);
+
+    const usedNames = new Set<string>();
+    const sheets: SheetManifest[] = [];
+
+    for (let order = 0; order < workbook.sheets.length; order++) {
+      const sheet = workbook.sheets[order];
+      const base = this.uniqueBase(sheet.name, order, usedNames);
+      const colCount = sheet.rows.reduce((max, row) => Math.max(max, row.length), 0);
+
+      const shards = shardSheet(sheet.rows, target.maxShardBytes);
+      const shardEntries: ShardEntry[] = [];
+      for (let part = 0; part < shards.length; part++) {
+        const file = `${base}.part${part}.csv`;
+        await this.adapter.write(normalizePath(`${dir}/${file}`), shards[part].csv);
+        shardEntries.push({
+          file,
+          startRow: shards[part].startRow,
+          endRow: shards[part].endRow,
+          bytes: shards[part].bytes,
+        });
+      }
+
+      sheets.push({
+        name: sheet.name,
+        order,
+        rowCount: sheet.rows.length,
+        colCount,
+        shards: shardEntries,
+        formulaCells: sheet.formulaCells ?? [],
+      });
+    }
+
+    const manifest: MirrorManifest = {
+      schemaVersion: MIRROR_SCHEMA_VERSION,
+      workbook: target.workbookId,
+      sourceHash: workbook.sourceHash,
+      hasMacros: workbook.hasMacros ?? false,
+      generatedAt: new Date((target.now ?? Date.now)()).toISOString(),
+      maxShardBytes: target.maxShardBytes,
+      sheets,
+    };
+    await this.adapter.write(
+      normalizePath(`${dir}/manifest.json`),
+      JSON.stringify(manifest, null, 2)
+    );
+
+    return { manifest, regenerated: true };
+  }
+
+  /** Recursive mkdir (each missing segment in turn — the `vault.adapter` pattern). */
+  private async ensureFolder(path: string): Promise<void> {
+    const segments = normalizePath(path).split('/').filter((s) => s.length > 0);
+    let current = '';
+    for (const segment of segments) {
+      current = current.length > 0 ? `${current}/${segment}` : segment;
+      if (!(await this.adapter.exists(current))) {
+        await this.adapter.mkdir(current);
+      }
+    }
+  }
+
+  /**
+   * Remove the immediate `.csv` + `manifest.json` files of a prior generation so
+   * a refresh leaves no stale shards. Subfolders (notably `_archive/`) are left
+   * untouched.
+   */
+  private async clearShardCsvs(dir: string): Promise<void> {
+    let listing: { files: string[]; folders: string[] };
+    try {
+      listing = await this.adapter.list(dir);
+    } catch {
+      return;
+    }
+    for (const filePath of listing.files) {
+      if (/\.csv$/.test(filePath) || /\/manifest\.json$/.test(filePath)) {
+        await this.adapter.remove(filePath);
+      }
+    }
+  }
+
+  /**
+   * Filesystem-safe, collision-free basename for a sheet. Sheet names can hold
+   * characters illegal in filenames or collapse to the same slug, so we sanitize
+   * and disambiguate with the sheet's order.
+   */
+  private uniqueBase(sheetName: string, order: number, used: Set<string>): string {
+    const sanitized = sheetName.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
+    let base = sanitized.length > 0 ? sanitized : `sheet${order}`;
+    if (used.has(base.toLowerCase())) {
+      base = `${base}-${order}`;
+    }
+    used.add(base.toLowerCase());
+    return base;
+  }
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/WorkbookWriteBackService.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/WorkbookWriteBackService.ts
@@ -1,0 +1,176 @@
+/**
+ * WorkbookWriteBackService — the lossless write-back leg (Phase 2).
+ *
+ * Flow (see docs/plans/spreadsheet-mirror-versioning-plan.md §3.6):
+ *   1. read the ORIGINAL workbook values from the source `.xlsx`
+ *   2. divergence guard — refuse if the source changed since the mirror was made
+ *   3. parse the EDITED CSV shards, diff vs original → changed data cells
+ *   4. formula-cell guard — never clobber a live formula
+ *   5. dryRun / no-op → return the summary without writing
+ *   6. snapshot the prior CSV shards (value-level restore point)
+ *   7. hucre-apply the changed cells → new `.xlsx` bytes (charts preserved)
+ *   8. re-project the mirror from the updated workbook
+ *
+ * The actual binary write of the new `.xlsx` to the vault is the caller's job
+ * (Electron `vault.adapter.writeBinary`); this service returns the new bytes.
+ */
+
+import { normalizePath } from 'obsidian';
+import type { DataAdapter } from 'obsidian';
+import { parseCsv } from './csv';
+import { coerceToOriginalType, diffSheet, partitionByFormula, type CellEdit } from './diff';
+import type { SnapshotArchiveService } from '../../../../services/storage/SnapshotArchiveService';
+import type { MirrorTarget, WorkbookMirrorService } from './WorkbookMirrorService';
+import type { CellValue, CellWrite, MirrorManifest, SheetManifest, XlsxSource, XlsxWriter } from './types';
+
+export interface WriteBackOptions {
+  /** Compute + return the summary without writing anything. */
+  dryRun?: boolean;
+  /** Proceed even if the source `.xlsx` diverged from the mirror. */
+  force?: boolean;
+}
+
+export interface SheetChangeSummary {
+  sheet: string;
+  applied: number;
+  /** A1 refs of edits skipped because they targeted a formula cell. */
+  blockedFormulaCells: string[];
+  samples: Array<{ a1: string; before: string; after: string }>;
+}
+
+export interface WriteBackSummary {
+  sheetsChanged: number;
+  cellsApplied: number;
+  cellsBlocked: number;
+  sheets: SheetChangeSummary[];
+}
+
+export type WriteBackReason = 'no-mirror' | 'divergence' | 'dry-run' | 'no-changes' | 'applied';
+
+export interface WriteBackResult {
+  summary: WriteBackSummary;
+  applied: boolean;
+  reason: WriteBackReason;
+  archivePath?: string | null;
+  newBytes?: Uint8Array;
+  newSourceHash?: string;
+}
+
+const EMPTY_SUMMARY: WriteBackSummary = { sheetsChanged: 0, cellsApplied: 0, cellsBlocked: 0, sheets: [] };
+
+export class WorkbookWriteBackService {
+  constructor(
+    private adapter: DataAdapter,
+    private xlsxSource: XlsxSource,
+    private xlsxWriter: XlsxWriter,
+    private mirror: WorkbookMirrorService,
+    private snapshot: SnapshotArchiveService
+  ) {}
+
+  async apply(
+    target: MirrorTarget,
+    sourceBytes: Uint8Array,
+    options: WriteBackOptions = {}
+  ): Promise<WriteBackResult> {
+    const manifest = await this.mirror.readManifest(target);
+    if (!manifest) {
+      return { summary: EMPTY_SUMMARY, applied: false, reason: 'no-mirror' };
+    }
+
+    const original = await this.xlsxSource.readWorkbook(sourceBytes);
+    if (!options.force && original.sourceHash !== manifest.sourceHash) {
+      return { summary: EMPTY_SUMMARY, applied: false, reason: 'divergence' };
+    }
+
+    const { summary, writes } = await this.plan(target, manifest, original);
+
+    if (options.dryRun) {
+      return { summary, applied: false, reason: 'dry-run' };
+    }
+    if (writes.length === 0) {
+      return { summary, applied: false, reason: 'no-changes' };
+    }
+
+    const archivePath = await this.snapshot.archiveCopy(this.mirror.mirrorDir(target));
+    const newBytes = await this.xlsxWriter.applyCellWrites(sourceBytes, writes);
+
+    // Re-project the mirror from the updated workbook (new sourceHash → rewrite).
+    const updated = await this.xlsxSource.readWorkbook(newBytes);
+    await this.mirror.generate(updated, target);
+
+    return {
+      summary,
+      applied: true,
+      reason: 'applied',
+      archivePath,
+      newBytes,
+      newSourceHash: updated.sourceHash,
+    };
+  }
+
+  /** Diff every sheet's edited shards vs the original; apply the formula guard. */
+  private async plan(
+    target: MirrorTarget,
+    manifest: MirrorManifest,
+    original: { sheets: Array<{ name: string; rows: CellValue[][] }> }
+  ): Promise<{ summary: WriteBackSummary; writes: CellWrite[] }> {
+    const dir = this.mirror.mirrorDir(target);
+    const sheets: SheetChangeSummary[] = [];
+    const writes: CellWrite[] = [];
+    let cellsBlocked = 0;
+
+    for (const sheetManifest of manifest.sheets) {
+      const editedRows = await this.readEditedSheet(dir, sheetManifest);
+      const originalRows = original.sheets.find((s) => s.name === sheetManifest.name)?.rows ?? [];
+
+      const edits = diffSheet(sheetManifest.name, originalRows, editedRows);
+      const { applied, blocked } = partitionByFormula(edits, new Set(sheetManifest.formulaCells));
+
+      for (const edit of applied) {
+        const originalCell = originalRows[edit.row]?.[edit.col] ?? null;
+        writes.push({
+          sheet: sheetManifest.name,
+          row: edit.row,
+          col: edit.col,
+          value: coerceToOriginalType(originalCell, edit.after),
+        });
+      }
+
+      cellsBlocked += blocked.length;
+      sheets.push({
+        sheet: sheetManifest.name,
+        applied: applied.length,
+        blockedFormulaCells: blocked.map((b) => b.a1),
+        samples: applied.slice(0, 5).map((e: CellEdit) => ({ a1: e.a1, before: e.before, after: e.after })),
+      });
+    }
+
+    return {
+      summary: {
+        sheetsChanged: sheets.filter((s) => s.applied > 0).length,
+        cellsApplied: writes.length,
+        cellsBlocked,
+        sheets,
+      },
+      writes,
+    };
+  }
+
+  /** Reassemble a sheet's edited rows by parsing its shards in manifest order. */
+  private async readEditedSheet(dir: string, sheet: SheetManifest): Promise<string[][]> {
+    const rows: string[][] = [];
+    for (const shard of sheet.shards) {
+      const path = normalizePath(`${dir}/${shard.file}`);
+      let text: string;
+      try {
+        text = await this.adapter.read(path);
+      } catch {
+        continue;
+      }
+      for (const row of parseCsv(text)) {
+        rows.push(row);
+      }
+    }
+    return rows;
+  }
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
@@ -102,3 +102,57 @@ export function serializeRows(rows: CellValue[][]): string {
   }
   return rows.map(serializeRow).join('\n') + '\n';
 }
+
+/**
+ * Serialize an arbitrary JSON-ish analysis result to CSV. Accepts an array of
+ * rows (`unknown[][]`), an array of records (`Record[]` — columns are the union
+ * of keys, first-seen order), or an array of scalars (single column). Throws on
+ * a non-array result (a scalar/object can't be a table).
+ */
+export function dataToCsv(data: unknown): string {
+  if (!Array.isArray(data)) {
+    throw new Error('CSV output requires a list of rows (arrays) or records (objects).');
+  }
+  if (data.length === 0) {
+    return '';
+  }
+  if (Array.isArray(data[0])) {
+    return serializeRows((data as unknown[][]).map((row) => row.map(toCsvCell)));
+  }
+  if (isRecord(data[0])) {
+    const cols: string[] = [];
+    const seen = new Set<string>();
+    for (const rec of data as Record<string, unknown>[]) {
+      for (const key of Object.keys(rec)) {
+        if (!seen.has(key)) {
+          seen.add(key);
+          cols.push(key);
+        }
+      }
+    }
+    const rows: CellValue[][] = [cols];
+    for (const rec of data as Record<string, unknown>[]) {
+      rows.push(cols.map((col) => toCsvCell(rec[col])));
+    }
+    return serializeRows(rows);
+  }
+  return serializeRows((data as unknown[]).map((value) => [toCsvCell(value)]));
+}
+
+function toCsvCell(value: unknown): CellValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
@@ -1,0 +1,40 @@
+/**
+ * CSV (de)serialization for the spreadsheet mirror — RFC-4180 quoting, LF line
+ * endings (the repo's canonical EOL; see CLAUDE.md). Pure + engine-agnostic.
+ */
+
+import type { CellValue } from './types';
+
+/** UTF-8 byte length of a string (browser/Node-safe; no Buffer dependency). */
+export function utf8Bytes(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
+
+/**
+ * Serialize one cell. Booleans render as `TRUE`/`FALSE` (Excel convention);
+ * null/undefined render empty. Values containing `"`, `,`, CR, or LF are
+ * double-quoted with `"` doubled.
+ */
+export function serializeCell(value: CellValue): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  const raw = typeof value === 'boolean' ? (value ? 'TRUE' : 'FALSE') : String(value);
+  if (/[",\r\n]/.test(raw)) {
+    return `"${raw.replace(/"/g, '""')}"`;
+  }
+  return raw;
+}
+
+/** Serialize one row to a CSV line (no trailing newline). */
+export function serializeRow(row: CellValue[]): string {
+  return row.map(serializeCell).join(',');
+}
+
+/** Serialize rows to a CSV block, one LF-terminated line per row. */
+export function serializeRows(rows: CellValue[][]): string {
+  if (rows.length === 0) {
+    return '';
+  }
+  return rows.map(serializeRow).join('\n') + '\n';
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/csv.ts
@@ -11,19 +11,83 @@ export function utf8Bytes(s: string): number {
 }
 
 /**
- * Serialize one cell. Booleans render as `TRUE`/`FALSE` (Excel convention);
- * null/undefined render empty. Values containing `"`, `,`, CR, or LF are
- * double-quoted with `"` doubled.
+ * The UNQUOTED string form of a cell — booleans as `TRUE`/`FALSE`, null/undefined
+ * as empty. This is the canonical form used to COMPARE an original cell against
+ * an edited CSV field (the CSV parser yields already-unquoted strings).
  */
-export function serializeCell(value: CellValue): string {
+export function cellToRaw(value: CellValue): string {
   if (value === null || value === undefined) {
     return '';
   }
-  const raw = typeof value === 'boolean' ? (value ? 'TRUE' : 'FALSE') : String(value);
+  return typeof value === 'boolean' ? (value ? 'TRUE' : 'FALSE') : String(value);
+}
+
+/**
+ * Serialize one cell to its CSV field form. Values containing `"`, `,`, CR, or
+ * LF are double-quoted with `"` doubled.
+ */
+export function serializeCell(value: CellValue): string {
+  const raw = cellToRaw(value);
   if (/[",\r\n]/.test(raw)) {
     return `"${raw.replace(/"/g, '""')}"`;
   }
   return raw;
+}
+
+/**
+ * Parse a CSV block into a grid of (unquoted) string fields — RFC-4180:
+ * `""` is an escaped quote inside a quoted field, and quoted fields may contain
+ * commas and newlines. Tolerates CRLF. A trailing newline does not produce a
+ * spurious empty row; a fully empty input yields no rows.
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let sawField = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += c;
+      }
+      continue;
+    }
+    if (c === '"') {
+      inQuotes = true;
+      sawField = true;
+    } else if (c === ',') {
+      row.push(field);
+      field = '';
+      sawField = true;
+    } else if (c === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      sawField = false;
+    } else if (c === '\r') {
+      // tolerate CRLF — the \n handles the row break
+    } else {
+      field += c;
+      sawField = true;
+    }
+  }
+
+  if (sawField || field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
 }
 
 /** Serialize one row to a CSV line (no trailing newline). */

--- a/src/agents/apps/dataAnalysis/spreadsheet/diff.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/diff.ts
@@ -1,0 +1,98 @@
+/**
+ * Cell diffing + the formula-cell guard for the write-back leg. Pure.
+ *
+ * The mirror CSV (the AI's edited surface) is diffed against the ORIGINAL
+ * workbook values to find changed data cells. Comparison is done on the unquoted
+ * string form (the CSV parser yields unquoted strings; {@link cellToRaw} renders
+ * the original the same way), so type ambiguity never produces a false diff.
+ */
+
+import { cellToRaw } from './csv';
+import type { CellValue } from './types';
+
+export interface CellEdit {
+  sheet: string;
+  /** 0-based row / column. */
+  row: number;
+  col: number;
+  /** A1 reference, e.g. `B4`. */
+  a1: string;
+  before: string;
+  after: string;
+}
+
+/** 0-based column index → spreadsheet letters (0→A, 25→Z, 26→AA). */
+export function colLetter(col: number): string {
+  let n = col + 1;
+  let s = '';
+  while (n > 0) {
+    const rem = (n - 1) % 26;
+    s = String.fromCharCode(65 + rem) + s;
+    n = Math.floor((n - 1) / 26);
+  }
+  return s;
+}
+
+/** 0-based (row, col) → A1 reference. */
+export function a1Ref(row: number, col: number): string {
+  return `${colLetter(col)}${row + 1}`;
+}
+
+/**
+ * Diff a sheet's ORIGINAL values against its EDITED (parsed-CSV) grid. Handles
+ * ragged dimensions (added/removed rows or columns) by comparing over the union.
+ */
+export function diffSheet(
+  sheet: string,
+  original: CellValue[][],
+  edited: string[][]
+): CellEdit[] {
+  const edits: CellEdit[] = [];
+  const rowCount = Math.max(original.length, edited.length);
+
+  for (let row = 0; row < rowCount; row++) {
+    const o = original[row] ?? [];
+    const e = edited[row] ?? [];
+    const colCount = Math.max(o.length, e.length);
+    for (let col = 0; col < colCount; col++) {
+      const before = cellToRaw(o[col] ?? null);
+      const after = e[col] ?? '';
+      if (before !== after) {
+        edits.push({ sheet, row, col, a1: a1Ref(row, col), before, after });
+      }
+    }
+  }
+  return edits;
+}
+
+/**
+ * Split edits into those we will APPLY and those BLOCKED because they target a
+ * formula cell (the write-back never clobbers a live formula by default).
+ */
+export function partitionByFormula(
+  edits: CellEdit[],
+  formulaCells: Set<string>
+): { applied: CellEdit[]; blocked: CellEdit[] } {
+  const applied: CellEdit[] = [];
+  const blocked: CellEdit[] = [];
+  for (const edit of edits) {
+    (formulaCells.has(edit.a1) ? blocked : applied).push(edit);
+  }
+  return { applied, blocked };
+}
+
+/**
+ * Coerce an edited string to the ORIGINAL cell's type where compatible, so a
+ * numeric column stays numeric and a boolean stays boolean on write-back; text
+ * (e.g. a leading-zero ZIP) is left as-is.
+ */
+export function coerceToOriginalType(original: CellValue, edited: string): CellValue {
+  if (typeof original === 'number' && edited.trim() !== '' && !Number.isNaN(Number(edited))) {
+    return Number(edited);
+  }
+  if (typeof original === 'boolean') {
+    if (edited === 'TRUE') return true;
+    if (edited === 'FALSE') return false;
+  }
+  return edited;
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/shard.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/shard.ts
@@ -1,0 +1,62 @@
+/**
+ * Sheet sharding — split a sheet's rows into contiguous CSV shards each within
+ * `maxShardBytes` (the storage cap, e.g. 5MB). The mirror writes one file per
+ * shard; the manifest records each shard's row range for reassembly.
+ *
+ * A single row that alone exceeds the budget gets its own (oversize) shard
+ * rather than looping forever — a row cannot be split across files.
+ */
+
+import type { CellValue } from './types';
+import { serializeRow, utf8Bytes } from './csv';
+
+export interface RowShard {
+  csv: string;
+  /** 0-based inclusive first source row. */
+  startRow: number;
+  /** 0-based exclusive last source row. */
+  endRow: number;
+  bytes: number;
+}
+
+/**
+ * Greedily pack rows into shards. An empty sheet yields a single empty shard so
+ * the sheet is always represented and reassembly is well-defined.
+ */
+export function shardSheet(rows: CellValue[][], maxShardBytes: number): RowShard[] {
+  if (rows.length === 0) {
+    return [{ csv: '', startRow: 0, endRow: 0, bytes: 0 }];
+  }
+
+  const budget = Math.max(1, maxShardBytes);
+  const shards: RowShard[] = [];
+
+  let lines: string[] = [];
+  let bytes = 0;
+  let startRow = 0;
+
+  const flush = (endRow: number) => {
+    const csv = lines.length > 0 ? lines.join('\n') + '\n' : '';
+    shards.push({ csv, startRow, endRow, bytes: utf8Bytes(csv) });
+    lines = [];
+    bytes = 0;
+    startRow = endRow;
+  };
+
+  for (let i = 0; i < rows.length; i++) {
+    const line = serializeRow(rows[i]);
+    const lineBytes = utf8Bytes(line) + 1; // +1 for the LF terminator
+
+    // Close the current shard before adding a row that would overflow it — but
+    // never flush an empty buffer (a lone oversize row still goes in its own shard).
+    if (lines.length > 0 && bytes + lineBytes > budget) {
+      flush(i);
+    }
+
+    lines.push(line);
+    bytes += lineBytes;
+  }
+
+  flush(rows.length);
+  return shards;
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/types.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared types for the spreadsheet mirror + versioning subsystem.
+ * See docs/plans/spreadsheet-mirror-versioning-plan.md.
+ *
+ * The mirror is a PROJECTION of a workbook: values-only CSV shards the AI edits,
+ * with the original `.xlsx` retained as the source of truth (formula/format/chart
+ * store). These types describe the parsed workbook (engine-agnostic) and the
+ * on-disk manifest that indexes the shards.
+ */
+
+/** A single CSV-representable cell value. Formulas are surfaced as their cached value. */
+export type CellValue = string | number | boolean | null;
+
+export interface ParsedSheet {
+  name: string;
+  /** Row-major grid of cached values. */
+  rows: CellValue[][];
+  /**
+   * A1-style refs of cells that hold a formula in the source workbook. The CSV
+   * shows the cached value; these are flagged so a consumer knows to recompute
+   * from inputs rather than trust a possibly-stale cached number, and so the
+   * write-back's formula-cell guard can avoid clobbering them.
+   */
+  formulaCells?: string[];
+}
+
+export interface ParsedWorkbook {
+  sheets: ParsedSheet[];
+  /** Content hash of the source `.xlsx` bytes — divergence + idempotency key. */
+  sourceHash: string;
+  /** True when the source carries VBA macros (write-back must keep `.xlsm`). */
+  hasMacros?: boolean;
+}
+
+/** Engine seam: reads source `.xlsx` bytes into a {@link ParsedWorkbook}. */
+export interface XlsxSource {
+  readWorkbook(bytes: Uint8Array): Promise<ParsedWorkbook>;
+}
+
+export const MIRROR_SCHEMA_VERSION = 1;
+
+/** One CSV shard of a sheet, sized to stay under `maxShardBytes`. */
+export interface ShardEntry {
+  /** Basename within the mirror folder, e.g. `Sheet1.part0.csv`. */
+  file: string;
+  /** 0-based inclusive first source row in this shard. */
+  startRow: number;
+  /** 0-based exclusive last source row in this shard. */
+  endRow: number;
+  /** UTF-8 byte length of the shard's CSV. */
+  bytes: number;
+}
+
+export interface SheetManifest {
+  name: string;
+  /** Position in the workbook (CSV files are an unordered set; this restores order). */
+  order: number;
+  rowCount: number;
+  colCount: number;
+  shards: ShardEntry[];
+  /** A1 refs of formula cells (see {@link ParsedSheet.formulaCells}). */
+  formulaCells: string[];
+}
+
+export interface MirrorManifest {
+  schemaVersion: number;
+  /** Workbook id (basename), e.g. `budget`. */
+  workbook: string;
+  sourceHash: string;
+  hasMacros: boolean;
+  generatedAt: string;
+  maxShardBytes: number;
+  sheets: SheetManifest[];
+}

--- a/src/agents/apps/dataAnalysis/spreadsheet/types.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/types.ts
@@ -85,6 +85,8 @@ export interface MirrorManifest {
   schemaVersion: number;
   /** Workbook id (basename), e.g. `budget`. */
   workbook: string;
+  /** Vault-relative path of the source `.xlsx` (so auto-sync can locate it). */
+  sourcePath: string;
   sourceHash: string;
   hasMacros: boolean;
   generatedAt: string;

--- a/src/agents/apps/dataAnalysis/spreadsheet/types.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/types.ts
@@ -37,6 +37,25 @@ export interface XlsxSource {
   readWorkbook(bytes: Uint8Array): Promise<ParsedWorkbook>;
 }
 
+/** A single cell to write back into the source workbook. */
+export interface CellWrite {
+  sheet: string;
+  /** 0-based row. */
+  row: number;
+  /** 0-based column. */
+  col: number;
+  value: CellValue;
+}
+
+/**
+ * Engine seam: applies cell writes into the source `.xlsx` bytes and returns the
+ * new bytes, preserving every untouched part (charts/images/pivots) byte-for-byte.
+ * Backed by `hucre` in production (see `HucreXlsxWriter`).
+ */
+export interface XlsxWriter {
+  applyCellWrites(sourceBytes: Uint8Array, writes: CellWrite[]): Promise<Uint8Array>;
+}
+
 export const MIRROR_SCHEMA_VERSION = 1;
 
 /** One CSV shard of a sheet, sized to stay under `maxShardBytes`. */

--- a/src/agents/apps/dataAnalysis/spreadsheet/workbookId.ts
+++ b/src/agents/apps/dataAnalysis/spreadsheet/workbookId.ts
@@ -1,0 +1,6 @@
+/** Derive a filesystem-safe mirror id from a workbook's vault path. */
+export function workbookIdFromPath(path: string): string {
+  const base = (path.split('/').pop() ?? path).replace(/\.(xlsx|xlsm|xls)$/i, '');
+  const safe = base.replace(/[^A-Za-z0-9._-]+/g, '_').replace(/^_+|_+$/g, '');
+  return safe.length > 0 ? safe : 'workbook';
+}

--- a/src/agents/apps/dataAnalysis/tools/applyToWorkbook.ts
+++ b/src/agents/apps/dataAnalysis/tools/applyToWorkbook.ts
@@ -1,0 +1,142 @@
+/**
+ * ApplyToWorkbookTool — write the edited CSV mirror back into the source
+ * `.xlsx`/`.xlsm` losslessly: only changed DATA cells are applied (formula cells
+ * are guarded), and every untouched part (charts/images/pivots/formatting) is
+ * preserved byte-for-byte by the hucre engine. Snapshots the prior CSV shards
+ * before writing and re-projects the mirror afterward. Desktop-only.
+ *
+ * Refuses if the source `.xlsx` changed since the mirror was made (pass
+ * `force: true` to override) and supports `dryRun` to preview the change set.
+ */
+
+import { normalizePath } from 'obsidian';
+import { BaseTool } from '../../../baseTool';
+import { CommonResult, CommonParameters } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { isDesktop } from '../../../../utils/platform';
+import { isValidPath } from '../../../../utils/pathUtils';
+import type { ToolStatusTense } from '../../../interfaces/ITool';
+import { verbs } from '../../../utils/toolStatusLabels';
+import { DataAnalysisAgent } from '../DataAnalysisAgent';
+import { HucreXlsxSource } from '../spreadsheet/HucreXlsxSource';
+import { HucreXlsxWriter } from '../spreadsheet/HucreXlsxWriter';
+import { WorkbookMirrorService } from '../spreadsheet/WorkbookMirrorService';
+import { WorkbookWriteBackService } from '../spreadsheet/WorkbookWriteBackService';
+import { SnapshotArchiveService } from '../../../../services/storage/SnapshotArchiveService';
+import { workbookIdFromPath } from '../spreadsheet/workbookId';
+
+export interface ApplyToWorkbookParams extends CommonParameters {
+  /** Vault-relative path to the source `.xlsx`/`.xlsm`. */
+  path: string;
+  /** Preview the change set without writing. */
+  dryRun?: boolean;
+  /** Proceed even if the source diverged from the mirror. */
+  force?: boolean;
+}
+
+export class ApplyToWorkbookTool extends BaseTool<ApplyToWorkbookParams, CommonResult> {
+  private agent: DataAnalysisAgent;
+
+  constructor(agent: DataAnalysisAgent) {
+    super(
+      'applyToWorkbook',
+      'Apply To Workbook',
+      'Write the edited CSV mirror back into the source .xlsx/.xlsm losslessly — only changed ' +
+        'data cells are applied (formula cells are never overwritten), and charts/images/pivots/' +
+        'formatting are preserved. Snapshots the prior shards and re-projects the mirror. Pass ' +
+        'dryRun:true to preview, force:true to override a divergence guard. Desktop only.',
+      '0.1.0'
+    );
+    this.agent = agent;
+  }
+
+  getStatusLabel(_params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+    return verbs('Applying to workbook', 'Applied to workbook', 'Apply failed')[tense];
+  }
+
+  async execute(params: ApplyToWorkbookParams): Promise<CommonResult> {
+    if (!isDesktop()) {
+      return this.prepareResult(false, undefined, 'Spreadsheet write-back is desktop-only.');
+    }
+    const vault = this.agent.getVault();
+    if (!vault) {
+      return this.prepareResult(false, undefined, 'Vault not available.');
+    }
+    if (!params.path || !isValidPath(params.path)) {
+      return this.prepareResult(false, undefined,
+        `Invalid path: "${params.path}" — must be vault-relative, no ".." or absolute paths.`);
+    }
+
+    let buffer: ArrayBuffer;
+    try {
+      buffer = await vault.adapter.readBinary(normalizePath(params.path));
+    } catch {
+      return this.prepareResult(false, undefined, `Workbook not found or unreadable: "${params.path}"`);
+    }
+
+    try {
+      const mod = await this.agent.getHucreModule();
+      const source = new HucreXlsxSource(() => Promise.resolve(mod));
+      const writer = new HucreXlsxWriter(() => Promise.resolve(mod));
+      const mirror = new WorkbookMirrorService(vault.adapter);
+      const snapshot = new SnapshotArchiveService(vault.adapter);
+      const writeBack = new WorkbookWriteBackService(vault.adapter, source, writer, mirror, snapshot);
+
+      const { root, maxShardBytes } = this.agent.getMirrorStorage();
+      const target = { root, workbookId: workbookIdFromPath(params.path), maxShardBytes };
+
+      const result = await writeBack.apply(target, new Uint8Array(buffer), {
+        dryRun: params.dryRun,
+        force: params.force,
+      });
+
+      if (result.applied && result.newBytes) {
+        await vault.adapter.writeBinary(normalizePath(params.path), toArrayBuffer(result.newBytes));
+      }
+
+      return this.prepareResult(true, {
+        applied: result.applied,
+        reason: result.reason,
+        archivePath: result.archivePath ?? null,
+        summary: result.summary,
+      });
+    } catch (error) {
+      return this.prepareResult(false, undefined,
+        `Failed to apply to workbook: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    const schema = {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Vault-relative path to the .xlsx/.xlsm workbook (no leading slash).' },
+        dryRun: { type: 'boolean', description: 'Preview the change set without writing. Default false.' },
+        force: { type: 'boolean', description: 'Apply even if the source diverged from the mirror. Default false.' },
+      },
+      required: ['path'],
+      description: 'Write the edited CSV mirror back into the source workbook losslessly.',
+    };
+    return this.getMergedSchema(schema as JSONSchema);
+  }
+
+  getResultSchema(): Record<string, unknown> {
+    return {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        applied: { type: 'boolean' },
+        reason: { type: 'string' },
+        archivePath: { type: ['string', 'null'] },
+        summary: { type: 'object' },
+        error: { type: 'string' },
+      },
+      required: ['success'],
+    };
+  }
+}
+
+/** Copy a Uint8Array (possibly a view) into a standalone ArrayBuffer for writeBinary. */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.slice().buffer;
+}

--- a/src/agents/apps/dataAnalysis/tools/listCapabilities.ts
+++ b/src/agents/apps/dataAnalysis/tools/listCapabilities.ts
@@ -1,0 +1,49 @@
+/**
+ * ListCapabilitiesTool — advertise the sandbox's available packages and the
+ * supported input formats so the AI knows what it can write against.
+ */
+
+import { BaseTool } from '../../../baseTool';
+import { CommonParameters, CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { isDesktop } from '../../../../utils/platform';
+import { BaseAppAgent } from '../../BaseAppAgent';
+import { SUPPORTED_PACKAGES } from '../types';
+
+export class ListCapabilitiesTool extends BaseTool<CommonParameters, CommonResult> {
+  private agent: BaseAppAgent;
+
+  constructor(agent: BaseAppAgent) {
+    super(
+      'listCapabilities',
+      'List Capabilities',
+      'List the Python packages and input formats supported by the Data Analysis sandbox.',
+      '0.1.0'
+    );
+    this.agent = agent;
+  }
+
+  execute(): Promise<CommonResult> {
+    return Promise.resolve(
+      this.prepareResult(true, {
+        runtime: 'Pyodide (CPython 3.13, WebAssembly)',
+        desktopOnly: true,
+        sandbox:
+          'Off-thread Web Worker, no Node integration, in-memory filesystem. Best-effort ' +
+          'isolation: blocks accidental network/vault access; not a hard sandbox for hostile code.',
+        packages: [...SUPPORTED_PACKAGES],
+        inputFormats: ['.csv', '.xlsx'],
+        notes: [
+          "Read inputs via the injected `inputs` dict: pd.read_csv(inputs['name']) / pd.read_excel(inputs['name']).",
+          'Return a JSON-serializable value (e.g. df...to_dict("records")).',
+          'Results over maxRows (default 1500) are rejected — aggregate or limit.',
+        ],
+        available: isDesktop(),
+      })
+    );
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({ type: 'object', properties: {} });
+  }
+}

--- a/src/agents/apps/dataAnalysis/tools/mirrorWorkbook.ts
+++ b/src/agents/apps/dataAnalysis/tools/mirrorWorkbook.ts
@@ -72,7 +72,8 @@ export class MirrorWorkbookTool extends BaseTool<MirrorWorkbookParams, CommonRes
       const { root, maxShardBytes } = this.agent.getMirrorStorage();
       const workbookId = workbookIdFromPath(params.path);
       const mirror = new WorkbookMirrorService(vault.adapter);
-      const { manifest, regenerated } = await mirror.generate(workbook, { root, workbookId, maxShardBytes });
+      const { manifest, regenerated } = await mirror.generate(workbook,
+        { root, workbookId, maxShardBytes, sourcePath: normalizePath(params.path) });
 
       return this.prepareResult(true, {
         mirrorDir: mirror.mirrorDir({ root, workbookId, maxShardBytes }),

--- a/src/agents/apps/dataAnalysis/tools/mirrorWorkbook.ts
+++ b/src/agents/apps/dataAnalysis/tools/mirrorWorkbook.ts
@@ -1,0 +1,121 @@
+/**
+ * MirrorWorkbookTool — project an `.xlsx`/`.xlsm` into editable, sharded CSV
+ * files under `<root>/spreadsheets/<workbookId>/` (the AI's value surface). The
+ * original workbook stays the source of truth (formulas/charts/formatting); the
+ * CSVs are a regenerated projection. Idempotent — re-mirroring an unchanged file
+ * is a no-op. Desktop-only (uses the vendored hucre engine).
+ */
+
+import { normalizePath } from 'obsidian';
+import { BaseTool } from '../../../baseTool';
+import { CommonResult, CommonParameters } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { isDesktop } from '../../../../utils/platform';
+import { isValidPath } from '../../../../utils/pathUtils';
+import type { ToolStatusTense } from '../../../interfaces/ITool';
+import { verbs } from '../../../utils/toolStatusLabels';
+import { DataAnalysisAgent } from '../DataAnalysisAgent';
+import { HucreXlsxSource } from '../spreadsheet/HucreXlsxSource';
+import { WorkbookMirrorService } from '../spreadsheet/WorkbookMirrorService';
+import { workbookIdFromPath } from '../spreadsheet/workbookId';
+
+export interface MirrorWorkbookParams extends CommonParameters {
+  /** Vault-relative path to the source `.xlsx`/`.xlsm`. */
+  path: string;
+}
+
+export class MirrorWorkbookTool extends BaseTool<MirrorWorkbookParams, CommonResult> {
+  private agent: DataAnalysisAgent;
+
+  constructor(agent: DataAnalysisAgent) {
+    super(
+      'mirrorWorkbook',
+      'Mirror Workbook',
+      'Project an Excel workbook (.xlsx/.xlsm) into editable CSV shards under ' +
+        '<root>/spreadsheets/<id>/ — one CSV per sheet (sharded by size), plus a manifest. ' +
+        'Edit those CSVs, then call applyToWorkbook to write changes back losslessly. ' +
+        'Idempotent. Desktop only.',
+      '0.1.0'
+    );
+    this.agent = agent;
+  }
+
+  getStatusLabel(_params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+    return verbs('Mirroring workbook', 'Mirrored workbook', 'Mirror failed')[tense];
+  }
+
+  async execute(params: MirrorWorkbookParams): Promise<CommonResult> {
+    if (!isDesktop()) {
+      return this.prepareResult(false, undefined, 'Spreadsheet mirroring is desktop-only.');
+    }
+    const vault = this.agent.getVault();
+    if (!vault) {
+      return this.prepareResult(false, undefined, 'Vault not available.');
+    }
+    if (!params.path || !isValidPath(params.path)) {
+      return this.prepareResult(false, undefined,
+        `Invalid path: "${params.path}" — must be vault-relative, no ".." or absolute paths.`);
+    }
+
+    let buffer: ArrayBuffer;
+    try {
+      buffer = await vault.adapter.readBinary(normalizePath(params.path));
+    } catch {
+      return this.prepareResult(false, undefined, `Workbook not found or unreadable: "${params.path}"`);
+    }
+
+    try {
+      const mod = await this.agent.getHucreModule();
+      const source = new HucreXlsxSource(() => Promise.resolve(mod));
+      const workbook = await source.readWorkbook(new Uint8Array(buffer));
+
+      const { root, maxShardBytes } = this.agent.getMirrorStorage();
+      const workbookId = workbookIdFromPath(params.path);
+      const mirror = new WorkbookMirrorService(vault.adapter);
+      const { manifest, regenerated } = await mirror.generate(workbook, { root, workbookId, maxShardBytes });
+
+      return this.prepareResult(true, {
+        mirrorDir: mirror.mirrorDir({ root, workbookId, maxShardBytes }),
+        regenerated,
+        hasMacros: manifest.hasMacros,
+        sheets: manifest.sheets.map((s) => ({
+          name: s.name,
+          rows: s.rowCount,
+          cols: s.colCount,
+          shards: s.shards.map((sh) => sh.file),
+          formulaCells: s.formulaCells.length,
+        })),
+      });
+    } catch (error) {
+      return this.prepareResult(false, undefined,
+        `Failed to mirror workbook: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    const schema = {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Vault-relative path to the .xlsx/.xlsm workbook (no leading slash).' },
+      },
+      required: ['path'],
+      description: 'Project a workbook into editable CSV shards under <root>/spreadsheets/<id>/.',
+    };
+    return this.getMergedSchema(schema as JSONSchema);
+  }
+
+  getResultSchema(): Record<string, unknown> {
+    return {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean' },
+        mirrorDir: { type: 'string' },
+        regenerated: { type: 'boolean' },
+        hasMacros: { type: 'boolean' },
+        sheets: { type: 'array' },
+        error: { type: 'string' },
+      },
+      required: ['success'],
+    };
+  }
+}

--- a/src/agents/apps/dataAnalysis/tools/runAnalysis.ts
+++ b/src/agents/apps/dataAnalysis/tools/runAnalysis.ts
@@ -1,0 +1,223 @@
+/**
+ * RunAnalysisTool — execute Python (pandas) against vault CSV/Excel data in a
+ * sandboxed, network-isolated Pyodide worker.
+ *
+ * Trusted-host responsibilities (the guest does none of this):
+ *   - desktop gate, parameter validation
+ *   - read input files from the vault (path-jailed via isValidPath) and enforce
+ *     the input-size cap
+ *   - run the code in the sandbox with a wall-clock timeout
+ *   - enforce the output row cap and optionally persist the result to the vault
+ */
+
+import { normalizePath } from 'obsidian';
+import { BaseTool } from '../../../baseTool';
+import { CommonResult } from '../../../../types';
+import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
+import { isDesktop } from '../../../../utils/platform';
+import { isValidPath } from '../../../../utils/pathUtils';
+import type { ToolStatusTense } from '../../../interfaces/ITool';
+import { verbs } from '../../../utils/toolStatusLabels';
+import { DataAnalysisAgent } from '../DataAnalysisAgent';
+import { RunAnalysisParams, SandboxFile } from '../types';
+import {
+  clampInputBytes,
+  clampMaxRows,
+  clampOutputBytes,
+  clampTimeout,
+  enforceOutputBudget,
+  enforceRowCap,
+  formatBytesMb,
+  sandboxFileName,
+  validateInputPath,
+} from '../services/guards';
+
+export class RunAnalysisTool extends BaseTool<RunAnalysisParams, CommonResult> {
+  private agent: DataAnalysisAgent;
+
+  constructor(agent: DataAnalysisAgent) {
+    super(
+      'runAnalysis',
+      'Run Analysis',
+      'Run Python (pandas) against vault CSV/Excel files in an isolated runtime ' +
+        '(off-thread, no Node, in-memory filesystem), returning a bounded result. Provide `code` ' +
+        'and optional `inputs` (a map of ' +
+        "variable name -> vault path); read them in Python via `inputs['name']`, e.g. " +
+        "`pd.read_csv(inputs['budget'])` or `pd.read_excel(inputs['sales'])`. Return a " +
+        'JSON-serializable value (results over 1500 rows are rejected — aggregate or limit). ' +
+        'Desktop only. Isolation is best-effort (blocks accidental network/vault access), not a ' +
+        'hard sandbox for untrusted code.',
+      '0.1.0'
+    );
+    this.agent = agent;
+  }
+
+  getStatusLabel(_params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+    return verbs('Analyzing data', 'Analyzed data', 'Analysis failed')[tense];
+  }
+
+  async execute(params: RunAnalysisParams): Promise<CommonResult> {
+    if (!isDesktop()) {
+      return this.prepareResult(false, undefined, 'Data Analysis is desktop-only.');
+    }
+
+    const code = params.code;
+    if (typeof code !== 'string' || !code.trim()) {
+      return this.prepareResult(false, undefined, 'Missing "code" — provide Python to run.');
+    }
+
+    const vault = this.agent.getVault();
+    if (!vault) {
+      return this.prepareResult(false, undefined, 'Vault not available.');
+    }
+
+    const maxRows = clampMaxRows(params.maxRows);
+    const maxOutputBytes = clampOutputBytes(params.maxOutputBytes);
+    const maxInputBytes = clampInputBytes(params.maxInputBytes);
+    const timeoutMs = clampTimeout(params.timeoutMs);
+
+    // Validate the output path up front, before doing any work.
+    if (params.outputPath !== undefined && !isValidPath(params.outputPath)) {
+      return this.prepareResult(false, undefined,
+        `Invalid output path: "${params.outputPath}" — must be vault-relative, no ".." or absolute paths`);
+    }
+
+    // Gather + size-cap input files (trusted host reads; guest never sees the vault).
+    // Each file gets an index-prefixed path so two vars that sanitize to the same
+    // name can't collide and silently overwrite each other on disk.
+    const files: SandboxFile[] = [];
+    const inputEntries = Object.entries(params.inputs ?? {});
+    for (let i = 0; i < inputEntries.length; i++) {
+      const [varName, inputPath] = inputEntries[i];
+      const check = validateInputPath(inputPath);
+      if (!check.ok) {
+        return this.prepareResult(false, undefined, check.error);
+      }
+      let buffer: ArrayBuffer;
+      try {
+        buffer = await vault.adapter.readBinary(normalizePath(inputPath));
+      } catch {
+        return this.prepareResult(false, undefined, `Input not found or unreadable: "${inputPath}"`);
+      }
+      if (buffer.byteLength > maxInputBytes) {
+        return this.prepareResult(false, undefined,
+          `Input "${inputPath}" is ${formatBytesMb(buffer.byteLength)}MB (max ` +
+          `${formatBytesMb(maxInputBytes)}MB). Pre-filter the file and retry.`);
+      }
+      files.push({
+        varName,
+        sandboxPath: `/data/${i}_${sandboxFileName(varName, inputPath)}`,
+        bytes: new Uint8Array(buffer),
+      });
+    }
+
+    // Run in the sandbox.
+    let result;
+    try {
+      const sandbox = await this.agent.getSandbox();
+      result = await sandbox.run({ code, files, timeoutMs });
+    } catch (error) {
+      return this.prepareResult(false, undefined,
+        `Failed to run analysis: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    if (!result.success) {
+      return this.prepareResult(false, undefined, result.error ?? 'Analysis failed.');
+    }
+
+    // Enforce the output row cap (top-level arrays) and the universal byte
+    // backstop (any shape, so a {rows:[...]} / to_dict() can't bypass the cap).
+    const cap = enforceRowCap(result.data, maxRows);
+    if (!cap.ok) {
+      return this.prepareResult(false, undefined, cap.error);
+    }
+    const budget = enforceOutputBudget(result.data, maxOutputBytes);
+    if (!budget.ok) {
+      return this.prepareResult(false, undefined, budget.error);
+    }
+
+    // Optionally persist the result.
+    let writtenPath: string | undefined;
+    if (params.outputPath) {
+      const outPath = normalizePath(params.outputPath);
+      try {
+        await this.writeResult(vault, outPath, result.data);
+        writtenPath = outPath;
+      } catch (error) {
+        return this.prepareResult(false, undefined,
+          `Computed the result but failed to write "${outPath}": ` +
+          `${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    return this.prepareResult(true, {
+      result: result.data,
+      rows: cap.rowCount,
+      logs: result.logs ?? [],
+      stats: result.stats,
+      ...(writtenPath ? { outputPath: writtenPath } : {}),
+    });
+  }
+
+  private async writeResult(
+    vault: NonNullable<ReturnType<DataAnalysisAgent['getVault']>>,
+    outPath: string,
+    data: unknown
+  ): Promise<void> {
+    const content = JSON.stringify(data, null, 2);
+    const existing = vault.getAbstractFileByPath(outPath);
+    if (existing) {
+      await vault.adapter.write(outPath, content);
+    } else {
+      const dir = outPath.includes('/') ? outPath.slice(0, outPath.lastIndexOf('/')) : '';
+      if (dir && !vault.getAbstractFileByPath(dir)) {
+        await vault.createFolder(dir).catch(() => undefined);
+      }
+      await vault.create(outPath, content);
+    }
+  }
+
+  getParameterSchema(): JSONSchema {
+    const schema: JSONSchema = {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description:
+            "Python source to execute. Read inputs via the injected `inputs` dict, e.g. " +
+            "`pd.read_csv(inputs['budget'])`. The final expression / returned value is sent back " +
+            '(must be JSON-serializable; results over maxRows are rejected).',
+        },
+        inputs: {
+          type: 'object',
+          description:
+            'Map of variable name -> vault-relative file path (.csv/.xlsx). Each file is read by ' +
+            "the host and exposed to Python as inputs['name'].",
+          additionalProperties: { type: 'string' },
+        },
+        maxRows: {
+          type: 'number',
+          description: 'Reject results with more than this many rows (default 1500, hard max 10000).',
+        },
+        maxOutputBytes: {
+          type: 'number',
+          description: 'Reject results whose serialized JSON exceeds this many bytes (default ~512KB).',
+        },
+        maxInputBytes: {
+          type: 'number',
+          description: 'Reject input files larger than this many bytes (default ~10MB).',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Wall-clock budget; runaway code is terminated (default 5000, hard max 30000).',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Optional vault path to write the result JSON to after a successful run.',
+        },
+      },
+      required: ['code'],
+    };
+    return this.getMergedSchema(schema);
+  }
+}

--- a/src/agents/apps/dataAnalysis/tools/runAnalysis.ts
+++ b/src/agents/apps/dataAnalysis/tools/runAnalysis.ts
@@ -19,6 +19,7 @@ import { isValidPath } from '../../../../utils/pathUtils';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { verbs } from '../../../utils/toolStatusLabels';
 import { DataAnalysisAgent } from '../DataAnalysisAgent';
+import { dataToCsv } from '../spreadsheet/csv';
 import { RunAnalysisParams, SandboxFile } from '../types';
 import {
   clampInputBytes,
@@ -164,7 +165,9 @@ export class RunAnalysisTool extends BaseTool<RunAnalysisParams, CommonResult> {
     outPath: string,
     data: unknown
   ): Promise<void> {
-    const content = JSON.stringify(data, null, 2);
+    // A `.csv` outputPath writes tabular CSV (so pandas results can land in a
+    // spreadsheet mirror shard, auto-syncing back to .xlsx); anything else is JSON.
+    const content = /\.csv$/i.test(outPath) ? dataToCsv(data) : JSON.stringify(data, null, 2);
     const existing = vault.getAbstractFileByPath(outPath);
     if (existing) {
       await vault.adapter.write(outPath, content);

--- a/src/agents/apps/dataAnalysis/tools/runPython.ts
+++ b/src/agents/apps/dataAnalysis/tools/runPython.ts
@@ -1,5 +1,5 @@
 /**
- * RunAnalysisTool — execute Python (pandas) against vault CSV/Excel data in a
+ * RunPythonTool — execute Python (pandas) against vault CSV/Excel data in a
  * sandboxed, network-isolated Pyodide worker.
  *
  * Trusted-host responsibilities (the guest does none of this):
@@ -20,7 +20,7 @@ import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { verbs } from '../../../utils/toolStatusLabels';
 import { DataAnalysisAgent } from '../DataAnalysisAgent';
 import { dataToCsv } from '../spreadsheet/csv';
-import { RunAnalysisParams, SandboxFile } from '../types';
+import { RunPythonParams, SandboxFile } from '../types';
 import {
   clampInputBytes,
   clampMaxRows,
@@ -33,13 +33,13 @@ import {
   validateInputPath,
 } from '../services/guards';
 
-export class RunAnalysisTool extends BaseTool<RunAnalysisParams, CommonResult> {
+export class RunPythonTool extends BaseTool<RunPythonParams, CommonResult> {
   private agent: DataAnalysisAgent;
 
   constructor(agent: DataAnalysisAgent) {
     super(
-      'runAnalysis',
-      'Run Analysis',
+      'runPython',
+      'Run Python',
       'Run Python (pandas) against vault CSV/Excel files in an isolated runtime ' +
         '(off-thread, no Node, in-memory filesystem), returning a bounded result. Provide `code` ' +
         'and optional `inputs` (a map of ' +
@@ -57,7 +57,7 @@ export class RunAnalysisTool extends BaseTool<RunAnalysisParams, CommonResult> {
     return verbs('Analyzing data', 'Analyzed data', 'Analysis failed')[tense];
   }
 
-  async execute(params: RunAnalysisParams): Promise<CommonResult> {
+  async execute(params: RunPythonParams): Promise<CommonResult> {
     if (!isDesktop()) {
       return this.prepareResult(false, undefined, 'Data Analysis is desktop-only.');
     }

--- a/src/agents/apps/dataAnalysis/types.ts
+++ b/src/agents/apps/dataAnalysis/types.ts
@@ -8,8 +8,8 @@
 
 import { CommonParameters } from '../../../types';
 
-/** Parameters for the `runAnalysis` tool. */
-export interface RunAnalysisParams extends CommonParameters {
+/** Parameters for the `runPython` tool. */
+export interface RunPythonParams extends CommonParameters {
   /** Python source. Returns a JSON-serializable value (e.g. df...to_dict('records')). */
   code: string;
   /**

--- a/src/agents/apps/dataAnalysis/types.ts
+++ b/src/agents/apps/dataAnalysis/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Data Analysis app — shared types.
+ *
+ * The app runs Python (pandas) against vault CSV/Excel data inside a
+ * locked-down Pyodide Web Worker. Data is injected by the trusted host;
+ * the guest has no vault, network, or host-filesystem access. Desktop-only.
+ */
+
+import { CommonParameters } from '../../../types';
+
+/** Parameters for the `runAnalysis` tool. */
+export interface RunAnalysisParams extends CommonParameters {
+  /** Python source. Returns a JSON-serializable value (e.g. df...to_dict('records')). */
+  code: string;
+  /**
+   * Map of variable name -> vault-relative file path. The host reads each file
+   * and writes its bytes into the worker FS; a Python global `inputs` maps the
+   * same names to in-sandbox paths, so user code does `pd.read_csv(inputs['x'])`.
+   */
+  inputs?: Record<string, string>;
+  /** Reject results with more than this many rows (default 1500). */
+  maxRows?: number;
+  /** Reject results whose serialized JSON exceeds this many bytes (default 512KB). */
+  maxOutputBytes?: number;
+  /** Reject input files larger than this many bytes (default 10MB). */
+  maxInputBytes?: number;
+  /** Wall-clock budget; runaway code is killed by terminating the worker. */
+  timeoutMs?: number;
+  /** Optional vault path: host writes the result JSON here after a successful run. */
+  outputPath?: string;
+}
+
+/** A file injected into the sandbox's in-memory FS. */
+export interface SandboxFile {
+  /** Caller's variable name (key of `inputs`). */
+  varName: string;
+  /** Absolute path inside the worker MEMFS, e.g. "/data/budget.csv". */
+  sandboxPath: string;
+  /** Raw file bytes. */
+  bytes: Uint8Array;
+}
+
+export interface SandboxRunRequest {
+  code: string;
+  files: SandboxFile[];
+  timeoutMs: number;
+}
+
+export interface SandboxRunResult {
+  success: boolean;
+  data?: unknown;
+  logs?: string[];
+  error?: string;
+  stats?: { durationMs: number };
+}
+
+/** Sandbox contract — lets the tool be unit-tested with a fake implementation. */
+export interface IAnalysisSandbox {
+  ensureReady(): Promise<void>;
+  run(request: SandboxRunRequest): Promise<SandboxRunResult>;
+  dispose(): void;
+}
+
+export const DATA_ANALYSIS_DEFAULTS = {
+  maxRows: 1500,
+  maxRowsHardCap: 10_000,
+  maxOutputBytes: 512 * 1024,
+  maxOutputBytesHardCap: 4 * 1024 * 1024,
+  maxInputBytes: 10 * 1024 * 1024,
+  maxInputBytesHardCap: 50 * 1024 * 1024,
+  timeoutMs: 5_000,
+  timeoutHardCapMs: 30_000,
+} as const;
+
+/** Compiled Pyodide packages loaded via loadPackage (pandas pulls numpy + deps). */
+export const PYODIDE_PACKAGES = ['pandas'] as const;
+
+/** Packages advertised to callers — derived in one place to avoid drift. */
+export const SUPPORTED_PACKAGES = ['pandas', 'numpy', 'openpyxl', 'python-dateutil', 'pytz'] as const;

--- a/src/agents/apps/index.ts
+++ b/src/agents/apps/index.ts
@@ -4,3 +4,4 @@
 export { BaseAppAgent } from './BaseAppAgent';
 export { ComposerAgent } from './composer/ComposerAgent';
 export { WebToolsAgent } from './webTools/WebToolsAgent';
+export { DataAnalysisAgent } from './dataAnalysis/DataAnalysisAgent';

--- a/src/agents/apps/skills/services/SkillWriteService.ts
+++ b/src/agents/apps/skills/services/SkillWriteService.ts
@@ -17,9 +17,15 @@
 
 import { normalizePath } from 'obsidian';
 import type { DataAdapter } from 'obsidian';
+import { SnapshotArchiveService } from '../../../../services/storage/SnapshotArchiveService';
 
 export class SkillWriteService {
-  constructor(private adapter: DataAdapter) {}
+  /** Shared version-in-place snapshot primitive (co-located `_archive/<ts>/`). */
+  private readonly snapshot: SnapshotArchiveService;
+
+  constructor(private adapter: DataAdapter) {
+    this.snapshot = new SnapshotArchiveService(adapter);
+  }
 
   /** True only when the folder exists AND contains a SKILL.md. */
   async exists(folderPath: string): Promise<boolean> {
@@ -162,6 +168,10 @@ export class SkillWriteService {
    * Snapshot the CURRENT folder into `<folderPath>/_archive/<ts>/` (only if a
    * prior SKILL.md exists), then run `write()`. Returns the archive path, or
    * null when there was no prior version to snapshot.
+   *
+   * The snapshot mechanics (timestamp, same-instant disambiguation, skip
+   * `_`/`.`-prefixed children) live in the shared {@link SnapshotArchiveService};
+   * this method only owns the skill-specific gate (a prior SKILL.md must exist).
    */
   async archiveThenReplace(folderPath: string, write: () => Promise<void>): Promise<string | null> {
     const folder = normalizePath(folderPath);
@@ -172,16 +182,7 @@ export class SkillWriteService {
       return null;
     }
 
-    const ts = new Date(Date.now()).toISOString().replace(/[:.]/g, '-');
-    // Disambiguate same-millisecond snapshots so a second archive in the same
-    // ISO instant doesn't overwrite the first: append -1, -2, … until free.
-    let archivePath = normalizePath(`${folder}/_archive/${ts}`);
-    let suffix = 1;
-    while (await this.adapter.exists(archivePath)) {
-      archivePath = normalizePath(`${folder}/_archive/${ts}-${suffix}`);
-      suffix += 1;
-    }
-    await this.copyTree(folder, archivePath);
+    const archivePath = await this.snapshot.archiveCopy(folder);
 
     await write();
     return archivePath;

--- a/src/services/apps/AppManager.ts
+++ b/src/services/apps/AppManager.ts
@@ -13,6 +13,8 @@ import { logger } from '../../utils/logger';
 import { ElevenLabsAgent } from '../../agents/apps/elevenlabs/ElevenLabsAgent';
 import { ComposerAgent } from '../../agents/apps/composer/ComposerAgent';
 import { WebToolsAgent } from '../../agents/apps/webTools/WebToolsAgent';
+import { DataAnalysisAgent } from '../../agents/apps/dataAnalysis/DataAnalysisAgent';
+import { isDesktop } from '../../utils/platform';
 import { SkillsAgent } from '../../agents/apps/skills/SkillsAgent';
 import type { AppRuntimeContext } from '../../agents/apps/AppRuntimeContext';
 import { App } from 'obsidian';
@@ -233,6 +235,11 @@ export class AppManager {
     registry.set('composer', () => new ComposerAgent());
     registry.set('web-tools', () => new WebToolsAgent());
     registry.set('skills', () => new SkillsAgent());
+
+    // Desktop-only apps (heavy/Node-dependent runtimes — not registered on mobile)
+    if (isDesktop()) {
+      registry.set('data-analysis', () => new DataAnalysisAgent());
+    }
 
     return registry;
   }

--- a/src/services/apps/AppManager.ts
+++ b/src/services/apps/AppManager.ts
@@ -238,7 +238,7 @@ export class AppManager {
 
     // Desktop-only apps (heavy/Node-dependent runtimes — not registered on mobile)
     if (isDesktop()) {
-      registry.set('data-analysis', () => new DataAnalysisAgent());
+      registry.set('data', () => new DataAnalysisAgent());
     }
 
     return registry;

--- a/src/services/storage/SnapshotArchiveService.ts
+++ b/src/services/storage/SnapshotArchiveService.ts
@@ -1,0 +1,134 @@
+/**
+ * SnapshotArchiveService — the generic "version-in-place" snapshot primitive.
+ *
+ * Location: src/services/storage/SnapshotArchiveService.ts
+ *
+ * Before overwriting a folder's contents, snapshot the CURRENT tree into a
+ * co-located, timestamped `<folder>/<archiveDir>/<ts>/` so the prior version is
+ * recoverable (last-writer-wins with an undo net). This is the reusable form of
+ * the pattern first written inline for the Skills app
+ * (`SkillWriteService.archiveThenReplace`) and now shared by the
+ * spreadsheet-mirror versioning layer (its second consumer).
+ *
+ * NOT to be confused with the two OTHER "archive" flavors in the codebase:
+ *   - the soft `is_archived` flag (states/tasks/skills) — a reversible *status*,
+ *     not a file snapshot;
+ *   - `StorageManager.archive` — *relocates* (moves) a file/folder to
+ *     `.archive/<ts>/`, not version-in-place.
+ *
+ * All I/O goes through Obsidian's {@link DataAdapter} (`vault.adapter`) so it
+ * works on desktop AND mobile and can see dot/hidden paths. Every path is run
+ * through {@link normalizePath}.
+ */
+
+import { normalizePath } from 'obsidian';
+import type { DataAdapter } from 'obsidian';
+
+export interface SnapshotArchiveOptions {
+  /** Subfolder under the target that holds snapshots. Default `_archive`. */
+  archiveDirName?: string;
+  /** Clock injection point for deterministic tests. Default {@link Date.now}. */
+  now?: () => number;
+}
+
+export class SnapshotArchiveService {
+  private readonly archiveDirName: string;
+  private readonly now: () => number;
+
+  constructor(private adapter: DataAdapter, options: SnapshotArchiveOptions = {}) {
+    this.archiveDirName = options.archiveDirName ?? '_archive';
+    this.now = options.now ?? Date.now;
+  }
+
+  /**
+   * Snapshot `folderPath`'s current tree into
+   * `<folderPath>/<archiveDirName>/<ts>[-n]/` and return that archive path.
+   *
+   * `<ts>` is an ISO-8601 instant with `:`/`.` replaced by `-`; same-instant
+   * collisions get a `-1`, `-2`, … suffix so a second snapshot in the same
+   * millisecond never clobbers the first. Children whose basename starts with
+   * `_` or `.` are skipped, so the archive folder never recursively archives
+   * itself and dotfiles are left out.
+   *
+   * The caller decides WHETHER a prior version is worth snapshotting; this just
+   * performs the copy.
+   */
+  async archiveCopy(folderPath: string): Promise<string> {
+    const folder = normalizePath(folderPath);
+    const ts = new Date(this.now()).toISOString().replace(/[:.]/g, '-');
+
+    let archivePath = normalizePath(`${folder}/${this.archiveDirName}/${ts}`);
+    let suffix = 1;
+    while (await this.adapter.exists(archivePath)) {
+      archivePath = normalizePath(`${folder}/${this.archiveDirName}/${ts}-${suffix}`);
+      suffix += 1;
+    }
+
+    await this.copyTree(folder, archivePath);
+    return archivePath;
+  }
+
+  /**
+   * Recursive mkdir. `adapter.mkdir` throws if a segment already exists, so each
+   * missing segment is created in turn (the `vault.adapter` write pattern).
+   */
+  async ensureFolder(path: string): Promise<void> {
+    const normalized = normalizePath(path);
+    const segments = normalized.split('/').filter((s) => s.length > 0);
+    let current = '';
+    for (const segment of segments) {
+      current = current.length > 0 ? `${current}/${segment}` : segment;
+      if (!(await this.adapter.exists(current))) {
+        await this.adapter.mkdir(current);
+      }
+    }
+  }
+
+  /**
+   * Recursively copy a folder's tree (purely additive), SKIPPING any child whose
+   * basename starts with `_` or `.` — so `_archive/` (and dotfiles) are never
+   * pulled into a snapshot.
+   */
+  async copyTree(srcFolder: string, destFolder: string): Promise<void> {
+    const src = normalizePath(srcFolder);
+    const dest = normalizePath(destFolder);
+
+    await this.ensureFolder(dest);
+
+    let listing: { files: string[]; folders: string[] };
+    try {
+      listing = await this.adapter.list(src);
+    } catch {
+      return;
+    }
+
+    for (const filePath of listing.files) {
+      const base = SnapshotArchiveService.basename(filePath);
+      if (SnapshotArchiveService.isSkipped(base)) {
+        continue;
+      }
+      const content = await this.adapter.read(filePath);
+      await this.adapter.write(normalizePath(`${dest}/${base}`), content);
+    }
+
+    for (const subFolder of listing.folders) {
+      const base = SnapshotArchiveService.basename(subFolder);
+      if (SnapshotArchiveService.isSkipped(base)) {
+        continue;
+      }
+      await this.copyTree(subFolder, normalizePath(`${dest}/${base}`));
+    }
+  }
+
+  /** Basename of a vault-relative path (handles trailing slash). */
+  private static basename(path: string): string {
+    const trimmed = path.replace(/\/+$/, '');
+    const idx = trimmed.lastIndexOf('/');
+    return idx === -1 ? trimmed : trimmed.slice(idx + 1);
+  }
+
+  /** Skip `_`-prefixed (e.g. `_archive`) and `.`-prefixed children. */
+  private static isSkipped(basename: string): boolean {
+    return basename.startsWith('_') || basename.startsWith('.');
+  }
+}

--- a/tests/unit/DataAnalysisGuards.test.ts
+++ b/tests/unit/DataAnalysisGuards.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the Data Analysis host-side guardrails — the pure, deterministic
+ * logic that bounds inputs/outputs (row cap, size/timeout clamps, path jailing,
+ * sandbox filename derivation). No Pyodide / Electron involved.
+ */
+
+import {
+  countResultRows,
+  enforceRowCap,
+  enforceOutputBudget,
+  clampMaxRows,
+  clampOutputBytes,
+  clampInputBytes,
+  clampTimeout,
+  validateInputPath,
+  sandboxFileName,
+  formatBytesMb,
+} from '../../src/agents/apps/dataAnalysis/services/guards';
+import { DATA_ANALYSIS_DEFAULTS } from '../../src/agents/apps/dataAnalysis/types';
+
+describe('Data Analysis guards', () => {
+  describe('countResultRows', () => {
+    it('counts array rows', () => {
+      expect(countResultRows([{ a: 1 }, { a: 2 }])).toBe(2);
+      expect(countResultRows([])).toBe(0);
+    });
+    it('returns null for non-arrays (scalars/objects are uncapped)', () => {
+      expect(countResultRows(42)).toBeNull();
+      expect(countResultRows({ total: 9 })).toBeNull();
+      expect(countResultRows(null)).toBeNull();
+      expect(countResultRows(undefined)).toBeNull();
+    });
+  });
+
+  describe('enforceRowCap', () => {
+    it('rejects an over-cap array with an aggregate-or-limit message', () => {
+      const rows = Array.from({ length: 8432 }, (_, i) => ({ i }));
+      const out = enforceRowCap(rows, 1500);
+      expect(out.ok).toBe(false);
+      expect(out.rowCount).toBe(8432);
+      expect(out.error).toContain('8,432 rows');
+      expect(out.error).toContain('max 1,500');
+      expect(out.error?.toLowerCase()).toContain('aggregate');
+    });
+    it('passes an at/under-cap array', () => {
+      expect(enforceRowCap([{ a: 1 }, { a: 2 }, { a: 3 }], 1500).ok).toBe(true);
+      const exactly = Array.from({ length: 1500 }, (_, i) => ({ i }));
+      expect(enforceRowCap(exactly, 1500).ok).toBe(true);
+    });
+    it('never caps scalar/object results', () => {
+      expect(enforceRowCap({ avg: 12.5 }, 1500).ok).toBe(true);
+      expect(enforceRowCap(7, 1).ok).toBe(true);
+    });
+  });
+
+  describe('enforceOutputBudget (universal backstop)', () => {
+    it('rejects oversized results of ANY shape — closing the non-array row-cap bypass', () => {
+      // a nested-dict shape that the row cap (top-level array only) would miss
+      const sneaky = { rows: Array.from({ length: 500 }, (_, i) => ({ i, v: 'x'.repeat(20) })) };
+      const out = enforceOutputBudget(sneaky, 1024);
+      expect(out.ok).toBe(false);
+      expect(out.error).toMatch(/KB/);
+    });
+    it('passes small results', () => {
+      expect(enforceOutputBudget({ avg: 12.5 }, 512 * 1024).ok).toBe(true);
+      expect(enforceOutputBudget([{ a: 1 }], 512 * 1024).ok).toBe(true);
+    });
+    it('rejects non-serializable results instead of throwing', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      const out = enforceOutputBudget(circular, 1024);
+      expect(out.ok).toBe(false);
+      expect(out.error).toMatch(/not JSON-serializable/);
+    });
+  });
+
+  describe('clampOutputBytes', () => {
+    it('clamps to default and hard cap', () => {
+      expect(clampOutputBytes(undefined)).toBe(512 * 1024);
+      expect(clampOutputBytes(2048)).toBe(2048);
+      expect(clampOutputBytes(Number.MAX_SAFE_INTEGER)).toBe(4 * 1024 * 1024);
+    });
+  });
+
+  describe('clampMaxRows', () => {
+    it('defaults when missing/invalid', () => {
+      expect(clampMaxRows(undefined)).toBe(DATA_ANALYSIS_DEFAULTS.maxRows);
+      expect(clampMaxRows(0)).toBe(DATA_ANALYSIS_DEFAULTS.maxRows);
+      expect(clampMaxRows(-5)).toBe(DATA_ANALYSIS_DEFAULTS.maxRows);
+      expect(clampMaxRows(NaN)).toBe(DATA_ANALYSIS_DEFAULTS.maxRows);
+    });
+    it('honors valid requests but caps at the hard ceiling', () => {
+      expect(clampMaxRows(50)).toBe(50);
+      expect(clampMaxRows(999999)).toBe(DATA_ANALYSIS_DEFAULTS.maxRowsHardCap);
+      expect(clampMaxRows(3.9)).toBe(3); // floored
+    });
+  });
+
+  describe('clampInputBytes / clampTimeout', () => {
+    it('clamp to defaults and hard caps', () => {
+      expect(clampInputBytes(undefined)).toBe(DATA_ANALYSIS_DEFAULTS.maxInputBytes);
+      expect(clampInputBytes(1_000_000)).toBe(1_000_000);
+      expect(clampInputBytes(Number.MAX_SAFE_INTEGER)).toBe(DATA_ANALYSIS_DEFAULTS.maxInputBytesHardCap);
+
+      expect(clampTimeout(undefined)).toBe(DATA_ANALYSIS_DEFAULTS.timeoutMs);
+      expect(clampTimeout(2000)).toBe(2000);
+      expect(clampTimeout(10 ** 9)).toBe(DATA_ANALYSIS_DEFAULTS.timeoutHardCapMs);
+    });
+  });
+
+  describe('validateInputPath', () => {
+    it('accepts vault-relative paths', () => {
+      expect(validateInputPath('data/budget.csv').ok).toBe(true);
+      expect(validateInputPath('Q3.xlsx').ok).toBe(true);
+    });
+    it('rejects traversal and absolute paths', () => {
+      expect(validateInputPath('../../etc/passwd').ok).toBe(false);
+      expect(validateInputPath('/etc/passwd').ok).toBe(false);
+      expect(validateInputPath('a/../../b').ok).toBe(false);
+    });
+  });
+
+  describe('sandboxFileName', () => {
+    it('preserves the source extension and sanitizes the var name', () => {
+      expect(sandboxFileName('budget', 'data/budget.csv')).toBe('budget.csv');
+      expect(sandboxFileName('sales 2024', 'reports/q3.xlsx')).toBe('sales_2024.xlsx');
+      expect(sandboxFileName('x', 'noext')).toBe('x');
+    });
+    it('falls back to "input" for empty/symbol-only names', () => {
+      expect(sandboxFileName('***', 'a.csv')).toBe('input.csv');
+    });
+  });
+
+  describe('formatBytesMb', () => {
+    it('formats MB to one decimal', () => {
+      expect(formatBytesMb(10 * 1024 * 1024)).toBe('10.0');
+      expect(formatBytesMb(1024 * 1024 + 512 * 1024)).toBe('1.5');
+    });
+  });
+});

--- a/tests/unit/PyodideEnsurer.test.ts
+++ b/tests/unit/PyodideEnsurer.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the pinned Pyodide asset manifest. The download/write mechanics
+ * require a live network + Electron and are validated separately; here we lock
+ * the manifest's shape so a version bump can't silently drop a required wheel.
+ */
+
+import {
+  buildPyodideAssetManifest,
+  PYODIDE_VERSION,
+} from '../../src/agents/apps/dataAnalysis/services/PyodideEnsurer';
+
+describe('Pyodide asset manifest', () => {
+  const manifest = buildPyodideAssetManifest();
+  const files = manifest.map((a) => a.file);
+
+  it('includes the core runtime files', () => {
+    for (const core of ['pyodide.js', 'pyodide.asm.js', 'pyodide.asm.wasm', 'python_stdlib.zip', 'pyodide-lock.json']) {
+      expect(files).toContain(core);
+    }
+  });
+
+  it('includes pandas + numpy + their compiled deps', () => {
+    expect(files.some((f) => f.startsWith('pandas-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('numpy-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('python_dateutil-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('pytz-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('six-'))).toBe(true);
+  });
+
+  it('includes micropip + packaging (needed to install the Excel wheels)', () => {
+    expect(files.some((f) => f.startsWith('micropip-'))).toBe(true);
+    expect(files.some((f) => f.startsWith('packaging-'))).toBe(true);
+  });
+
+  it('includes the Excel wheels from PyPI', () => {
+    const openpyxl = manifest.find((a) => a.file.startsWith('openpyxl-'));
+    const etxml = manifest.find((a) => a.file.startsWith('et_xmlfile-'));
+    expect(openpyxl?.url).toContain('files.pythonhosted.org');
+    expect(etxml?.url).toContain('files.pythonhosted.org');
+  });
+
+  it('pins CDN assets to the declared version', () => {
+    const cdn = manifest.filter((a) => a.url.includes('cdn.jsdelivr.net'));
+    expect(cdn.length).toBeGreaterThan(0);
+    for (const a of cdn) {
+      expect(a.url).toContain(`/pyodide/v${PYODIDE_VERSION}/full/`);
+      expect(a.url.endsWith(a.file)).toBe(true);
+    }
+  });
+
+  it('gives every asset a positive size floor and a valid URL', () => {
+    for (const a of manifest) {
+      expect(a.minBytes).toBeGreaterThan(0);
+      expect(a.url).toMatch(/^https:\/\//);
+      expect(a.file.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/RunAnalysisTool.test.ts
+++ b/tests/unit/RunAnalysisTool.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit tests for RunAnalysisTool — the trusted-host orchestration around the
+ * sandbox: desktop gating, parameter + path + size validation, output row-cap
+ * enforcement, and result persistence. The Pyodide sandbox is faked so these
+ * run without any WASM/Electron dependency.
+ */
+
+// Control the desktop gate deterministically.
+jest.mock('../../src/utils/platform', () => ({
+  isDesktop: jest.fn(() => true),
+  isElectron: jest.fn(() => true),
+}));
+
+import { isDesktop } from '../../src/utils/platform';
+import { RunAnalysisTool } from '../../src/agents/apps/dataAnalysis/tools/runAnalysis';
+import { DataAnalysisAgent } from '../../src/agents/apps/dataAnalysis/DataAnalysisAgent';
+import { IAnalysisSandbox, SandboxRunRequest, SandboxRunResult } from '../../src/agents/apps/dataAnalysis/types';
+
+const isDesktopMock = isDesktop as jest.Mock;
+
+class FakeSandbox implements IAnalysisSandbox {
+  lastRequest: SandboxRunRequest | null = null;
+  constructor(private readonly result: SandboxRunResult) {}
+  ensureReady(): Promise<void> {
+    return Promise.resolve();
+  }
+  run(request: SandboxRunRequest): Promise<SandboxRunResult> {
+    this.lastRequest = request;
+    return Promise.resolve(this.result);
+  }
+  dispose(): void {
+    /* no-op */
+  }
+}
+
+function makeVault(overrides: Record<string, unknown> = {}) {
+  return {
+    adapter: {
+      readBinary: jest.fn(async () => new TextEncoder().encode('category,amount\nfood,10\n').buffer),
+      write: jest.fn(async () => undefined),
+    },
+    getAbstractFileByPath: jest.fn(() => null),
+    create: jest.fn(async () => undefined),
+    createFolder: jest.fn(async () => undefined),
+    ...overrides,
+  } as unknown as NonNullable<ReturnType<DataAnalysisAgent['getVault']>>;
+}
+
+function makeAgent(sandbox: IAnalysisSandbox, vault = makeVault()): DataAnalysisAgent {
+  const agent = new DataAnalysisAgent();
+  agent.setVault(vault);
+  agent.setSandbox(sandbox);
+  return agent;
+}
+
+const ctx = { memory: 'm', goal: 'g' } as never;
+
+beforeEach(() => {
+  isDesktopMock.mockReturnValue(true);
+});
+
+describe('RunAnalysisTool', () => {
+  it('refuses on mobile', async () => {
+    isDesktopMock.mockReturnValue(false);
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const res = await tool.execute({ code: 'x', context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/desktop-only/i);
+  });
+
+  it('rejects missing code', async () => {
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const res = await tool.execute({ code: '   ', context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Missing "code"/);
+  });
+
+  it('returns a successful bounded result', async () => {
+    const data = [{ category: 'food', avg: 7.58 }];
+    const sandbox = new FakeSandbox({ success: true, data, logs: ['ok'], stats: { durationMs: 12 } });
+    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    const res = await tool.execute({ code: 'pd...', context: ctx });
+    expect(res.success).toBe(true);
+    const payload = res.data as { result: unknown; rows: number; logs: string[] };
+    expect(payload.result).toEqual(data);
+    expect(payload.rows).toBe(1);
+    expect(payload.logs).toEqual(['ok']);
+  });
+
+  it('enforces the output row cap', async () => {
+    const rows = Array.from({ length: 2000 }, (_, i) => ({ i }));
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: rows })));
+    const res = await tool.execute({ code: 'pd...', maxRows: 1500, context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toContain('2,000 rows');
+    expect(res.error).toContain('max 1,500');
+  });
+
+  it('rejects traversal input paths before reading', async () => {
+    const vault = makeVault();
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
+    const res = await tool.execute({ code: 'x', inputs: { evil: '../../secrets.csv' }, context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Invalid input path/);
+    expect((vault.adapter as { readBinary: jest.Mock }).readBinary).not.toHaveBeenCalled();
+  });
+
+  it('enforces the input size cap', async () => {
+    const big = new Uint8Array(2 * 1024 * 1024).buffer; // 2MB
+    const vault = makeVault({ adapter: { readBinary: jest.fn(async () => big), write: jest.fn() } });
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
+    const res = await tool.execute({
+      code: 'x',
+      inputs: { big: 'data/big.csv' },
+      maxInputBytes: 1024 * 1024, // 1MB cap
+      context: ctx,
+    });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/max 1\.0MB/);
+  });
+
+  it('injects inputs into the sandbox with a /data path and the var name', async () => {
+    const sandbox = new FakeSandbox({ success: true, data: [{ ok: 1 }] });
+    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    await tool.execute({ code: 'x', inputs: { budget: 'data/budget.csv' }, context: ctx });
+    expect(sandbox.lastRequest?.files).toHaveLength(1);
+    expect(sandbox.lastRequest?.files[0]).toMatchObject({
+      varName: 'budget',
+      sandboxPath: '/data/0_budget.csv',
+    });
+  });
+
+  it('gives colliding var names distinct sandbox paths (no silent overwrite)', async () => {
+    const sandbox = new FakeSandbox({ success: true, data: [{ ok: 1 }] });
+    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    // "a b" and "a_b" both sanitize to "a_b" — index prefix must keep them apart
+    await tool.execute({ code: 'x', inputs: { 'a b': 'x.csv', a_b: 'y.csv' }, context: ctx });
+    const paths = sandbox.lastRequest?.files.map((f) => f.sandboxPath);
+    expect(new Set(paths).size).toBe(2);
+    expect(paths).toEqual(['/data/0_a_b.csv', '/data/1_a_b.csv']);
+  });
+
+  it('enforces the output byte budget for non-array shapes (row-cap bypass closed)', async () => {
+    const sneaky = { rows: Array.from({ length: 100 }, (_, i) => ({ i })) };
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: sneaky })));
+    const res = await tool.execute({ code: 'x', maxOutputBytes: 50, context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/KB \(max/);
+  });
+
+  it('persists the result to outputPath when provided', async () => {
+    const vault = makeVault();
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [{ a: 1 }] }), vault));
+    const res = await tool.execute({ code: 'x', outputPath: 'reports/out.json', context: ctx });
+    expect(res.success).toBe(true);
+    expect((vault as { create: jest.Mock }).create).toHaveBeenCalledWith('reports/out.json', expect.stringContaining('"a": 1'));
+    expect((res.data as { outputPath: string }).outputPath).toBe('reports/out.json');
+  });
+
+  it('rejects an invalid outputPath', async () => {
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const res = await tool.execute({ code: 'x', outputPath: '../escape.json', context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/Invalid output path/);
+  });
+
+  it('surfaces a sandbox failure', async () => {
+    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: false, error: 'boom (traceback)' })));
+    const res = await tool.execute({ code: 'x', context: ctx });
+    expect(res.success).toBe(false);
+    expect(res.error).toBe('boom (traceback)');
+  });
+});

--- a/tests/unit/RunPythonTool.test.ts
+++ b/tests/unit/RunPythonTool.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for RunAnalysisTool — the trusted-host orchestration around the
+ * Unit tests for RunPythonTool — the trusted-host orchestration around the
  * sandbox: desktop gating, parameter + path + size validation, output row-cap
  * enforcement, and result persistence. The Pyodide sandbox is faked so these
  * run without any WASM/Electron dependency.
@@ -12,7 +12,7 @@ jest.mock('../../src/utils/platform', () => ({
 }));
 
 import { isDesktop } from '../../src/utils/platform';
-import { RunAnalysisTool } from '../../src/agents/apps/dataAnalysis/tools/runAnalysis';
+import { RunPythonTool } from '../../src/agents/apps/dataAnalysis/tools/runPython';
 import { DataAnalysisAgent } from '../../src/agents/apps/dataAnalysis/DataAnalysisAgent';
 import { IAnalysisSandbox, SandboxRunRequest, SandboxRunResult } from '../../src/agents/apps/dataAnalysis/types';
 
@@ -59,17 +59,17 @@ beforeEach(() => {
   isDesktopMock.mockReturnValue(true);
 });
 
-describe('RunAnalysisTool', () => {
+describe('RunPythonTool', () => {
   it('refuses on mobile', async () => {
     isDesktopMock.mockReturnValue(false);
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
     const res = await tool.execute({ code: 'x', context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/desktop-only/i);
   });
 
   it('rejects missing code', async () => {
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
     const res = await tool.execute({ code: '   ', context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/Missing "code"/);
@@ -78,7 +78,7 @@ describe('RunAnalysisTool', () => {
   it('returns a successful bounded result', async () => {
     const data = [{ category: 'food', avg: 7.58 }];
     const sandbox = new FakeSandbox({ success: true, data, logs: ['ok'], stats: { durationMs: 12 } });
-    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    const tool = new RunPythonTool(makeAgent(sandbox));
     const res = await tool.execute({ code: 'pd...', context: ctx });
     expect(res.success).toBe(true);
     const payload = res.data as { result: unknown; rows: number; logs: string[] };
@@ -89,7 +89,7 @@ describe('RunAnalysisTool', () => {
 
   it('enforces the output row cap', async () => {
     const rows = Array.from({ length: 2000 }, (_, i) => ({ i }));
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: rows })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: rows })));
     const res = await tool.execute({ code: 'pd...', maxRows: 1500, context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toContain('2,000 rows');
@@ -98,7 +98,7 @@ describe('RunAnalysisTool', () => {
 
   it('rejects traversal input paths before reading', async () => {
     const vault = makeVault();
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
     const res = await tool.execute({ code: 'x', inputs: { evil: '../../secrets.csv' }, context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/Invalid input path/);
@@ -108,7 +108,7 @@ describe('RunAnalysisTool', () => {
   it('enforces the input size cap', async () => {
     const big = new Uint8Array(2 * 1024 * 1024).buffer; // 2MB
     const vault = makeVault({ adapter: { readBinary: jest.fn(async () => big), write: jest.fn() } });
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [] }), vault));
     const res = await tool.execute({
       code: 'x',
       inputs: { big: 'data/big.csv' },
@@ -121,7 +121,7 @@ describe('RunAnalysisTool', () => {
 
   it('injects inputs into the sandbox with a /data path and the var name', async () => {
     const sandbox = new FakeSandbox({ success: true, data: [{ ok: 1 }] });
-    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    const tool = new RunPythonTool(makeAgent(sandbox));
     await tool.execute({ code: 'x', inputs: { budget: 'data/budget.csv' }, context: ctx });
     expect(sandbox.lastRequest?.files).toHaveLength(1);
     expect(sandbox.lastRequest?.files[0]).toMatchObject({
@@ -132,7 +132,7 @@ describe('RunAnalysisTool', () => {
 
   it('gives colliding var names distinct sandbox paths (no silent overwrite)', async () => {
     const sandbox = new FakeSandbox({ success: true, data: [{ ok: 1 }] });
-    const tool = new RunAnalysisTool(makeAgent(sandbox));
+    const tool = new RunPythonTool(makeAgent(sandbox));
     // "a b" and "a_b" both sanitize to "a_b" — index prefix must keep them apart
     await tool.execute({ code: 'x', inputs: { 'a b': 'x.csv', a_b: 'y.csv' }, context: ctx });
     const paths = sandbox.lastRequest?.files.map((f) => f.sandboxPath);
@@ -142,7 +142,7 @@ describe('RunAnalysisTool', () => {
 
   it('enforces the output byte budget for non-array shapes (row-cap bypass closed)', async () => {
     const sneaky = { rows: Array.from({ length: 100 }, (_, i) => ({ i })) };
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: sneaky })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: sneaky })));
     const res = await tool.execute({ code: 'x', maxOutputBytes: 50, context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/KB \(max/);
@@ -150,7 +150,7 @@ describe('RunAnalysisTool', () => {
 
   it('persists the result to outputPath when provided', async () => {
     const vault = makeVault();
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [{ a: 1 }] }), vault));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [{ a: 1 }] }), vault));
     const res = await tool.execute({ code: 'x', outputPath: 'reports/out.json', context: ctx });
     expect(res.success).toBe(true);
     expect((vault as { create: jest.Mock }).create).toHaveBeenCalledWith('reports/out.json', expect.stringContaining('"a": 1'));
@@ -158,14 +158,14 @@ describe('RunAnalysisTool', () => {
   });
 
   it('rejects an invalid outputPath', async () => {
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: true, data: [] })));
     const res = await tool.execute({ code: 'x', outputPath: '../escape.json', context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toMatch(/Invalid output path/);
   });
 
   it('surfaces a sandbox failure', async () => {
-    const tool = new RunAnalysisTool(makeAgent(new FakeSandbox({ success: false, error: 'boom (traceback)' })));
+    const tool = new RunPythonTool(makeAgent(new FakeSandbox({ success: false, error: 'boom (traceback)' })));
     const res = await tool.execute({ code: 'x', context: ctx });
     expect(res.success).toBe(false);
     expect(res.error).toBe('boom (traceback)');

--- a/tests/unit/SnapshotArchiveService.test.ts
+++ b/tests/unit/SnapshotArchiveService.test.ts
@@ -1,0 +1,140 @@
+/**
+ * SnapshotArchiveService — tests for the shared version-in-place snapshot
+ * primitive extracted from SkillWriteService (spike S1). The Skills behavior
+ * itself is locked by SkillWriteService.test.ts (no-behavior-change proof); these
+ * exercise the generic service directly, including the bits Skills doesn't reach
+ * (configurable archive dir, injected clock, same-instant disambiguation).
+ *
+ * Reuses the same in-memory DataAdapter fake shape as SkillWriteService.test.ts.
+ */
+
+import { SnapshotArchiveService } from '../../src/services/storage/SnapshotArchiveService';
+import type { DataAdapter } from 'obsidian';
+
+function makeAdapter() {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+
+  const norm = (p: string) => p.replace(/\/+$/, '');
+
+  const immediateChildren = (dir: string) => {
+    const prefix = norm(dir) + '/';
+    const childFiles: string[] = [];
+    const childFolders: string[] = [];
+    for (const f of files.keys()) {
+      if (f.startsWith(prefix) && !f.slice(prefix.length).includes('/')) {
+        childFiles.push(f);
+      }
+    }
+    for (const f of folders) {
+      if (f.startsWith(prefix) && !f.slice(prefix.length).includes('/')) {
+        childFolders.push(f);
+      }
+    }
+    return { files: childFiles, folders: childFolders };
+  };
+
+  const adapter = {
+    async exists(path: string): Promise<boolean> {
+      const p = norm(path);
+      return files.has(p) || folders.has(p);
+    },
+    async list(path: string) {
+      return immediateChildren(path);
+    },
+    async read(path: string): Promise<string> {
+      const p = norm(path);
+      if (!files.has(p)) {
+        throw new Error(`no such file: ${p}`);
+      }
+      return files.get(p) as string;
+    },
+    async write(path: string, data: string): Promise<void> {
+      const p = norm(path);
+      const segs = p.split('/');
+      let cur = '';
+      for (let i = 0; i < segs.length - 1; i++) {
+        cur = cur.length > 0 ? `${cur}/${segs[i]}` : segs[i];
+        folders.add(cur);
+      }
+      files.set(p, data);
+    },
+    async mkdir(path: string): Promise<void> {
+      const p = norm(path);
+      if (folders.has(p)) {
+        throw new Error(`folder exists: ${p}`);
+      }
+      folders.add(p);
+    },
+    async remove(path: string): Promise<void> {
+      files.delete(norm(path));
+    },
+    async rmdir(path: string, _recursive: boolean): Promise<void> {
+      folders.delete(norm(path));
+    },
+  };
+
+  return { adapter: adapter as unknown as DataAdapter, files, folders };
+}
+
+describe('SnapshotArchiveService', () => {
+  const FIXED = Date.parse('2026-05-31T12:34:56.789Z');
+
+  it('snapshots the current tree into _archive/<ts>/ and returns that path', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new SnapshotArchiveService(adapter, { now: () => FIXED });
+    const folder = 'Nexus/spreadsheets/budget';
+
+    await adapter.write(`${folder}/Sheet1.part0.csv`, 'region,amount\nEMEA,100\n');
+    await adapter.write(`${folder}/manifest.json`, '{"v":1}');
+
+    const archived = await svc.archiveCopy(folder);
+
+    expect(archived).toBe(`${folder}/_archive/2026-05-31T12-34-56-789Z`);
+    expect(files.get(`${archived}/Sheet1.part0.csv`)).toBe('region,amount\nEMEA,100\n');
+    expect(files.get(`${archived}/manifest.json`)).toBe('{"v":1}');
+  });
+
+  it('skips _-prefixed and .-prefixed children (never archives the archive)', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new SnapshotArchiveService(adapter, { now: () => FIXED });
+    const folder = 'Nexus/spreadsheets/budget';
+
+    await adapter.write(`${folder}/Sheet1.part0.csv`, 'data');
+    await adapter.write(`${folder}/_archive/older/Sheet1.part0.csv`, 'PRIOR');
+    await adapter.write(`${folder}/.hidden`, 'secret');
+
+    const archived = await svc.archiveCopy(folder);
+
+    expect(files.get(`${archived}/Sheet1.part0.csv`)).toBe('data');
+    expect(files.has(`${archived}/_archive/older/Sheet1.part0.csv`)).toBe(false);
+    expect(files.has(`${archived}/.hidden`)).toBe(false);
+  });
+
+  it('disambiguates same-instant snapshots with -1, -2, … suffixes', async () => {
+    const { adapter } = makeAdapter();
+    const svc = new SnapshotArchiveService(adapter, { now: () => FIXED });
+    const folder = 'Nexus/spreadsheets/budget';
+    await adapter.write(`${folder}/Sheet1.part0.csv`, 'v1');
+
+    const first = await svc.archiveCopy(folder);
+    const second = await svc.archiveCopy(folder);
+    const third = await svc.archiveCopy(folder);
+
+    expect(first).toBe(`${folder}/_archive/2026-05-31T12-34-56-789Z`);
+    expect(second).toBe(`${folder}/_archive/2026-05-31T12-34-56-789Z-1`);
+    expect(third).toBe(`${folder}/_archive/2026-05-31T12-34-56-789Z-2`);
+  });
+
+  it('honors a custom archiveDirName', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new SnapshotArchiveService(adapter, { now: () => FIXED, archiveDirName: '_versions' });
+    const folder = 'Nexus/spreadsheets/budget';
+    await adapter.write(`${folder}/Sheet1.part0.csv`, 'data');
+
+    const archived = await svc.archiveCopy(folder);
+
+    expect(archived).toContain(`${folder}/_versions/`);
+    expect(files.get(`${archived}/Sheet1.part0.csv`)).toBe('data');
+  });
+});

--- a/tests/unit/SpreadsheetAutoSync.test.ts
+++ b/tests/unit/SpreadsheetAutoSync.test.ts
@@ -1,0 +1,100 @@
+/**
+ * SpreadsheetAutoSync — scheduling logic: path filtering, debounce coalescing,
+ * and self-write (re-projection) loop suppression. The actual sync is injected,
+ * and timers are driven by a manual fake clock so the tests are deterministic.
+ */
+
+import { SpreadsheetAutoSync } from '../../src/agents/apps/dataAnalysis/spreadsheet/SpreadsheetAutoSync';
+import { dataToCsv } from '../../src/agents/apps/dataAnalysis/spreadsheet/csv';
+
+/** Minimal manual timer + clock so debounce/cooldown are deterministic. */
+function fakeClock() {
+  let now = 0;
+  let seq = 1;
+  const timers = new Map<number, { fire: number; fn: () => void }>();
+  return {
+    now: () => now,
+    setTimer: (fn: () => void, ms: number) => {
+      const id = seq++;
+      timers.set(id, { fire: now + ms, fn });
+      return id;
+    },
+    clearTimer: (h: number) => { timers.delete(h); },
+    advance: async (ms: number) => {
+      now += ms;
+      const due = [...timers.entries()].filter(([, t]) => t.fire <= now).sort((a, b) => a[1].fire - b[1].fire);
+      for (const [id, t] of due) { timers.delete(id); t.fn(); }
+      await Promise.resolve();
+    },
+  };
+}
+
+describe('SpreadsheetAutoSync.workbookIdOf', () => {
+  const sync = new SpreadsheetAutoSync({ getRoot: () => 'Nexus', sync: async () => undefined });
+
+  it('matches mirror CSV shards and extracts the workbook id', () => {
+    expect(sync.workbookIdOf('Nexus/spreadsheets/budget/Data.part0.csv')).toBe('budget');
+  });
+  it('ignores manifest.json, non-mirror paths, and snapshot shards', () => {
+    expect(sync.workbookIdOf('Nexus/spreadsheets/budget/manifest.json')).toBeNull();
+    expect(sync.workbookIdOf('Nexus/spreadsheets/budget/_archive/x/Data.part0.csv')).toBeNull();
+    expect(sync.workbookIdOf('OtherFolder/budget/Data.part0.csv')).toBeNull();
+    expect(sync.workbookIdOf('Nexus/spreadsheets/budget.xlsx')).toBeNull();
+  });
+});
+
+describe('SpreadsheetAutoSync scheduling', () => {
+  it('debounces a burst of edits into a single sync', async () => {
+    const clock = fakeClock();
+    const calls: string[] = [];
+    const sync = new SpreadsheetAutoSync({
+      getRoot: () => 'Nexus',
+      sync: async (id) => { calls.push(id); },
+      debounceMs: 1000,
+      ...clock,
+    });
+
+    sync.notifyModified('Nexus/spreadsheets/budget/Data.part0.csv');
+    await clock.advance(400);
+    sync.notifyModified('Nexus/spreadsheets/budget/Data.part1.csv'); // resets debounce
+    await clock.advance(400);
+    expect(calls).toEqual([]); // not yet
+    await clock.advance(700); // 1000ms since last edit
+    expect(calls).toEqual(['budget']); // coalesced into one
+  });
+
+  it('suppresses re-projection writes during sync + cooldown (no loop)', async () => {
+    const clock = fakeClock();
+    const calls: string[] = [];
+    const sync = new SpreadsheetAutoSync({
+      getRoot: () => 'Nexus',
+      // The sync itself "writes" a shard (re-projection) — must NOT re-trigger.
+      sync: async (id) => {
+        calls.push(id);
+        sync.notifyModified('Nexus/spreadsheets/budget/Data.part0.csv');
+      },
+      debounceMs: 1000,
+      cooldownMs: 500,
+      ...clock,
+    });
+
+    sync.notifyModified('Nexus/spreadsheets/budget/Data.part0.csv');
+    await clock.advance(1000); // fire sync #1 (which self-writes during run)
+    await clock.advance(2000); // let any spurious debounce elapse
+    expect(calls).toEqual(['budget']); // exactly one — no loop
+  });
+});
+
+describe('dataToCsv (runAnalysis CSV output)', () => {
+  it('serializes array-of-records with a header row', () => {
+    expect(dataToCsv([{ region: 'EMEA', amount: 100 }, { region: 'APAC', amount: 200 }]))
+      .toBe('region,amount\nEMEA,100\nAPAC,200\n');
+  });
+  it('serializes array-of-arrays verbatim and array-of-scalars as one column', () => {
+    expect(dataToCsv([['a', 'b'], [1, 2]])).toBe('a,b\n1,2\n');
+    expect(dataToCsv([1, 2, 3])).toBe('1\n2\n3\n');
+  });
+  it('throws on a non-tabular result', () => {
+    expect(() => dataToCsv({ total: 5 })).toThrow(/list of rows/);
+  });
+});

--- a/tests/unit/SpreadsheetAutoSync.test.ts
+++ b/tests/unit/SpreadsheetAutoSync.test.ts
@@ -85,7 +85,7 @@ describe('SpreadsheetAutoSync scheduling', () => {
   });
 });
 
-describe('dataToCsv (runAnalysis CSV output)', () => {
+describe('dataToCsv (runPython CSV output)', () => {
   it('serializes array-of-records with a header row', () => {
     expect(dataToCsv([{ region: 'EMEA', amount: 100 }, { region: 'APAC', amount: 200 }]))
       .toBe('region,amount\nEMEA,100\nAPAC,200\n');

--- a/tests/unit/SpreadsheetMirror.test.ts
+++ b/tests/unit/SpreadsheetMirror.test.ts
@@ -154,11 +154,23 @@ describe('WorkbookMirrorService', () => {
 });
 
 describe('HucreXlsxSource', () => {
-  it('maps hucre reader output to a ParsedWorkbook with a content hash', async () => {
+  it('maps openXlsx output to a ParsedWorkbook + detects formula cells from XML', async () => {
+    const sheetXml = '<worksheet><sheetData>' +
+      '<row r="1"><c r="A1" t="str"><v>x</v></c></row>' +
+      '<row r="2"><c r="A2"><f>SUM(A1)</f><v>1</v></c></row>' +
+      '</sheetData></worksheet>';
     const fakeModule = {
-      async readXlsx(_bytes: Uint8Array) {
-        return { sheets: [{ name: 'S', rows: [['x', 1, true, null, new Date('2026-01-02T00:00:00Z')]] }], hasMacros: true };
+      async openXlsx(_bytes: Uint8Array) {
+        return {
+          sheets: [{ name: 'S', rows: [['x', 1, true, null, new Date('2026-01-02T00:00:00Z')]] }],
+          _rawEntries: new Map<string, Uint8Array>([
+            ['xl/worksheets/sheet1.xml', new TextEncoder().encode(sheetXml)],
+          ]),
+          _modifiedParts: new Set<string>(),
+          hasMacros: true,
+        };
       },
+      async saveXlsx() { return new Uint8Array(); },
     };
     const src = new HucreXlsxSource(async () => fakeModule);
     const bytes = new Uint8Array([1, 2, 3, 4]);
@@ -166,6 +178,7 @@ describe('HucreXlsxSource', () => {
 
     expect(wb.hasMacros).toBe(true);
     expect(wb.sheets[0].rows[0]).toEqual(['x', 1, true, null, '2026-01-02T00:00:00.000Z']);
+    expect(wb.sheets[0].formulaCells).toEqual(['A2']);
     expect(wb.sourceHash).toBe(fnv1aHex(bytes));
   });
 

--- a/tests/unit/SpreadsheetMirror.test.ts
+++ b/tests/unit/SpreadsheetMirror.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Phase 1 (mirror generation) tests — the pure projection core: CSV
+ * serialization, byte-budget sharding, the WorkbookMirrorService (idempotency,
+ * sharding, sheet-name collisions, stale-shard cleanup), the HucreXlsxSource
+ * value mapping (fake module), and the pinned hucre asset manifest.
+ *
+ * Reuses the in-memory DataAdapter fake shape from the other storage tests.
+ */
+
+import type { DataAdapter } from 'obsidian';
+import { serializeRows, serializeRow, utf8Bytes } from '../../src/agents/apps/dataAnalysis/spreadsheet/csv';
+import { shardSheet } from '../../src/agents/apps/dataAnalysis/spreadsheet/shard';
+import { WorkbookMirrorService } from '../../src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService';
+import { HucreXlsxSource, fnv1aHex } from '../../src/agents/apps/dataAnalysis/spreadsheet/HucreXlsxSource';
+import { buildHucreAssetManifest, HUCRE_VERSION } from '../../src/agents/apps/dataAnalysis/spreadsheet/HucreAssets';
+import type { MirrorManifest, ParsedWorkbook } from '../../src/agents/apps/dataAnalysis/spreadsheet/types';
+
+function makeAdapter() {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  const norm = (p: string) => p.replace(/\/+$/, '');
+  const immediateChildren = (dir: string) => {
+    const prefix = norm(dir) + '/';
+    const childFiles: string[] = [];
+    const childFolders: string[] = [];
+    for (const f of files.keys()) {
+      if (f.startsWith(prefix) && !f.slice(prefix.length).includes('/')) childFiles.push(f);
+    }
+    for (const f of folders) {
+      if (f.startsWith(prefix) && !f.slice(prefix.length).includes('/')) childFolders.push(f);
+    }
+    return { files: childFiles, folders: childFolders };
+  };
+  const adapter = {
+    async exists(path: string) { const p = norm(path); return files.has(p) || folders.has(p); },
+    async list(path: string) { return immediateChildren(path); },
+    async read(path: string) {
+      const p = norm(path);
+      if (!files.has(p)) throw new Error(`no such file: ${p}`);
+      return files.get(p) as string;
+    },
+    async write(path: string, data: string) {
+      const p = norm(path);
+      const segs = p.split('/');
+      let cur = '';
+      for (let i = 0; i < segs.length - 1; i++) { cur = cur ? `${cur}/${segs[i]}` : segs[i]; folders.add(cur); }
+      files.set(p, data);
+    },
+    async mkdir(path: string) { const p = norm(path); if (folders.has(p)) throw new Error('exists'); folders.add(p); },
+    async remove(path: string) { files.delete(norm(path)); },
+    async rmdir(path: string) { folders.delete(norm(path)); },
+  };
+  return { adapter: adapter as unknown as DataAdapter, files, folders };
+}
+
+const TARGET = { root: 'Nexus', workbookId: 'budget', maxShardBytes: 1_000_000, now: () => Date.parse('2026-05-31T00:00:00Z') };
+
+describe('csv serialization', () => {
+  it('quotes values containing comma, quote, or newline (RFC-4180); LF lines', () => {
+    expect(serializeRow(['a', 'b,c', 'he said "hi"', 'line\nbreak'])).toBe('a,"b,c","he said ""hi""","line\nbreak"');
+    expect(serializeRow([1, true, false, null])).toBe('1,TRUE,FALSE,');
+    expect(serializeRows([['a', 1], ['b', 2]])).toBe('a,1\nb,2\n');
+    expect(serializeRows([])).toBe('');
+  });
+});
+
+describe('shardSheet', () => {
+  it('empty sheet yields a single empty shard', () => {
+    expect(shardSheet([], 1000)).toEqual([{ csv: '', startRow: 0, endRow: 0, bytes: 0 }]);
+  });
+
+  it('splits rows into contiguous shards under the byte budget', () => {
+    const rows = Array.from({ length: 10 }, (_, i) => [`row${i}`, i]);
+    const oneRowBytes = utf8Bytes(serializeRow(rows[0])) + 1;
+    const shards = shardSheet(rows, oneRowBytes * 3); // ~3 rows per shard
+
+    expect(shards.length).toBeGreaterThan(1);
+    // contiguous, complete coverage
+    expect(shards[0].startRow).toBe(0);
+    expect(shards[shards.length - 1].endRow).toBe(10);
+    for (let i = 1; i < shards.length; i++) expect(shards[i].startRow).toBe(shards[i - 1].endRow);
+    for (const s of shards) expect(s.bytes).toBeLessThanOrEqual(oneRowBytes * 3);
+  });
+
+  it('a lone oversize row gets its own shard rather than looping', () => {
+    const rows = [['x'.repeat(5000)], ['small']];
+    const shards = shardSheet(rows, 100);
+    expect(shards[0]).toMatchObject({ startRow: 0, endRow: 1 });
+    expect(shards.length).toBe(2);
+  });
+});
+
+describe('WorkbookMirrorService', () => {
+  const wb = (sourceHash: string): ParsedWorkbook => ({
+    sourceHash,
+    sheets: [
+      { name: 'Data', rows: [['region', 'amount'], ['EMEA', 100], ['APAC', 200]], formulaCells: ['B4'] },
+      { name: 'Summary', rows: [['total', 300]] },
+    ],
+  });
+
+  it('writes manifest + per-sheet CSV shards under <root>/spreadsheets/<id>', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new WorkbookMirrorService(adapter);
+
+    const { manifest, regenerated } = await svc.generate(wb('h1'), TARGET);
+
+    expect(regenerated).toBe(true);
+    expect(manifest.sourceHash).toBe('h1');
+    expect(manifest.sheets.map((s) => s.name)).toEqual(['Data', 'Summary']);
+    expect(manifest.sheets[0].formulaCells).toEqual(['B4']);
+    expect(files.get('Nexus/spreadsheets/budget/Data.part0.csv')).toBe('region,amount\nEMEA,100\nAPAC,200\n');
+    expect(files.get('Nexus/spreadsheets/budget/Summary.part0.csv')).toBe('total,300\n');
+    expect(files.has('Nexus/spreadsheets/budget/manifest.json')).toBe(true);
+  });
+
+  it('is idempotent: same sourceHash skips the rewrite', async () => {
+    const { adapter } = makeAdapter();
+    const svc = new WorkbookMirrorService(adapter);
+    await svc.generate(wb('h1'), TARGET);
+    const second = await svc.generate(wb('h1'), TARGET);
+    expect(second.regenerated).toBe(false);
+  });
+
+  it('a changed sourceHash regenerates and clears stale shards (but not _archive)', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new WorkbookMirrorService(adapter);
+    await svc.generate(wb('h1'), TARGET);
+    // simulate a prior larger sheet leaving an extra shard + an archive snapshot
+    await adapter.write('Nexus/spreadsheets/budget/Data.part9.csv', 'stale');
+    await adapter.write('Nexus/spreadsheets/budget/_archive/old/Data.part0.csv', 'snapshot');
+
+    const second = await svc.generate(wb('h2'), TARGET);
+    expect(second.regenerated).toBe(true);
+    expect(files.has('Nexus/spreadsheets/budget/Data.part9.csv')).toBe(false);      // stale shard cleared
+    expect(files.get('Nexus/spreadsheets/budget/_archive/old/Data.part0.csv')).toBe('snapshot'); // archive preserved
+  });
+
+  it('disambiguates colliding sanitized sheet names', async () => {
+    const { adapter, files } = makeAdapter();
+    const svc = new WorkbookMirrorService(adapter);
+    const collide: ParsedWorkbook = {
+      sourceHash: 'h',
+      sheets: [
+        { name: 'Q1/Q2', rows: [['a']] },
+        { name: 'Q1:Q2', rows: [['b']] },
+      ],
+    };
+    await svc.generate(collide, TARGET);
+    // both sanitize to "Q1_Q2"; the second is disambiguated by order
+    expect(files.get('Nexus/spreadsheets/budget/Q1_Q2.part0.csv')).toBe('a\n');
+    expect(files.get('Nexus/spreadsheets/budget/Q1_Q2-1.part0.csv')).toBe('b\n');
+  });
+});
+
+describe('HucreXlsxSource', () => {
+  it('maps hucre reader output to a ParsedWorkbook with a content hash', async () => {
+    const fakeModule = {
+      async readXlsx(_bytes: Uint8Array) {
+        return { sheets: [{ name: 'S', rows: [['x', 1, true, null, new Date('2026-01-02T00:00:00Z')]] }], hasMacros: true };
+      },
+    };
+    const src = new HucreXlsxSource(async () => fakeModule);
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const wb = await src.readWorkbook(bytes);
+
+    expect(wb.hasMacros).toBe(true);
+    expect(wb.sheets[0].rows[0]).toEqual(['x', 1, true, null, '2026-01-02T00:00:00.000Z']);
+    expect(wb.sourceHash).toBe(fnv1aHex(bytes));
+  });
+
+  it('fnv1aHex is stable and content-sensitive', () => {
+    expect(fnv1aHex(new Uint8Array([1, 2, 3]))).toBe(fnv1aHex(new Uint8Array([1, 2, 3])));
+    expect(fnv1aHex(new Uint8Array([1, 2, 3]))).not.toBe(fnv1aHex(new Uint8Array([1, 2, 4])));
+  });
+});
+
+describe('hucre asset manifest', () => {
+  it('pins a single bundled xlsx asset at the locked version', () => {
+    const manifest = buildHucreAssetManifest();
+    expect(manifest).toHaveLength(1);
+    expect(manifest[0].url).toContain(`hucre@${HUCRE_VERSION}/xlsx`);
+    expect(manifest[0].minBytes).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/SpreadsheetWriteBack.test.ts
+++ b/tests/unit/SpreadsheetWriteBack.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Phase 2 (write-back) tests. The hucre engine is faked with a "JSON-as-xlsx"
+ * source/writer so the REAL logic under test — CSV parse, cell diff, formula
+ * guard, snapshot, re-projection, divergence/dryRun handling — runs end-to-end
+ * over the in-memory adapter with the real WorkbookMirrorService +
+ * SnapshotArchiveService.
+ */
+
+import type { DataAdapter } from 'obsidian';
+import { parseCsv, serializeRows } from '../../src/agents/apps/dataAnalysis/spreadsheet/csv';
+import { WorkbookMirrorService } from '../../src/agents/apps/dataAnalysis/spreadsheet/WorkbookMirrorService';
+import { WorkbookWriteBackService } from '../../src/agents/apps/dataAnalysis/spreadsheet/WorkbookWriteBackService';
+import { SnapshotArchiveService } from '../../src/services/storage/SnapshotArchiveService';
+import type { CellWrite, ParsedWorkbook, XlsxSource, XlsxWriter } from '../../src/agents/apps/dataAnalysis/spreadsheet/types';
+
+function makeAdapter() {
+  const files = new Map<string, string>();
+  const folders = new Set<string>();
+  const norm = (p: string) => p.replace(/\/+$/, '');
+  const children = (dir: string) => {
+    const prefix = norm(dir) + '/';
+    const f: string[] = [];
+    const d: string[] = [];
+    for (const k of files.keys()) if (k.startsWith(prefix) && !k.slice(prefix.length).includes('/')) f.push(k);
+    for (const k of folders) if (k.startsWith(prefix) && !k.slice(prefix.length).includes('/')) d.push(k);
+    return { files: f, folders: d };
+  };
+  const adapter = {
+    async exists(p: string) { const n = norm(p); return files.has(n) || folders.has(n); },
+    async list(p: string) { return children(p); },
+    async read(p: string) { const n = norm(p); if (!files.has(n)) throw new Error(`no file ${n}`); return files.get(n) as string; },
+    async write(p: string, data: string) {
+      const n = norm(p);
+      const segs = n.split('/');
+      let cur = '';
+      for (let i = 0; i < segs.length - 1; i++) { cur = cur ? `${cur}/${segs[i]}` : segs[i]; folders.add(cur); }
+      files.set(n, data);
+    },
+    async mkdir(p: string) { const n = norm(p); if (folders.has(n)) throw new Error('exists'); folders.add(n); },
+    async remove(p: string) { files.delete(norm(p)); },
+    async rmdir(p: string) { folders.delete(norm(p)); },
+  };
+  return { adapter: adapter as unknown as DataAdapter, files, folders };
+}
+
+const enc = (wb: ParsedWorkbook) => new TextEncoder().encode(JSON.stringify(wb));
+const dec = (b: Uint8Array): ParsedWorkbook => JSON.parse(new TextDecoder().decode(b)) as ParsedWorkbook;
+
+/** JSON-as-xlsx engine fakes — exercise the real orchestration without hucre. */
+const fakeSource: XlsxSource = { async readWorkbook(b) { return dec(b); } };
+
+class FakeWriter implements XlsxWriter {
+  lastWrites: CellWrite[] = [];
+  async applyCellWrites(bytes: Uint8Array, writes: CellWrite[]): Promise<Uint8Array> {
+    this.lastWrites = writes;
+    const wb = dec(bytes);
+    for (const w of writes) {
+      const sheet = wb.sheets.find((s) => s.name === w.sheet)!;
+      while (sheet.rows.length <= w.row) sheet.rows.push([]);
+      const row = sheet.rows[w.row];
+      while (row.length <= w.col) row.push(null);
+      row[w.col] = w.value;
+    }
+    wb.sourceHash = `${wb.sourceHash}-applied`;
+    return enc(wb);
+  }
+}
+
+const TARGET = { root: 'Nexus', workbookId: 'budget', maxShardBytes: 1_000_000, now: () => 0 };
+
+function baseWorkbook(hash = 'h1', formulaCells: string[] = []): ParsedWorkbook {
+  return {
+    sourceHash: hash,
+    sheets: [{ name: 'Data', rows: [['region', 'amount'], ['EMEA', 100], ['APAC', 200]], formulaCells }],
+  };
+}
+
+async function setup(formulaCells: string[] = []) {
+  const { adapter, files } = makeAdapter();
+  const mirror = new WorkbookMirrorService(adapter);
+  const snapshot = new SnapshotArchiveService(adapter, { now: () => Date.parse('2026-05-31T00:00:00Z') });
+  const writer = new FakeWriter();
+  const wb = baseWorkbook('h1', formulaCells);
+  await mirror.generate(wb, TARGET);
+  const writeBack = new WorkbookWriteBackService(adapter, fakeSource, writer, mirror, snapshot);
+  return { adapter, files, mirror, writer, writeBack, sourceBytes: enc(wb) };
+}
+
+const editShard = (files: Map<string, string>, content: string) =>
+  files.set('Nexus/spreadsheets/budget/Data.part0.csv', content);
+
+describe('parseCsv ↔ serializeRows round-trip', () => {
+  it('parses quoted fields with commas, quotes, and newlines', () => {
+    const rows = [['a', 'b,c'], ['he "q"', 'x\ny']];
+    expect(parseCsv(serializeRows(rows))).toEqual([['a', 'b,c'], ['he "q"', 'x\ny']]);
+    expect(parseCsv('')).toEqual([]);
+  });
+});
+
+describe('WorkbookWriteBackService', () => {
+  it('applies a data-cell edit: diff → write → snapshot → re-project', async () => {
+    const { files, writer, writeBack, mirror, sourceBytes } = await setup();
+    editShard(files, 'region,amount\nEMEA,999\nAPAC,200\n'); // EMEA 100 → 999 (B2)
+
+    const res = await writeBack.apply(TARGET, sourceBytes);
+
+    expect(res.applied).toBe(true);
+    expect(res.reason).toBe('applied');
+    expect(res.summary.cellsApplied).toBe(1);
+    expect(res.summary.sheets[0].samples[0]).toEqual({ a1: 'B2', before: '100', after: '999' });
+    // coerced back to a number for the write
+    expect(writer.lastWrites).toEqual([{ sheet: 'Data', row: 1, col: 1, value: 999 }]);
+    // snapshot captured the edited shard before re-projection
+    expect(res.archivePath).toBeTruthy();
+    expect(files.get(`${res.archivePath}/Data.part0.csv`)).toBe('region,amount\nEMEA,999\nAPAC,200\n');
+    // mirror re-projected from the updated workbook (new hash)
+    const manifest = await mirror.readManifest(TARGET);
+    expect(manifest!.sourceHash).toBe('h1-applied');
+  });
+
+  it('formula-cell guard blocks an edit to a formula cell', async () => {
+    const { files, writer, writeBack, sourceBytes } = await setup(['B3']); // APAC amount is a formula
+    editShard(files, 'region,amount\nEMEA,100\nAPAC,300\n'); // tries to change B3
+
+    const res = await writeBack.apply(TARGET, sourceBytes);
+
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe('no-changes');
+    expect(res.summary.cellsApplied).toBe(0);
+    expect(res.summary.cellsBlocked).toBe(1);
+    expect(res.summary.sheets[0].blockedFormulaCells).toEqual(['B3']);
+    expect(writer.lastWrites).toEqual([]);
+  });
+
+  it('dryRun returns the plan without writing or snapshotting', async () => {
+    const { files, writeBack, sourceBytes } = await setup();
+    editShard(files, 'region,amount\nEMEA,999\nAPAC,200\n');
+
+    const res = await writeBack.apply(TARGET, sourceBytes, { dryRun: true });
+
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe('dry-run');
+    expect(res.summary.cellsApplied).toBe(1);
+    expect(res.newBytes).toBeUndefined();
+    expect([...files.keys()].some((k) => k.includes('/_archive/'))).toBe(false);
+  });
+
+  it('refuses when the source diverged from the mirror (unless forced)', async () => {
+    const { writeBack } = await setup();
+    const diverged = enc(baseWorkbook('h2')); // different sourceHash than the mirror's h1
+
+    const res = await writeBack.apply(TARGET, diverged);
+
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe('divergence');
+  });
+
+  it('no-op when nothing changed', async () => {
+    const { writeBack, sourceBytes } = await setup();
+    const res = await writeBack.apply(TARGET, sourceBytes); // shards untouched
+    expect(res.applied).toBe(false);
+    expect(res.reason).toBe('no-changes');
+  });
+});


### PR DESCRIPTION
## What

A desktop-only **Data Analysis** app (id `data`, opt-in via Settings → Apps) with two capabilities:

1. **`runPython`** — run Python (pandas) against vault CSV/Excel data in a sandboxed Pyodide worker; returns a bounded result or writes output (JSON, or **CSV** when `outputPath` ends in `.csv`).
2. **Lossless spreadsheet round-trip** — `mirrorWorkbook` projects an `.xlsx` into editable, sharded CSVs under `<NexusRoot>/spreadsheets/<id>/`; edits are written back **automatically** (debounced vault watcher) via `applyToWorkbook`, preserving formulas/charts/images/pivots byte-for-byte.

Tools: `runPython`, `listCapabilities`, `mirrorWorkbook`, `applyToWorkbook`.

## runPython sandbox (best-effort isolation, not a hard sandbox)

Python runs in a separate Worker (no Node integration, MEMFS-only Pyodide, realm-wide network scrub, zero references to Obsidian `App`/`Vault`). The trusted host reads only path-jailed inputs and injects bytes; the sandbox is data-in/result-out. Residual risk (an in-realm escape re-deriving `fetch`) is bounded to exfiltrating already-provided bytes — no vault/FS/Obsidian/RCE. Copy says "best-effort isolation," not "can't break out." Guards: serialized concurrency, per-run timeout + `terminate()`, memory ceiling, output-byte cap, NaN/int64/datetime marshalling. Pyodide + openpyxl vendored as runtime assets (kept out of main.js).

## Spreadsheet round-trip design

- **CSV = projection, `.xlsx` = source of truth.** Mirror is regenerated from the workbook; the CSV is the AI's value surface. Formulas are **never evaluated or flattened** — they stay live (Excel recalcs on open); the write-back guards formula cells and the AI recomputes via pandas/Skills.
- **Engine: [`hucre`](https://github.com/productdevbook/hucre)** (MIT, zero-dep, pure-TS) — surgical cell edits leave every untouched part (charts/images/pivots) byte-intact. Spike-validated; **vendored as a runtime asset** (302 KB > main.js headroom), loaded via Blob-URL ESM import.
- **Automatic write-back** — `SpreadsheetAutoSync` debounces vault `modify` on mirror CSVs, runs the write-back, snapshots prior shards, and re-projects (loop-safe). `applyToWorkbook` remains as a manual `dryRun`/`force` path.
- **Versioning** — `SnapshotArchiveService` (extracted from the Skills app's `archiveThenReplace`, byte-identical) snapshots prior shards before each apply. Divergence guard refuses if the `.xlsx` changed outside the mirror.
- **Sharding** — CSVs split to `maxShardBytes` (existing storage setting); mirror lives under the renameable, synced Nexus root.

## Tests / build

- ~190 unit tests across the app + spreadsheet subsystem (`RunPythonTool`, `DataAnalysisGuards`, `PyodideEnsurer`, `SnapshotArchiveService`, `SpreadsheetMirror`, `SpreadsheetWriteBack`, `SpreadsheetAutoSync`, `AppManager`). Build + lint clean; `main.js` ≈ 4.80 MB (< 5 MB; hucre/Pyodide not bundled).
- Design + spike docs under `docs/plans/` (`spreadsheet-mirror-versioning-plan`, `spike-findings-hucre`, `spike-findings-pyodide`).

## ⚠️ NOT yet validated in Obsidian — opt-in/dormant on merge

Everything is unit-tested + builds, but the **Electron-bound paths have not run in a real desktop build**: Pyodide worker + asset download, hucre download/Blob-import + real `.xlsx` fidelity, the auto-sync watcher, multi-sheet → worksheet-part mapping, and the vault `writeBinary` that **mutates real workbooks**. The app is opt-in (disabled until enabled in Settings → Apps), so merging exposes nobody automatically. Manual smoke-test checklist: `docs/plans/spreadsheet-mirror-manual-test.md`.

https://claude.ai/code/session_01KDo5RRp23GBAJNwuXxhkg4