### PR TITLE
feat(apps): App.onload() lifecycle hook

### DIFF
--- a/src/agents/apps/BaseAppAgent.ts
+++ b/src/agents/apps/BaseAppAgent.ts
@@ -187,6 +187,16 @@ export abstract class BaseAppAgent extends BaseAgent {
   }
 
   /**
+   * Lifecycle hook called by AppManager once the agent is fully configured
+   * (app/vault/credentials/runtime injected) and registered as a live app.
+   * Override to start background work (e.g. file watchers). The matching
+   * teardown is {@link BaseAgent.onunload}. Default: no-op.
+   */
+  onload(): void {
+    // Default: no-op
+  }
+
+  /**
    * Hook called when credentials change.
    * Override to reinitialize HTTP clients, etc.
    */

--- a/src/services/apps/AppManager.ts
+++ b/src/services/apps/AppManager.ts
@@ -57,6 +57,7 @@ export class AppManager {
         }
         this.apps.set(appId, agent);
         this.registerCallback(agent);
+        agent.onload();
         logger.systemLog(`App loaded: ${appId}`);
       } catch (error) {
         logger.systemError(error as Error, `App Load: ${appId}`);
@@ -148,6 +149,7 @@ export class AppManager {
       if (agent) {
         this.apps.set(appId, agent);
         this.registerCallback(agent);
+        agent.onload();
       }
     } else if (!enabled && this.apps.has(appId)) {
       // Unregister but keep config


### PR DESCRIPTION
Adds a no-op `onload()` hook to `BaseAppAgent`, invoked by `AppManager` once an app agent is fully configured and registered as a live app (both the initial-load and enable-toggle paths). Matching teardown is the existing `BaseAgent.onunload()`.

Gives apps a single place to start background work (file watchers) that must run only for a genuinely loaded+enabled app — not in `setApp()`, which also runs for transient preview/registration instances and leaks duplicate watchers.

**Foundation** for the data-analysis single-mirror fix and the skills auto-sync watcher (both stacked on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)