### PR TITLE
feat(skills): automatic sync watcher + recursive loadSkill structure

### DIFF
--- a/src/agents/apps/BaseAppAgent.ts
+++ b/src/agents/apps/BaseAppAgent.ts
@@ -187,6 +187,16 @@ export abstract class BaseAppAgent extends BaseAgent {
   }
 
   /**
+   * Lifecycle hook called by AppManager once the agent is fully configured
+   * (app/vault/credentials/runtime injected) and registered as a live app.
+   * Override to start background work (e.g. file watchers). The matching
+   * teardown is {@link BaseAgent.onunload}. Default: no-op.
+   */
+  onload(): void {
+    // Default: no-op
+  }
+
+  /**
    * Hook called when credentials change.
    * Override to reinitialize HTTP clients, etc.
    */

--- a/src/agents/apps/skills/SkillsAgent.ts
+++ b/src/agents/apps/skills/SkillsAgent.ts
@@ -20,6 +20,8 @@ import { CreateSkillTool } from './tools/createSkill';
 import { UpdateSkillTool } from './tools/updateSkill';
 import { ArchiveSkillTool } from './tools/archiveSkill';
 import { SyncSkillsTool } from './tools/syncSkills';
+import { SkillSyncWatcher } from './services/SkillSyncWatcher';
+import { resolveSkillsRuntime } from './services/SkillsContext';
 
 const SKILLS_MANIFEST: AppManifest = {
   id: 'skills',
@@ -43,6 +45,9 @@ const SKILLS_MANIFEST: AppManifest = {
 };
 
 export class SkillsAgent extends BaseAppAgent {
+  /** Automatic, debounced import + index-refresh. Null until onload(). */
+  private syncWatcher: SkillSyncWatcher | null = null;
+
   constructor() {
     super(SKILLS_MANIFEST);
     this.registerTool(new ListSkillsTool(this));
@@ -51,5 +56,29 @@ export class SkillsAgent extends BaseAppAgent {
     this.registerTool(new UpdateSkillTool(this));
     this.registerTool(new ArchiveSkillTool(this));
     this.registerTool(new SyncSkillsTool(this));
+  }
+
+  /**
+   * Start the automatic skill sync once the app is live (app/vault/runtime
+   * injected). The watcher resolves the runtime lazily on each run, so it's
+   * safe to start even if storage is still warming up.
+   */
+  onload(): void {
+    const app = this.getApp();
+    if (!app || this.syncWatcher) {
+      return;
+    }
+    this.syncWatcher = new SkillSyncWatcher(app, () => {
+      const r = resolveSkillsRuntime(this);
+      return r.ok ? r.rt : null;
+    });
+    this.syncWatcher.start();
+  }
+
+  /** Tear down the watcher when the app is disabled/uninstalled. */
+  onunload(): void {
+    this.syncWatcher?.stop();
+    this.syncWatcher = null;
+    super.onunload();
   }
 }

--- a/src/agents/apps/skills/services/SkillSyncWatcher.ts
+++ b/src/agents/apps/skills/services/SkillSyncWatcher.ts
@@ -1,0 +1,178 @@
+/**
+ * SkillSyncWatcher — automatic, debounced skill import + index refresh.
+ *
+ * Located at: src/agents/apps/skills/services/SkillSyncWatcher.ts
+ * Removes the need to call `syncSkills` by hand: it watches for skill-folder
+ * changes and (debounced) imports provider dotfolders into the mirror, then
+ * refreshes the SQLite index from the mirror. Started by SkillsAgent.onload(),
+ * stopped by SkillsAgent.onunload().
+ *
+ * Coverage / platform reality:
+ *   - The MIRROR (`<root>/skills/…`) is a normal, non-hidden vault path, so the
+ *     documented `vault.on('create'|'modify'|'delete'|'rename')` events fire for
+ *     it on BOTH desktop and mobile.
+ *   - The SOURCE provider dotfolders (`<vault>/.<provider>/skills/…`) are HIDDEN
+ *     and are NOT indexed by Obsidian's vault, so the documented events NEVER
+ *     fire for them. To make edits to those event-driven we also subscribe to
+ *     the undocumented `vault.on('raw')` event, which the desktop
+ *     FileSystemAdapter emits for any path under the vault dir (including
+ *     dotfolders). On mobile `raw` is silent — there, hidden-source changes are
+ *     picked up by the on-load sync instead. Both legs are best-effort.
+ *
+ * Scope: import + index-refresh ONLY. Sync-BACK (mirror → origin dotfolder)
+ * writes to the user's real provider folders and stays explicit (the syncSkills
+ * tool / updateSkill), so automatic activity can never clobber a source of truth.
+ *
+ * Loop-safety: import skips byte-identical writes (hash-gated), so the mirror
+ * writes it makes settle after one no-op cycle; `_archive/` churn is ignored.
+ *
+ * Mirrors the debounce shape of src/database/sync/JsonlVaultWatcher.ts.
+ */
+
+import type { App, EventRef, TAbstractFile, Vault } from 'obsidian';
+import type { SkillsRuntime } from './SkillsContext';
+import { SkillSyncService } from './SkillSyncService';
+
+/** Vault augmented with the undocumented `raw` event (desktop file-watcher). */
+type VaultWithRaw = Vault & {
+  on(name: 'raw', callback: (path: string) => void): EventRef;
+};
+
+export class SkillSyncWatcher {
+  private readonly eventRefs: EventRef[] = [];
+  private debounceTimer?: number;
+  private running = false;
+  private pending = false;
+  private disposed = false;
+  /** Bounded retries for the initial sync while storage is still warming up. */
+  private initialRetries = 5;
+
+  constructor(
+    private readonly app: App,
+    /** Resolved at FIRE time (not start time) so a not-yet-ready store self-heals. */
+    private readonly resolveRuntime: () => SkillsRuntime | null,
+    private readonly debounceMs = 2000
+  ) {}
+
+  /** Subscribe to vault events and kick off the initial catch-up sync. */
+  start(): void {
+    const vault = this.app.vault;
+
+    // Documented events — fire for the (non-hidden) mirror on desktop + mobile.
+    this.eventRefs.push(
+      vault.on('create', (f: TAbstractFile) => this.onPath(f.path)),
+      vault.on('modify', (f: TAbstractFile) => this.onPath(f.path)),
+      vault.on('delete', (f: TAbstractFile) => this.onPath(f.path)),
+      vault.on('rename', (f: TAbstractFile, oldPath: string) => {
+        this.onPath(f.path);
+        this.onPath(oldPath);
+      })
+    );
+
+    // Undocumented `raw` event — desktop-only coverage for hidden provider
+    // dotfolders. Guarded: absent/throwing registration is fine (mobile).
+    try {
+      this.eventRefs.push(
+        (vault as VaultWithRaw).on('raw', (path: string) => this.onPath(path))
+      );
+    } catch {
+      /* `raw` unsupported on this platform — mirror events + on-load sync cover it. */
+    }
+
+    // Catch up on anything that changed while the app was closed.
+    this.schedule();
+  }
+
+  /** Unsubscribe and cancel any pending run. */
+  stop(): void {
+    this.disposed = true;
+    if (this.debounceTimer !== undefined) {
+      window.clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+    for (const ref of this.eventRefs) {
+      this.app.vault.offref(ref);
+    }
+    this.eventRefs.length = 0;
+  }
+
+  private onPath(path: string): void {
+    if (this.disposed || !path) {
+      return;
+    }
+    if (this.isSkillPath(path)) {
+      this.schedule();
+    }
+  }
+
+  /**
+   * True for paths under the mirror root or under any `.<provider>/skills/` source
+   * dotfolder. `_archive/` snapshots are excluded so our own archive writes don't
+   * re-trigger the watcher.
+   */
+  private isSkillPath(path: string): boolean {
+    const norm = path.replace(/\\/g, '/');
+    if (norm.includes('/_archive/') || norm.includes('/_archive')) {
+      return false;
+    }
+    const rt = this.resolveRuntime();
+    if (rt && (norm === rt.skillsRoot || norm.startsWith(`${rt.skillsRoot}/`))) {
+      return true;
+    }
+    // `.<provider>/skills/...` at (or below) the vault root.
+    return /(^|\/)\.[^/]+\/skills(\/|$)/.test(norm);
+  }
+
+  private schedule(): void {
+    if (this.disposed) {
+      return;
+    }
+    if (this.debounceTimer !== undefined) {
+      window.clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = window.setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.run();
+    }, this.debounceMs);
+  }
+
+  private async run(): Promise<void> {
+    if (this.disposed) {
+      return;
+    }
+    // Coalesce overlapping runs — re-run once after the in-flight one finishes.
+    if (this.running) {
+      this.pending = true;
+      return;
+    }
+
+    const rt = this.resolveRuntime();
+    if (!rt) {
+      // Storage not ready yet — retry the initial catch-up a bounded number of times.
+      if (this.initialRetries > 0) {
+        this.initialRetries -= 1;
+        this.schedule();
+      }
+      return;
+    }
+    this.initialRetries = 0;
+
+    this.running = true;
+    try {
+      const sync = new SkillSyncService(rt.vaultAdapter, rt.skillsRoot, rt.index);
+      // import: provider dotfolders → mirror (hash-gated, archive-then-replace).
+      await sync.import();
+      // refresh the SQLite index from the (now-current) mirror.
+      const parsed = await rt.scanner.scan();
+      await rt.index.syncFromScan(parsed);
+    } catch {
+      /* best-effort — a later event (or the next edit) retries. */
+    } finally {
+      this.running = false;
+      if (this.pending && !this.disposed) {
+        this.pending = false;
+        this.schedule();
+      }
+    }
+  }
+}

--- a/src/agents/apps/skills/tools/loadSkill.ts
+++ b/src/agents/apps/skills/tools/loadSkill.ts
@@ -10,6 +10,7 @@
  */
 
 import { normalizePath } from 'obsidian';
+import type { DataAdapter } from 'obsidian';
 import { BaseTool } from '../../../baseTool';
 import { CommonParameters, CommonResult } from '../../../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
@@ -20,6 +21,7 @@ import { SkillUsageService, type SkillUsageHistory } from '../services/SkillUsag
 interface LoadSkillParams extends CommonParameters {
   name: string;
   source?: string;
+  recursive?: boolean;
   includeHistory?: boolean;
   // Injected at the top level by ToolBatchExecutionService.applyContextDefaults
   // (CLI-first contract) — used to attribute usage history to the session (§9).
@@ -70,15 +72,15 @@ export class LoadSkillTool extends BaseTool<LoadSkillParams, CommonResult> {
         `Could not read SKILL.md for skill "${record.name}" (${record.provider}) at ${skillMdPath}`);
     }
 
-    // List the skill folder's files for navigation.
-    let files: string[] = [];
-    try {
-      const listing = await r.rt.vaultAdapter.list(record.vaultPath);
-      files = listing.files;
-    } catch {
-      // Folder listing is best-effort — a missing listing should not fail the load.
-      files = [];
-    }
+    // Build the skill folder structure for navigation (loadWorkspace-shaped):
+    // top-level items by default (folders marked with a trailing `/`), or the
+    // full recursive file tree when `recursive` is true. Best-effort — a missing
+    // listing should not fail the load.
+    const structure = await this.buildStructure(
+      r.rt.vaultAdapter,
+      record.vaultPath,
+      params.recursive === true
+    );
 
     // Stamp recency so this load surfaces first next time.
     await r.rt.index.touchLoaded(record.id);
@@ -108,10 +110,12 @@ export class LoadSkillTool extends BaseTool<LoadSkillParams, CommonResult> {
       }
     }
 
-    // loadWorkspace-shaped payload (§12): instructions + files nested in `skill`,
-    // top-level nudge. `alternatives` surfaces the other recency-ordered matches
-    // when a bare name was ambiguous across providers. `usageHistory` is omitted
-    // when includeHistory:false or on fetch error.
+    // loadWorkspace-shaped payload (§12): instructions + folder structure nested
+    // in `skill`, top-level nudge. `structure` mirrors loadWorkspace's
+    // `workspaceStructure` (string[], folders trailing `/`, recursive opt-in).
+    // `alternatives` surfaces the other recency-ordered matches when a bare name
+    // was ambiguous across providers. `usageHistory` is omitted when
+    // includeHistory:false or on fetch error.
     return this.prepareResult(true, {
       skill: {
         name: record.name,
@@ -119,12 +123,11 @@ export class LoadSkillTool extends BaseTool<LoadSkillParams, CommonResult> {
         description: record.description,
         vaultPath: record.vaultPath,
         instructions,
-        files: files.map((path) => ({
-          path,
-          type: path.endsWith('/SKILL.md') ? 'skill' : 'resource',
-        })),
+        structure,
       },
-      nudge: 'Use your normal `content read` tool to open any of the files listed above.',
+      nudge: 'Skill folder structure is in `skill.structure` (paths relative to the skill folder; ' +
+        'folders end with `/`). Use your normal `content read` tool — prefixing paths with ' +
+        '`skill.vaultPath` — to open any bundled file. Pass `recursive: true` for the full file tree.',
       alternatives: matches.slice(1).map((m) => ({
         name: m.name,
         provider: m.provider,
@@ -132,6 +135,62 @@ export class LoadSkillTool extends BaseTool<LoadSkillParams, CommonResult> {
       })),
       ...(usageHistory ? { usageHistory } : {}),
     });
+  }
+
+  /**
+   * Build a loadWorkspace-shaped folder structure for the skill folder, read via
+   * `vault.adapter` (so it sees the same dot/hidden-safe tree the scanner walks).
+   *
+   * - top-level (default): item basenames, folders marked with a trailing `/`.
+   * - recursive: flat, sorted relative file paths (folders are descended into,
+   *   not listed) — matching WorkspaceFileCollector's recursive output.
+   *
+   * `_`/`.`-prefixed entries (e.g. co-located `_archive/` sync snapshots) are
+   * excluded at every level, consistent with the scanner. Best-effort: any
+   * adapter failure yields `[]` rather than failing the load.
+   */
+  private async buildStructure(
+    adapter: DataAdapter,
+    root: string,
+    recursive: boolean
+  ): Promise<string[]> {
+    const isIgnored = (base: string): boolean => base.startsWith('_') || base.startsWith('.');
+    try {
+      if (recursive) {
+        const out: string[] = [];
+        const walk = async (dir: string): Promise<void> => {
+          const listing = await adapter.list(dir);
+          for (const file of listing.files) {
+            out.push(file.replace(`${root}/`, ''));
+          }
+          for (const folder of listing.folders) {
+            if (isIgnored(LoadSkillTool.basename(folder))) {
+              continue;
+            }
+            await walk(folder);
+          }
+        };
+        await walk(root);
+        return out.sort();
+      }
+
+      const listing = await adapter.list(root);
+      const folders = listing.folders
+        .map((f) => LoadSkillTool.basename(f))
+        .filter((base) => !isIgnored(base))
+        .map((base) => `${base}/`);
+      const files = listing.files.map((f) => LoadSkillTool.basename(f));
+      return [...folders, ...files].sort();
+    } catch {
+      return [];
+    }
+  }
+
+  /** Basename of a vault-relative path (handles trailing slash). */
+  private static basename(path: string): string {
+    const trimmed = path.replace(/\/+$/, '');
+    const idx = trimmed.lastIndexOf('/');
+    return idx === -1 ? trimmed : trimmed.slice(idx + 1);
   }
 
   getParameterSchema(): JSONSchema {
@@ -145,6 +204,12 @@ export class LoadSkillTool extends BaseTool<LoadSkillParams, CommonResult> {
         source: {
           type: 'string',
           description: 'Optional provider id. Required only when the name is ambiguous across providers.',
+        },
+        recursive: {
+          type: 'boolean',
+          description: 'Show the full recursive file tree (true) or top-level items only (false). ' +
+            'Default: false (top-level only, folders marked with a trailing /).',
+          default: false,
         },
         includeHistory: {
           type: 'boolean',

--- a/src/services/apps/AppManager.ts
+++ b/src/services/apps/AppManager.ts
@@ -57,6 +57,7 @@ export class AppManager {
         }
         this.apps.set(appId, agent);
         this.registerCallback(agent);
+        agent.onload();
         logger.systemLog(`App loaded: ${appId}`);
       } catch (error) {
         logger.systemError(error as Error, `App Load: ${appId}`);
@@ -148,6 +149,7 @@ export class AppManager {
       if (agent) {
         this.apps.set(appId, agent);
         this.registerCallback(agent);
+        agent.onload();
       }
     } else if (!enabled && this.apps.has(appId)) {
       // Unregister but keep config

--- a/tests/unit/SkillSyncWatcher.test.ts
+++ b/tests/unit/SkillSyncWatcher.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for SkillSyncWatcher — verifies debounced, event-driven auto-sync:
+ * path filtering (mirror + hidden source, `_archive/` excluded), coalescing,
+ * the undocumented `raw` event leg, and clean teardown.
+ */
+
+jest.mock('../../src/agents/apps/skills/services/SkillSyncService', () => ({
+  SkillSyncService: jest.fn().mockImplementation(() => ({
+    import: jest.fn().mockResolvedValue({ imported: [], skipped: [], archived: [] }),
+  })),
+}));
+
+import { SkillSyncWatcher } from '../../src/agents/apps/skills/services/SkillSyncWatcher';
+import { SkillSyncService } from '../../src/agents/apps/skills/services/SkillSyncService';
+import type { SkillsRuntime } from '../../src/agents/apps/skills/services/SkillsContext';
+
+const MockedSyncService = SkillSyncService as unknown as jest.Mock;
+
+type VaultEvent = 'create' | 'modify' | 'delete' | 'rename' | 'raw';
+type EventHandler = (...args: unknown[]) => void;
+
+function createMockApp() {
+  const handlers = new Map<VaultEvent, Set<EventHandler>>([
+    ['create', new Set()],
+    ['modify', new Set()],
+    ['delete', new Set()],
+    ['rename', new Set()],
+    ['raw', new Set()],
+  ]);
+
+  const offref = jest.fn((ref: unknown) => {
+    const r = ref as { _event: VaultEvent; _fn: EventHandler };
+    handlers.get(r._event)?.delete(r._fn);
+  });
+
+  const on = jest.fn((event: VaultEvent, fn: EventHandler) => {
+    handlers.get(event)?.add(fn);
+    return { _event: event, _fn: fn };
+  });
+
+  const fire = (event: VaultEvent, ...args: unknown[]) => {
+    for (const fn of handlers.get(event) ?? []) {
+      fn(...args);
+    }
+  };
+
+  return { app: { vault: { on, offref } } as never, fire, handlers };
+}
+
+function makeRuntime(): SkillsRuntime {
+  return {
+    skillsRoot: 'Nexus/skills',
+    vaultAdapter: {} as never,
+    index: { syncFromScan: jest.fn().mockResolvedValue(undefined) } as never,
+    scanner: { scan: jest.fn().mockResolvedValue([]) } as never,
+    sqlite: {} as never,
+  };
+}
+
+describe('SkillSyncWatcher', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    MockedSyncService.mockClear();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('debounces and coalesces a burst of mirror events into one sync', async () => {
+    const { app, fire } = createMockApp();
+    const rt = makeRuntime();
+    const watcher = new SkillSyncWatcher(app, () => rt, 2000);
+    watcher.start();
+
+    // The initial catch-up sync schedules immediately on start(); flush it.
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(MockedSyncService).toHaveBeenCalledTimes(1);
+    MockedSyncService.mockClear();
+
+    // Burst of edits inside one window → a single sync.
+    fire('modify', { path: 'Nexus/skills/claude/test/SKILL.md' });
+    fire('modify', { path: 'Nexus/skills/claude/test/reference.md' });
+    fire('create', { path: 'Nexus/skills/claude/test/scripts/run.sh' });
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(MockedSyncService).toHaveBeenCalledTimes(1);
+    expect(rt.scanner.scan).toHaveBeenCalled();
+    expect(rt.index.syncFromScan).toHaveBeenCalled();
+  });
+
+  it('ignores non-skill paths and `_archive/` churn', async () => {
+    const { app, fire } = createMockApp();
+    const rt = makeRuntime();
+    const watcher = new SkillSyncWatcher(app, () => rt, 2000);
+    watcher.start();
+    await jest.advanceTimersByTimeAsync(2000); // drain initial sync
+    MockedSyncService.mockClear();
+
+    fire('modify', { path: 'notes/journal.md' });
+    fire('create', { path: 'Nexus/other/file.md' });
+    fire('modify', { path: 'Nexus/skills/claude/test/_archive/20260531/SKILL.md' });
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(MockedSyncService).not.toHaveBeenCalled();
+  });
+
+  it('reacts to hidden provider dotfolders via the `raw` event', async () => {
+    const { app, fire } = createMockApp();
+    const rt = makeRuntime();
+    const watcher = new SkillSyncWatcher(app, () => rt, 2000);
+    watcher.start();
+    await jest.advanceTimersByTimeAsync(2000); // drain initial sync
+    MockedSyncService.mockClear();
+
+    fire('raw', '.claude/skills/test-skill/SKILL.md');
+    await jest.advanceTimersByTimeAsync(2000);
+
+    expect(MockedSyncService).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries the initial sync while the runtime is not yet ready', async () => {
+    const { app } = createMockApp();
+    let ready = false;
+    const rt = makeRuntime();
+    const watcher = new SkillSyncWatcher(app, () => (ready ? rt : null), 2000);
+    watcher.start();
+
+    await jest.advanceTimersByTimeAsync(2000); // runtime null → no sync, reschedules
+    expect(MockedSyncService).not.toHaveBeenCalled();
+
+    ready = true;
+    await jest.advanceTimersByTimeAsync(2000); // retry now succeeds
+    expect(MockedSyncService).toHaveBeenCalledTimes(1);
+  });
+
+  it('stop() unsubscribes every handler and cancels pending work', async () => {
+    const { app, fire } = createMockApp();
+    const offref = (app as unknown as { vault: { offref: jest.Mock } }).vault.offref;
+    const rt = makeRuntime();
+    const watcher = new SkillSyncWatcher(app, () => rt, 2000);
+    watcher.start();
+    await jest.advanceTimersByTimeAsync(2000); // drain initial sync
+    MockedSyncService.mockClear();
+
+    fire('modify', { path: 'Nexus/skills/claude/test/SKILL.md' });
+    watcher.stop();
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(offref).toHaveBeenCalled();          // create+modify+delete+rename+raw
+    expect(MockedSyncService).not.toHaveBeenCalled(); // pending run was cancelled
+  });
+});


### PR DESCRIPTION
> **Stacked on #230** (App.onload() hook). Review/merge that first — this PR's diff reduces to just the skills files once it lands.

- **SkillSyncWatcher** — debounced automatic import + index refresh, so users no longer call `syncSkills` by hand. Started in `onload()`, stopped in `onunload()`. Watches the (non-hidden) mirror via documented vault events on desktop+mobile, and the hidden provider dotfolders via the desktop-only `raw` event (mobile falls back to on-load sync). Scope is import + index-refresh **only** — sync-back stays explicit so automatic activity never clobbers a source of truth. Hash-gated writes keep it loop-safe.
- **loadSkill** — add a `recursive` param and return a loadWorkspace-shaped `structure` (string[], folders trailing `/`) instead of a flat top-level file list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)