### PR TITLE
Wave 3 PR4: Workflow editor + File picker port + mobile polish

### DIFF
--- a/src/components/workspace/FilePickerRenderer.ts
+++ b/src/components/workspace/FilePickerRenderer.ts
@@ -91,7 +91,7 @@ export class FilePickerRenderer {
     });
 
     // Tree container
-    this.treeContainer = container.createDiv('nexus-folder-tree');
+    this.treeContainer = container.createDiv('ws-tree');
 
     // Render root
     this.renderRoot();
@@ -259,7 +259,7 @@ export class FilePickerRenderer {
 
     // Empty folder message (only when not searching)
     if (renderedCount === 0 && !this.searchQuery) {
-      const empty = container.createDiv({ cls: 'nexus-tree-empty' });
+      const empty = container.createDiv({ cls: 'ws-tree-empty' });
       empty.dataset.depth = String(depth + 1);
       empty.textContent = 'Empty folder';
     }
@@ -273,15 +273,15 @@ export class FilePickerRenderer {
   private renderFolderRow(folder: TFolder, container: HTMLElement, depth: number): void {
     const isExpanded = this.expandedFolders.has(folder.path);
 
-    const row = container.createDiv({ cls: 'nexus-tree-row nexus-tree-folder' });
+    const row = container.createDiv({ cls: 'ws-tree-row is-folder' });
     row.dataset.depth = String(depth);
 
     // Folder icon (changes based on expanded state)
-    const iconEl = row.createSpan({ cls: 'nexus-tree-icon' });
+    const iconEl = row.createSpan({ cls: 'ws-tree-icon' });
     setIcon(iconEl, isExpanded ? 'folder-open' : 'folder');
 
     // Folder name
-    row.createSpan({ text: folder.name, cls: 'nexus-tree-name' });
+    row.createSpan({ text: folder.name, cls: 'ws-tree-name' });
 
     // Click to expand/collapse
     const clickHandler = () => {
@@ -296,7 +296,7 @@ export class FilePickerRenderer {
 
     // Render children if expanded
     if (isExpanded) {
-      const childrenContainer = container.createDiv({ cls: 'nexus-tree-children' });
+      const childrenContainer = container.createDiv({ cls: 'ws-tree-children' });
       this.renderFolderChildren(folder, childrenContainer, depth + 1);
     }
   }
@@ -307,11 +307,11 @@ export class FilePickerRenderer {
   private renderFileRow(file: TFile, container: HTMLElement, depth: number): void {
     const isSelected = this.selectedFiles.has(file.path);
 
-    const row = container.createDiv({ cls: 'nexus-tree-row nexus-tree-file' });
+    const row = container.createDiv({ cls: 'ws-tree-row is-file' });
     row.dataset.depth = String(depth);
 
-    // Checkbox
-    const checkbox = row.createEl('input', { type: 'checkbox', cls: 'nexus-tree-checkbox' });
+    // Checkbox — backs the real `selectedFiles: Set<string>` multi-select.
+    const checkbox = row.createEl('input', { type: 'checkbox', cls: 'ws-tree-checkbox' });
     checkbox.checked = isSelected;
     const changeHandler = (e: Event) => {
       e.stopPropagation();
@@ -324,11 +324,11 @@ export class FilePickerRenderer {
     this.safeRegisterDomEvent(checkbox, 'change', changeHandler);
 
     // File icon
-    const iconEl = row.createSpan({ cls: 'nexus-tree-icon' });
+    const iconEl = row.createSpan({ cls: 'ws-tree-icon' });
     setIcon(iconEl, 'file-text');
 
     // File name
-    row.createSpan({ text: file.name, cls: 'nexus-tree-name' });
+    row.createSpan({ text: file.name, cls: 'ws-tree-name' });
 
     // Click row to toggle checkbox
     const rowClickHandler = (e: MouseEvent) => {

--- a/src/components/workspace/ProjectDetailRenderer.ts
+++ b/src/components/workspace/ProjectDetailRenderer.ts
@@ -206,7 +206,7 @@ export class ProjectDetailRenderer {
         this.component.registerDomEvent(editBtn, 'click', () => callbacks.onOpenTaskDetail(task));
 
         const deleteBtn = control.createEl('button', {
-            cls: 'clickable-icon mod-warning',
+            cls: 'clickable-icon nexus-icon-danger',
             attr: { 'aria-label': 'Delete task' }
         });
         setIcon(deleteBtn, 'trash');

--- a/src/components/workspace/WorkflowEditorRenderer.ts
+++ b/src/components/workspace/WorkflowEditorRenderer.ts
@@ -1,4 +1,4 @@
-import { ButtonComponent, Notice, Setting } from 'obsidian';
+import { ButtonComponent, Component, Notice, Setting } from 'obsidian';
 import type {
   WorkflowCatchUpPolicy,
   WorkflowFrequency,
@@ -7,6 +7,7 @@ import type {
 } from '../../database/types/workspace/WorkspaceTypes';
 import type { CustomPrompt } from '../../types/mcp/CustomPromptTypes';
 import { v4 as uuidv4 } from '../../utils/uuid';
+import { BoxedSection } from '../../settings/components/BoxedSection';
 
 export type Workflow = WorkspaceWorkflow;
 
@@ -42,7 +43,8 @@ export class WorkflowEditorRenderer {
     private availablePrompts: CustomPrompt[],
     private onSave: SaveOrRunHandler,
     private onCancel: () => void,
-    private onRunNow: SaveOrRunHandler
+    private onRunNow: SaveOrRunHandler,
+    private component: Component
   ) {}
 
   render(container: HTMLElement, workflow: Workflow, isNew: boolean, options?: { showBackButton?: boolean }): void {
@@ -65,74 +67,105 @@ export class WorkflowEditorRenderer {
 
     const form = container.createDiv('nexus-workflow-form');
 
-    new Setting(form)
-      .setName('Workflow name')
-      .setDesc('Name this workflow.')
-      .addText(text => text
-        .setPlaceholder('For example, weekly blog planning')
-        .setValue(this.workflow.name)
-        .onChange(value => {
-          this.workflow.name = value;
-        }));
+    // Identity section — workflow name + when.
+    new BoxedSection(form, {
+      title: 'Identity',
+      titleId: 'wf-id-h',
+      unbounded: true,
+      body: body => {
+        new Setting(body)
+          .setName('Workflow name')
+          .setDesc('Name this workflow.')
+          .addText(text => text
+            .setPlaceholder('For example, weekly blog planning')
+            .setValue(this.workflow.name)
+            .onChange(value => {
+              this.workflow.name = value;
+            }));
 
-    new Setting(form)
-      .setName('When')
-      .setDesc('Describe when this workflow should be used.')
-      .addText(text => text
-        .setPlaceholder('Plan next week\'s posts.')
-        .setValue(this.workflow.when)
-        .onChange(value => {
-          this.workflow.when = value;
-        }));
+        new Setting(body)
+          .setName('When')
+          .setDesc('Describe when this workflow should be used.')
+          .addText(text => text
+            .setPlaceholder('Plan next week\'s posts.')
+            .setValue(this.workflow.when)
+            .onChange(value => {
+              this.workflow.when = value;
+            }));
+      }
+    }, this.component);
 
-    new Setting(form)
-      .setName('Prompt')
-      .setDesc('Optional saved prompt/agent to bind to this workflow.')
-      .addDropdown(dropdown => {
-        dropdown.addOption('', 'None');
-        this.availablePrompts.forEach(prompt => {
-          dropdown.addOption(prompt.id, prompt.name);
+    // Prompt section — optional saved-prompt binding.
+    new BoxedSection(form, {
+      title: 'Prompt',
+      titleId: 'wf-prompt-h',
+      unbounded: true,
+      body: body => {
+        new Setting(body)
+          .setName('Prompt')
+          .setDesc('Optional saved prompt/agent to bind to this workflow.')
+          .addDropdown(dropdown => {
+            dropdown.addOption('', 'None');
+            this.availablePrompts.forEach(prompt => {
+              dropdown.addOption(prompt.id, prompt.name);
+            });
+            dropdown.setValue(this.workflow.promptId || '');
+            dropdown.onChange(value => {
+              const selectedPrompt = this.availablePrompts.find(prompt => prompt.id === value);
+              this.workflow.promptId = selectedPrompt?.id;
+              this.workflow.promptName = selectedPrompt?.name;
+            });
+          });
+      }
+    }, this.component);
+
+    // Steps section — workflow-specific extra context.
+    new BoxedSection(form, {
+      title: 'Steps',
+      titleId: 'wf-steps-h',
+      unbounded: true,
+      body: body => {
+        new Setting(body)
+          .setName('Steps')
+          .setDesc('These instructions are sent as the workflow-specific extra context.')
+          .addTextArea(text => {
+            text.setPlaceholder('Research the topic, draft an outline, and write the first section.');
+            text.setValue(this.workflow.steps);
+            text.inputEl.rows = 8;
+            text.onChange(value => {
+              this.workflow.steps = value;
+            });
+          });
+      }
+    }, this.component);
+
+    // Schedule section — the Enabled toggle lives in the header toolbar; the
+    // conditional frequency fields live in the body and re-render in place.
+    let scheduleFields!: HTMLElement;
+    new BoxedSection(form, {
+      title: 'Schedule',
+      titleId: 'wf-sched-h',
+      unbounded: true,
+      toolbar: toolbar => {
+        const toggleLabel = toolbar.createEl('label', { cls: 'ws-section-toggle' });
+        const toggle = toggleLabel.createEl('input', {
+          type: 'checkbox',
+          attr: { 'aria-label': 'Enable schedule' }
         });
-        dropdown.setValue(this.workflow.promptId || '');
-        dropdown.onChange(value => {
-          const selectedPrompt = this.availablePrompts.find(prompt => prompt.id === value);
-          this.workflow.promptId = selectedPrompt?.id;
-          this.workflow.promptName = selectedPrompt?.name;
-        });
-      });
-
-    new Setting(form)
-      .setName('Steps')
-      .setDesc('These instructions are sent as the workflow-specific extra context.')
-      .addTextArea(text => {
-        text.setPlaceholder('Research the topic, draft an outline, and write the first section.');
-        text.setValue(this.workflow.steps);
-        text.inputEl.rows = 8;
-        text.onChange(value => {
-          this.workflow.steps = value;
-        });
-      });
-
-    const scheduleSection = form.createDiv('nexus-workflow-schedule');
-    scheduleSection.createEl('h3', {
-      text: 'Schedule',
-      cls: 'nexus-workflow-section-title'
-    });
-
-    const scheduleFields = scheduleSection.createDiv('nexus-workflow-schedule-fields');
-
-    new Setting(scheduleSection)
-      .setName('Enable schedule')
-      .setDesc('Run this workflow automatically on a recurring schedule.')
-      .addToggle(toggle => {
-        toggle.setValue(this.workflow.schedule?.enabled ?? false);
-        toggle.onChange(value => {
-          this.workflow.schedule = value ? this.buildEnabledSchedule(this.workflow.schedule) : undefined;
+        toggle.checked = this.workflow.schedule?.enabled ?? false;
+        toggleLabel.createSpan({ text: 'Enabled' });
+        this.component.registerDomEvent(toggle, 'change', () => {
+          this.workflow.schedule = toggle.checked
+            ? this.buildEnabledSchedule(this.workflow.schedule)
+            : undefined;
           this.renderScheduleFields(scheduleFields);
         });
-      });
-
-    this.renderScheduleFields(scheduleFields);
+      },
+      body: body => {
+        scheduleFields = body.createDiv('nexus-workflow-schedule-fields');
+        this.renderScheduleFields(scheduleFields);
+      }
+    }, this.component);
 
     const actions = container.createDiv('nexus-form-actions');
 

--- a/src/components/workspace/WorkspaceDetailRenderer.ts
+++ b/src/components/workspace/WorkspaceDetailRenderer.ts
@@ -365,7 +365,7 @@ export class WorkspaceDetailRenderer {
         this.component.registerDomEvent(editBtn, 'click', () => callbacks.onOpenProjectDetail(project));
 
         const deleteBtn = control.createEl('button', {
-            cls: 'clickable-icon mod-warning',
+            cls: 'clickable-icon nexus-icon-danger',
             attr: { 'aria-label': 'Delete project' }
         });
         setIcon(deleteBtn, 'trash');

--- a/src/settings/tabs/WorkspacesTab.ts
+++ b/src/settings/tabs/WorkspacesTab.ts
@@ -647,7 +647,8 @@ export class WorkspacesTab {
                 this.currentView = 'detail';
                 this.render();
             },
-            async (workflowToRun) => { await this.runWorkflowFromEditor(workflowToRun); }
+            async (workflowToRun) => { await this.runWorkflowFromEditor(workflowToRun); },
+            this.services.component
         );
 
         this.workflowRenderer.render(contentContainer, workflow, isNew, { showBackButton: false });

--- a/styles.css
+++ b/styles.css
@@ -5259,119 +5259,6 @@ body.is-mobile .message-action-btn.message-branch-next {
     border-top: 1px solid var(--background-modifier-border);
 }
 
-/* Folder Tree */
-.nexus-folder-tree {
-    max-height: 400px;
-    overflow-y: auto;
-    border: 1px solid var(--background-modifier-border);
-    border-radius: var(--radius-s);
-    margin-top: var(--space-m);
-    padding: var(--space-s) 0;
-}
-
-.nexus-tree-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-s);
-    padding: var(--space-xs) var(--space-l);
-    cursor: pointer;
-    transition: background 0.1s ease;
-}
-
-.nexus-tree-row:hover {
-    background: var(--background-modifier-hover);
-}
-
-.nexus-tree-folder {
-    font-weight: var(--font-medium);
-}
-
-.nexus-tree-file {
-    color: var(--text-normal);
-}
-
-.nexus-tree-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 18px;
-    height: 18px;
-    color: var(--text-muted);
-    flex-shrink: 0;
-}
-
-.nexus-tree-icon svg {
-    width: 16px;
-    height: 16px;
-}
-
-.nexus-tree-folder .nexus-tree-icon {
-    color: var(--text-accent);
-}
-
-.nexus-tree-checkbox {
-    width: 16px;
-    height: 16px;
-    margin: 0;
-    cursor: pointer;
-    flex-shrink: 0;
-}
-
-.nexus-tree-name {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.nexus-tree-children {
-    /* Children container - no special styling needed */
-}
-
-/* Depth-based indentation using data attributes */
-.nexus-tree-row[data-depth="0"],
-.nexus-tree-empty[data-depth="1"] { padding-left: 16px; }
-
-.nexus-tree-row[data-depth="1"],
-.nexus-tree-empty[data-depth="2"] { padding-left: 36px; }
-
-.nexus-tree-row[data-depth="2"],
-.nexus-tree-empty[data-depth="3"] { padding-left: 56px; }
-
-.nexus-tree-row[data-depth="3"],
-.nexus-tree-empty[data-depth="4"] { padding-left: 76px; }
-
-.nexus-tree-row[data-depth="4"],
-.nexus-tree-empty[data-depth="5"] { padding-left: 96px; }
-
-.nexus-tree-row[data-depth="5"],
-.nexus-tree-empty[data-depth="6"] { padding-left: 116px; }
-
-.nexus-tree-row[data-depth="6"],
-.nexus-tree-empty[data-depth="7"] { padding-left: 136px; }
-
-.nexus-tree-row[data-depth="7"],
-.nexus-tree-empty[data-depth="8"] { padding-left: 156px; }
-
-.nexus-tree-row[data-depth="8"],
-.nexus-tree-empty[data-depth="9"] { padding-left: 176px; }
-
-.nexus-tree-row[data-depth="9"],
-.nexus-tree-empty[data-depth="10"] { padding-left: 196px; }
-
-.nexus-tree-row[data-depth="10"],
-.nexus-tree-empty[data-depth="11"] { padding-left: 216px; }
-
-.nexus-tree-empty {
-    padding-top: var(--space-s);
-    padding-bottom: var(--space-s);
-    padding-right: var(--space-m);
-    color: var(--text-faint);
-    font-size: var(--font-ui-smaller);
-    font-style: italic;
-}
-
 .nexus-file-picker-info {
     margin-bottom: var(--space-s);
 }
@@ -8771,7 +8658,8 @@ body.is-mobile .nexus-task-board-shell {
     background: var(--interactive-accent);
     color: var(--text-on-accent);
     border: 1px solid var(--interactive-accent);
-    padding: var(--space-xs) var(--space-s);
+    /* Tap-target floor: 6px 12px → ~30px tall for mobile parity (WCAG 2.5.5). */
+    padding: 6px var(--space-m);
     font-size: 12px;
     font-family: inherit;
     font-weight: 500;
@@ -8853,4 +8741,169 @@ body.is-mobile .nexus-task-board-shell {
 .ws-section-select:hover {
     color: var(--text-normal);
     border-color: var(--background-modifier-border-hover);
+}
+
+/* =====================================================================
+ * Workspace settings — file-picker tree (.ws-tree family)
+ *
+ * Mockup: docs/mockups/workspace-tab-redesign-v3-subpages.html
+ * Used by: src/components/workspace/FilePickerRenderer.ts
+ * Multi-select tree with lazy-expanded folders + checkbox selection.
+ * Depth indentation via [data-depth] caps with clamp() on mobile.
+ * ===================================================================== */
+
+.ws-tree {
+    max-height: 360px;
+    overflow-y: auto;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: var(--radius-s);
+    margin-top: var(--space-m);
+    padding: var(--space-s) 0;
+}
+
+.ws-tree::-webkit-scrollbar {
+    width: 10px;
+}
+
+.ws-tree::-webkit-scrollbar-thumb {
+    background: var(--background-modifier-border);
+    border-radius: 5px;
+    border: 2px solid var(--background-secondary);
+}
+
+.ws-tree-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-s);
+    padding: var(--space-xs) var(--space-l);
+    cursor: pointer;
+    font-size: 13px;
+    color: var(--text-normal);
+    transition: background 0.1s ease;
+}
+
+.ws-tree-row:hover {
+    background: var(--background-modifier-hover);
+}
+
+.ws-tree-row.is-folder .ws-tree-name {
+    font-weight: var(--font-medium);
+}
+
+.ws-tree-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    color: var(--text-muted);
+    flex-shrink: 0;
+}
+
+.ws-tree-icon svg {
+    width: 16px;
+    height: 16px;
+}
+
+.ws-tree-row.is-folder .ws-tree-icon {
+    color: var(--text-accent);
+}
+
+.ws-tree-checkbox {
+    accent-color: var(--interactive-accent);
+    width: 14px;
+    height: 14px;
+    margin: 0;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.ws-tree-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Depth-based indentation via [data-depth]. The base indent (--space-l) plus a
+ * clamp()-bounded per-level step keeps deep trees from overflowing on narrow
+ * (mobile) viewports while preserving hierarchy on desktop. */
+.ws-tree-row[data-depth="0"],
+.ws-tree-empty[data-depth="1"] { padding-left: var(--space-l); }
+.ws-tree-row[data-depth="1"],
+.ws-tree-empty[data-depth="2"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px)); }
+.ws-tree-row[data-depth="2"],
+.ws-tree-empty[data-depth="3"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 2); }
+.ws-tree-row[data-depth="3"],
+.ws-tree-empty[data-depth="4"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 3); }
+.ws-tree-row[data-depth="4"],
+.ws-tree-empty[data-depth="5"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 4); }
+.ws-tree-row[data-depth="5"],
+.ws-tree-empty[data-depth="6"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 5); }
+.ws-tree-row[data-depth="6"],
+.ws-tree-empty[data-depth="7"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 6); }
+.ws-tree-row[data-depth="7"],
+.ws-tree-empty[data-depth="8"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 7); }
+.ws-tree-row[data-depth="8"],
+.ws-tree-empty[data-depth="9"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 8); }
+.ws-tree-row[data-depth="9"],
+.ws-tree-empty[data-depth="10"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 9); }
+.ws-tree-row[data-depth="10"],
+.ws-tree-empty[data-depth="11"] { padding-left: calc(var(--space-l) + clamp(10px, 5vw, 20px) * 10); }
+
+.ws-tree-empty {
+    padding-top: var(--space-s);
+    padding-bottom: var(--space-s);
+    padding-right: var(--space-m);
+    color: var(--text-faint);
+    font-size: var(--font-ui-smaller);
+    font-style: italic;
+}
+
+/* Paired short form fields (e.g., Hour + Minute in the workflow schedule).
+ * Collapses to a single column under the mobile breakpoint below. */
+.ws-field-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-m);
+}
+
+.ws-field-grid .ws-field {
+    margin-top: 0;
+}
+
+/* Graceful degradation: only pin the sticky section header on browsers that
+ * support position: sticky (older iOS WebView lacks reliable support). */
+@supports not (position: sticky) {
+    .ws-section-header {
+        position: static;
+    }
+}
+
+/* =====================================================================
+ * Mobile breakpoint (~480px) — workspace settings primitives
+ *
+ * isDesktopOnly: false — production runs on Obsidian mobile. Let the tab
+ * scroll naturally instead of nesting an internal scroll context, collapse
+ * paired fields to a single column, and tighten meta clusters.
+ * ===================================================================== */
+@media (max-width: 480px) {
+    .ws-field-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .ws-section-body {
+        max-height: none;
+        overflow: visible;
+    }
+
+    .task-meta {
+        gap: var(--space-s);
+    }
+
+    .ws-tree {
+        max-height: none;
+        overflow: visible;
+    }
 }

--- a/tests/unit/DeleteIconDanger.test.ts
+++ b/tests/unit/DeleteIconDanger.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Delete-icon danger-class regression (PR4 polish fix).
+ *
+ * BUG (user-reported during PR4 smoke, pre-existing from PR2): the Projects-list
+ * project-row delete button AND the project-detail task-row delete button used
+ * `clickable-icon mod-warning`. Obsidian's `mod-warning` paints a filled-red
+ * square that swamps the trash glyph, so both rendered as a solid red square.
+ *
+ * FIX: both icon buttons use `clickable-icon nexus-icon-danger` instead — a
+ * transparent clickable-icon whose glyph turns red on hover (mirrors the
+ * working StatesSectionRenderer delete idiom; CSS at styles.css `.clickable-icon
+ * .nexus-icon-danger`).
+ *
+ * These assertions lock the fix in: each delete button must carry
+ * `nexus-icon-danger` and must NOT carry `mod-warning`. They prevent the
+ * red-square regression from returning at either site.
+ *
+ * Uses the local _children-tracking MockContainer pattern (mirrors
+ * ProjectDetailRenderer.test.ts / WorkspaceContextConsolidation.test.ts).
+ */
+
+import { App, Component } from 'obsidian';
+import { WorkspaceDetailRenderer, DetailCallbacks } from '../../src/components/workspace/WorkspaceDetailRenderer';
+import { ProjectDetailRenderer, ProjectDetailEditorState, ProjectDetailCallbacks } from '../../src/components/workspace/ProjectDetailRenderer';
+import type { ProjectMetadata } from '../../src/database/repositories/interfaces/IProjectRepository';
+import type { TaskMetadata, TaskPriority, TaskStatus } from '../../src/database/repositories/interfaces/ITaskRepository';
+
+// ----------------------------------------------------------------------------
+// Local MockContainer w/ _children + attribute tracking
+// ----------------------------------------------------------------------------
+type MockEl = {
+  tagName: string;
+  className: string;
+  attributes: Record<string, string>;
+  createEl: jest.Mock<MockEl, [string, unknown?]>;
+  createDiv: jest.Mock<MockEl, [unknown?]>;
+  createSpan: jest.Mock<MockEl, [unknown?]>;
+  addClass: jest.Mock<void, [string]>;
+  setAttribute: jest.Mock<void, [string, string]>;
+  empty: jest.Mock<void, []>;
+  addEventListener: jest.Mock<void, [string, EventListenerOrEventListenerObject]>;
+  removeEventListener: jest.Mock<void, []>;
+  textContent: string;
+  _children: MockEl[];
+};
+
+function makeEl(cls = '', tag = 'DIV'): MockEl {
+  const el: MockEl = {
+    tagName: tag.toUpperCase(),
+    className: cls,
+    attributes: {},
+    createEl: jest.fn((t?: string, opts?: { cls?: string; text?: string; attr?: Record<string, string> }) => {
+      const c = makeEl(opts?.cls || '', (t || 'DIV').toUpperCase());
+      if (opts?.text) c.textContent = opts.text;
+      if (opts?.attr) Object.assign(c.attributes, opts.attr);
+      el._children.push(c);
+      return c;
+    }),
+    createDiv: jest.fn((arg?: unknown) => {
+      let cls2 = '';
+      if (typeof arg === 'string') cls2 = arg;
+      else if (arg && typeof arg === 'object' && 'cls' in (arg as Record<string, unknown>)) {
+        cls2 = String((arg as { cls?: string }).cls ?? '');
+      }
+      const child = makeEl(cls2);
+      el._children.push(child);
+      return child;
+    }),
+    createSpan: jest.fn((arg?: unknown) => {
+      let cls2 = '';
+      let text = '';
+      if (arg && typeof arg === 'object') {
+        cls2 = String((arg as { cls?: string }).cls ?? '');
+        text = String((arg as { text?: string }).text ?? '');
+      }
+      const child = makeEl(cls2, 'SPAN');
+      if (text) child.textContent = text;
+      el._children.push(child);
+      return child;
+    }),
+    addClass: jest.fn((c: string) => { el.className = `${el.className} ${c}`.trim(); }),
+    setAttribute: jest.fn((k: string, v: string) => { el.attributes[k] = v; }),
+    empty: jest.fn(() => { el._children.length = 0; }),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    textContent: '',
+    _children: []
+  };
+  return el;
+}
+
+function findButtonByAriaLabel(root: MockEl, label: string): MockEl | undefined {
+  let found: MockEl | undefined;
+  const visit = (el: MockEl) => {
+    if (el.tagName === 'BUTTON' && el.attributes['aria-label'] === label) {
+      found = el;
+    }
+    el._children.forEach(visit);
+  };
+  root._children.forEach(visit);
+  return found;
+}
+
+// ----------------------------------------------------------------------------
+// Fixtures
+// ----------------------------------------------------------------------------
+function makeProject(over: Partial<ProjectMetadata> = {}): ProjectMetadata {
+  return {
+    id: 'p-1',
+    workspaceId: 'ws-1',
+    name: 'Project one',
+    description: '',
+    status: 'active',
+    created: 1_700_000_000_000,
+    updated: 1_700_000_000_000,
+    ...over
+  } as ProjectMetadata;
+}
+
+function makeTask(over: Partial<TaskMetadata> = {}): TaskMetadata {
+  return {
+    id: 't-1',
+    workspaceId: 'ws-1',
+    projectId: 'p-1',
+    title: 'Task one',
+    status: 'todo' as TaskStatus,
+    priority: 'medium' as TaskPriority,
+    created: 1_700_000_000_000,
+    updated: 1_700_000_000_000,
+    ...over
+  } as TaskMetadata;
+}
+
+function makeDetailCallbacks(over: Partial<DetailCallbacks> = {}): DetailCallbacks {
+  return {
+    onNavigateList: jest.fn(),
+    onNavigateDetail: jest.fn(),
+    onNavigateProjects: jest.fn(),
+    onNavigateProjectDetail: jest.fn(),
+    onSaveWorkspace: jest.fn().mockResolvedValue(null),
+    onDeleteWorkspace: jest.fn().mockResolvedValue(undefined),
+    onOpenWorkflowEditor: jest.fn(),
+    onRunWorkflow: jest.fn(),
+    onOpenFilePicker: jest.fn(),
+    onRefreshDetail: jest.fn(),
+    getAvailableAgents: () => [],
+    getTaskService: jest.fn().mockResolvedValue(null),
+    onRefreshProjects: jest.fn().mockResolvedValue(undefined),
+    onOpenProjectDetail: jest.fn(),
+    onToggleProjectArchive: jest.fn().mockResolvedValue(undefined),
+    safeRegisterDomEvent: jest.fn(),
+    getStatesService: jest.fn().mockResolvedValue(null),
+    getApp: () => new App(),
+    ...over
+  } as DetailCallbacks;
+}
+
+function makeProjectDetailCallbacks(over: Partial<ProjectDetailCallbacks> = {}): ProjectDetailCallbacks {
+  return {
+    getWorkspace: () => ({ id: 'ws-1', name: 'Workspace' }),
+    getProject: () => ({
+      id: 'p-1',
+      workspaceId: 'ws-1',
+      name: 'Project',
+      description: '',
+      status: 'active'
+    } as ProjectDetailEditorState),
+    getTasks: () => [],
+    onNavigateList: jest.fn(),
+    onNavigateDetail: jest.fn(),
+    onNavigateProjects: jest.fn(),
+    onSaveProject: jest.fn().mockResolvedValue(undefined),
+    onDeleteProject: jest.fn().mockResolvedValue(undefined),
+    onOpenTaskDetail: jest.fn(),
+    onDeleteTask: jest.fn().mockResolvedValue(undefined),
+    ...over
+  };
+}
+
+describe('Delete-icon danger class — red-square regression guard', () => {
+  it('project-row delete button uses nexus-icon-danger, not mod-warning', () => {
+    const container = makeEl();
+    const renderer = new WorkspaceDetailRenderer(new Component());
+
+    renderer.renderProjects(
+      container as unknown as HTMLElement,
+      { id: 'ws-1', name: 'Workspace' },
+      [makeProject()],
+      [],
+      makeDetailCallbacks()
+    );
+
+    const deleteBtn = findButtonByAriaLabel(container, 'Delete project');
+    expect(deleteBtn).toBeDefined();
+    expect(deleteBtn!.className).toContain('clickable-icon');
+    expect(deleteBtn!.className).toContain('nexus-icon-danger');
+    expect(deleteBtn!.className).not.toContain('mod-warning');
+  });
+
+  it('task-row delete button uses nexus-icon-danger, not mod-warning', () => {
+    const container = makeEl();
+    const renderer = new ProjectDetailRenderer(new App(), new Component());
+
+    renderer.render(
+      container as unknown as HTMLElement,
+      makeProjectDetailCallbacks({ getTasks: () => [makeTask()] })
+    );
+
+    const deleteBtn = findButtonByAriaLabel(container, 'Delete task');
+    expect(deleteBtn).toBeDefined();
+    expect(deleteBtn!.className).toContain('clickable-icon');
+    expect(deleteBtn!.className).toContain('nexus-icon-danger');
+    expect(deleteBtn!.className).not.toContain('mod-warning');
+  });
+});

--- a/tests/unit/FilePickerRenderer.test.ts
+++ b/tests/unit/FilePickerRenderer.test.ts
@@ -1,0 +1,328 @@
+/**
+ * FilePickerRenderer Tests (Wave 3 PR4)
+ *
+ * PR4 ported the folder-tree shell to the v3.1 `.ws-tree-*` class family
+ * (renamed from `.nexus-tree-*`). The LOAD-BEARING regression guard for this
+ * PR: the file checkboxes were KEPT (they back a real `selectedFiles:Set<string>`
+ * multi-select), unlike PR2's decorative task-completion checkbox which was
+ * swept. This file asserts:
+ *   1. The tree emits `.ws-tree` / `.ws-tree-row` (+ is-folder/is-file) /
+ *      `.ws-tree-checkbox` / `.ws-tree-icon` / `.ws-tree-name` after the rename.
+ *   2. `data-depth` is retained on rows.
+ *   3. Checkbox toggle preserves `selectedFiles` (round-trip add/remove) — the
+ *      regression guard that the checkboxes were NOT swept.
+ *
+ * Test strategy: a children-tracking mock element (the project runs jest in a
+ * jsdom-less `node` testEnvironment) + a hand-built TFolder/TFile tree wired
+ * into a stub App.vault that supplies getRoot()/getAbstractFileByPath().
+ */
+
+import { FilePickerRenderer } from '../../src/components/workspace/FilePickerRenderer';
+import { App, TFile, TFolder, Component } from 'obsidian';
+
+// ============================================================================
+// Children-tracking mock element
+// ============================================================================
+
+interface MockElement {
+  tagName: string;
+  className: string;
+  type?: string;
+  checked?: boolean;
+  textContent: string;
+  dataset: Record<string, string>;
+  _children: MockElement[];
+  _attrs: Record<string, string>;
+  _listeners: Record<string, Array<(e: unknown) => void>>;
+  createEl: jest.Mock;
+  createDiv: jest.Mock;
+  createSpan: jest.Mock;
+  addClass: jest.Mock;
+  setAttribute: jest.Mock;
+  addEventListener: jest.Mock;
+  dispatchEvent: jest.Mock;
+  empty: jest.Mock;
+  remove: jest.Mock;
+}
+
+function createMockEl(cls = ''): MockElement {
+  const el: MockElement = {
+    tagName: 'DIV',
+    className: cls,
+    textContent: '',
+    dataset: {},
+    _children: [],
+    _attrs: {},
+    _listeners: {},
+    addClass: jest.fn(),
+    setAttribute: jest.fn((k: string, v: string) => { el._attrs[k] = v; }),
+    addEventListener: jest.fn((type: string, handler: (e: unknown) => void) => {
+      (el._listeners[type] ||= []).push(handler);
+    }),
+    dispatchEvent: jest.fn((evt: { type: string }) => {
+      // Production change/click handlers call e.stopPropagation(); supply a
+      // no-op so a plain {type} payload from a test can drive the handler.
+      const payload = { stopPropagation: () => undefined, ...evt };
+      (el._listeners[evt.type] || []).forEach(h => h(payload));
+      return true;
+    }),
+    empty: jest.fn(() => { el._children = []; }),
+    remove: jest.fn(),
+    createEl: jest.fn((tag?: string, opts?: { cls?: string; text?: string; type?: string; attr?: Record<string, string> }) => {
+      const child = createMockEl(opts?.cls || '');
+      child.tagName = (tag || 'DIV').toUpperCase();
+      if (opts?.text) child.textContent = opts.text;
+      if (opts?.type) child.type = opts.type;
+      if (opts?.attr) Object.assign(child._attrs, opts.attr);
+      el._children.push(child);
+      return child;
+    }),
+    createDiv: jest.fn((arg?: string | { cls?: string; text?: string }) => {
+      const c = typeof arg === 'string' ? arg : arg?.cls || '';
+      const child = createMockEl(c);
+      if (typeof arg === 'object' && arg?.text) child.textContent = arg.text;
+      el._children.push(child);
+      return child;
+    }),
+    createSpan: jest.fn((opts?: { cls?: string; text?: string }) => {
+      const child = createMockEl(opts?.cls || '');
+      if (opts?.text) child.textContent = opts.text;
+      el._children.push(child);
+      return child;
+    }),
+  };
+  return el;
+}
+
+/** Recursively flatten all descendant elements (incl. self). */
+function flatten(el: MockElement): MockElement[] {
+  return [el, ...el._children.flatMap(flatten)];
+}
+
+/** Collect every element whose class contains the given token. */
+function byClass(root: MockElement, token: string): MockElement[] {
+  return flatten(root).filter(e => e.className.split(/\s+/).includes(token));
+}
+
+// ============================================================================
+// Vault tree fixture
+// ============================================================================
+
+function makeFile(path: string): TFile {
+  const name = path.split('/').pop() || path;
+  return new TFile(name, path);
+}
+
+function makeFolder(path: string, children: Array<TFile | TFolder>): TFolder {
+  const folder = new TFolder(path);
+  folder.children = children;
+  return folder;
+}
+
+/**
+ * Build a stub App with a vault tree:
+ *   /
+ *   ├── notes/        (folder)
+ *   │   ├── alpha.md
+ *   │   └── beta.md
+ *   └── readme.md
+ */
+function makeAppWithTree(): { app: App; root: TFolder; alpha: TFile; beta: TFile } {
+  const alpha = makeFile('notes/alpha.md');
+  const beta = makeFile('notes/beta.md');
+  const readme = makeFile('readme.md');
+  const notes = makeFolder('notes', [alpha, beta]);
+  const root = makeFolder('/', [notes, readme]);
+
+  const app = new App();
+  (app.vault as unknown as { getRoot: () => TFolder }).getRoot = () => root;
+  (app.vault as unknown as { getAbstractFileByPath: (p: string) => unknown }).getAbstractFileByPath = (p: string) => {
+    if (p === 'notes') return notes;
+    if (p === 'notes/alpha.md') return alpha;
+    if (p === 'notes/beta.md') return beta;
+    if (p === 'readme.md') return readme;
+    return null;
+  };
+  return { app, root, alpha, beta };
+}
+
+function renderPicker(opts: { initialSelection?: string; rootFolder?: string } = {}): {
+  renderer: FilePickerRenderer;
+  container: MockElement;
+  onSelect: jest.Mock;
+  onCancel: jest.Mock;
+} {
+  const { app } = makeAppWithTree();
+  const onSelect = jest.fn();
+  const onCancel = jest.fn();
+  const component = new Component();
+  const renderer = new FilePickerRenderer(
+    app,
+    onSelect,
+    onCancel,
+    opts.initialSelection,
+    opts.rootFolder,
+    'Select Files',
+    component
+  );
+  const container = createMockEl('root');
+  renderer.render(container as unknown as HTMLElement);
+  return { renderer, container, onSelect, onCancel };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('FilePickerRenderer (PR4 .ws-tree class rename + checkbox preservation)', () => {
+  describe('class rename — emits .ws-tree-* (not .nexus-tree-*)', () => {
+    it('creates a .ws-tree container', () => {
+      const { container } = renderPicker();
+      expect(byClass(container, 'ws-tree').length).toBe(1);
+    });
+
+    it('emits .ws-tree-row rows for the root children', () => {
+      const { container } = renderPicker();
+      // Root has a "notes" folder + a "readme.md" file = 2 top-level rows.
+      expect(byClass(container, 'ws-tree-row').length).toBe(2);
+    });
+
+    it('tags folder rows with is-folder and file rows with is-file', () => {
+      const { container } = renderPicker();
+      expect(byClass(container, 'is-folder').length).toBe(1); // notes/
+      expect(byClass(container, 'is-file').length).toBe(1);   // readme.md
+    });
+
+    it('emits .ws-tree-icon and .ws-tree-name spans on every row', () => {
+      const { container } = renderPicker();
+      // 2 rows × 1 icon + 1 name each.
+      expect(byClass(container, 'ws-tree-icon').length).toBe(2);
+      expect(byClass(container, 'ws-tree-name').length).toBe(2);
+    });
+
+    it('does NOT emit any legacy .nexus-tree-* classes', () => {
+      const { container } = renderPicker();
+      const legacy = flatten(container).filter(e =>
+        /\bnexus-tree-/.test(e.className)
+      );
+      expect(legacy).toEqual([]);
+    });
+  });
+
+  describe('checkbox — KEPT (load-bearing multi-select), not swept', () => {
+    it('emits a .ws-tree-checkbox input on each file row', () => {
+      const { container } = renderPicker();
+      const checkboxes = byClass(container, 'ws-tree-checkbox');
+      // Only the file row (readme.md) gets a checkbox; the folder row does not.
+      expect(checkboxes.length).toBe(1);
+      expect(checkboxes[0].type).toBe('checkbox');
+    });
+
+    it('reflects the initial selection as a checked checkbox', () => {
+      const { container } = renderPicker({ initialSelection: 'readme.md' });
+      const checkbox = byClass(container, 'ws-tree-checkbox')[0];
+      expect(checkbox.checked).toBe(true);
+    });
+
+    it('leaves the checkbox unchecked when the file is not initially selected', () => {
+      const { container } = renderPicker();
+      const checkbox = byClass(container, 'ws-tree-checkbox')[0];
+      expect(checkbox.checked).toBe(false);
+    });
+  });
+
+  describe('selectedFiles round-trip (the regression guard)', () => {
+    function fileCheckbox(container: MockElement): MockElement {
+      return byClass(container, 'ws-tree-checkbox')[0];
+    }
+
+    it('adds the file path to selectedFiles when the checkbox is checked', () => {
+      const { renderer, container } = renderPicker();
+      expect(renderer.getSelectedPaths()).toEqual([]);
+
+      const checkbox = fileCheckbox(container);
+      checkbox.checked = true;
+      checkbox.dispatchEvent({ type: 'change' });
+
+      expect(renderer.getSelectedPaths()).toContain('readme.md');
+    });
+
+    it('removes the file path from selectedFiles when the checkbox is unchecked', () => {
+      const { renderer, container } = renderPicker({ initialSelection: 'readme.md' });
+      expect(renderer.getSelectedPaths()).toEqual(['readme.md']);
+
+      const checkbox = fileCheckbox(container);
+      checkbox.checked = false;
+      checkbox.dispatchEvent({ type: 'change' });
+
+      expect(renderer.getSelectedPaths()).toEqual([]);
+    });
+
+    it('full round-trip: select → deselect → reselect leaves a single entry', () => {
+      const { renderer, container } = renderPicker();
+      const checkbox = fileCheckbox(container);
+
+      checkbox.checked = true;
+      checkbox.dispatchEvent({ type: 'change' });
+      checkbox.checked = false;
+      checkbox.dispatchEvent({ type: 'change' });
+      checkbox.checked = true;
+      checkbox.dispatchEvent({ type: 'change' });
+
+      expect(renderer.getSelectedPaths()).toEqual(['readme.md']);
+    });
+
+    it('getSelectedPath returns the first selected path (single-select compat)', () => {
+      const { renderer, container } = renderPicker();
+      const checkbox = fileCheckbox(container);
+      checkbox.checked = true;
+      checkbox.dispatchEvent({ type: 'change' });
+      expect(renderer.getSelectedPath()).toBe('readme.md');
+    });
+
+    it('handleDone (Done button) calls onSelect with the first selected path', () => {
+      const { renderer, container, onSelect, onCancel } = renderPicker();
+      const checkbox = fileCheckbox(container);
+      checkbox.checked = true;
+      checkbox.dispatchEvent({ type: 'change' });
+
+      // handleDone is private; reach it via the public render-wired Done button
+      // by invoking the renderer's own handler through getSelectedPaths-backed
+      // onSelect. Simulate Done directly.
+      (renderer as unknown as { handleDone: () => void }).handleDone();
+      expect(onSelect).toHaveBeenCalledWith('readme.md');
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('handleDone calls onCancel when nothing is selected', () => {
+      const { renderer, onSelect, onCancel } = renderPicker();
+      (renderer as unknown as { handleDone: () => void }).handleDone();
+      expect(onSelect).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe('data-depth retention', () => {
+    it('stamps data-depth=0 on top-level rows', () => {
+      const { container } = renderPicker();
+      const rows = byClass(container, 'ws-tree-row');
+      for (const row of rows) {
+        expect(row.dataset.depth).toBe('0');
+      }
+    });
+  });
+
+  describe('empty state', () => {
+    it('renders the folder-not-found message when the root folder is missing', () => {
+      const app = new App();
+      (app.vault as unknown as { getRoot: () => TFolder | null }).getRoot = () => null;
+      (app.vault as unknown as { getAbstractFileByPath: (p: string) => unknown }).getAbstractFileByPath = () => null;
+      const renderer = new FilePickerRenderer(app, jest.fn(), jest.fn(), undefined, 'missing-folder', 'Select', new Component());
+      const container = createMockEl('root');
+      renderer.render(container as unknown as HTMLElement);
+      const empty = byClass(container, 'nexus-file-picker-empty');
+      expect(empty.length).toBe(1);
+      expect(empty[0].textContent).toBe('Folder not found');
+    });
+  });
+});

--- a/tests/unit/WorkflowEditorRenderer.test.ts
+++ b/tests/unit/WorkflowEditorRenderer.test.ts
@@ -1,0 +1,381 @@
+/**
+ * WorkflowEditorRenderer Tests (Wave 3 PR4)
+ *
+ * PR4 ported the workflow editor onto the shared BoxedSection primitive:
+ *   - Identity / Prompt / Steps / Schedule each wrapped in `new BoxedSection`
+ *     (4 sections, unbounded), per the v3.1 mockup (the authoritative visual
+ *     contract — team-lead confirmed the 4-section split is blessed).
+ *   - The required 5th ctor param `component: Component` is threaded into
+ *     EVERY BoxedSection construction (BoxedSection needs it for
+ *     registerDomEvent-based cleanup).
+ *   - The Schedule "Enabled" toggle moved into the section header toolbar; its
+ *     handler still empties+rebuilds the schedule fields div in place — this is
+ *     the one piece of stateful behavior carried verbatim through the port and
+ *     the highest behavior-change surface in this PR.
+ *
+ * Test strategy: jest.mock the BoxedSection module with a spy-class that records
+ * (container, config, component) per construction and synchronously invokes the
+ * toolbar/body callbacks against a children-tracking mock element. This lets us
+ * assert the 4-section contract + the component threading + the schedule
+ * re-render side-effect without a real DOM (the project runs jest in a
+ * jsdom-less `node` testEnvironment — see prior Wave-3 test memories).
+ */
+
+import type { BoxedSectionConfig } from '../../src/settings/components/BoxedSection';
+
+// ============================================================================
+// BoxedSection spy-class mock — records every construction.
+// ============================================================================
+
+interface RecordedSection {
+  container: unknown;
+  config: BoxedSectionConfig;
+  component: unknown;
+  bodyEl: MockElement;
+  toolbarEl?: MockElement;
+}
+
+const recordedSections: RecordedSection[] = [];
+
+jest.mock('../../src/settings/components/BoxedSection', () => {
+  return {
+    BoxedSection: class {
+      private bodyEl: MockElement;
+      constructor(container: unknown, config: BoxedSectionConfig, component: unknown) {
+        const bodyEl = createMockEl('ws-section-body');
+        const record: RecordedSection = { container, config, component, bodyEl };
+        // Invoke toolbar callback (if any) against a fresh toolbar element so
+        // production toolbar wiring (the Schedule Enabled toggle) executes.
+        if (config.toolbar) {
+          const toolbarEl = createMockEl('ws-section-toolbar');
+          record.toolbarEl = toolbarEl;
+          config.toolbar(toolbarEl as unknown as HTMLElement);
+        }
+        // Invoke the body callback against a body element so the schedule
+        // fields div is created and renderScheduleFields runs once.
+        config.body(bodyEl as unknown as HTMLElement);
+        this.bodyEl = bodyEl;
+        recordedSections.push(record);
+      }
+      getBody(): unknown { return this.bodyEl; }
+      getElement(): unknown { return createMockEl('ws-section'); }
+    }
+  };
+});
+
+import { WorkflowEditorRenderer, Workflow } from '../../src/components/workspace/WorkflowEditorRenderer';
+import { Component } from 'obsidian';
+
+// ============================================================================
+// Children-tracking mock element (richer than core.ts createMockElement —
+// tracks _children, dataset, and captured registerDomEvent handlers).
+// ============================================================================
+
+type MockEl = MockElement;
+
+interface MockElement {
+  tagName: string;
+  className: string;
+  id: string;
+  type?: string;
+  checked?: boolean;
+  rows?: number;
+  textContent: string;
+  dataset: Record<string, string>;
+  _children: MockElement[];
+  _attrs: Record<string, string>;
+  createEl: jest.Mock;
+  createDiv: jest.Mock;
+  createSpan: jest.Mock;
+  addClass: jest.Mock;
+  removeClass: jest.Mock;
+  setAttribute: jest.Mock;
+  addEventListener: jest.Mock;
+  empty: jest.Mock;
+  remove: jest.Mock;
+  inputEl?: MockElement;
+}
+
+function createMockEl(cls = ''): MockElement {
+  const el: MockElement = {
+    tagName: 'DIV',
+    className: cls,
+    id: '',
+    textContent: '',
+    dataset: {},
+    _children: [],
+    _attrs: {},
+    addClass: jest.fn(),
+    removeClass: jest.fn(),
+    setAttribute: jest.fn((k: string, v: string) => { el._attrs[k] = v; }),
+    addEventListener: jest.fn(),
+    empty: jest.fn(() => { el._children = []; }),
+    remove: jest.fn(),
+    createEl: jest.fn((tag?: string, opts?: { cls?: string; text?: string; type?: string; attr?: Record<string, string> }) => {
+      const child = createMockEl(opts?.cls || '');
+      child.tagName = (tag || 'DIV').toUpperCase();
+      if (opts?.text) child.textContent = opts.text;
+      if (opts?.type) child.type = opts.type;
+      if (opts?.attr) Object.assign(child._attrs, opts.attr);
+      el._children.push(child);
+      return child;
+    }),
+    createDiv: jest.fn((arg?: string | { cls?: string }) => {
+      const c = typeof arg === 'string' ? arg : arg?.cls || '';
+      const child = createMockEl(c);
+      el._children.push(child);
+      return child;
+    }),
+    createSpan: jest.fn((opts?: { cls?: string; text?: string }) => {
+      const child = createMockEl(opts?.cls || '');
+      if (opts?.text) child.textContent = opts.text;
+      el._children.push(child);
+      return child;
+    }),
+  };
+  return el;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: 'wf-1',
+    name: 'Weekly planning',
+    when: 'Plan next week',
+    steps: 'Research, outline, draft',
+    ...overrides
+  };
+}
+
+/**
+ * Build a renderer with a Component whose registerDomEvent is spied. The spy
+ * is attached BEFORE render() so we can read .mock.calls afterward to recover
+ * the schedule-toggle change handler (Component.registerDomEvent is a real
+ * method on the mock, not a jest.fn by default).
+ */
+function makeSpiedComponent(): Component {
+  const component = new Component();
+  jest.spyOn(component, 'registerDomEvent');
+  return component;
+}
+
+function renderEditor(workflow: Workflow, isNew = false): {
+  component: Component;
+  onSave: jest.Mock;
+  onCancel: jest.Mock;
+  onRunNow: jest.Mock;
+  container: MockElement;
+} {
+  const component = makeSpiedComponent();
+  const onSave = jest.fn();
+  const onCancel = jest.fn();
+  const onRunNow = jest.fn();
+  const renderer = new WorkflowEditorRenderer([], onSave, onCancel, onRunNow, component);
+  const container = createMockEl('root');
+  renderer.render(container as unknown as HTMLElement, workflow, isNew);
+  return { component, onSave, onCancel, onRunNow, container };
+}
+
+function sectionByTitle(title: string): RecordedSection {
+  const found = recordedSections.find(s => s.config.title === title);
+  if (!found) throw new Error(`No BoxedSection rendered with title "${title}". Got: ${recordedSections.map(s => s.config.title).join(', ')}`);
+  return found;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('WorkflowEditorRenderer (PR4 BoxedSection port)', () => {
+  beforeEach(() => {
+    recordedSections.length = 0;
+  });
+
+  describe('section structure — exactly 4 BoxedSections', () => {
+    it('renders exactly 4 BoxedSections', () => {
+      renderEditor(makeWorkflow());
+      expect(recordedSections).toHaveLength(4);
+    });
+
+    it('renders Identity, Prompt, Steps, Schedule in that order', () => {
+      renderEditor(makeWorkflow());
+      const titles = recordedSections.map(s => s.config.title);
+      expect(titles).toEqual(['Identity', 'Prompt', 'Steps', 'Schedule']);
+    });
+
+    it('marks every section unbounded (form sections own their own flow)', () => {
+      renderEditor(makeWorkflow());
+      for (const section of recordedSections) {
+        expect(section.config.unbounded).toBe(true);
+      }
+    });
+
+    it('assigns a stable titleId to each section (aria-labelledby anchor)', () => {
+      renderEditor(makeWorkflow());
+      expect(sectionByTitle('Identity').config.titleId).toBe('wf-id-h');
+      expect(sectionByTitle('Prompt').config.titleId).toBe('wf-prompt-h');
+      expect(sectionByTitle('Steps').config.titleId).toBe('wf-steps-h');
+      expect(sectionByTitle('Schedule').config.titleId).toBe('wf-sched-h');
+    });
+  });
+
+  describe('component threading (the required 5th ctor param)', () => {
+    it('threads the same Component instance into all 4 BoxedSections', () => {
+      const { component } = renderEditor(makeWorkflow());
+      expect(recordedSections).toHaveLength(4);
+      for (const section of recordedSections) {
+        expect(section.component).toBe(component);
+      }
+    });
+
+    it('never constructs a BoxedSection without a component', () => {
+      renderEditor(makeWorkflow());
+      for (const section of recordedSections) {
+        expect(section.component).toBeInstanceOf(Component);
+      }
+    });
+  });
+
+  describe('Schedule section — Enabled toggle in the header toolbar', () => {
+    it('renders the Enabled toggle in the toolbar (not the body)', () => {
+      renderEditor(makeWorkflow());
+      const schedule = sectionByTitle('Schedule');
+      expect(schedule.config.toolbar).toBeDefined();
+      // Toolbar created a .ws-section-toggle label containing the checkbox.
+      const label = schedule.toolbarEl?._children.find(c => c.className === 'ws-section-toggle');
+      expect(label).toBeDefined();
+      const checkbox = label?._children.find(c => c.type === 'checkbox');
+      expect(checkbox).toBeDefined();
+    });
+
+    it('reflects the workflow.schedule.enabled state on the toggle checkbox', () => {
+      renderEditor(makeWorkflow({ schedule: { enabled: true, frequency: 'daily', hour: 9, minute: 0, catchUp: 'latest' } }));
+      const schedule = sectionByTitle('Schedule');
+      const label = schedule.toolbarEl?._children.find(c => c.className === 'ws-section-toggle');
+      const checkbox = label?._children.find(c => c.type === 'checkbox');
+      expect(checkbox?.checked).toBe(true);
+    });
+
+    it('toggle is unchecked when no schedule exists', () => {
+      renderEditor(makeWorkflow({ schedule: undefined }));
+      const schedule = sectionByTitle('Schedule');
+      const label = schedule.toolbarEl?._children.find(c => c.className === 'ws-section-toggle');
+      const checkbox = label?._children.find(c => c.type === 'checkbox');
+      expect(checkbox?.checked).toBe(false);
+    });
+
+    it('registers the toggle change handler through component.registerDomEvent', () => {
+      // Positive assertion only: the Obsidian Component mock's registerDomEvent
+      // internally calls el.addEventListener for cleanup tracking, so a
+      // negative "addEventListener was not called" assertion is unsatisfiable
+      // (documented Wave-3 lesson). Assert the registration happened on the
+      // checkbox with the 'change' event instead.
+      const { component } = renderEditor(makeWorkflow());
+      const calls = (component.registerDomEvent as unknown as jest.Mock).mock.calls;
+      const changeReg = calls.find((c: unknown[]) => c[1] === 'change');
+      expect(changeReg).toBeDefined();
+      const checkbox = changeReg![0] as MockElement;
+      expect(checkbox.type).toBe('checkbox');
+    });
+  });
+
+  describe('Schedule conditional re-render (highest behavior-change surface)', () => {
+    /**
+     * The toggle handler is wired via component.registerDomEvent(checkbox,
+     * 'change', handler). We capture that handler from the mocked Component,
+     * flip the checkbox, invoke the handler, and assert the schedule-fields
+     * div was emptied + rebuilt — the in-place re-render contract.
+     */
+    function captureToggleHandler(component: Component): { handler: () => void; checkbox: MockElement; fieldsDiv: MockElement } {
+      const calls = (component.registerDomEvent as unknown as jest.Mock).mock.calls;
+      // Find the change registration on the checkbox element.
+      const reg = calls.find((c: unknown[]) => c[1] === 'change');
+      if (!reg) throw new Error('No change handler registered on the schedule toggle');
+      const checkbox = reg[0] as MockElement;
+      const handler = reg[2] as () => void;
+      // The schedule fields div is the first child created in the Schedule body.
+      const schedule = sectionByTitle('Schedule');
+      const fieldsDiv = schedule.bodyEl._children.find(c => c.className === 'nexus-workflow-schedule-fields');
+      if (!fieldsDiv) throw new Error('schedule fields div not found in Schedule body');
+      return { handler, checkbox, fieldsDiv };
+    }
+
+    it('captures the Enabled-toggle change handler through registerDomEvent', () => {
+      const { component } = renderEditor(makeWorkflow({ schedule: undefined }));
+      const { handler } = captureToggleHandler(component);
+      expect(typeof handler).toBe('function');
+    });
+
+    it('re-renders the schedule fields div (empty+rebuild) when toggled ON', () => {
+      const { component } = renderEditor(makeWorkflow({ schedule: undefined }));
+      const { handler, checkbox, fieldsDiv } = captureToggleHandler(component);
+      const emptyCallsBefore = fieldsDiv.empty.mock.calls.length;
+
+      checkbox.checked = true;
+      handler();
+
+      // renderScheduleFields(fieldsDiv) starts with container.empty().
+      expect(fieldsDiv.empty.mock.calls.length).toBeGreaterThan(emptyCallsBefore);
+    });
+
+    it('builds the enabled schedule on the workflow when toggled ON', () => {
+      const component = makeSpiedComponent();
+      const renderer = new WorkflowEditorRenderer([], jest.fn(), jest.fn(), jest.fn(), component);
+      const container = createMockEl('root');
+      renderer.render(container as unknown as HTMLElement, makeWorkflow({ schedule: undefined }), false);
+
+      expect(renderer.getWorkflow().schedule).toBeUndefined();
+
+      const calls = (component.registerDomEvent as unknown as jest.Mock).mock.calls;
+      const reg = calls.find((c: unknown[]) => c[1] === 'change');
+      const checkbox = reg[0] as MockElement;
+      const handler = reg[2] as () => void;
+
+      checkbox.checked = true;
+      handler();
+
+      const wf = renderer.getWorkflow();
+      expect(wf.schedule).toBeDefined();
+      expect(wf.schedule?.enabled).toBe(true);
+      // buildEnabledSchedule defaults to a daily schedule.
+      expect(wf.schedule?.frequency).toBe('daily');
+    });
+
+    it('clears the workflow schedule when toggled OFF', () => {
+      const component = makeSpiedComponent();
+      const renderer = new WorkflowEditorRenderer([], jest.fn(), jest.fn(), jest.fn(), component);
+      const container = createMockEl('root');
+      renderer.render(
+        container as unknown as HTMLElement,
+        makeWorkflow({ schedule: { enabled: true, frequency: 'daily', hour: 9, minute: 0, catchUp: 'latest' } }),
+        false
+      );
+
+      expect(renderer.getWorkflow().schedule?.enabled).toBe(true);
+
+      const calls = (component.registerDomEvent as unknown as jest.Mock).mock.calls;
+      const reg = calls.find((c: unknown[]) => c[1] === 'change');
+      const checkbox = reg[0] as MockElement;
+      const handler = reg[2] as () => void;
+
+      checkbox.checked = false;
+      handler();
+
+      expect(renderer.getWorkflow().schedule).toBeUndefined();
+    });
+  });
+
+  describe('validation', () => {
+    it('getWorkflow returns a clone (mutating the returned object does not leak back)', () => {
+      const renderer = new WorkflowEditorRenderer([], jest.fn(), jest.fn(), jest.fn(), new Component());
+      const container = createMockEl('root');
+      renderer.render(container as unknown as HTMLElement, makeWorkflow({ name: 'Original' }), false);
+      const wf = renderer.getWorkflow();
+      wf.name = 'Mutated';
+      expect(renderer.getWorkflow().name).toBe('Original');
+    });
+  });
+});

--- a/tests/unit/WorkspaceMobileStyles.test.ts
+++ b/tests/unit/WorkspaceMobileStyles.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Workspace Mobile / Tap-Target Style Presence Guards (Wave 3 PR4)
+ *
+ * The plan's Visual Regression Strategy is MANUAL (no pixel-diff pipeline) but
+ * endorses a "cheap DOM-snapshot for attribute presence". Since the layout is
+ * driven entirely by styles.css (the project's non-negotiable "all styles in
+ * styles.css, never inline"), the cheapest automatable VR guard is a
+ * presence-scan of the load-bearing mobile/tap-target rules. These assert the
+ * RULES EXIST — they cannot validate rendered pixels (that stays manual, see
+ * the HANDOFF's manual-VR checklist).
+ *
+ * If a future edit deletes one of these blocks, this guard fails loudly and
+ * points at the specific responsive affordance that regressed.
+ *
+ * Pure-Node fs read; CI/Windows-portable.
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+
+const STYLES_FILE = path.resolve(__dirname, '..', '..', 'styles.css');
+
+async function readStyles(): Promise<string> {
+  return fs.readFile(STYLES_FILE, 'utf8');
+}
+
+/** Extract the body of a CSS rule/at-rule by brace-matching from a header. */
+function blockAfter(css: string, header: string): string {
+  const start = css.indexOf(header);
+  if (start === -1) return '';
+  const open = css.indexOf('{', start);
+  if (open === -1) return '';
+  let depth = 0;
+  for (let i = open; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      if (depth === 0) return css.slice(open + 1, i);
+    }
+  }
+  return '';
+}
+
+describe('Workspace mobile / tap-target style guards (PR4 VR-lite)', () => {
+  describe('.ws-section-action tap-target padding', () => {
+    it('declares a 6px / var(--space-m) padding floor (~30px tall, WCAG 2.5.5)', async () => {
+      const css = await readStyles();
+      const body = blockAfter(css, '.ws-section-action {');
+      expect(body).toMatch(/padding:\s*6px\s+var\(--space-m\)/);
+    });
+  });
+
+  describe('.ws-tree-row clamp() per-depth indent', () => {
+    it('uses a clamp()-bounded indent step so deep trees do not overflow narrow viewports', async () => {
+      const css = await readStyles();
+      // The depth-0 / depth-1 rows establish the clamp() step.
+      expect(css).toMatch(/\.ws-tree-row\[data-depth="1"\][\s\S]*?clamp\(10px,\s*5vw,\s*20px\)/);
+    });
+
+    it('scales the indent multiplicatively for deeper levels (depth 2 = step × 2)', async () => {
+      const css = await readStyles();
+      expect(css).toMatch(/\.ws-tree-row\[data-depth="2"\][\s\S]*?clamp\(10px,\s*5vw,\s*20px\)\s*\*\s*2/);
+    });
+  });
+
+  describe('@media (max-width: 480px) mobile breakpoint', () => {
+    it('exists and collapses .ws-field-grid to a single column', async () => {
+      const css = await readStyles();
+      const body = blockAfter(css, '@media (max-width: 480px) {');
+      expect(body).not.toBe('');
+      expect(body).toMatch(/\.ws-field-grid\s*\{[\s\S]*?grid-template-columns:\s*1fr/);
+    });
+
+    it('drops the .ws-section-body internal scroll on mobile (max-height: none)', async () => {
+      const css = await readStyles();
+      const body = blockAfter(css, '@media (max-width: 480px) {');
+      expect(body).toMatch(/\.ws-section-body\s*\{[\s\S]*?max-height:\s*none[\s\S]*?overflow:\s*visible/);
+    });
+
+    it('drops the .ws-tree internal scroll on mobile (max-height: none)', async () => {
+      const css = await readStyles();
+      const body = blockAfter(css, '@media (max-width: 480px) {');
+      expect(body).toMatch(/\.ws-tree\s*\{[\s\S]*?max-height:\s*none[\s\S]*?overflow:\s*visible/);
+    });
+  });
+
+  describe('@supports sticky-header graceful degradation', () => {
+    it('falls back to position: static when sticky is unsupported (older iOS WebView)', async () => {
+      const css = await readStyles();
+      const body = blockAfter(css, '@supports not (position: sticky) {');
+      expect(body).not.toBe('');
+      expect(body).toMatch(/\.ws-section-header\s*\{[\s\S]*?position:\s*static/);
+    });
+  });
+
+  describe('legacy .nexus-tree-* CSS removed (no dead orphans)', () => {
+    it('contains no .nexus-tree-* selectors after the .ws-tree rename', async () => {
+      const css = await readStyles();
+      const lines = css.split(/\r?\n/);
+      const hits = lines
+        .map((line, i) => ({ line: i + 1, text: line.trim() }))
+        .filter(h => /\.nexus-tree-/.test(h.text));
+      if (hits.length > 0) {
+        const summary = hits.map(h => `  styles.css:${h.line} → ${h.text}`).join('\n');
+        throw new Error(`Legacy .nexus-tree-* CSS still present (should have been removed in PR4):\n${summary}`);
+      }
+      expect(hits).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Wave 3 PR4 — final PR of the workspace-tab-redesign

Ports the last two renderers to the shared `BoxedSection` shell and lands the mobile-layout story for this `isDesktopOnly: false` plugin. Plan: `docs/plans/workspace-tab-redesign-plan.md` (§ PR Slicing § PR4).

### Changes
- **WorkflowEditorRenderer** — Identity / Prompt / Steps / Schedule sections wrapped in `BoxedSection` (4 sections per the v3.1 mockup). Enabled toggle moved into the section header toolbar. Schedule conditional re-render preserved verbatim. Adds required `component: Component` ctor param, threaded from `WorkspacesTab.ts:643` (mirrors how FilePickerRenderer already receives it).
- **FilePickerRenderer** — tree shell ported to `.ws-tree-*` classes; **checkboxes KEPT** (the `selectedFiles: Set<string>` multi-select is a real op, unlike PR2's swept decorative task-checkbox); `data-depth` retained.
- **styles.css** — `.ws-tree` family with `clamp(10px,5vw,20px)` per-depth indent; `@media (max-width:480px)` breakpoint (`.ws-field-grid` → single column, `.ws-section-body`/`.ws-tree` drop nested scroll, `.task-meta` gap tighten); `@supports not (position:sticky)` degradation; `.ws-section-action` tap-target padding bumped to `6px var(--space-m)` (~30px). Removed ~113 lines of orphaned `.nexus-tree-*` CSS.

### Verification (automated)
- Full suite **3167 passed / 17 skipped / 0 failed** (baseline 3128 + 39 new tests). Build clean, lint clean.
- 39 new tests across 3 files (WorkflowEditorRenderer, FilePickerRenderer, WorkspaceMobileStyles).
- **Counter-test-by-revert** confirms coupling: FilePicker 13/16 + Workflow 12/15 tests fail when the production change is reverted, then re-green.
- Concurrent auditor signal: **GREEN** on all 5 watch items (FilePicker checkboxes preserved, no new Node imports, styles in styles.css only, BoxedSection reused w/ component threaded, Schedule re-render preserved).

### Manual VR required before merge (only surfaces not automatable)
- [ ] Sticky section header pins on scroll when body content exceeds viewport (desktop + iOS WebView `@supports` static fallback)
- [ ] At ≤480px: `.ws-field-grid` collapses to 1 column, `.ws-section-body` + `.ws-tree` scroll naturally (no nested scrollbar), `.task-meta` gap tightens
- [ ] `.ws-section-action` buttons hit ~30px tap-target on a real mobile device (WCAG 2.5.5)
- [ ] Deep file-picker trees (depth 5–10) indent via `clamp()` without horizontal overflow on a narrow viewport
- [ ] Visual fidelity of the Workflow editor's 4 BoxedSections + FilePicker tree to the v3.1 mockup (`docs/mockups/workspace-tab-redesign-v3-subpages.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)