### PR TITLE
feat(taskManager): expose linked-notes metadata to AI + linkType taxonomy + createTask linkType-at-creation

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -22,7 +22,9 @@ import {
   ProjectSummary,
   WorkspaceTaskSummary,
   LinkType,
-  TaskStatus
+  TaskStatus,
+  TaskWithNoteLinks,
+  TaskNoteLink
 } from '../types';
 import type { IProjectRepository, ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
 import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/repositories/interfaces/ITaskRepository';
@@ -280,10 +282,10 @@ export class TaskService {
     return taskId;
   }
 
-  async listTasks(projectId: string, options?: TaskListOptions): Promise<PaginatedResult<TaskMetadata>> {
+  async listTasks(projectId: string, options?: TaskListOptions): Promise<PaginatedResult<TaskWithNoteLinks>> {
     await this.ensureQueryReady();
 
-    return this.taskRepo.getByProject(projectId, {
+    const result = await this.taskRepo.getByProject(projectId, {
       page: options?.page,
       pageSize: options?.pageSize,
       status: options?.status,
@@ -293,6 +295,11 @@ export class TaskService {
       sortBy: options?.sortBy,
       sortOrder: options?.sortOrder
     });
+
+    return {
+      ...result,
+      items: await this.attachNoteLinks(result.items)
+    };
   }
 
   async listWorkspaceTasks(workspaceId: string, options?: TaskListOptions): Promise<PaginatedResult<TaskMetadata>> {
@@ -450,7 +457,7 @@ export class TaskService {
   // DAG Queries
   // ────────────────────────────────────────────────────────────────
 
-  async getNextActions(projectId: string): Promise<TaskMetadata[]> {
+  async getNextActions(projectId: string): Promise<TaskWithNoteLinks[]> {
     await this.ensureQueryReady();
 
     const allTasks = await this.taskRepo.getByProject(projectId, { pageSize: 10000 });
@@ -462,12 +469,14 @@ export class TaskService {
 
     // Sort by priority then creation date
     const priorityOrder: Record<string, number> = { critical: 1, high: 2, medium: 3, low: 4 };
-    return allTasks.items
+    const ready = allTasks.items
       .filter(t => readyIds.has(t.id))
       .sort((a, b) => {
         const pDiff = (priorityOrder[a.priority] ?? 3) - (priorityOrder[b.priority] ?? 3);
         return pDiff !== 0 ? pDiff : a.created - b.created;
       });
+
+    return this.attachNoteLinks(ready);
   }
 
   async getBlockedTasks(projectId: string): Promise<TaskWithBlockers[]> {
@@ -485,20 +494,30 @@ export class TaskService {
     const blockedNodes = this.dagService.getBlockedTasks(nodes, allEdges);
     const blockedIds = new Set(blockedNodes.map(n => n.id));
 
+    // Enrich every task once with its note links, then build the result from a lookup.
+    // Both the blocked task and its blockers are AI-facing task content, so both carry links.
+    const enriched = await this.attachNoteLinks(allTasks.items);
+    const enrichedById = new Map<string, TaskWithNoteLinks>();
+    for (const t of enriched) {
+      enrichedById.set(t.id, t);
+    }
+
     const result: TaskWithBlockers[] = [];
     for (const task of allTasks.items) {
       if (!blockedIds.has(task.id)) continue;
 
       // Find which dependencies are blocking
-      const blockers: TaskMetadata[] = [];
+      const blockers: TaskWithNoteLinks[] = [];
       for (const edge of allEdges) {
         if (edge.taskId !== task.id) continue;
         const depTask = taskMap.get(edge.dependsOnTaskId);
         if (depTask && depTask.status !== 'done' && depTask.status !== 'cancelled') {
-          blockers.push(depTask);
+          const enrichedDep = enrichedById.get(depTask.id);
+          if (enrichedDep) blockers.push(enrichedDep);
         }
       }
-      result.push({ task, blockedBy: blockers });
+      const enrichedTask = enrichedById.get(task.id);
+      if (enrichedTask) result.push({ task: enrichedTask, blockedBy: blockers });
     }
 
     return result;
@@ -513,16 +532,20 @@ export class TaskService {
     const allTasks = await this.taskRepo.getByProject(task.projectId, { pageSize: 10000 });
     const allEdges = await this.taskRepo.getAllDependencyEdges(task.projectId);
 
-    const taskMap = new Map<string, TaskMetadata>();
-    for (const t of allTasks.items) {
-      taskMap.set(t.id, t);
+    // Enrich the root and every project task once, then build the tree from a lookup.
+    // The root may not appear in getByProject results (e.g. cross-project edge cases),
+    // so enrich it alongside the project tasks to guarantee it carries note links.
+    const enriched = await this.attachNoteLinks([task, ...allTasks.items]);
+    const enrichedById = new Map<string, TaskWithNoteLinks>();
+    for (const t of enriched) {
+      enrichedById.set(t.id, t);
     }
 
     const nodes: TaskNode[] = allTasks.items.map(t => ({ id: t.id, status: t.status }));
     const { dependencies, dependents } = this.dagService.getDependencyTree(taskId, nodes, allEdges);
-    const mapTaskIds = (taskIds: string[]): Array<{ task: TaskMetadata; dependencies: never[]; dependents: never[] }> =>
-      taskIds.reduce<Array<{ task: TaskMetadata; dependencies: never[]; dependents: never[] }>>((acc, relatedTaskId) => {
-        const relatedTask = taskMap.get(relatedTaskId);
+    const mapTaskIds = (taskIds: string[]): DependencyTree[] =>
+      taskIds.reduce<DependencyTree[]>((acc, relatedTaskId) => {
+        const relatedTask = enrichedById.get(relatedTaskId);
         if (relatedTask) {
           acc.push({ task: relatedTask, dependencies: [], dependents: [] });
         }
@@ -530,7 +553,7 @@ export class TaskService {
       }, []);
 
     return {
-      task,
+      task: enrichedById.get(task.id) ?? { ...task, noteLinks: [] },
       dependencies: mapTaskIds(dependencies),
       dependents: mapTaskIds(dependents)
     };
@@ -578,6 +601,34 @@ export class TaskService {
     await this.ensureQueryReady();
 
     return this.taskRepo.getNoteLinks(taskId);
+  }
+
+  /**
+   * Enrich a batch of tasks with their linked-note metadata for AI-facing read surfaces.
+   *
+   * Note links live in a separate table from tasks, so they must be joined per task.
+   * Fetches are parallelized with Promise.all (no batch repo method exists) and each
+   * task's lookup falls back to an empty array on failure so one bad task never sinks
+   * the whole read. Mirrors the UI enrichment in TaskBoardDataController.
+   *
+   * N+1 note: this issues one getNoteLinks call per task. Parallelization keeps it to a
+   * single await; an aggregate repo method (e.g. getNoteLinksForTasks) would reduce the
+   * round-trip count if list sizes grow — documented as acceptable for current scale.
+   */
+  private async attachNoteLinks(tasks: TaskMetadata[]): Promise<TaskWithNoteLinks[]> {
+    const linkArrays = await Promise.all(
+      tasks.map(task =>
+        this.getNoteLinks(task.id).catch(() => [] as NoteLink[])
+      )
+    );
+
+    return tasks.map((task, index) => ({
+      ...task,
+      noteLinks: linkArrays[index].map((link): TaskNoteLink => ({
+        notePath: link.notePath,
+        linkType: link.linkType
+      }))
+    }));
   }
 
   async getTasksForNote(notePath: string): Promise<TaskMetadata[]> {
@@ -655,6 +706,14 @@ export class TaskService {
       .sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0))
       .slice(0, 5);
 
+    // Enrich only the two short lists surfaced to the AI (max 5 each) with note links —
+    // enriching the entire workspace task set would be wasteful since the summary only
+    // returns these slices.
+    const [nextActionsWithLinks, completedWithLinks] = await Promise.all([
+      this.attachNoteLinks(topNextActions),
+      this.attachNoteLinks(completed)
+    ]);
+
     return {
       projects: {
         total: projects.totalItems,
@@ -665,8 +724,8 @@ export class TaskService {
         total: allTasks.totalItems,
         byStatus,
         overdue,
-        nextActions: topNextActions,
-        recentlyCompleted: completed
+        nextActions: nextActionsWithLinks,
+        recentlyCompleted: completedWithLinks
       }
     };
   }

--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -24,7 +24,8 @@ import {
   LinkType,
   TaskStatus,
   TaskWithNoteLinks,
-  TaskNoteLink
+  TaskNoteLink,
+  LinkedNoteInput
 } from '../types';
 import type { IProjectRepository, ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
 import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/repositories/interfaces/ITaskRepository';
@@ -48,6 +49,18 @@ export interface TaskBoardNotifier {
  */
 export type WorkspaceResolver = (workspaceId: string) => Promise<string | null>;
 export type TaskQueryReadyWaiter = () => Promise<boolean>;
+
+/**
+ * Normalize a createTask linkedNotes item to a uniform { notePath, linkType } shape.
+ * A plain string is a vault path with linkType defaulting to "reference"; an object
+ * keeps its notePath and falls back to "reference" when linkType is omitted.
+ */
+function normalizeLinkedNote(link: LinkedNoteInput): { notePath: string; linkType: LinkType } {
+  if (typeof link === 'string') {
+    return { notePath: link, linkType: 'reference' };
+  }
+  return { notePath: link.notePath, linkType: link.linkType ?? 'reference' };
+}
 
 export class TaskService {
   private resolveWorkspace: WorkspaceResolver | null;
@@ -264,10 +277,13 @@ export class TaskService {
       }
     }
 
-    // Create initial note links
+    // Create initial note links. Each item is either a plain string (vault path,
+    // linkType defaults to "reference") or an object { notePath, linkType? }.
+    // Normalize to { notePath, linkType } first so the link-creation loop has a
+    // single shape.
     if (data.linkedNotes && data.linkedNotes.length > 0) {
-      for (const notePath of data.linkedNotes) {
-        await this.taskRepo.addNoteLink(taskId, notePath, 'reference');
+      for (const link of data.linkedNotes.map(normalizeLinkedNote)) {
+        await this.taskRepo.addNoteLink(taskId, link.notePath, link.linkType);
       }
     }
 

--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -30,6 +30,7 @@ import {
 import type { IProjectRepository, ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
 import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/repositories/interfaces/ITaskRepository';
 import { PaginatedResult } from '../../../types/pagination/PaginationTypes';
+import { logger } from '../../../utils/logger';
 
 export interface TaskBoardEventPayload {
   workspaceId: string;
@@ -54,10 +55,20 @@ export type TaskQueryReadyWaiter = () => Promise<boolean>;
  * Normalize a createTask linkedNotes item to a uniform { notePath, linkType } shape.
  * A plain string is a vault path with linkType defaulting to "reference"; an object
  * keeps its notePath and falls back to "reference" when linkType is omitted.
+ *
+ * notePath is required and must be non-empty. Tool param schemas are advisory only —
+ * they are not enforced at runtime before reaching the service — so guard here to reject
+ * a missing/empty/whitespace notePath rather than silently persist an empty link.
  */
 function normalizeLinkedNote(link: LinkedNoteInput): { notePath: string; linkType: LinkType } {
   if (typeof link === 'string') {
+    if (link.trim().length === 0) {
+      throw new Error('linkedNotes: notePath is required and cannot be empty');
+    }
     return { notePath: link, linkType: 'reference' };
+  }
+  if (!link.notePath || link.notePath.trim().length === 0) {
+    throw new Error('linkedNotes: notePath is required and cannot be empty');
   }
   return { notePath: link.notePath, linkType: link.linkType ?? 'reference' };
 }
@@ -510,15 +521,13 @@ export class TaskService {
     const blockedNodes = this.dagService.getBlockedTasks(nodes, allEdges);
     const blockedIds = new Set(blockedNodes.map(n => n.id));
 
-    // Enrich every task once with its note links, then build the result from a lookup.
-    // Both the blocked task and its blockers are AI-facing task content, so both carry links.
-    const enriched = await this.attachNoteLinks(allTasks.items);
-    const enrichedById = new Map<string, TaskWithNoteLinks>();
-    for (const t of enriched) {
-      enrichedById.set(t.id, t);
-    }
-
-    const result: TaskWithBlockers[] = [];
+    // First pass: build the result from raw tasks, recording which task IDs actually
+    // land in the response (blocked tasks ∪ their active blockers). We then enrich ONLY
+    // that subset with note links, rather than every task in the project — getNoteLinks
+    // is one query per task, so enriching all project tasks here would be O(all-tasks)
+    // even when only a handful are returned.
+    const rawResult: TaskWithBlockers[] = [];
+    const returnedIds = new Set<string>();
     for (const task of allTasks.items) {
       if (!blockedIds.has(task.id)) continue;
 
@@ -528,15 +537,30 @@ export class TaskService {
         if (edge.taskId !== task.id) continue;
         const depTask = taskMap.get(edge.dependsOnTaskId);
         if (depTask && depTask.status !== 'done' && depTask.status !== 'cancelled') {
-          const enrichedDep = enrichedById.get(depTask.id);
-          if (enrichedDep) blockers.push(enrichedDep);
+          returnedIds.add(depTask.id);
+          // Cast: placeholder until enrichment below replaces this with the enriched task.
+          blockers.push(depTask as TaskWithNoteLinks);
         }
       }
-      const enrichedTask = enrichedById.get(task.id);
-      if (enrichedTask) result.push({ task: enrichedTask, blockedBy: blockers });
+      returnedIds.add(task.id);
+      rawResult.push({ task: task as TaskWithNoteLinks, blockedBy: blockers });
     }
 
-    return result;
+    // Enrich only the tasks that appear in the result, then swap placeholders for the
+    // enriched versions via a lookup (keeps the enrich-once dedup — each returned task
+    // is fetched at most once).
+    const enriched = await this.attachNoteLinks(
+      allTasks.items.filter(t => returnedIds.has(t.id))
+    );
+    const enrichedById = new Map<string, TaskWithNoteLinks>();
+    for (const t of enriched) {
+      enrichedById.set(t.id, t);
+    }
+
+    return rawResult.map(entry => ({
+      task: enrichedById.get(entry.task.id) ?? { ...entry.task, noteLinks: [] },
+      blockedBy: entry.blockedBy.map(b => enrichedById.get(b.id) ?? { ...b, noteLinks: [] })
+    }));
   }
 
   async getDependencyTree(taskId: string): Promise<DependencyTree> {
@@ -548,17 +572,32 @@ export class TaskService {
     const allTasks = await this.taskRepo.getByProject(task.projectId, { pageSize: 10000 });
     const allEdges = await this.taskRepo.getAllDependencyEdges(task.projectId);
 
-    // Enrich the root and every project task once, then build the tree from a lookup.
-    // The root may not appear in getByProject results (e.g. cross-project edge cases),
-    // so enrich it alongside the project tasks to guarantee it carries note links.
-    const enriched = await this.attachNoteLinks([task, ...allTasks.items]);
+    const nodes: TaskNode[] = allTasks.items.map(t => ({ id: t.id, status: t.status }));
+    const { dependencies, dependents } = this.dagService.getDependencyTree(taskId, nodes, allEdges);
+
+    // Enrich ONLY the tasks that appear in the tree (root ∪ dependencies ∪ dependents),
+    // not every task in the project. getNoteLinks is one query per task, so enriching all
+    // project tasks would be O(all-tasks) even when the tree is small. The root may not
+    // appear in getByProject results (e.g. cross-project edge cases), so include it
+    // explicitly to guarantee it carries note links.
+    const treeIds = new Set<string>([task.id, ...dependencies, ...dependents]);
+    const tasksById = new Map<string, TaskMetadata>();
+    for (const t of allTasks.items) {
+      tasksById.set(t.id, t);
+    }
+    const tasksToEnrich: TaskMetadata[] = [task];
+    for (const id of treeIds) {
+      if (id === task.id) continue;
+      const t = tasksById.get(id);
+      if (t) tasksToEnrich.push(t);
+    }
+
+    const enriched = await this.attachNoteLinks(tasksToEnrich);
     const enrichedById = new Map<string, TaskWithNoteLinks>();
     for (const t of enriched) {
       enrichedById.set(t.id, t);
     }
 
-    const nodes: TaskNode[] = allTasks.items.map(t => ({ id: t.id, status: t.status }));
-    const { dependencies, dependents } = this.dagService.getDependencyTree(taskId, nodes, allEdges);
     const mapTaskIds = (taskIds: string[]): DependencyTree[] =>
       taskIds.reduce<DependencyTree[]>((acc, relatedTaskId) => {
         const relatedTask = enrichedById.get(relatedTaskId);
@@ -634,7 +673,18 @@ export class TaskService {
   private async attachNoteLinks(tasks: TaskMetadata[]): Promise<TaskWithNoteLinks[]> {
     const linkArrays = await Promise.all(
       tasks.map(task =>
-        this.getNoteLinks(task.id).catch(() => [] as NoteLink[])
+        this.getNoteLinks(task.id).catch((error) => {
+          // Degrade to [] so one bad task never sinks the whole read, but route the
+          // failure through the observability seam so a persistent getNoteLinks failure
+          // is distinguishable from a task that genuinely has no links. systemWarn is the
+          // project's centralized warn-level seam (muted by default; flipping warn on
+          // emits everywhere) — so this is latent until warn-level logging is enabled.
+          logger.systemWarn(
+            `getNoteLinks failed for task ${task.id}; returning empty noteLinks: ${error instanceof Error ? error.message : String(error)}`,
+            'TaskService.attachNoteLinks'
+          );
+          return [] as NoteLink[];
+        })
       )
     );
 

--- a/src/agents/taskManager/tools/links/linkNote.ts
+++ b/src/agents/taskManager/tools/links/linkNote.ts
@@ -19,7 +19,7 @@ export class LinkNoteTool extends BaseTool<LinkNoteParameters, LinkNoteResult> {
     super(
       'linkNote',
       'Link Note',
-      'Create or remove a bidirectional link between a vault note and a task. Link types: reference (related note), output (task produces this note), input (task consumes this note). Use action=unlink to remove an existing link.',
+      'Create or remove a bidirectional link between a vault note and a task. Link types: input (task depends on / consumes the note — a required source / precondition, forms a data-flow edge), output (task produces the note — the artifact/result, forms a data-flow edge), reference (related/contextual note the task does NOT consume — association only, not part of the data flow). Use action=unlink to remove an existing link.',
       '1.0.0'
     );
   }
@@ -57,7 +57,7 @@ export class LinkNoteTool extends BaseTool<LinkNoteParameters, LinkNoteResult> {
         linkType: {
           type: 'string',
           enum: ['reference', 'output', 'input'],
-          description: 'Type of link (default: reference). reference=related note, output=task produces this note, input=task consumes this note'
+          description: 'Type of link (default: reference). input=the task DEPENDS ON / CONSUMES this note (required source material; a precondition — forms a data-flow edge). output=the task PRODUCES this note (the artifact/result — forms a data-flow edge). reference=related/contextual note the task does NOT consume (association only, not part of the data flow).'
         },
         action: {
           type: 'string',

--- a/src/agents/taskManager/tools/tasks/createTask.ts
+++ b/src/agents/taskManager/tools/tasks/createTask.ts
@@ -19,7 +19,7 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
     super(
       'create',
       'Create Task',
-      'Create a task within a project. Requires a projectId (from createProject or listProjects). Supports optional priority (critical/high/medium/low), assignee, dueDate, tags, dependsOn[] for DAG edges (cycles rejected), parentTaskId for subtask nesting, and linkedNotes[] for vault note links. Returns the new taskId.',
+      'Create a task within a project. Requires a projectId (from createProject or listProjects). Supports optional priority (critical/high/medium/low), assignee, dueDate, tags, dependsOn[] for DAG edges (cycles rejected), parentTaskId for subtask nesting, and linkedNotes[] for vault note links (each as a plain path string defaulting to reference, or an object { notePath, linkType } to set input/output/reference at creation). Returns the new taskId.',
       '1.0.0'
     );
   }
@@ -69,7 +69,23 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
         assignee: { type: 'string', description: 'Assignee name or identifier (optional)' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Tags for categorization (optional)' },
         dependsOn: { type: 'array', items: { type: 'string' }, description: 'Task IDs this task depends on — creates DAG edges. Task cannot start until all dependencies are done. Cycles are rejected with an error.' },
-        linkedNotes: { type: 'array', items: { type: 'string' }, description: 'Vault note paths to link to this task. Each link is created with linkType=reference (related/contextual note the task does NOT consume — association only). To create input links (the task DEPENDS ON / CONSUMES the note — a precondition, data-flow edge) or output links (the task PRODUCES the note — the artifact/result, data-flow edge), use the linkNote tool or updateTask addNoteLinks, which accept an explicit linkType.' },
+        linkedNotes: {
+          type: 'array',
+          description: 'Vault notes to link to this task. Each item is EITHER a plain string vault path (linkType defaults to "reference") OR an object { notePath, linkType } to set the relationship explicitly. linkType values: input = the task DEPENDS ON / CONSUMES this note (required source material; a precondition — forms a data-flow edge). output = the task PRODUCES this note (the artifact/result — forms a data-flow edge). reference = related/contextual note the task does NOT consume (association only, not part of the data flow). Links can also be added or changed after creation via the linkNote tool or updateTask addNoteLinks.',
+          items: {
+            oneOf: [
+              { type: 'string', description: 'Vault note path, e.g. "folder/note.md" (linkType defaults to reference)' },
+              {
+                type: 'object',
+                properties: {
+                  notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
+                  linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'input=consumed/required source, output=produced artifact, reference=related but not consumed (default: reference)' }
+                },
+                required: ['notePath']
+              }
+            ]
+          }
+        },
         metadata: { type: 'object', description: 'Custom metadata key-value pairs (optional)', additionalProperties: true }
       },
       required: ['projectId', 'title']

--- a/src/agents/taskManager/tools/tasks/createTask.ts
+++ b/src/agents/taskManager/tools/tasks/createTask.ts
@@ -69,7 +69,7 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
         assignee: { type: 'string', description: 'Assignee name or identifier (optional)' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Tags for categorization (optional)' },
         dependsOn: { type: 'array', items: { type: 'string' }, description: 'Task IDs this task depends on — creates DAG edges. Task cannot start until all dependencies are done. Cycles are rejected with an error.' },
-        linkedNotes: { type: 'array', items: { type: 'string' }, description: 'Vault note paths to link to this task (link type defaults to reference)' },
+        linkedNotes: { type: 'array', items: { type: 'string' }, description: 'Vault note paths to link to this task. Each link is created with linkType=reference (related/contextual note the task does NOT consume — association only). To create input links (the task DEPENDS ON / CONSUMES the note — a precondition, data-flow edge) or output links (the task PRODUCES the note — the artifact/result, data-flow edge), use the linkNote tool or updateTask addNoteLinks, which accept an explicit linkType.' },
         metadata: { type: 'object', description: 'Custom metadata key-value pairs (optional)', additionalProperties: true }
       },
       required: ['projectId', 'title']

--- a/src/agents/taskManager/tools/tasks/listTasks.ts
+++ b/src/agents/taskManager/tools/tasks/listTasks.ts
@@ -19,7 +19,7 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
     super(
       'list',
       'List Tasks',
-      'List tasks in a project with optional filters for status (todo/in_progress/done/cancelled), priority, assignee, and parentTaskId. Returns paginated task objects with full metadata including dependencies and timestamps.',
+      'List tasks in a project with optional filters for status (todo/in_progress/done/cancelled), priority, assignee, and parentTaskId. Returns paginated task objects with full metadata including timestamps and linked vault notes (noteLinks, each with notePath + linkType: input/output/reference).',
       '1.0.0'
     );
   }
@@ -107,7 +107,18 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
               dueDate: { type: 'number', description: 'Due date timestamp (ms since epoch)' },
               assignee: { type: 'string', description: 'Assigned person or identifier' },
               tags: { type: 'array', items: { type: 'string' }, description: 'Categorization tags' },
-              metadata: { type: 'object', description: 'Custom metadata key-value pairs' }
+              metadata: { type: 'object', description: 'Custom metadata key-value pairs' },
+              noteLinks: {
+                type: 'array',
+                description: 'Vault notes linked to this task. notePath is the vault path; linkType is the relationship: input=task depends on/consumes the note (a precondition/data-flow source), output=task produces the note (a data-flow result), reference=related/contextual note the task does not consume.',
+                items: {
+                  type: 'object',
+                  properties: {
+                    notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
+                    linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'input=consumed/required source, output=produced artifact, reference=related but not consumed' }
+                  }
+                }
+              }
             }
           }
         },

--- a/src/agents/taskManager/tools/tasks/listTasks.ts
+++ b/src/agents/taskManager/tools/tasks/listTasks.ts
@@ -116,7 +116,8 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
                   properties: {
                     notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
                     linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'input=consumed/required source, output=produced artifact, reference=related but not consumed' }
-                  }
+                  },
+                  required: ['notePath', 'linkType']
                 }
               }
             }

--- a/src/agents/taskManager/tools/tasks/queryTasks.ts
+++ b/src/agents/taskManager/tools/tasks/queryTasks.ts
@@ -99,7 +99,18 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
         dueDate: { type: 'number', description: 'Due date timestamp (ms since epoch)' },
         assignee: { type: 'string', description: 'Assigned person or identifier' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Categorization tags' },
-        metadata: { type: 'object', description: 'Custom metadata key-value pairs' }
+        metadata: { type: 'object', description: 'Custom metadata key-value pairs' },
+        noteLinks: {
+          type: 'array',
+          description: 'Vault notes linked to this task. notePath is the vault path; linkType is the relationship: input=task depends on/consumes the note (a precondition/data-flow source), output=task produces the note (a data-flow result), reference=related/contextual note the task does not consume.',
+          items: {
+            type: 'object',
+            properties: {
+              notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
+              linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'input=consumed/required source, output=produced artifact, reference=related but not consumed' }
+            }
+          }
+        }
       }
     };
 

--- a/src/agents/taskManager/tools/tasks/queryTasks.ts
+++ b/src/agents/taskManager/tools/tasks/queryTasks.ts
@@ -108,8 +108,31 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
             properties: {
               notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
               linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'input=consumed/required source, output=produced artifact, reference=related but not consumed' }
-            }
+            },
+            required: ['notePath', 'linkType']
           }
+        }
+      }
+    };
+
+    // A dependencyTree node: a task (carrying noteLinks) plus its recursive child arrays.
+    // Each node's task uses the full taskObjectSchema above, so the AI-advertised schema
+    // shows that tree nodes carry noteLinks (the runtime already returns them). The nested
+    // dependencies/dependents are described generically to avoid an infinitely-deep schema.
+    const dependencyNodeSchema: JSONSchema = {
+      type: 'object',
+      description: 'Recursive DependencyTree node',
+      properties: {
+        task: { ...taskObjectSchema, description: 'The task at this node (includes noteLinks)' },
+        dependencies: {
+          type: 'array',
+          description: 'Upstream nodes (recursive — each is a DependencyTree node with task, dependencies[], dependents[])',
+          items: { type: 'object', description: 'Recursive DependencyTree node' }
+        },
+        dependents: {
+          type: 'array',
+          description: 'Downstream nodes (recursive — each is a DependencyTree node with task, dependencies[], dependents[])',
+          items: { type: 'object', description: 'Recursive DependencyTree node' }
         }
       }
     };
@@ -143,16 +166,16 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
           type: 'object',
           description: 'Returned for dependencyTree query — recursive upstream/downstream dependency graph for the specified task',
           properties: {
-            task: { ...taskObjectSchema, description: 'The root task of the tree' },
+            task: { ...taskObjectSchema, description: 'The root task of the tree (includes noteLinks)' },
             dependencies: {
               type: 'array',
-              description: 'Upstream tasks this task depends on (recursive — each has its own dependencies/dependents)',
-              items: { type: 'object', description: 'Recursive DependencyTree node with task, dependencies[], and dependents[]' }
+              description: 'Upstream tasks this task depends on (recursive — each node carries its task with noteLinks plus its own dependencies/dependents)',
+              items: dependencyNodeSchema
             },
             dependents: {
               type: 'array',
-              description: 'Downstream tasks that depend on this task (recursive — each has its own dependencies/dependents)',
-              items: { type: 'object', description: 'Recursive DependencyTree node with task, dependencies[], and dependents[]' }
+              description: 'Downstream tasks that depend on this task (recursive — each node carries its task with noteLinks plus its own dependencies/dependents)',
+              items: dependencyNodeSchema
             }
           }
         },

--- a/src/agents/taskManager/tools/tasks/updateTask.ts
+++ b/src/agents/taskManager/tools/tasks/updateTask.ts
@@ -103,7 +103,7 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
             type: 'object',
             properties: {
               notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md"' },
-              linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'Type of link (default: reference)' }
+              linkType: { type: 'string', enum: ['reference', 'output', 'input'], description: 'Type of link (default: reference). input=the task DEPENDS ON / CONSUMES this note (required source material; a precondition — forms a data-flow edge). output=the task PRODUCES this note (the artifact/result — forms a data-flow edge). reference=related/contextual note the task does NOT consume (association only, not part of the data flow).' }
             },
             required: ['notePath']
           }

--- a/src/agents/taskManager/types.ts
+++ b/src/agents/taskManager/types.ts
@@ -75,6 +75,16 @@ export interface TaskWithNoteLinks extends TaskMetadata {
   noteLinks: TaskNoteLink[];
 }
 
+/**
+ * A linked-note argument accepted by createTask. Either:
+ *  - a plain string (vault path) → linkType defaults to "reference", or
+ *  - an object { notePath, linkType? } → linkType defaults to "reference" when omitted.
+ * Normalized to { notePath, linkType } early in TaskService.createTask so the
+ * link-creation loop has a single shape. The string form preserves all existing
+ * callers and the CLI/CSV parser path.
+ */
+export type LinkedNoteInput = string | { notePath: string; linkType?: LinkType };
+
 // ────────────────────────────────────────────────────────────────
 // CRUD DTOs
 // ────────────────────────────────────────────────────────────────
@@ -101,7 +111,7 @@ export interface CreateTaskData {
   assignee?: string;
   tags?: string[];
   dependsOn?: string[];
-  linkedNotes?: string[];
+  linkedNotes?: LinkedNoteInput[];
   metadata?: Record<string, unknown>;
 }
 
@@ -204,7 +214,7 @@ export interface CreateTaskParameters extends CommonParameters {
   assignee?: string;
   tags?: string[];
   dependsOn?: string[];
-  linkedNotes?: string[];
+  linkedNotes?: LinkedNoteInput[];
   metadata?: Record<string, unknown>;
 }
 

--- a/src/agents/taskManager/types.ts
+++ b/src/agents/taskManager/types.ts
@@ -38,19 +38,42 @@ export interface TaskNode {
 }
 
 export interface DependencyTree {
-  task: TaskMetadata;
+  task: TaskWithNoteLinks;
   dependencies: DependencyTree[];
   dependents: DependencyTree[];
 }
 
 export interface TaskWithBlockers {
-  task: TaskMetadata;
-  blockedBy: TaskMetadata[];
+  task: TaskWithNoteLinks;
+  blockedBy: TaskWithNoteLinks[];
 }
 
 // NoteLink is re-exported from ITaskRepository above via the LinkType re-export line.
 // Re-export it explicitly here for consumers importing from this file.
 export type { NoteLink } from '../../database/repositories/interfaces/ITaskRepository';
+
+/**
+ * A single linked-note reference as surfaced on AI-facing task read shapes.
+ * Projected from the stored NoteLink record down to the two fields the AI needs:
+ * the vault path and the relationship type. See TaskWithNoteLinks.
+ */
+export interface TaskNoteLink {
+  notePath: string;
+  linkType: LinkType;
+}
+
+/**
+ * A task enriched with its linked-note metadata for AI-facing read surfaces.
+ *
+ * TaskMetadata is the pure SQLite storage shape (no joined data); note links live
+ * in a separate table. This derived view tacks the joined noteLinks onto the task
+ * object at the service/result layer so every surface the AI reads tasks back from
+ * (listTasks, queryTasks, loadWorkspace summary) can carry them without polluting
+ * the storage interface. Mirrors the UI's TaskBoardDataController enrichment pattern.
+ */
+export interface TaskWithNoteLinks extends TaskMetadata {
+  noteLinks: TaskNoteLink[];
+}
 
 // ────────────────────────────────────────────────────────────────
 // CRUD DTOs
@@ -136,8 +159,8 @@ export interface WorkspaceTaskSummary {
     total: number;
     byStatus: Record<TaskStatus, number>;
     overdue: number;
-    nextActions: TaskMetadata[];
-    recentlyCompleted: TaskMetadata[];
+    nextActions: TaskWithNoteLinks[];
+    recentlyCompleted: TaskWithNoteLinks[];
   };
 }
 
@@ -268,7 +291,7 @@ export interface CreateTaskResult extends CommonResult {
 }
 
 export interface ListTasksResult extends CommonResult {
-  tasks?: TaskMetadata[];
+  tasks?: TaskWithNoteLinks[];
   pagination?: {
     page: number;
     pageSize: number;
@@ -284,7 +307,7 @@ export type MoveTaskResult = CommonResult
 
 export interface QueryTasksResult extends CommonResult {
   query?: string;
-  tasks?: TaskMetadata[];
+  tasks?: TaskWithNoteLinks[];
   tree?: DependencyTree;
   blockedTasks?: TaskWithBlockers[];
 }

--- a/tests/unit/TaskManagerTools.test.ts
+++ b/tests/unit/TaskManagerTools.test.ts
@@ -424,6 +424,14 @@ describe('TaskManager Tools', () => {
       const result = await tool.execute({ ...baseParams, projectId: '' });
       expect(result.success).toBe(false);
     });
+
+    it('result schema advertises noteLinks items with required notePath + linkType', () => {
+      const schema = tool.getResultSchema() as Record<string, any>;
+      const taskItem = schema.properties.tasks.items;
+      expect(taskItem.properties.noteLinks).toBeDefined();
+      const noteLinkItem = taskItem.properties.noteLinks.items;
+      expect(noteLinkItem.required).toEqual(['notePath', 'linkType']);
+    });
   });
 
   // ============================================================================
@@ -699,6 +707,25 @@ describe('TaskManager Tools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unknown query type');
+    });
+
+    it('result schema advertises noteLinks items with required notePath + linkType', () => {
+      const schema = tool.getResultSchema() as Record<string, any>;
+      const noteLinkItem = schema.properties.tasks.items.properties.noteLinks.items;
+      expect(noteLinkItem.required).toEqual(['notePath', 'linkType']);
+    });
+
+    it('dependencyTree node schema advertises noteLinks on the recursive node task', () => {
+      const schema = tool.getResultSchema() as Record<string, any>;
+      const tree = schema.properties.tree;
+      // Root task carries noteLinks.
+      expect(tree.properties.task.properties.noteLinks).toBeDefined();
+      // Recursive dependency/dependent nodes carry a task with noteLinks (runtime returns
+      // them, so the AI-advertised schema must show them).
+      const depNode = tree.properties.dependencies.items;
+      expect(depNode.properties.task.properties.noteLinks).toBeDefined();
+      const dependentNode = tree.properties.dependents.items;
+      expect(dependentNode.properties.task.properties.noteLinks).toBeDefined();
     });
   });
 

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -109,6 +109,11 @@ describe('TaskService', () => {
     taskBoardNotifier = {
       notify: jest.fn()
     };
+    // Read surfaces (listTasks, getNextActions, getBlockedTasks, getDependencyTree,
+    // getWorkspaceSummary) enrich tasks with note links via getNoteLinks; default to
+    // an empty array so unrelated tests don't trip the enrichment. Tests that assert
+    // noteLinks override this per-task.
+    taskRepo.getNoteLinks.mockResolvedValue([]);
     service = new TaskService(projectRepo, taskRepo, dagService, undefined, taskBoardNotifier, waitForQueryReady);
   });
 
@@ -440,6 +445,124 @@ describe('TaskService', () => {
         status: 'todo',
         priority: 'high'
       }));
+    });
+  });
+
+  // ============================================================================
+  // Note Links enrichment on AI-facing read surfaces
+  // ============================================================================
+
+  describe('noteLinks enrichment on read surfaces', () => {
+    it('listTasks attaches noteLinks (notePath + linkType) to each task', async () => {
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([
+        createMockTask({ id: 't1' })
+      ]));
+      taskRepo.getNoteLinks.mockResolvedValue([
+        { taskId: 't1', notePath: 'notes/source.md', linkType: 'input', created: 1 },
+        { taskId: 't1', notePath: 'notes/result.md', linkType: 'output', created: 2 }
+      ]);
+
+      const result = await service.listTasks('proj-1');
+
+      expect(taskRepo.getNoteLinks).toHaveBeenCalledWith('t1');
+      expect(result.items[0].noteLinks).toEqual([
+        { notePath: 'notes/source.md', linkType: 'input' },
+        { notePath: 'notes/result.md', linkType: 'output' }
+      ]);
+    });
+
+    it('listTasks returns an empty noteLinks array when a task has no links', async () => {
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([createMockTask({ id: 't1' })]));
+      taskRepo.getNoteLinks.mockResolvedValue([]);
+
+      const result = await service.listTasks('proj-1');
+
+      expect(result.items[0].noteLinks).toEqual([]);
+    });
+
+    it('listTasks falls back to an empty noteLinks array when the lookup rejects', async () => {
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([createMockTask({ id: 't1' })]));
+      taskRepo.getNoteLinks.mockRejectedValue(new Error('lookup failed'));
+
+      const result = await service.listTasks('proj-1');
+
+      expect(result.items[0].noteLinks).toEqual([]);
+    });
+
+    it('getNextActions attaches noteLinks to ready tasks', async () => {
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([
+        createMockTask({ id: 't1', status: 'todo', priority: 'high' })
+      ]));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([]);
+      taskRepo.getNoteLinks.mockResolvedValue([
+        { taskId: 't1', notePath: 'spec.md', linkType: 'reference', created: 1 }
+      ]);
+
+      const result = await service.getNextActions('proj-1');
+
+      expect(result[0].noteLinks).toEqual([{ notePath: 'spec.md', linkType: 'reference' }]);
+    });
+
+    it('getBlockedTasks attaches noteLinks to both the blocked task and its blockers', async () => {
+      const depTask = createMockTask({ id: 'dep', status: 'in_progress' });
+      const blockedTask = createMockTask({ id: 'blocked', status: 'todo' });
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([depTask, blockedTask]));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([
+        { taskId: 'blocked', dependsOnTaskId: 'dep' }
+      ]);
+      taskRepo.getNoteLinks.mockImplementation(async (taskId: string) =>
+        taskId === 'blocked'
+          ? [{ taskId: 'blocked', notePath: 'out.md', linkType: 'output', created: 1 }]
+          : [{ taskId: 'dep', notePath: 'in.md', linkType: 'input', created: 1 }]
+      );
+
+      const result = await service.getBlockedTasks('proj-1');
+
+      expect(result[0].task.noteLinks).toEqual([{ notePath: 'out.md', linkType: 'output' }]);
+      expect(result[0].blockedBy[0].noteLinks).toEqual([{ notePath: 'in.md', linkType: 'input' }]);
+    });
+
+    it('getDependencyTree attaches noteLinks to root, dependencies, and dependents', async () => {
+      const rootTask = createMockTask({ id: 'root', projectId: 'proj-1' });
+      const depTask = createMockTask({ id: 'dep', projectId: 'proj-1' });
+      const dependentTask = createMockTask({ id: 'dependent', projectId: 'proj-1' });
+
+      taskRepo.getById.mockResolvedValue(rootTask);
+      taskRepo.getByProject.mockResolvedValue(paginatedResult([rootTask, depTask, dependentTask]));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([
+        { taskId: 'root', dependsOnTaskId: 'dep' },
+        { taskId: 'dependent', dependsOnTaskId: 'root' }
+      ]);
+      taskRepo.getNoteLinks.mockResolvedValue([
+        { taskId: 'x', notePath: 'n.md', linkType: 'reference', created: 1 }
+      ]);
+
+      const result = await service.getDependencyTree('root');
+
+      expect(result.task.noteLinks).toEqual([{ notePath: 'n.md', linkType: 'reference' }]);
+      expect(result.dependencies[0].task.noteLinks).toEqual([{ notePath: 'n.md', linkType: 'reference' }]);
+      expect(result.dependents[0].task.noteLinks).toEqual([{ notePath: 'n.md', linkType: 'reference' }]);
+    });
+
+    it('getWorkspaceSummary attaches noteLinks to nextActions and recentlyCompleted', async () => {
+      const project = createMockProject({ id: 'proj-1', status: 'active' });
+      const tasks = [
+        createMockTask({ id: 'ready', status: 'todo', priority: 'high', projectId: 'proj-1' }),
+        createMockTask({ id: 'done', status: 'done', completedAt: 5000, projectId: 'proj-1' })
+      ];
+
+      projectRepo.getByWorkspace.mockResolvedValue(paginatedResult([project]));
+      taskRepo.getByWorkspace.mockResolvedValue(paginatedResult(tasks));
+      taskRepo.getByProject.mockResolvedValue(paginatedResult(tasks));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([]);
+      taskRepo.getNoteLinks.mockResolvedValue([
+        { taskId: 'x', notePath: 'doc.md', linkType: 'reference', created: 1 }
+      ]);
+
+      const result = await service.getWorkspaceSummary('ws-1');
+
+      expect(result.tasks.nextActions[0].noteLinks).toEqual([{ notePath: 'doc.md', linkType: 'reference' }]);
+      expect(result.tasks.recentlyCompleted[0].noteLinks).toEqual([{ notePath: 'doc.md', linkType: 'reference' }]);
     });
   });
 

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -412,6 +412,56 @@ describe('TaskService', () => {
       expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'path/to/note2.md', 'reference');
     });
 
+    it('should create note links from object form with explicit linkType', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await service.createTask('proj-1', {
+        title: 'Task with typed notes',
+        linkedNotes: [
+          { notePath: 'src.md', linkType: 'input' },
+          { notePath: 'out.md', linkType: 'output' },
+          { notePath: 'ctx.md', linkType: 'reference' }
+        ]
+      });
+
+      expect(taskRepo.addNoteLink).toHaveBeenCalledTimes(3);
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'src.md', 'input');
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'out.md', 'output');
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'ctx.md', 'reference');
+    });
+
+    it('should default object-form linkType to reference when omitted', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await service.createTask('proj-1', {
+        title: 'Task',
+        linkedNotes: [{ notePath: 'note.md' }]
+      });
+
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'note.md', 'reference');
+    });
+
+    it('should handle a mixed array of string and object note links', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await service.createTask('proj-1', {
+        title: 'Task with mixed notes',
+        linkedNotes: [
+          'plain.md',
+          { notePath: 'consumed.md', linkType: 'input' },
+          { notePath: 'untyped.md' }
+        ]
+      });
+
+      expect(taskRepo.addNoteLink).toHaveBeenCalledTimes(3);
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'plain.md', 'reference');
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'consumed.md', 'input');
+      expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'untyped.md', 'reference');
+    });
+
     it('should set default priority to medium', async () => {
       projectRepo.getById.mockResolvedValue(createMockProject());
       taskRepo.create.mockResolvedValue('task-new');

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -462,6 +462,49 @@ describe('TaskService', () => {
       expect(taskRepo.addNoteLink).toHaveBeenCalledWith('task-new', 'untyped.md', 'reference');
     });
 
+    it('should throw when an object-form note link is missing notePath', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await expect(
+        service.createTask('proj-1', {
+          title: 'Task',
+          // notePath omitted on the object form — must not silently persist an empty link
+          linkedNotes: [{ linkType: 'input' } as unknown as { notePath: string; linkType: 'input' }]
+        })
+      ).rejects.toThrow('notePath is required');
+
+      expect(taskRepo.addNoteLink).not.toHaveBeenCalled();
+    });
+
+    it('should throw when an object-form note link has an empty/whitespace notePath', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await expect(
+        service.createTask('proj-1', {
+          title: 'Task',
+          linkedNotes: [{ notePath: '   ', linkType: 'input' }]
+        })
+      ).rejects.toThrow('notePath is required');
+
+      expect(taskRepo.addNoteLink).not.toHaveBeenCalled();
+    });
+
+    it('should throw when a string-form note link is empty/whitespace', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+      taskRepo.create.mockResolvedValue('task-new');
+
+      await expect(
+        service.createTask('proj-1', {
+          title: 'Task',
+          linkedNotes: ['  ']
+        })
+      ).rejects.toThrow('notePath is required');
+
+      expect(taskRepo.addNoteLink).not.toHaveBeenCalled();
+    });
+
     it('should set default priority to medium', async () => {
       projectRepo.getById.mockResolvedValue(createMockProject());
       taskRepo.create.mockResolvedValue('task-new');
@@ -613,6 +656,57 @@ describe('TaskService', () => {
 
       expect(result.tasks.nextActions[0].noteLinks).toEqual([{ notePath: 'doc.md', linkType: 'reference' }]);
       expect(result.tasks.recentlyCompleted[0].noteLinks).toEqual([{ notePath: 'doc.md', linkType: 'reference' }]);
+    });
+
+    // F1: getBlockedTasks/getDependencyTree must enrich ONLY the tasks they actually
+    // return, not every task in the project (getByProject pageSize 10000). These assert
+    // the getNoteLinks fan-out is bounded by the returned subset.
+
+    it('getBlockedTasks calls getNoteLinks only for blocked tasks and their blockers, not unrelated project tasks', async () => {
+      const depTask = createMockTask({ id: 'dep', status: 'in_progress' });
+      const blockedTask = createMockTask({ id: 'blocked', status: 'todo' });
+      // Two unrelated tasks that exist in the project but are neither blocked nor blockers.
+      const unrelated1 = createMockTask({ id: 'unrelated1', status: 'todo' });
+      const unrelated2 = createMockTask({ id: 'unrelated2', status: 'done' });
+      taskRepo.getByProject.mockResolvedValue(
+        paginatedResult([depTask, blockedTask, unrelated1, unrelated2])
+      );
+      taskRepo.getAllDependencyEdges.mockResolvedValue([
+        { taskId: 'blocked', dependsOnTaskId: 'dep' }
+      ]);
+      taskRepo.getNoteLinks.mockResolvedValue([]);
+
+      await service.getBlockedTasks('proj-1');
+
+      // Only 'blocked' (returned) + 'dep' (its blocker) should be enriched.
+      const enrichedIds = taskRepo.getNoteLinks.mock.calls.map(call => call[0]).sort();
+      expect(enrichedIds).toEqual(['blocked', 'dep']);
+      expect(taskRepo.getNoteLinks).not.toHaveBeenCalledWith('unrelated1');
+      expect(taskRepo.getNoteLinks).not.toHaveBeenCalledWith('unrelated2');
+    });
+
+    it('getDependencyTree calls getNoteLinks only for the root, dependencies, and dependents, not unrelated project tasks', async () => {
+      const rootTask = createMockTask({ id: 'root', projectId: 'proj-1' });
+      const depTask = createMockTask({ id: 'dep', projectId: 'proj-1' });
+      const dependentTask = createMockTask({ id: 'dependent', projectId: 'proj-1' });
+      // Unrelated task in the same project but not in root's dependency tree.
+      const unrelated = createMockTask({ id: 'unrelated', projectId: 'proj-1' });
+
+      taskRepo.getById.mockResolvedValue(rootTask);
+      taskRepo.getByProject.mockResolvedValue(
+        paginatedResult([rootTask, depTask, dependentTask, unrelated])
+      );
+      taskRepo.getAllDependencyEdges.mockResolvedValue([
+        { taskId: 'root', dependsOnTaskId: 'dep' },
+        { taskId: 'dependent', dependsOnTaskId: 'root' }
+      ]);
+      taskRepo.getNoteLinks.mockResolvedValue([]);
+
+      await service.getDependencyTree('root');
+
+      const enrichedIds = taskRepo.getNoteLinks.mock.calls.map(call => call[0]).sort();
+      expect(enrichedIds).toEqual(['dep', 'dependent', 'root']);
+      expect(taskRepo.getNoteLinks).not.toHaveBeenCalledWith('unrelated');
     });
   });
 

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -252,11 +252,41 @@ function buildStubRegistry(): Map<string, IAgent> {
     }),
   ]);
 
+  // unionItemsAgent → create(linkedNotes: array<oneOf[string, object]>)
+  // Mirrors the real createTask.linkedNotes union schema so the CLI coercion
+  // path for the widened linkedNotes (string CSV back-compat + object JSON
+  // literal) is exercised end-to-end through normalizeExecutionCalls.
+  const unionItemsAgent = makeStubAgent('unionItemsAgent', [
+    makeStubTool('create', {
+      type: 'object',
+      properties: {
+        linkedNotes: {
+          type: 'array',
+          items: {
+            oneOf: [
+              { type: 'string' },
+              {
+                type: 'object',
+                properties: {
+                  notePath: { type: 'string' },
+                  linkType: { type: 'string', enum: ['reference', 'output', 'input'] },
+                },
+                required: ['notePath'],
+              },
+            ],
+          },
+        },
+      },
+      required: [],
+    }),
+  ]);
+
   return new Map<string, IAgent>([
     ['contentManager', contentAgent],
     ['storageManager', storageAgent],
     ['numericAgent', coerceAgent],
     ['oneOfAgent', oneOfAgent],
+    ['unionItemsAgent', unionItemsAgent],
     ['toolManager', makeStubAgent('toolManager', [])], // excluded from --help
   ]);
 }
@@ -294,7 +324,7 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
     it('"--help" expands to all agents except toolManager', () => {
       const result = makeNormalizer().normalizeDiscoveryRequests({ tool: '--help' });
       const agents = result.map(r => r.agent).sort();
-      expect(agents).toEqual(['contentManager', 'numericAgent', 'oneOfAgent', 'storageManager']);
+      expect(agents).toEqual(['contentManager', 'numericAgent', 'oneOfAgent', 'storageManager', 'unionItemsAgent']);
     });
 
     it('throws on unknown agent token', () => {
@@ -1400,6 +1430,48 @@ describe('EC-3: array<X> coerces every element to X', () => {
       tool: 'numeric convert --pages "1,not-a-number,3"',
     });
     expect(call.params.pages).toEqual([1, 'not-a-number', 3]);
+  });
+});
+
+describe('union-items array (createTask.linkedNotes shape): string CSV back-compat + object JSON literal', () => {
+  // The widened createTask.linkedNotes uses items: { oneOf: [string, object] },
+  // so getSchemaType derives array<unknown> (no single items.type). That routes
+  // through the array<...> branch: JSON array literals parse (preserving object
+  // items) and bare CSV splits into strings. This guards both the back-compat
+  // string path and the new object-item path at the CLI layer.
+
+  it('string CSV form still parses to a string[] (back-compat)', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'union-items create --linked-notes "a.md,b.md"',
+    });
+    expect(call.params.linkedNotes).toEqual(['a.md', 'b.md']);
+  });
+
+  it('string JSON-array form still parses to a string[] (back-compat)', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'union-items create --linked-notes \'["a.md","b.md"]\'',
+    });
+    expect(call.params.linkedNotes).toEqual(['a.md', 'b.md']);
+  });
+
+  it('object JSON-literal form parses to objects with linkType', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'union-items create --linked-notes \'[{"notePath":"src.md","linkType":"input"},{"notePath":"out.md","linkType":"output"}]\'',
+    });
+    expect(call.params.linkedNotes).toEqual([
+      { notePath: 'src.md', linkType: 'input' },
+      { notePath: 'out.md', linkType: 'output' },
+    ]);
+  });
+
+  it('mixed JSON-literal array (string + object items) is preserved per item', () => {
+    const [call] = makeNormalizer().normalizeExecutionCalls({
+      tool: 'union-items create --linked-notes \'["plain.md",{"notePath":"consumed.md","linkType":"input"}]\'',
+    });
+    expect(call.params.linkedNotes).toEqual([
+      'plain.md',
+      { notePath: 'consumed.md', linkType: 'input' },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

Task-manager linked notes were **write-only** from the AI/MCP surface — the AI could *set* note links (createTask / linkNote / updateTask) but nothing returned them, and the `input`/`output`/`reference` linkType was persisted yet undocumented for the model. This PR closes the read gap and documents the taxonomy, then lets the AI assign linkType at task creation.

### Commit 1 — `14c9fb62` expose noteLinks on AI read surfaces + document taxonomy
- New derived view `TaskWithNoteLinks` (extends the pure-SQLite `TaskMetadata`); a single `TaskService.attachNoteLinks` helper (parallel `getNoteLinks` via `Promise.all` + per-task `.catch(()=>[])`) populates every AI-facing read surface:
  - `listTasks`
  - `queryTasks` — all three modes (`nextActions`; `blockedTasks` task **and** blockers; `dependencyTree` root + deps + dependents)
  - `loadWorkspace` task summary (`nextActions` + `recentlyCompleted`)
- `getBlockedTasks`/`getDependencyTree` enrich once into a Map then build by lookup (no double-fetch of shared tasks); summary enriches only the ≤5 slices.
- Documented the `input`/`output`/`reference` taxonomy in the `linkNote`, `updateTask` (`addNoteLinks`), and `createTask` (`linkedNotes`) tool schemas:
  - **input** = task depends on / consumes the note (data-flow edge)
  - **output** = task produces the note (data-flow edge)
  - **reference** = related/contextual, not consumed
- Ack-only surfaces (createTask/updateTask/linkNote returns, openTasks) correctly left unchanged.

### Commit 2 — `5cca5104` createTask sets linkType at creation
- `createTask.linkedNotes` widened to a union: plain path strings (default `reference`, full back-compat) **or** `{ notePath, linkType }` objects.
- Pure `normalizeLinkedNote` helper resolves each item early → single `addNoteLink` loop.
- Schema → `items.oneOf [string, object]` with inline taxonomy.
- Verified both forms route correctly through `ToolCliNormalizer` (string CSV → `string[]`; JSON-array literal → objects preserved) — **no parser changes needed**.

## Why
`linkType` forms a note-level "secondary DAG" (a task's `output` note becoming another task's `input` is an implicit data-flow edge). Surfacing it to the AI makes that graph legible; documenting the taxonomy makes the model use it correctly.

## Verification
- Full suite **3218 passed / 0 failed / 17 skipped** (+15 new tests)
- `npm run build` clean; `npm run lint` clean
- **No** `CURRENT_SCHEMA_VERSION` bump (read-shape + schema-doc only)
- Mobile-safe (no new Node imports)
- ⚠️ Not yet manually tested in Obsidian (unit + build only)

## Notes
- CLI flag is `--linked-notes` (kebab — existing convention, not new)
- `TaskService.ts` / test files cross the 600-line maintainability threshold (pre-existing; nudged by additive helper + tests) — deferred tech-debt, not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)