### PR TITLE
[codex] Fix cold cache rebuild persistence

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -776,7 +776,6 @@ export class HybridStorageAdapter implements IStorageAdapter {
           throw new Error(`Cache rebuild failed: ${summary}`);
         }
 
-        await this.sqliteCache.save();
         options.onProgress?.('Complete', 1, 1);
       } finally {
         // Clear on both success and failure so a follow-up rebuild can

--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -256,7 +256,8 @@ export class SyncCoordinator {
    * Full rebuild of SQLite from JSONL files.
    *
    * NOTE: Uses smaller batch size (25) to avoid OOM errors with sql.js asm.js version.
-   * Saves after each file to prevent memory accumulation.
+   * Saves once after replay and FTS rebuild so cold-start cache rebuilds do not
+   * repeatedly export and rewrite the full SQLite blob.
    */
   async fullRebuild(options: SyncOptions = {}): Promise<SyncResult> {
     const startTime = Date.now();
@@ -285,6 +286,10 @@ export class SyncCoordinator {
       eventsApplied += taskResult.applied;
       filesProcessed.push(...taskResult.files);
 
+      if (errors.length > 0) {
+        return this.createResult(false, eventsApplied, 0, errors, startTime, filesProcessed);
+      }
+
       // Rebuild FTS and save
       options.onProgress?.('Rebuilding search indexes', 0, 1);
       await this.sqliteCache.rebuildFTSIndexes();
@@ -296,13 +301,6 @@ export class SyncCoordinator {
       return this.createResult(errors.length === 0, eventsApplied, 0, errors, startTime, filesProcessed);
     } catch (error) {
       console.error('[SyncCoordinator] Full rebuild failed:', error);
-      // Still save sync state so we don't rebuild again on next restart
-      try {
-        await this.sqliteCache.updateSyncState(this.deviceId, Date.now(), {});
-        await this.sqliteCache.save();
-      } catch (saveError) {
-        console.error('[SyncCoordinator] Failed to save sync state:', saveError);
-      }
       return this.createResult(false, eventsApplied, 0, [...errors, `Rebuild failed: ${String(error)}`], startTime, filesProcessed);
     }
   }
@@ -472,8 +470,6 @@ export class SyncCoordinator {
         files.push(file);
         options.onProgress?.('Processing workspaces', i + 1, workspaceFiles.length);
 
-        // Save after each file to prevent memory accumulation (OOM prevention)
-        await this.sqliteCache.save();
       } catch (e) {
         errors.push(`Failed to process ${file}: ${String(e)}`);
       }
@@ -521,8 +517,6 @@ export class SyncCoordinator {
         files.push(file);
         options.onProgress?.('Processing conversations', i + 1, conversationFiles.length);
 
-        // Save after each file to prevent memory accumulation (OOM prevention)
-        await this.sqliteCache.save();
       } catch (e) {
         errors.push(`Failed to process ${file}: ${String(e)}`);
       }
@@ -621,8 +615,6 @@ export class SyncCoordinator {
         files.push(file);
         options.onProgress?.('Processing tasks', i + 1, taskFiles.length);
 
-        // Save after each file to prevent memory accumulation (OOM prevention)
-        await this.sqliteCache.save();
       } catch (e) {
         errors.push(`Failed to process ${file}: ${String(e)}`);
       }

--- a/tests/integration/cache-backend-rebuild-cache.test.ts
+++ b/tests/integration/cache-backend-rebuild-cache.test.ts
@@ -4,10 +4,11 @@
  * This is the storage half of the split test plan (modal seam lives in
  * cache-backend-rebuild-modal-smoke.test.ts). Asserts that the rebuild call
  * sequence drives stopAutoSave -> close -> blobStore.remove -> initialize ->
- * fullRebuild -> save in order, with the REAL IndexedDB-backed blob store and
- * mocked sqliteCache + syncCoordinator. The blob store starts populated with a
- * synthesized SQLite blob; rebuild must wipe it and the post-rebuild state of
- * IDB must show the blob absent until the next save lands.
+ * fullRebuild in order, with the REAL IndexedDB-backed blob store and mocked
+ * sqliteCache + syncCoordinator. The blob store starts populated with a
+ * synthesized SQLite blob; rebuild must wipe it before replay. Successful
+ * fullRebuild owns the final save, so these tests pin that the adapter does not
+ * add a redundant save after fullRebuild returns.
  */
 
 jest.mock('@dao-xyz/sqlite3-vec/wasm', () => jest.fn(), { virtual: true });
@@ -67,6 +68,7 @@ async function buildRebuildHarness(): Promise<RebuildHarness> {
   const syncCoordinator: SyncCoordinatorMock = {
     fullRebuild: jest.fn(async () => {
       callOrder.push('fullRebuild');
+      await cacheLifecycle.save();
       return { success: true, errors: [] };
     })
   };
@@ -91,7 +93,7 @@ async function buildRebuildHarness(): Promise<RebuildHarness> {
 }
 
 describe('HybridStorageAdapter.rebuildCache (storage seam)', () => {
-  it('drives the full call sequence: stopAutoSave -> close -> remove -> initialize -> fullRebuild -> save', async () => {
+  it('drives the full call sequence: stopAutoSave -> close -> remove -> initialize -> fullRebuild save', async () => {
     const h = await buildRebuildHarness();
     const removeSpy = jest.spyOn(h.blobStore, 'remove');
 
@@ -218,6 +220,7 @@ describe('HybridStorageAdapter.rebuildCache (storage seam)', () => {
       h.syncCoordinator.fullRebuild.mockImplementation(async () => {
         await new Promise<void>((r) => setTimeout(r, 50));
         h.callOrder.push('fullRebuild');
+        await h.cacheLifecycle.save();
         return { success: true, errors: [] };
       });
 
@@ -300,7 +303,11 @@ describe('HybridStorageAdapter.rebuildCache (storage seam)', () => {
       await expect(h.adapter.rebuildCache()).rejects.toThrow(/transient replay error/);
 
       // Restore healthy fullRebuild for the retry.
-      h.syncCoordinator.fullRebuild.mockResolvedValue({ success: true, errors: [] });
+      h.syncCoordinator.fullRebuild.mockImplementation(async () => {
+        h.callOrder.push('fullRebuild');
+        await h.cacheLifecycle.save();
+        return { success: true, errors: [] };
+      });
 
       // Follow-up rebuild — must start a fresh cycle and succeed.
       await expect(h.adapter.rebuildCache()).resolves.toBeUndefined();

--- a/tests/perf/startup-rebuild-large-trace-store.test.ts
+++ b/tests/perf/startup-rebuild-large-trace-store.test.ts
@@ -121,7 +121,7 @@ describe('startup rebuild large trace-store harness', () => {
       expect(cache.markedEventIds.size).toBe(fixture.eventCount);
       expect(cache.rebuiltFts).toBe(true);
       expect(cache.syncState).not.toBeNull();
-      expect(cache.saveCalls).toBeGreaterThanOrEqual(2);
+      expect(cache.saveCalls).toBe(1);
       expect(progress.some(item => item.stage === 'Processing workspace events')).toBe(true);
       expect(progress).toContainEqual({
         stage: 'Processing workspace events',

--- a/tests/unit/SyncCoordinator.test.ts
+++ b/tests/unit/SyncCoordinator.test.ts
@@ -1,6 +1,206 @@
+import type { StorageEvent } from '../../src/database/interfaces/StorageEvents';
 import { SyncCoordinator, type IJSONLWriter, type ISQLiteCacheManager, type SyncState } from '../../src/database/sync/SyncCoordinator';
 
 describe('SyncCoordinator', () => {
+  it('saves full rebuild once after replaying all JSONL files', async () => {
+    const now = 1_000;
+    const eventsByFile: Record<string, StorageEvent[]> = {
+      'workspaces/ws_one.jsonl': [{
+        id: 'workspace-event-1',
+        type: 'workspace_created',
+        deviceId: 'desktop-device',
+        timestamp: now,
+        data: {
+          id: 'workspace-1',
+          name: 'Workspace one',
+          rootFolder: '',
+          created: now
+        }
+      }],
+      'workspaces/ws_two.jsonl': [{
+        id: 'workspace-event-2',
+        type: 'workspace_created',
+        deviceId: 'desktop-device',
+        timestamp: now + 1,
+        data: {
+          id: 'workspace-2',
+          name: 'Workspace two',
+          rootFolder: '',
+          created: now + 1
+        }
+      }],
+      'conversations/conv_one.jsonl': [{
+        id: 'conversation-event-1',
+        type: 'metadata',
+        deviceId: 'desktop-device',
+        timestamp: now + 2,
+        data: {
+          id: 'conversation-1',
+          title: 'Conversation one',
+          created: now + 2,
+          vault: 'Test vault'
+        }
+      }],
+      'conversations/conv_two.jsonl': [{
+        id: 'conversation-event-2',
+        type: 'metadata',
+        deviceId: 'desktop-device',
+        timestamp: now + 3,
+        data: {
+          id: 'conversation-2',
+          title: 'Conversation two',
+          created: now + 3,
+          vault: 'Test vault'
+        }
+      }],
+      'tasks/project_one.jsonl': [{
+        id: 'task-event-1',
+        type: 'project_created',
+        deviceId: 'desktop-device',
+        timestamp: now + 4,
+        data: {
+          id: 'project-1',
+          workspaceId: 'workspace-1',
+          name: 'Project one',
+          status: 'active',
+          created: now + 4,
+          updated: now + 4
+        }
+      }],
+      'tasks/project_two.jsonl': [{
+        id: 'task-event-2',
+        type: 'project_created',
+        deviceId: 'desktop-device',
+        timestamp: now + 5,
+        data: {
+          id: 'project-2',
+          workspaceId: 'workspace-2',
+          name: 'Project two',
+          status: 'active',
+          created: now + 5,
+          updated: now + 5
+        }
+      }]
+    };
+    const workspaces = new Map<string, { id: string; name: string; isArchived: boolean }>();
+
+    const jsonlWriter: IJSONLWriter = {
+      getDeviceId: jest.fn(() => 'mobile-device'),
+      listFiles: jest.fn(async (category) => {
+        if (category === 'workspaces') {
+          return ['workspaces/ws_one.jsonl', 'workspaces/ws_two.jsonl'];
+        }
+        if (category === 'conversations') {
+          return ['conversations/conv_one.jsonl', 'conversations/conv_two.jsonl'];
+        }
+        return ['tasks/project_one.jsonl', 'tasks/project_two.jsonl'];
+      }),
+      getFileModTime: jest.fn(async () => null),
+      readEvents: jest.fn(async <T extends StorageEvent>(file: string): Promise<T[]> => {
+        return (eventsByFile[file] ?? []) as T[];
+      }),
+      getEventsNotFromDevice: jest.fn(async () => [])
+    };
+
+    const sqliteCache: ISQLiteCacheManager = {
+      getSyncState: jest.fn(async () => null),
+      updateSyncState: jest.fn(async () => undefined),
+      isEventApplied: jest.fn(async () => false),
+      markEventApplied: jest.fn(async () => undefined),
+      run: jest.fn(async (sql, params = []) => {
+        if (sql.includes('INTO workspaces')) {
+          workspaces.set(String(params[0]), {
+            id: String(params[0]),
+            name: String(params[1]),
+            isArchived: params[7] === 1
+          });
+        }
+        return { changes: 1, lastInsertRowid: 1 };
+      }),
+      query: jest.fn(async <T>(sql: string, params = []): Promise<T[]> => {
+        if (sql.includes('FROM workspaces WHERE name = ? AND isArchived = 0')) {
+          const name = String(params[0]);
+          return Array.from(workspaces.values())
+            .filter(workspace => workspace.name === name && !workspace.isArchived)
+            .map(workspace => ({ id: workspace.id, lastAccessed: now })) as T[];
+        }
+        return [];
+      }),
+      queryOne: jest.fn(async <T>(sql: string, params = []): Promise<T | null> => {
+        if (sql.includes('FROM workspaces WHERE id = ?')) {
+          const id = String(params[0]);
+          return workspaces.has(id) ? ({ id } as T) : null;
+        }
+        return null;
+      }),
+      clearAllData: jest.fn(async () => {
+        workspaces.clear();
+      }),
+      rebuildFTSIndexes: jest.fn(async () => undefined),
+      save: jest.fn(async () => undefined)
+    };
+
+    const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
+    const result = await coordinator.fullRebuild();
+
+    expect(result.success).toBe(true);
+    expect(result.eventsApplied).toBe(6);
+    expect(result.filesProcessed).toHaveLength(6);
+    expect(sqliteCache.markEventApplied).toHaveBeenCalledTimes(6);
+    expect(sqliteCache.rebuildFTSIndexes).toHaveBeenCalledTimes(1);
+    expect(sqliteCache.updateSyncState).toHaveBeenCalledTimes(1);
+    expect(sqliteCache.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not persist sync state or save a partial cache when full rebuild replay fails', async () => {
+    const failingEvent: StorageEvent = {
+      id: 'workspace-event-fails',
+      type: 'workspace_created',
+      deviceId: 'desktop-device',
+      timestamp: 1_000,
+      data: {
+        id: 'workspace-fails',
+        name: 'Workspace fails',
+        rootFolder: '',
+        created: 1_000
+      }
+    };
+
+    const jsonlWriter: IJSONLWriter = {
+      getDeviceId: jest.fn(() => 'mobile-device'),
+      listFiles: jest.fn(async (category) => {
+        return category === 'workspaces' ? ['workspaces/ws_fails.jsonl'] : [];
+      }),
+      getFileModTime: jest.fn(async () => null),
+      readEvents: jest.fn(async <T extends StorageEvent>(): Promise<T[]> => [failingEvent as T]),
+      getEventsNotFromDevice: jest.fn(async () => [])
+    };
+
+    const sqliteCache: ISQLiteCacheManager = {
+      getSyncState: jest.fn(async () => null),
+      updateSyncState: jest.fn(async () => undefined),
+      isEventApplied: jest.fn(async () => false),
+      markEventApplied: jest.fn(async () => undefined),
+      run: jest.fn(async () => {
+        throw new Error('workspace insert failed');
+      }),
+      query: jest.fn(async () => []),
+      queryOne: jest.fn(async () => null),
+      clearAllData: jest.fn(async () => undefined),
+      rebuildFTSIndexes: jest.fn(async () => undefined),
+      save: jest.fn(async () => undefined)
+    };
+
+    const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
+    const result = await coordinator.fullRebuild();
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some(error => error.includes('workspace insert failed'))).toBe(true);
+    expect(sqliteCache.rebuildFTSIndexes).not.toHaveBeenCalled();
+    expect(sqliteCache.updateSyncState).not.toHaveBeenCalled();
+    expect(sqliteCache.save).not.toHaveBeenCalled();
+  });
+
   it('replays events from newly arrived files even when event timestamps are older than the last sync', async () => {
     const remoteEvent = {
       id: 'event-1',


### PR DESCRIPTION
## Summary

- Save cold cache full rebuilds once after replay and FTS rebuild instead of once per JSONL file.
- Stop `rebuildCache()` from adding a redundant save after `fullRebuild()` already persisted.
- Do not persist sync state or a cache blob when full rebuild replay fails.

## Root Cause

`SyncCoordinator.fullRebuild()` saved inside each workspace, conversation, and task file loop. On IndexedDB cache backends, each save exports the full SQLite WASM database and rewrites the whole cache blob, making cold rebuild work scale badly as JSONL history grows.

## Validation

- `npx jest --runInBand --runTestsByPath tests/unit/SyncCoordinator.test.ts`
- `npx jest --runInBand --runTestsByPath tests/integration/cache-backend-rebuild-cache.test.ts tests/perf/startup-rebuild-large-trace-store.test.ts`
- `npm run build`
