### PR TITLE
[codex] Add short task refs

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -31,6 +31,7 @@ import type { IProjectRepository, ProjectMetadata } from '../../../database/repo
 import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/repositories/interfaces/ITaskRepository';
 import { PaginatedResult } from '../../../types/pagination/PaginationTypes';
 import { logger } from '../../../utils/logger';
+import { formatTaskRef, taskRefToIdPrefix } from '../utils/taskRefs';
 
 export interface TaskBoardEventPayload {
   workspaceId: string;
@@ -116,6 +117,36 @@ export class TaskService {
     if (!ready) {
       throw new Error('Task storage is not ready yet');
     }
+  }
+
+  private async resolveTask(rawTaskId: string): Promise<TaskMetadata | null> {
+    const exact = await this.taskRepo.getById(rawTaskId);
+    if (exact) return exact;
+
+    const prefix = taskRefToIdPrefix(rawTaskId);
+    if (!prefix) return null;
+
+    const matches = await this.taskRepo.getByIdPrefix(prefix);
+    if (matches.length === 1) {
+      return matches[0];
+    }
+    if (matches.length > 1) {
+      throw new Error(`Task reference "${rawTaskId}" is ambiguous. Use a longer reference or the full taskId.`);
+    }
+
+    return null;
+  }
+
+  private async resolveTaskId(rawTaskId: string): Promise<string> {
+    const task = await this.resolveTask(rawTaskId);
+    return task?.id ?? rawTaskId;
+  }
+
+  private withTaskRef<T extends TaskMetadata>(task: T): T & { taskRef: string } {
+    return {
+      ...task,
+      taskRef: formatTaskRef(task.id)
+    };
   }
 
   // ────────────────────────────────────────────────────────────────
@@ -244,14 +275,16 @@ export class TaskService {
     }
 
     // Verify parent task exists if specified
+    let parentTaskId: string | undefined;
     if (data.parentTaskId) {
-      const parent = await this.taskRepo.getById(data.parentTaskId);
+      const parent = await this.resolveTask(data.parentTaskId);
       if (!parent) {
         throw new Error(`Parent task "${data.parentTaskId}" not found`);
       }
       if (parent.projectId !== projectId) {
         throw new Error('Parent task must be in the same project');
       }
+      parentTaskId = parent.id;
     }
 
     const taskId = await this.taskRepo.create({
@@ -259,7 +292,7 @@ export class TaskService {
       workspaceId: project.workspaceId,
       title: data.title,
       description: data.description,
-      parentTaskId: data.parentTaskId,
+      parentTaskId,
       priority: data.priority ?? 'medium',
       dueDate: data.dueDate,
       assignee: data.assignee,
@@ -270,13 +303,14 @@ export class TaskService {
     // Create initial dependency edges
     if (data.dependsOn && data.dependsOn.length > 0) {
       const allEdges = await this.taskRepo.getAllDependencyEdges(projectId);
-      for (const depId of data.dependsOn) {
-        const depTask = await this.taskRepo.getById(depId);
+      for (const rawDepId of data.dependsOn) {
+        const depTask = await this.resolveTask(rawDepId);
         if (!depTask) {
-          throw new Error(`Dependency task "${depId}" not found`);
+          throw new Error(`Dependency task "${rawDepId}" not found`);
         }
+        const depId = depTask.id;
         if (depTask.projectId !== projectId) {
-          throw new Error(`Dependency task "${depId}" is in a different project`);
+          throw new Error(`Dependency task "${rawDepId}" is in a different project`);
         }
         // Validate no cycle (add edge to check list for subsequent checks)
         const isSafe = this.dagService.validateNoCycle(taskId, depId, allEdges);
@@ -312,13 +346,15 @@ export class TaskService {
   async listTasks(projectId: string, options?: TaskListOptions): Promise<PaginatedResult<TaskWithNoteLinks>> {
     await this.ensureQueryReady();
 
+    const parentTaskId = options?.parentTaskId ? await this.resolveTaskId(options.parentTaskId) : undefined;
+
     const result = await this.taskRepo.getByProject(projectId, {
       page: options?.page,
       pageSize: options?.pageSize,
       status: options?.status,
       priority: options?.priority,
       assignee: options?.assignee,
-      parentTaskId: options?.parentTaskId,
+      parentTaskId,
       sortBy: options?.sortBy,
       sortOrder: options?.sortOrder
     });
@@ -349,10 +385,11 @@ export class TaskService {
   async updateTask(taskId: string, data: UpdateTaskData): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) {
       throw new Error(`Task "${taskId}" not found`);
     }
+    taskId = task.id;
 
     const updateData: Partial<TaskMetadata> & { updated: number } = {
       ...data,
@@ -382,10 +419,11 @@ export class TaskService {
   async moveTask(taskId: string, target: { projectId?: string; parentTaskId?: string | null }): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) {
       throw new Error(`Task "${taskId}" not found`);
     }
+    taskId = task.id;
 
     const updateData: Partial<TaskMetadata> & { updated: number } = { updated: Date.now() };
 
@@ -406,15 +444,16 @@ export class TaskService {
         // Move to top-level
         updateData.parentTaskId = undefined;
       } else {
-        const parent = await this.taskRepo.getById(target.parentTaskId);
+        const parent = await this.resolveTask(target.parentTaskId);
         if (!parent) {
           throw new Error(`Parent task "${target.parentTaskId}" not found`);
         }
+        const parentTaskId = parent.id;
         // Can't make a task its own parent
-        if (target.parentTaskId === taskId) {
+        if (parentTaskId === taskId) {
           throw new Error('A task cannot be its own parent');
         }
-        updateData.parentTaskId = target.parentTaskId;
+        updateData.parentTaskId = parentTaskId;
       }
     }
 
@@ -432,10 +471,11 @@ export class TaskService {
   async deleteTask(taskId: string): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) {
       throw new Error(`Task "${taskId}" not found`);
     }
+    taskId = task.id;
 
     await this.taskRepo.delete(taskId);
 
@@ -455,11 +495,13 @@ export class TaskService {
   async addDependency(taskId: string, dependsOnTaskId: string): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) throw new Error(`Task "${taskId}" not found`);
+    taskId = task.id;
 
-    const depTask = await this.taskRepo.getById(dependsOnTaskId);
+    const depTask = await this.resolveTask(dependsOnTaskId);
     if (!depTask) throw new Error(`Dependency task "${dependsOnTaskId}" not found`);
+    dependsOnTaskId = depTask.id;
 
     if (task.projectId !== depTask.projectId) {
       throw new Error('Dependencies must be within the same project');
@@ -477,6 +519,8 @@ export class TaskService {
   async removeDependency(taskId: string, dependsOnTaskId: string): Promise<void> {
     await this.ensureQueryReady();
 
+    taskId = await this.resolveTaskId(taskId);
+    dependsOnTaskId = await this.resolveTaskId(dependsOnTaskId);
     await this.taskRepo.removeDependency(taskId, dependsOnTaskId);
   }
 
@@ -558,16 +602,17 @@ export class TaskService {
     }
 
     return rawResult.map(entry => ({
-      task: enrichedById.get(entry.task.id) ?? { ...entry.task, noteLinks: [] },
-      blockedBy: entry.blockedBy.map(b => enrichedById.get(b.id) ?? { ...b, noteLinks: [] })
+      task: enrichedById.get(entry.task.id) ?? { ...this.withTaskRef(entry.task), noteLinks: [] },
+      blockedBy: entry.blockedBy.map(b => enrichedById.get(b.id) ?? { ...this.withTaskRef(b), noteLinks: [] })
     }));
   }
 
   async getDependencyTree(taskId: string): Promise<DependencyTree> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) throw new Error(`Task "${taskId}" not found`);
+    taskId = task.id;
 
     const allTasks = await this.taskRepo.getByProject(task.projectId, { pageSize: 10000 });
     const allEdges = await this.taskRepo.getAllDependencyEdges(task.projectId);
@@ -608,7 +653,7 @@ export class TaskService {
       }, []);
 
     return {
-      task: enrichedById.get(task.id) ?? { ...task, noteLinks: [] },
+      task: enrichedById.get(task.id) ?? { ...this.withTaskRef(task), noteLinks: [] },
       dependencies: mapTaskIds(dependencies),
       dependents: mapTaskIds(dependents)
     };
@@ -621,8 +666,9 @@ export class TaskService {
   async linkNote(taskId: string, notePath: string, linkType: LinkType): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
     if (!task) throw new Error(`Task "${taskId}" not found`);
+    taskId = task.id;
 
     await this.taskRepo.addNoteLink(taskId, notePath, linkType);
 
@@ -638,7 +684,8 @@ export class TaskService {
   async unlinkNote(taskId: string, notePath: string): Promise<void> {
     await this.ensureQueryReady();
 
-    const task = await this.taskRepo.getById(taskId);
+    const task = await this.resolveTask(taskId);
+    taskId = task?.id ?? taskId;
     await this.taskRepo.removeNoteLink(taskId, notePath);
 
     if (task) {
@@ -655,7 +702,8 @@ export class TaskService {
   async getNoteLinks(taskId: string): Promise<NoteLink[]> {
     await this.ensureQueryReady();
 
-    return this.taskRepo.getNoteLinks(taskId);
+    const task = await this.resolveTask(taskId);
+    return this.taskRepo.getNoteLinks(task?.id ?? taskId);
   }
 
   /**
@@ -673,7 +721,7 @@ export class TaskService {
   private async attachNoteLinks(tasks: TaskMetadata[]): Promise<TaskWithNoteLinks[]> {
     const linkArrays = await Promise.all(
       tasks.map(task =>
-        this.getNoteLinks(task.id).catch((error) => {
+        this.taskRepo.getNoteLinks(task.id).catch((error) => {
           // Degrade to [] so one bad task never sinks the whole read, but route the
           // failure through the observability seam so a persistent getNoteLinks failure
           // is distinguishable from a task that genuinely has no links. systemWarn is the
@@ -689,7 +737,7 @@ export class TaskService {
     );
 
     return tasks.map((task, index) => ({
-      ...task,
+      ...this.withTaskRef(task),
       noteLinks: linkArrays[index].map((link): TaskNoteLink => ({
         notePath: link.notePath,
         linkType: link.linkType

--- a/src/agents/taskManager/tools/links/linkNote.ts
+++ b/src/agents/taskManager/tools/links/linkNote.ts
@@ -19,7 +19,7 @@ export class LinkNoteTool extends BaseTool<LinkNoteParameters, LinkNoteResult> {
     super(
       'linkNote',
       'Link Note',
-      'Create or remove a bidirectional link between a vault note and a task. Link types: input (task depends on / consumes the note — a required source / precondition, forms a data-flow edge), output (task produces the note — the artifact/result, forms a data-flow edge), reference (related/contextual note the task does NOT consume — association only, not part of the data flow). Use action=unlink to remove an existing link.',
+      'Create or remove a bidirectional link between a vault note and a task. Accepts either the internal taskId or short taskRef. Link types: input (task depends on / consumes the note — a required source / precondition, forms a data-flow edge), output (task produces the note — the artifact/result, forms a data-flow edge), reference (related/contextual note the task does NOT consume — association only, not part of the data flow). Use action=unlink to remove an existing link.',
       '1.0.0'
     );
   }
@@ -52,7 +52,7 @@ export class LinkNoteTool extends BaseTool<LinkNoteParameters, LinkNoteResult> {
     return this.getMergedSchema({
       type: 'object',
       properties: {
-        taskId: { type: 'string', description: 'Task ID to link the note to (REQUIRED — from createTask or listTasks)' },
+        taskId: { type: 'string', description: 'Task ID or short taskRef to link the note to (REQUIRED — from createTask or listTasks)' },
         notePath: { type: 'string', description: 'Vault note path, e.g. "folder/note.md" (REQUIRED)' },
         linkType: {
           type: 'string',

--- a/src/agents/taskManager/tools/tasks/createTask.ts
+++ b/src/agents/taskManager/tools/tasks/createTask.ts
@@ -13,13 +13,14 @@ import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { createErrorMessage } from '../../../../utils/errorUtils';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
+import { formatTaskRef } from '../../utils/taskRefs';
 
 export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskResult> {
   constructor(private taskService: TaskService) {
     super(
       'create',
       'Create Task',
-      'Create a task within a project. Requires a projectId (from createProject or listProjects). Supports optional priority (critical/high/medium/low), assignee, dueDate, tags, dependsOn[] for DAG edges (cycles rejected), parentTaskId for subtask nesting, and linkedNotes[] for vault note links (each as a plain path string defaulting to reference, or an object { notePath, linkType } to set input/output/reference at creation). Returns the new taskId.',
+      'Create a task within a project. Requires a projectId (from createProject or listProjects). Supports optional priority (critical/high/medium/low), assignee, dueDate, tags, dependsOn[] for DAG edges (cycles rejected), parentTaskId for subtask nesting, and linkedNotes[] for vault note links (each as a plain path string defaulting to reference, or an object { notePath, linkType } to set input/output/reference at creation). Returns the internal taskId and a short taskRef; prefer taskRef for later task operations.',
       '1.0.0'
     );
   }
@@ -50,7 +51,7 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
         metadata: params.metadata
       });
 
-      return { success: true, taskId };
+      return { success: true, taskId, taskRef: formatTaskRef(taskId) };
     } catch (error) {
       return { success: false, error: createErrorMessage('Failed to create task: ', error) };
     }
@@ -63,12 +64,12 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
         projectId: { type: 'string', description: 'Project ID to create the task in (REQUIRED — from createProject or listProjects)' },
         title: { type: 'string', description: 'Task title (REQUIRED)' },
         description: { type: 'string', description: 'Task description (optional)' },
-        parentTaskId: { type: 'string', description: 'Parent task ID to nest this task under as a subtask (optional — from createTask or listTasks)' },
+        parentTaskId: { type: 'string', description: 'Parent task ID or taskRef to nest this task under as a subtask (optional — from createTask or listTasks)' },
         priority: { type: 'string', enum: ['critical', 'high', 'medium', 'low'], description: 'Task priority (default: medium)' },
         dueDate: { type: 'number', description: 'Due date as Unix timestamp in milliseconds (e.g., Date.now() + 86400000 for tomorrow)' },
         assignee: { type: 'string', description: 'Assignee name or identifier (optional)' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Tags for categorization (optional)' },
-        dependsOn: { type: 'array', items: { type: 'string' }, description: 'Task IDs this task depends on — creates DAG edges. Task cannot start until all dependencies are done. Cycles are rejected with an error.' },
+        dependsOn: { type: 'array', items: { type: 'string' }, description: 'Task IDs or taskRefs this task depends on — creates DAG edges. Task cannot start until all dependencies are done. Cycles are rejected with an error.' },
         linkedNotes: {
           type: 'array',
           description: 'Vault notes to link to this task. Each item is EITHER a plain string vault path (linkType defaults to "reference") OR an object { notePath, linkType } to set the relationship explicitly. linkType values: input = the task DEPENDS ON / CONSUMES this note (required source material; a precondition — forms a data-flow edge). output = the task PRODUCES this note (the artifact/result — forms a data-flow edge). reference = related/contextual note the task does NOT consume (association only, not part of the data flow). Links can also be added or changed after creation via the linkNote tool or updateTask addNoteLinks.',
@@ -97,7 +98,8 @@ export class CreateTaskTool extends BaseTool<CreateTaskParameters, CreateTaskRes
       type: 'object',
       properties: {
         success: { type: 'boolean' },
-        taskId: { type: 'string', description: 'ID of the created task' },
+        taskId: { type: 'string', description: 'Internal UUID of the created task' },
+        taskRef: { type: 'string', description: 'Short task reference, e.g. T-1a2b3c4d. Prefer this as taskId in later task operations.' },
         error: { type: 'string' }
       }
     };

--- a/src/agents/taskManager/tools/tasks/listTasks.ts
+++ b/src/agents/taskManager/tools/tasks/listTasks.ts
@@ -19,7 +19,7 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
     super(
       'list',
       'List Tasks',
-      'List tasks in a project with optional filters for status (todo/in_progress/done/cancelled), priority, assignee, and parentTaskId. Returns paginated task objects with full metadata including timestamps and linked vault notes (noteLinks, each with notePath + linkType: input/output/reference).',
+      'List tasks in a project with optional filters for status (todo/in_progress/done/cancelled), priority, assignee, and parentTaskId. Returns paginated task objects with full metadata, short taskRef, timestamps, and linked vault notes (noteLinks, each with notePath + linkType: input/output/reference).',
       '1.0.0'
     );
   }
@@ -66,7 +66,7 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
         status: { type: 'string', enum: ['todo', 'in_progress', 'done', 'cancelled'], description: 'Filter by task status' },
         priority: { type: 'string', enum: ['critical', 'high', 'medium', 'low'], description: 'Filter by priority' },
         assignee: { type: 'string', description: 'Filter by assignee' },
-        parentTaskId: { type: 'string', description: 'Filter by parent task (subtasks of this task)' },
+        parentTaskId: { type: 'string', description: 'Filter by parent task ID or taskRef (subtasks of this task)' },
         includeSubtasks: { type: 'boolean', description: 'Include subtasks in results (default: true)' },
         sortBy: { type: 'string', enum: ['created', 'updated', 'priority', 'title', 'dueDate'], description: 'Sort field (default: updated)' },
         sortOrder: { type: 'string', enum: ['asc', 'desc'], description: 'Sort direction (default: desc)' },
@@ -93,7 +93,8 @@ export class ListTasksTool extends BaseTool<ListTasksParameters, ListTasksResult
           items: {
             type: 'object',
             properties: {
-              id: { type: 'string', description: 'Task ID (use as taskId in other task operations)' },
+              id: { type: 'string', description: 'Internal task UUID' },
+              taskRef: { type: 'string', description: 'Short task reference, e.g. T-1a2b3c4d. Prefer this as taskId in updateTask, moveTask, linkNote, and dependency operations.' },
               projectId: { type: 'string', description: 'Parent project ID' },
               workspaceId: { type: 'string', description: 'Parent workspace ID' },
               parentTaskId: { type: 'string', description: 'Parent task ID if this is a subtask (null if top-level)' },

--- a/src/agents/taskManager/tools/tasks/moveTask.ts
+++ b/src/agents/taskManager/tools/tasks/moveTask.ts
@@ -12,14 +12,15 @@ import { MoveTaskParameters, MoveTaskResult } from '../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { createErrorMessage } from '../../../../utils/errorUtils';
 import { ToolStatusTense } from '../../../interfaces/ITool';
-import { verbs, labelWithId } from '../../../utils/toolStatusLabels';
+import { verbs } from '../../../utils/toolStatusLabels';
+import { formatTaskRefForLabel } from '../../utils/taskRefs';
 
 export class MoveTaskTool extends BaseTool<MoveTaskParameters, MoveTaskResult> {
   constructor(private taskService: TaskService) {
     super(
       'move',
       'Move Task',
-      'Move a task to a different project within the same workspace, or change its parent task (set parentTaskId to nest as subtask, null to make top-level). Requires a taskId (from createTask or listTasks).',
+      'Move a task to a different project within the same workspace, or change its parent task (set parentTaskId to nest as subtask, null to make top-level). Requires a taskId or short taskRef (from createTask or listTasks).',
       '1.0.0'
     );
   }
@@ -48,11 +49,11 @@ export class MoveTaskTool extends BaseTool<MoveTaskParameters, MoveTaskResult> {
     return this.getMergedSchema({
       type: 'object',
       properties: {
-        taskId: { type: 'string', description: 'Task ID to move (REQUIRED — from createTask or listTasks)' },
+        taskId: { type: 'string', description: 'Task ID or short taskRef to move (REQUIRED — from createTask or listTasks)' },
         projectId: { type: 'string', description: 'Target project ID to move the task to (from createProject or listProjects — must be in the same workspace)' },
         parentTaskId: {
           type: ['string', 'null'],
-          description: 'New parent task ID (null to make top-level, string to nest under another task)'
+          description: 'New parent task ID or taskRef (null to make top-level, string to nest under another task)'
         }
       },
       required: ['taskId']
@@ -61,7 +62,8 @@ export class MoveTaskTool extends BaseTool<MoveTaskParameters, MoveTaskResult> {
 
   getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
     const v = verbs('Moving task', 'Moved task', 'Failed to move task');
-    return labelWithId(v, params, tense, { keys: ['taskId'], fallback: 'task' });
+    const taskId = typeof params?.taskId === 'string' ? formatTaskRefForLabel(params.taskId) : 'task';
+    return `${v[tense]} ${taskId}`;
   }
 
   getResultSchema(): JSONSchema {

--- a/src/agents/taskManager/tools/tasks/queryTasks.ts
+++ b/src/agents/taskManager/tools/tasks/queryTasks.ts
@@ -19,7 +19,7 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
     super(
       'query',
       'Query Tasks',
-      'DAG-aware queries on a project\'s tasks. Three query types: nextActions returns tasks ready to start (status=todo and all dependencies done), blockedTasks returns tasks waiting on incomplete dependencies with their blocker details, dependencyTree returns the full upstream/downstream dependency graph for a specific task. Requires projectId; dependencyTree also requires taskId.',
+      'DAG-aware queries on a project\'s tasks. Three query types: nextActions returns tasks ready to start (status=todo and all dependencies done), blockedTasks returns tasks waiting on incomplete dependencies with their blocker details, dependencyTree returns the full upstream/downstream dependency graph for a specific task. Requires projectId; dependencyTree also requires taskId or short taskRef.',
       '1.0.0'
     );
   }
@@ -70,7 +70,7 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
           enum: ['nextActions', 'blockedTasks', 'dependencyTree'],
           description: 'Query type (REQUIRED). nextActions: tasks with status=todo whose dependencies are all done — these are ready to start. blockedTasks: tasks waiting on incomplete dependencies, returned with their blocker details. dependencyTree: full upstream/downstream dependency graph for a specific task (requires taskId).'
         },
-        taskId: { type: 'string', description: 'Task ID (REQUIRED for dependencyTree query — from createTask or listTasks)' }
+        taskId: { type: 'string', description: 'Task ID or short taskRef (REQUIRED for dependencyTree query — from createTask or listTasks)' }
       },
       required: ['projectId', 'query']
     });
@@ -85,7 +85,8 @@ export class QueryTasksTool extends BaseTool<QueryTasksParameters, QueryTasksRes
     const taskObjectSchema: JSONSchema = {
       type: 'object',
       properties: {
-        id: { type: 'string', description: 'Task ID' },
+        id: { type: 'string', description: 'Internal task UUID' },
+        taskRef: { type: 'string', description: 'Short task reference, e.g. T-1a2b3c4d. Prefer this as taskId in updateTask, moveTask, linkNote, and dependency operations.' },
         projectId: { type: 'string', description: 'Parent project ID' },
         workspaceId: { type: 'string', description: 'Parent workspace ID' },
         parentTaskId: { type: 'string', description: 'Parent task ID if subtask (null if top-level)' },

--- a/src/agents/taskManager/tools/tasks/updateTask.ts
+++ b/src/agents/taskManager/tools/tasks/updateTask.ts
@@ -12,14 +12,15 @@ import { UpdateTaskParameters, UpdateTaskResult } from '../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { createErrorMessage } from '../../../../utils/errorUtils';
 import { ToolStatusTense } from '../../../interfaces/ITool';
-import { verbs, labelWithId } from '../../../utils/toolStatusLabels';
+import { verbs } from '../../../utils/toolStatusLabels';
+import { formatTaskRefForLabel } from '../../utils/taskRefs';
 
 export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskResult> {
   constructor(private taskService: TaskService) {
     super(
       'update',
       'Update Task',
-      'Update task fields (title, description, status, priority, dueDate, assignee, tags), manage DAG dependencies (addDependencies/removeDependencies), and manage note links (addNoteLinks/removeNoteLinks). Dependency additions are validated for cycles. Requires a taskId (from createTask or listTasks).',
+      'Update task fields (title, description, status, priority, dueDate, assignee, tags), manage DAG dependencies (addDependencies/removeDependencies), and manage note links (addNoteLinks/removeNoteLinks). Dependency additions are validated for cycles. Requires a taskId or short taskRef (from createTask or listTasks).',
       '1.0.0'
     );
   }
@@ -86,7 +87,7 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
     return this.getMergedSchema({
       type: 'object',
       properties: {
-        taskId: { type: 'string', description: 'Task ID to update (REQUIRED — from createTask or listTasks)' },
+        taskId: { type: 'string', description: 'Task ID or short taskRef to update (REQUIRED — from createTask or listTasks)' },
         title: { type: 'string', description: 'New task title' },
         description: { type: 'string', description: 'New task description' },
         status: { type: 'string', enum: ['todo', 'in_progress', 'done', 'cancelled'], description: 'New task status (setting to done auto-records completedAt timestamp)' },
@@ -94,8 +95,8 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
         dueDate: { type: 'number', description: 'New due date as Unix timestamp in milliseconds (e.g., Date.now() + 86400000 for tomorrow)' },
         assignee: { type: 'string', description: 'New assignee name or identifier' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Replace entire tags array with these values' },
-        addDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs to add as DAG dependencies — this task cannot start until these are done. Cycles are rejected with an error.' },
-        removeDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs to remove from this task\'s dependencies' },
+        addDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs or taskRefs to add as DAG dependencies — this task cannot start until these are done. Cycles are rejected with an error.' },
+        removeDependencies: { type: 'array', items: { type: 'string' }, description: 'Task IDs or taskRefs to remove from this task\'s dependencies' },
         addNoteLinks: {
           type: 'array',
           description: 'Vault notes to link to this task',
@@ -117,7 +118,8 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
 
   getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
     const v = verbs('Updating task', 'Updated task', 'Failed to update task');
-    return labelWithId(v, params, tense, { keys: ['taskId'], fallback: 'task' });
+    const taskId = typeof params?.taskId === 'string' ? formatTaskRefForLabel(params.taskId) : 'task';
+    return `${v[tense]} ${taskId}`;
   }
 
   getResultSchema(): JSONSchema {

--- a/src/agents/taskManager/types.ts
+++ b/src/agents/taskManager/types.ts
@@ -72,6 +72,7 @@ export interface TaskNoteLink {
  * the storage interface. Mirrors the UI's TaskBoardDataController enrichment pattern.
  */
 export interface TaskWithNoteLinks extends TaskMetadata {
+  taskRef: string;
   noteLinks: TaskNoteLink[];
 }
 
@@ -298,6 +299,7 @@ export type ArchiveProjectResult = CommonResult
 
 export interface CreateTaskResult extends CommonResult {
   taskId?: string;
+  taskRef?: string;
 }
 
 export interface ListTasksResult extends CommonResult {

--- a/src/agents/taskManager/utils/taskRefs.ts
+++ b/src/agents/taskManager/utils/taskRefs.ts
@@ -1,0 +1,45 @@
+const TASK_REF_PREFIX = 'T-';
+const TASK_REF_LENGTH = 8;
+
+function compactTaskId(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/**
+ * Human-facing short reference for task IDs. UUIDs remain the storage key; refs
+ * are a compact alias for tool calls and status labels.
+ */
+export function formatTaskRef(taskId: string): string {
+  const compact = compactTaskId(taskId);
+  const suffix = compact.length > 0 ? compact.slice(0, TASK_REF_LENGTH) : taskId.trim().slice(0, TASK_REF_LENGTH);
+  return `${TASK_REF_PREFIX}${suffix}`;
+}
+
+/**
+ * Extract the normalized ID prefix represented by a task ref. Accepts the
+ * canonical `T-1a2b3c4d` shape and a bare compact prefix for convenience.
+ */
+export function taskRefToIdPrefix(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const prefixed = trimmed.match(/^t(?:ask)?[-_: ]?([a-z0-9][a-z0-9-_: ]{3,})$/i);
+  if (prefixed) {
+    return compactTaskId(prefixed[1]);
+  }
+
+  const compact = compactTaskId(trimmed);
+  if (/^[a-f0-9]{6,32}$/i.test(compact)) {
+    return compact;
+  }
+
+  return null;
+}
+
+export function formatTaskRefForLabel(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return 'task';
+  if (/^t(?:ask)?[-_: ]/i.test(trimmed)) return trimmed;
+  if (trimmed.length > 12) return formatTaskRef(trimmed);
+  return trimmed;
+}

--- a/src/database/repositories/TaskRepository.ts
+++ b/src/database/repositories/TaskRepository.ts
@@ -372,6 +372,22 @@ export class TaskRepository
     return rows.map(row => this.rowToEntity(row));
   }
 
+  async getByIdPrefix(prefix: string): Promise<TaskMetadata[]> {
+    const compactPrefix = prefix.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+    if (compactPrefix.length === 0) {
+      return [];
+    }
+
+    const rows = await this.sqliteCache.query<TaskRow>(
+      `SELECT * FROM tasks
+       WHERE LOWER(REPLACE(id, '-', '')) LIKE ?
+       ORDER BY created ASC
+       LIMIT 2`,
+      [`${compactPrefix}%`]
+    );
+    return rows.map(row => this.rowToEntity(row));
+  }
+
   async getDependencies(taskId: string): Promise<TaskMetadata[]> {
     const rows = await this.sqliteCache.query<TaskRow>(
       `SELECT t.* FROM tasks t

--- a/src/database/repositories/interfaces/ITaskRepository.ts
+++ b/src/database/repositories/interfaces/ITaskRepository.ts
@@ -131,6 +131,14 @@ export interface ITaskRepository extends IRepository<TaskMetadata> {
   getByStatus(projectId: string, status: TaskStatus): Promise<TaskMetadata[]>;
 
   /**
+   * Find tasks whose normalized ID starts with the given compact prefix.
+   *
+   * Used for human-facing short task refs. Callers should treat more than one
+   * result as ambiguous and ask for a longer/full ID.
+   */
+  getByIdPrefix(prefix: string): Promise<TaskMetadata[]>;
+
+  /**
    * Get tasks that this task depends ON (upstream dependencies)
    */
   getDependencies(taskId: string): Promise<TaskMetadata[]>;

--- a/tests/unit/TaskManagerTools.test.ts
+++ b/tests/unit/TaskManagerTools.test.ts
@@ -323,6 +323,7 @@ describe('TaskManager Tools', () => {
 
       expect(result.success).toBe(true);
       expect(result.taskId).toBe('task-new');
+      expect(result.taskRef).toBe('T-tasknew');
     });
 
     it('should return error when projectId missing', async () => {
@@ -428,6 +429,7 @@ describe('TaskManager Tools', () => {
     it('result schema advertises noteLinks items with required notePath + linkType', () => {
       const schema = tool.getResultSchema() as Record<string, any>;
       const taskItem = schema.properties.tasks.items;
+      expect(taskItem.properties.taskRef).toBeDefined();
       expect(taskItem.properties.noteLinks).toBeDefined();
       const noteLinkItem = taskItem.properties.noteLinks.items;
       expect(noteLinkItem.required).toEqual(['notePath', 'linkType']);
@@ -466,6 +468,15 @@ describe('TaskManager Tools', () => {
       const result = await tool.execute({ ...baseParams, taskId: '' });
       expect(result.success).toBe(false);
       expect(result.error).toContain('taskId');
+    });
+
+    it('should shorten UUID task IDs in status labels', () => {
+      const label = tool.getStatusLabel(
+        { taskId: '12345678-90ab-cdef-1234-567890abcdef' },
+        'present'
+      );
+
+      expect(label).toBe('Updating task T-12345678');
     });
 
     it('should add dependencies', async () => {

--- a/tests/unit/TaskRepository.test.ts
+++ b/tests/unit/TaskRepository.test.ts
@@ -167,6 +167,27 @@ describe('TaskRepository', () => {
     });
   });
 
+  describe('getByIdPrefix', () => {
+    it('queries normalized ID prefixes and maps matching rows', async () => {
+      (deps.sqliteCache.query as jest.Mock).mockResolvedValue([{ ...sampleRow }]);
+
+      const result = await repo.getByIdPrefix('task-1');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('task-1');
+      const queryCall = (deps.sqliteCache.query as jest.Mock).mock.calls[0];
+      expect(queryCall[0]).toContain("LOWER(REPLACE(id, '-', '')) LIKE ?");
+      expect(queryCall[1]).toEqual(['task1%']);
+    });
+
+    it('returns empty results for an empty prefix', async () => {
+      const result = await repo.getByIdPrefix('---');
+
+      expect(result).toEqual([]);
+      expect(deps.sqliteCache.query).not.toHaveBeenCalled();
+    });
+  });
+
   // ============================================================================
   // create
   // ============================================================================

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -79,6 +79,7 @@ function createMockTaskRepo(): jest.Mocked<ITaskRepository> {
     getByProject: jest.fn(),
     getByWorkspace: jest.fn(),
     getByStatus: jest.fn(),
+    getByIdPrefix: jest.fn(),
     getDependencies: jest.fn(),
     getDependents: jest.fn(),
     getChildren: jest.fn(),
@@ -558,6 +559,7 @@ describe('TaskService', () => {
       const result = await service.listTasks('proj-1');
 
       expect(taskRepo.getNoteLinks).toHaveBeenCalledWith('t1');
+      expect(result.items[0].taskRef).toBe('T-t1');
       expect(result.items[0].noteLinks).toEqual([
         { notePath: 'notes/source.md', linkType: 'input' },
         { notePath: 'notes/result.md', linkType: 'output' }
@@ -719,6 +721,35 @@ describe('TaskService', () => {
       expect(taskRepo.update).toHaveBeenCalledWith('task-1', expect.objectContaining({
         title: 'Updated Title'
       }));
+    });
+
+    it('should resolve a short taskRef before updating status', async () => {
+      const task = createMockTask({ id: '12345678-90ab-cdef-1234-567890abcdef' });
+      taskRepo.getById.mockImplementation(async (id: string) => (
+        id === task.id ? task : null
+      ));
+      taskRepo.getByIdPrefix.mockResolvedValue([task]);
+
+      await service.updateTask('T-12345678', { status: 'in_progress' });
+
+      expect(taskRepo.getByIdPrefix).toHaveBeenCalledWith('12345678');
+      expect(taskRepo.update).toHaveBeenCalledWith(task.id, expect.objectContaining({
+        status: 'in_progress'
+      }));
+    });
+
+    it('should reject ambiguous short taskRefs', async () => {
+      taskRepo.getById.mockResolvedValue(null);
+      taskRepo.getByIdPrefix.mockResolvedValue([
+        createMockTask({ id: '12345678-0000-0000-0000-000000000000' }),
+        createMockTask({ id: '12345678-ffff-ffff-ffff-ffffffffffff' })
+      ]);
+
+      await expect(
+        service.updateTask('T-12345678', { status: 'done' })
+      ).rejects.toThrow('ambiguous');
+
+      expect(taskRepo.update).not.toHaveBeenCalled();
     });
 
     it('should throw if task not found', async () => {


### PR DESCRIPTION
## Summary
- Add compact taskRef aliases such as T-12345678 for task manager read surfaces.
- Accept short refs anywhere task operations previously required UUID task IDs.
- Shorten task update/move status labels and cover the behavior with unit tests.

## Validation
- npm run build
- npm test