### PR TITLE
[codex] Use Obsidian file manager for moves

### DIFF
--- a/src/agents/storageManager/tools/move.ts
+++ b/src/agents/storageManager/tools/move.ts
@@ -28,7 +28,7 @@ export class MoveTool extends BaseTool<MoveParams, MoveResult> {
     super(
       'move',
       'Move',
-      'Move or rename a file or folder',
+      'Move or rename a file or folder and update internal links when enabled',
       '1.0.0'
     );
 
@@ -100,7 +100,7 @@ export class MoveTool extends BaseTool<MoveParams, MoveResult> {
         },
         newPath: {
           type: 'string',
-          description: 'Destination path'
+          description: 'Destination path. Uses Obsidian rename semantics, so internal links are updated when enabled in Obsidian settings.'
         },
         overwrite: {
           type: 'boolean',
@@ -109,7 +109,7 @@ export class MoveTool extends BaseTool<MoveParams, MoveResult> {
         }
       },
       required: ['path', 'newPath'],
-      description: 'Move or rename a file or folder (auto-detects type)'
+      description: 'Move or rename a file or folder (auto-detects type). Uses Obsidian rename semantics, so internal links are updated when enabled in Obsidian settings.'
     };
 
     // Merge with common schema (sessionId and context)

--- a/src/agents/storageManager/utils/FileOperations.ts
+++ b/src/agents/storageManager/utils/FileOperations.ts
@@ -197,7 +197,7 @@ export class FileOperations {
       await FileOperations.ensureFolder(app, folderPath);
     }
     
-    await app.vault.rename(file, normalizedNewPath);
+    await app.fileManager.renameFile(file, normalizedNewPath);
   }
   
   /**
@@ -244,7 +244,7 @@ export class FileOperations {
       await FileOperations.ensureFolder(app, parentPath);
     }
     
-    await app.vault.rename(folder, normalizedNewPath);
+    await app.fileManager.renameFile(folder, normalizedNewPath);
   }
   
   /**

--- a/src/core/VaultOperations.ts
+++ b/src/core/VaultOperations.ts
@@ -431,7 +431,7 @@ export class VaultOperations {
         return false;
       }
       
-      await this.vault.rename(sourceFile, normalizedTarget);
+      await this.app.fileManager.renameFile(sourceFile, normalizedTarget);
       this.fileCache.delete(normalizedSource);
       
       this.logger.debug(`Moved file from ${sourcePath} to ${targetPath}`);

--- a/tests/unit/FileOperations.test.ts
+++ b/tests/unit/FileOperations.test.ts
@@ -1,0 +1,46 @@
+import { App, TFile, TFolder } from 'obsidian';
+import { FileOperations } from '../../src/agents/storageManager/utils/FileOperations';
+
+function makeApp(filesByPath: Map<string, TFile | TFolder>): {
+  app: App;
+  renameFile: jest.Mock<Promise<void>, [TFile | TFolder, string]>;
+  vaultRename: jest.Mock<Promise<void>, [TFile | TFolder, string]>;
+} {
+  const renameFile = jest.fn<Promise<void>, [TFile | TFolder, string]>().mockResolvedValue(undefined);
+  const vaultRename = jest.fn<Promise<void>, [TFile | TFolder, string]>().mockResolvedValue(undefined);
+
+  const app = {
+    vault: {
+      getAbstractFileByPath: (path: string) => filesByPath.get(path) ?? null,
+      rename: vaultRename,
+    },
+    fileManager: {
+      renameFile,
+      trashFile: jest.fn<Promise<void>, [TFile | TFolder]>().mockResolvedValue(undefined),
+    },
+  } as unknown as App;
+
+  return { app, renameFile, vaultRename };
+}
+
+describe('FileOperations move helpers', () => {
+  it('moves notes through FileManager so Obsidian can update links', async () => {
+    const file = new TFile('Old.md', 'Old.md');
+    const { app, renameFile, vaultRename } = makeApp(new Map([['Old.md', file]]));
+
+    await FileOperations.moveNote(app, 'Old.md', 'New.md');
+
+    expect(renameFile).toHaveBeenCalledWith(file, 'New.md');
+    expect(vaultRename).not.toHaveBeenCalled();
+  });
+
+  it('moves folders through FileManager so Obsidian can update links', async () => {
+    const folder = new TFolder('Old folder');
+    const { app, renameFile, vaultRename } = makeApp(new Map([['Old folder', folder]]));
+
+    await FileOperations.moveFolder(app, 'Old folder', 'New folder');
+
+    expect(renameFile).toHaveBeenCalledWith(folder, 'New folder');
+    expect(vaultRename).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- route storage move/rename operations through Obsidian FileManager.renameFile
- update legacy VaultOperations move helper to use the same link-aware path
- add regression coverage for note and folder moves avoiding vault.rename

## Validation
- npx jest tests/unit/FileOperations.test.ts --runInBand
- npx tsc --noEmit --skipLibCheck
- npx eslint --no-warn-ignored src/agents/storageManager/utils/FileOperations.ts src/agents/storageManager/tools/move.ts src/core/VaultOperations.ts tests/unit/FileOperations.test.ts