### PR TITLE
[codex] Add video generation artifact jobs

### DIFF
--- a/docs/plans/async-artifact-jobs-and-research-plan.md
+++ b/docs/plans/async-artifact-jobs-and-research-plan.md
@@ -1,0 +1,176 @@
+# Async artifact jobs and deep research generation plan
+
+## Goal
+
+Add a shared completion pattern for long-running generated artifacts:
+
+- `generateVideo` starts video generation and saves completed MP4 output to the requested `outputPath`.
+- `generateResearch` starts deep research and saves completed Markdown output to the requested `outputPath`.
+- If the provider job outlives the tool call timeout, the tool result returns a structured `in_progress` payload with the provider job id, polling URL or response id, intended output path, and a human note explaining where the completed artifact should land.
+
+This keeps the chat/tool call useful even when the provider keeps working after the bot times out.
+
+## Provider research notes
+
+- OpenAI Responses API supports `background: true` and polling by response id with `GET /v1/responses/{response_id}`. OpenAI documents background response data retention as roughly 10 minutes, so Nexus should persist and poll promptly after timeout.
+  - Source: https://platform.openai.com/docs/guides/background
+  - Source: https://platform.openai.com/docs/guides/deep-research
+- Perplexity Sonar Deep Research supports async jobs through `POST /v1/async/sonar` and retrieval with `GET /v1/async/sonar/{request_id}`. Perplexity documents async job/result TTL as 7 days.
+  - Source: https://docs.perplexity.ai/docs/sonar/models/sonar-deep-research
+
+## Result contract
+
+Successful generated artifact tools should include:
+
+```ts
+{
+  status: "completed",
+  path: "Media/example.mp4",
+  provider: "openrouter",
+  model: "google/veo-3.1-lite",
+  note: "Video generation completed and saved to Media/example.mp4."
+}
+```
+
+Timed-out but recoverable generated artifact tools should include:
+
+```ts
+{
+  status: "in_progress",
+  path: "Research/topic.md",
+  provider: "openai",
+  model: "o3-deep-research",
+  providerJobId: "resp_...",
+  pollingUrl: "https://api.openai.com/v1/responses/resp_...",
+  note: "Research is still running. The requested output path is Research/topic.md; keep the provider job details so a follow-up status check can save the completed report there."
+}
+```
+
+The `note` is intentionally redundant with structured fields because LLM callers often preserve natural language better than nested metadata across turns.
+
+## Shared job registry
+
+Add `src/services/artifacts/ArtifactJobStore.ts`.
+
+Storage:
+
+- Vault path: `<configured Nexus storage root>/data/artifact-jobs.jsonl`, for example `Nexus/data/artifact-jobs.jsonl` or `Assistant data/data/artifact-jobs.jsonl`.
+- Resolve the root with `resolveVaultRoot(settings).dataPath`; never hardcode `.nexus` or `Nexus`.
+- The data path uses `vault.adapter`, consistent with existing configurable Nexus data storage.
+- One event per state transition so interrupted writes do not corrupt the whole registry.
+
+Job shape:
+
+```ts
+type ArtifactJobKind = "video" | "research";
+type ArtifactJobStatus = "queued" | "in_progress" | "completed" | "failed" | "expired";
+
+interface ArtifactJobRecord {
+  id: string;
+  kind: ArtifactJobKind;
+  provider: string;
+  model: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  status: ArtifactJobStatus;
+  outputPath: string;
+  overwrite: boolean;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+  promptPreview: string;
+  error?: string;
+  result?: Record<string, unknown>;
+}
+```
+
+## New status/finalization tool
+
+Add `promptManager.checkGeneratedArtifact`.
+
+Inputs:
+
+- `jobId` or provider details from a previous timed-out tool call
+- optional `outputPath` override
+- optional `overwrite`
+
+Behavior:
+
+- Loads the saved job record if `jobId` is provided.
+- Polls the provider.
+- If complete, saves the artifact to `outputPath`.
+- Returns the same `status`, `path`, and `note` contract as `generateVideo` / `generateResearch`.
+
+This is the tool the bot should call after it times out or after the user asks “did it finish?”
+
+## `generateResearch`
+
+Tool slug: `generateResearch`
+
+Initial providers:
+
+- `openai`
+- `perplexity`
+
+Parameters:
+
+```ts
+interface GenerateResearchParams {
+  prompt: string;
+  provider?: "openai" | "perplexity";
+  model?: string;
+  outputPath: string;
+  overwrite?: boolean;
+  format?: "report" | "brief" | "markdown";
+  reasoningEffort?: "low" | "medium" | "high";
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+```
+
+Default behavior:
+
+- Resolve provider/model from new Research generation settings.
+- Require `outputPath` ending in `.md`.
+- Save Markdown with title, generated body, citations/sources, and provider metadata footer.
+- Return a completion note that says where the report exists.
+
+Provider adapters:
+
+- `OpenAIResearchAdapter`
+  - Start: `POST /responses` with `background: true`.
+  - Poll: `GET /responses/{response_id}`.
+  - Parse output text and URL citations from the response output array.
+  - Expiration hint: roughly 10 minutes.
+- `PerplexityResearchAdapter`
+  - Start: `POST /v1/async/sonar` with `request.model = "sonar-deep-research"`.
+  - Poll: `GET /v1/async/sonar/{request_id}`.
+  - Parse `response.choices[0].message.content`, citations, and usage if present.
+  - Expiration hint: 7 days.
+
+## Implementation sequence
+
+1. Finish `generateVideo` result notes and structured timeout results.
+2. Add `ArtifactJobStore` and `checkGeneratedArtifact`.
+3. Add research model/provider registry and defaults settings.
+4. Add `ResearchGenerationService` with OpenAI and Perplexity adapters.
+5. Add `generateResearch` PromptManager tool and dynamic registration.
+6. Add unit tests for timeout job persistence, successful finalization, OpenAI response parsing, and Perplexity async response parsing.
+7. Add gated live smoke tests:
+   - OpenAI background timeout/retrieve without requiring a large paid report.
+   - Perplexity async submit/retrieve with paid execution opt-in.
+
+## Current implementation slice
+
+`generateVideo` now:
+
+- `status: "completed"` and a saved-path note on success.
+- Persists timed-out video jobs to `<configured Nexus storage root>/data/artifact-jobs.jsonl`.
+- Returns `status: "in_progress"`, Nexus `jobId`, provider job details, and an output-path note when the provider is still running after the tool timeout.
+
+`checkGeneratedArtifact` now:
+
+- Loads a saved generated artifact job by `jobId`.
+- Supports video jobs for Google and OpenRouter.
+- Polls the provider, saves the completed MP4 to the original `outputPath`, and updates the job record to `completed`, `in_progress`, or `failed`.
+- Returns the same `status`, `path`, and `note` contract planned for future generated artifact tools.

--- a/docs/plans/text-to-video-generation-plan.md
+++ b/docs/plans/text-to-video-generation-plan.md
@@ -1,0 +1,348 @@
+# Text-To-Video Generation Plan
+
+## Goal
+
+Add a PromptManager `generateVideo` tool and default video generation settings, following the same product shape as `generateAudio`: a small tool, a service that resolves defaults, provider adapters, and binary output saved directly to the vault.
+
+## Research Summary
+
+Primary provider recommendation: support Google direct and OpenRouter.
+
+Why:
+- Google documents direct text-to-video generation through `models.generateVideos` / REST `predictLongRunning`.
+- The API is explicitly asynchronous and returns a long-running operation that must be polled before downloading the MP4.
+- Veo 3.1 supports text-to-video, image-to-video, audio prompting, aspect ratio, and resolution controls.
+- It aligns with the current image generation stack, which already supports Google image models and vault reference images.
+- OpenRouter now exposes a dedicated asynchronous video generation API (`POST /api/v1/videos`) and a video model discovery endpoint (`GET /api/v1/videos/models`).
+- OpenRouter normalizes model differences across resolution, duration, aspect ratio, audio generation, frame images, and reference images, which matches the dynamic provider/model pattern already used for image generation.
+- Keeping the first pass to Google + OpenRouter mirrors the existing image-generation product surface and avoids adding another credentials system.
+
+Do not use OpenAI Sora as the primary provider.
+
+Why:
+- OpenAI's Videos API exists, but the current official docs state that Sora 2 video generation models and the Videos API are deprecated and will shut down on September 24, 2026.
+- If added, it should be behind an explicit deprecated/experimental adapter flag and not be the default path.
+
+Sources:
+- OpenAI Videos API: https://developers.openai.com/api/docs/guides/video-generation
+- Google Veo in Gemini API: https://ai.google.dev/gemini-api/docs/video
+- OpenRouter video generation docs: https://openrouter.ai/docs/guides/overview/multimodal/video-generation
+- OpenRouter video models endpoint: https://openrouter.ai/docs/api/api-reference/video-generation/list-videos-models/
+
+## Existing Repo Pattern
+
+Use these as the implementation template:
+
+- `src/agents/promptManager/tools/generateAudio.ts`
+- `src/services/audio/AudioGenerationService.ts`
+- `src/agents/promptManager/tools/generateImage.ts`
+- `src/services/llm/ImageGenerationService.ts`
+- `src/services/llm/types/SpeechTypes.ts`
+- `src/settings/tabs/DefaultsTab.ts`
+
+The important patterns:
+- Tool handles schema, status label, and error wrapping only.
+- Service validates path, resolves defaults, calls provider adapter, writes binary output with `vault.createBinary()`.
+- Defaults live in `LLMProviderSettings`, not in the tool.
+- Tool registration is conditional on configured providers.
+- Obsidian API rules apply: use `requestUrl()`, `normalizePath()`, `vault.createBinary()`, no inline styles, no dynamic `innerHTML`.
+
+## Proposed API
+
+Tool slug: `generateVideo`
+
+Parameters:
+
+```ts
+export interface GenerateVideoParams extends CommonParameters {
+  prompt: string;
+  provider?: 'google' | 'openrouter';
+  model?: string;
+  outputPath: string;
+  overwrite?: boolean;
+  aspectRatio?: '16:9' | '9:16' | '1:1';
+  resolution?: '720p' | '1080p' | '4k';
+  seconds?: number;
+  referenceImage?: string;
+  generateAudio?: boolean;
+  negativePrompt?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+```
+
+Initial v1 should support:
+- `prompt`
+- `provider`
+- `model`
+- `outputPath`
+- `overwrite`
+- `aspectRatio`
+- `resolution`
+- `referenceImage`
+
+Defer:
+- video extension
+- video edit/remix
+- character assets
+- batch queue
+- thumbnail/spritesheet download
+- webhooks
+
+Result:
+
+```ts
+export interface GenerateVideoResult {
+  path: string;
+  provider: VideoProvider;
+  model: string;
+  mimeType: 'video/mp4';
+  promptLength: number;
+  videoSize: number;
+  durationSeconds?: number;
+  aspectRatio?: string;
+  resolution?: string;
+  providerJobId?: string;
+}
+```
+
+## Types And Model Registry
+
+Add `src/services/llm/types/VideoTypes.ts`.
+
+Suggested declarations:
+
+```ts
+export type VideoProvider = 'google' | 'openrouter';
+export type VideoExecution = 'long-running-operation';
+export type VideoAspectRatio = '16:9' | '9:16' | '1:1';
+export type VideoResolution = '720p' | '1080p' | '4k';
+
+export interface VideoModelDeclaration {
+  provider: VideoProvider;
+  id: string;
+  name: string;
+  execution: VideoExecution;
+  supportsReferenceImage: boolean;
+  supportsAudioPrompting: boolean;
+  aspectRatios: VideoAspectRatio[];
+  resolutions: VideoResolution[];
+  defaultAspectRatio: VideoAspectRatio;
+  defaultResolution: VideoResolution;
+  maxSeconds?: number;
+}
+```
+
+Initial models:
+
+```ts
+[
+  {
+    provider: 'google',
+    id: 'veo-3.1-generate-preview',
+    name: 'Veo 3.1',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16', '1:1'],
+    resolutions: ['720p', '1080p', '4k'],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p'
+  },
+  {
+    provider: 'openrouter',
+    id: 'google/veo-3.1-fast',
+    name: 'Google: Veo 3.1 Fast via OpenRouter',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16', '1:1'],
+    resolutions: ['720p', '1080p'],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p'
+  }
+]
+```
+
+OpenRouter models should be discovered dynamically from `/api/v1/videos/models` where practical, with a small static fallback for offline schema generation and tests.
+
+## Settings
+
+Extend `src/types/llm/ProviderTypes.ts`:
+
+```ts
+export interface DefaultVideoModelSettings {
+  provider: 'google' | 'openrouter';
+  model: string;
+  aspectRatio?: VideoAspectRatio;
+  resolution?: VideoResolution;
+}
+
+export interface LLMProviderSettings {
+  defaultVideoModel?: DefaultVideoModelSettings;
+}
+```
+
+Default:
+
+```ts
+defaultVideoModel: {
+  provider: 'google',
+  model: 'veo-3.1-generate-preview',
+  aspectRatio: '16:9',
+  resolution: '720p'
+}
+```
+
+Settings UI:
+- Add a "Video generation" group to `DefaultsTab`, near image and voice defaults.
+- Provider dropdown: configured video-capable providers only.
+- Model dropdown: provider-scoped video models.
+- Aspect ratio dropdown: model-supported ratios.
+- Resolution dropdown: model-supported resolutions.
+- Show a warning if the selected provider is disabled or lacks an API key.
+
+No mockup is required for this small settings addition unless we redesign the whole defaults tab.
+
+## Service And Adapters
+
+Add:
+- `src/services/video/VideoGenerationService.ts`
+- `src/services/video/VideoGenerationTypes.ts`
+- `src/services/video/adapters/GoogleVideoAdapter.ts`
+- `src/services/video/adapters/OpenRouterVideoAdapter.ts`
+
+Service responsibilities:
+- Resolve provider/model/defaults.
+- Validate prompt.
+- Validate and normalize `outputPath`.
+- Validate reference image path with vault APIs.
+- Check existing file and `overwrite`.
+- Call adapter.
+- Save MP4 with `vault.createBinary()`.
+- Return lean metadata.
+
+Adapter interface:
+
+```ts
+export interface VideoGenerationAdapter {
+  readonly provider: VideoProvider;
+  isAvailable(): boolean;
+  generate(request: ResolvedVideoGenerationRequest): Promise<VideoGenerationAdapterResult>;
+}
+```
+
+Google adapter flow:
+- Start operation with `POST https://generativelanguage.googleapis.com/v1beta/models/{model}:predictLongRunning`.
+- Poll `GET https://generativelanguage.googleapis.com/v1beta/{operationName}` every 10 seconds by default.
+- Extract video URI from the completed response.
+- Download the MP4 with the same API key header.
+- Return `ArrayBuffer` and metadata.
+
+OpenRouter adapter flow:
+- Fetch/cached model metadata from `GET https://openrouter.ai/api/v1/videos/models`.
+- Submit generation with `POST https://openrouter.ai/api/v1/videos`.
+- Poll `GET https://openrouter.ai/api/v1/videos/{jobId}` or the returned `polling_url`.
+- When complete, download MP4 from `GET https://openrouter.ai/api/v1/videos/{jobId}/content` or an unsigned URL returned by the job status.
+- Return `ArrayBuffer`, model metadata, and provider job ID.
+
+Implementation note:
+- Use `requestUrl()`, not `fetch()`.
+- Use JSON REST first. Do not add `@google/genai` unless we hit a REST limitation.
+- Avoid Node-only modules so mobile compatibility is not worsened.
+
+## PromptManager Integration
+
+Add:
+- `src/agents/promptManager/tools/generateVideo.ts`
+- export from `src/agents/promptManager/tools/index.ts`
+- register in `PromptManagerAgent`
+
+Registration:
+- `shouldHaveGenerateVideo(settings)` returns true when Google or OpenRouter is enabled and configured.
+- On settings change, mirror the existing image/audio unregister/register refresh logic.
+
+Tool status label:
+- Running: `Generating video`
+- Success: `Generated video`
+- Failure: `Failed to generate video`
+
+Trace display:
+- Add `generateVideo` to `src/services/trace/TraceContentFormatter.ts`.
+
+Docs/schema:
+- Regenerate tool schemas after implementation.
+- Update `docs/TOOL_REFERENCE.md` if that file is maintained manually.
+
+## File Storage
+
+Default output path should be explicit, like audio:
+- Required `outputPath`.
+- Usually `video/{slug-or-timestamp}.mp4`.
+
+Rationale:
+- Video files are large.
+- The caller should choose the destination.
+- This follows the artifact guidance already in `AGENTS.md`.
+
+Overwrite behavior:
+- Same as `AudioGenerationService`: refuse existing file unless `overwrite: true`.
+- For overwrite, write a temporary file first, then trash/rename so failed downloads do not corrupt an existing asset.
+
+## Testing Plan
+
+Unit tests:
+- default resolution picks explicit params before settings before first available provider
+- unavailable provider errors are actionable
+- invalid path rejected
+- existing output path rejected without overwrite
+- reference image missing rejected
+- Google adapter maps start/poll/download success
+- Google adapter handles failed operation status
+- Google adapter handles timeout
+- OpenRouter adapter maps model discovery, submit, poll, and download success
+- OpenRouter adapter validates requested resolution/aspect ratio/duration against model metadata when available
+- PromptManager registers/unregisters `generateVideo` when Google/OpenRouter config changes
+
+Manual test in Obsidian:
+- Configure Google API key.
+- Confirm settings show Video generation defaults.
+- Use MCP `getTools` and verify `promptManager_generateVideo` appears.
+- Generate a short 720p video to `video/test-veo.mp4`.
+- Confirm the MP4 exists in the vault and plays in Obsidian/system player.
+- Test existing path without `overwrite`.
+- Test with a reference image from the vault.
+- Configure OpenRouter API key.
+- Confirm OpenRouter video models populate in defaults.
+- Generate a short video through OpenRouter and confirm the saved MP4.
+
+## Phasing
+
+Phase 1: Google/OpenRouter text-to-video
+- Add types, defaults, settings UI, service, Google adapter, OpenRouter adapter, PromptManager tool, trace label, tests.
+
+Phase 2: image-to-video polish
+- Support `referenceImage` fully, including MIME detection and base64 upload body.
+- Consider image size/resolution validation before sending requests.
+
+Phase 3: model discovery polish
+- Cache OpenRouter video model metadata with a short TTL.
+- Use provider metadata to drive the tool schema where available.
+- Add richer validation/error messages for unsupported resolution, aspect ratio, duration, frame images, and reference images.
+
+Phase 4: advanced video workflows
+- Extend existing videos.
+- Edit existing videos.
+- Download thumbnail/spritesheet artifacts.
+- Add queue persistence in `.nexus/` for long-running jobs that outlive an Obsidian session.
+
+## Open Questions
+
+1. Should the first implementation expose only text-to-video, or include `referenceImage` from day one?
+2. Should long-running video job state be persisted immediately, or is in-memory polling acceptable for v1?
+3. Should video generation be desktop-only if provider downloads prove unreliable on mobile?
+4. Should OpenRouter default to `google/veo-3.1-fast`, `google/veo-3.1`, or dynamic "first available by configured defaults"?
+
+## Recommendation
+
+Ship phase 1 with Google direct and OpenRouter, text-to-video plus optional reference image if the payload is straightforward in implementation. Keep OpenAI Sora out as a direct provider because its API is deprecated; if users want it anyway, OpenRouter can expose it through the same normalized video API while it remains available.

--- a/src/agents/promptManager/promptManager.ts
+++ b/src/agents/promptManager/promptManager.ts
@@ -9,6 +9,8 @@ import {
   ExecutePromptsTool,
   GenerateAudioTool,
   GenerateImageTool,
+  GenerateVideoTool,
+  CheckGeneratedArtifactTool,
   SubagentTool,
 } from './tools';
 import type { SubagentExecutor } from '../../services/chat/SubagentExecutor';
@@ -24,6 +26,7 @@ import { App, Vault, EventRef } from 'obsidian';
 import { LLMSettingsNotifier } from '../../services/llm/LLMSettingsNotifier';
 import { LLMProviderSettings } from '../../types';
 import type { MigratableDatabase } from '../../database/schema/SchemaMigrator';
+import { resolveVaultRoot } from '../../database/storage/VaultRootResolver';
 
 /**
  * PromptManager Agent for custom prompt operations
@@ -199,6 +202,33 @@ export class PromptManagerAgent extends BaseAgent {
       });
     }
 
+    if (this.shouldHaveGenerateVideo(llmProviders)) {
+      const artifactJobsPath = this.getArtifactJobsPath();
+      this.registerLazyTool({
+        slug: 'generateVideo', name: 'Generate Video',
+        description: 'Generate text-to-video MP4 files in the vault using Google Veo or OpenRouter video models.',
+        version: '1.0.0',
+        factory: () => new GenerateVideoTool({
+          app: this.app,
+          vault: this.vault,
+          llmSettings: this.settings.settings.llmProviders ?? null,
+          artifactJobsPath,
+        }),
+      });
+
+      this.registerLazyTool({
+        slug: 'checkGeneratedArtifact', name: 'Check Generated Artifact',
+        description: 'Check a previously timed-out generated artifact job and save the completed output to its requested vault path.',
+        version: '1.0.0',
+        factory: () => new CheckGeneratedArtifactTool({
+          app: this.app,
+          vault: this.vault,
+          llmSettings: this.settings.settings.llmProviders ?? null,
+          artifactJobsPath,
+        }),
+      });
+    }
+
     // Register subagent tool (internal chat only - executor wired up separately)
     // Supports both spawn and cancel actions via action parameter
     this.subagentTool = new SubagentTool();
@@ -221,6 +251,10 @@ export class PromptManagerAgent extends BaseAgent {
     const hasGenerateImage = this.hasTool('generateImage');
     const shouldHaveGenerateAudio = this.shouldHaveGenerateAudio(settings);
     const hasGenerateAudio = this.hasTool('generateAudio');
+    const shouldHaveGenerateVideo = this.shouldHaveGenerateVideo(settings);
+    const hasGenerateVideo = this.hasTool('generateVideo');
+    const hasCheckGeneratedArtifact = this.hasTool('checkGeneratedArtifact');
+
     if (shouldHaveGenerateImage && !hasGenerateImage) {
       // Register the tool - API key now available
       this.registerTool(new GenerateImageTool({
@@ -258,6 +292,54 @@ export class PromptManagerAgent extends BaseAgent {
       }));
     }
 
+    if (shouldHaveGenerateVideo && !hasGenerateVideo) {
+      const artifactJobsPath = this.getArtifactJobsPath();
+      this.registerTool(new GenerateVideoTool({
+        app: this.app,
+        vault: this.vault,
+        llmSettings: settings,
+        artifactJobsPath
+      }));
+    } else if (!shouldHaveGenerateVideo && hasGenerateVideo) {
+      this.unregisterTool('generateVideo');
+    } else if (shouldHaveGenerateVideo && hasGenerateVideo) {
+      const artifactJobsPath = this.getArtifactJobsPath();
+      this.unregisterTool('generateVideo');
+      this.registerTool(new GenerateVideoTool({
+        app: this.app,
+        vault: this.vault,
+        llmSettings: settings,
+        artifactJobsPath
+      }));
+    }
+
+    if (shouldHaveGenerateVideo && !hasCheckGeneratedArtifact) {
+      const artifactJobsPath = this.getArtifactJobsPath();
+      this.registerTool(new CheckGeneratedArtifactTool({
+        app: this.app,
+        vault: this.vault,
+        llmSettings: settings,
+        artifactJobsPath
+      }));
+    } else if (!shouldHaveGenerateVideo && hasCheckGeneratedArtifact) {
+      this.unregisterTool('checkGeneratedArtifact');
+    } else if (shouldHaveGenerateVideo && hasCheckGeneratedArtifact) {
+      const artifactJobsPath = this.getArtifactJobsPath();
+      this.unregisterTool('checkGeneratedArtifact');
+      this.registerTool(new CheckGeneratedArtifactTool({
+        app: this.app,
+        vault: this.vault,
+        llmSettings: settings,
+        artifactJobsPath
+      }));
+    }
+  }
+
+  private getArtifactJobsPath(): string {
+    const resolution = resolveVaultRoot(this.settings.settings, {
+      configDir: this.app.vault.configDir
+    });
+    return `${resolution.dataPath}/artifact-jobs.jsonl`;
   }
 
   private shouldHaveGenerateAudio(settings: LLMProviderSettings | undefined): boolean {
@@ -272,6 +354,14 @@ export class PromptManagerAgent extends BaseAgent {
     const elevenLabsConfig = this.settings.settings.apps?.apps.elevenlabs;
     const hasElevenLabsSpeech = elevenLabsConfig?.enabled === true && !!elevenLabsConfig.credentials.apiKey?.trim();
     return hasOpenAISpeech || hasGoogleSpeech || hasMistralSpeech || hasOpenRouterSpeech || hasElevenLabsSpeech;
+  }
+
+  private shouldHaveGenerateVideo(settings: LLMProviderSettings | undefined): boolean {
+    const googleConfig = settings?.providers?.google;
+    const hasGoogleVideo = googleConfig?.enabled === true && !!googleConfig.apiKey?.trim();
+    const openRouterConfig = settings?.providers?.openrouter;
+    const hasOpenRouterVideo = openRouterConfig?.enabled === true && !!openRouterConfig.apiKey?.trim();
+    return hasGoogleVideo || hasOpenRouterVideo;
   }
 
   /**

--- a/src/agents/promptManager/tools/checkGeneratedArtifact.ts
+++ b/src/agents/promptManager/tools/checkGeneratedArtifact.ts
@@ -1,0 +1,143 @@
+import { App, Vault } from 'obsidian';
+import { BaseTool } from '../../baseTool';
+import { CommonParameters, CommonResult } from '../../../types';
+import { JSONSchema } from '../../../types/schema/JSONSchemaTypes';
+import type { ToolStatusTense } from '../../interfaces/ITool';
+import { verbs } from '../../utils/toolStatusLabels';
+import type { LLMProviderSettings } from '../../../types/llm/ProviderTypes';
+import { ArtifactJobStore } from '../../../services/artifacts/ArtifactJobStore';
+import { VideoGenerationService } from '../../../services/video/VideoGenerationService';
+import type { PendingVideoGenerationJob } from '../../../services/video/VideoGenerationTypes';
+import type { VideoAspectRatio, VideoProvider, VideoResolution } from '../../../services/llm/types/VideoTypes';
+
+export interface CheckGeneratedArtifactParams extends CommonParameters {
+  jobId: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export class CheckGeneratedArtifactTool extends BaseTool<CheckGeneratedArtifactParams, CommonResult> {
+  private readonly jobStore: ArtifactJobStore;
+  private readonly videoService: VideoGenerationService;
+
+  constructor(dependencies: {
+    app: App;
+    vault: Vault;
+    llmSettings: LLMProviderSettings | null;
+    artifactJobsPath?: string;
+  }) {
+    super(
+      'checkGeneratedArtifact',
+      'Check Generated Artifact',
+      'Check a previously timed-out generated artifact job and save the completed output to its requested vault path.',
+      '1.0.0'
+    );
+
+    this.jobStore = new ArtifactJobStore(dependencies.vault, dependencies.artifactJobsPath);
+    this.videoService = new VideoGenerationService(dependencies.app, dependencies.vault, {
+      llmSettings: dependencies.llmSettings,
+    });
+  }
+
+  async execute(params: CheckGeneratedArtifactParams): Promise<CommonResult> {
+    try {
+      const job = await this.jobStore.get(params.jobId);
+      if (!job) {
+        return this.prepareResult(false, undefined, `Generated artifact job not found: ${params.jobId}`);
+      }
+
+      if (job.kind !== 'video') {
+        return this.prepareResult(false, undefined, `Generated artifact kind "${job.kind}" is not supported yet.`);
+      }
+
+      const provider = parseVideoProvider(job.provider);
+      if (!provider) {
+        return this.prepareResult(false, undefined, `Generated artifact provider "${job.provider}" is not supported for video jobs.`);
+      }
+
+      const result = await this.videoService.finalizePendingJob({
+        provider,
+        model: job.model,
+        outputPath: job.outputPath,
+        providerJobId: job.providerJobId,
+        pollingUrl: job.pollingUrl,
+        overwrite: job.overwrite,
+        request: parseVideoRequest(job.request),
+      }, {
+        pollIntervalMs: params.pollIntervalMs,
+        timeoutMs: params.timeoutMs,
+      });
+
+      const updated = await this.jobStore.update(job.id, {
+        status: result.status,
+        providerJobId: result.providerJobId,
+        pollingUrl: result.pollingUrl,
+        error: result.status === 'failed' ? result.error : undefined,
+        result: result.status === 'completed' ? result as unknown as Record<string, unknown> : undefined,
+      });
+
+      const data = {
+        ...result,
+        jobId: updated.id,
+      };
+
+      return this.prepareResult(result.status !== 'failed', data, result.status === 'failed' ? result.error : undefined);
+    } catch (error) {
+      return this.prepareResult(
+        false,
+        undefined,
+        `Generated artifact check failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  getStatusLabel(_params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+    const labels = verbs('Checking generated artifact', 'Checked generated artifact', 'Failed to check generated artifact');
+    return labels[tense];
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        jobId: {
+          type: 'string',
+          description: 'Nexus generated artifact job ID returned by a timed-out generation tool call.',
+        },
+        pollIntervalMs: {
+          type: 'number',
+          description: 'Optional polling interval while waiting for completion. Default: 5000.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Optional maximum time to wait in this status check. Default: 30000.',
+        },
+      },
+      required: ['jobId'],
+    });
+  }
+}
+
+function parseVideoProvider(provider: string): VideoProvider | null {
+  return provider === 'google' || provider === 'openrouter' ? provider : null;
+}
+
+function parseVideoRequest(request: Record<string, unknown> | undefined): PendingVideoGenerationJob['request'] {
+  if (!request) {
+    return undefined;
+  }
+
+  return {
+    seconds: typeof request.seconds === 'number' ? request.seconds : undefined,
+    aspectRatio: parseAspectRatio(request.aspectRatio),
+    resolution: parseResolution(request.resolution),
+  };
+}
+
+function parseAspectRatio(value: unknown): VideoAspectRatio | undefined {
+  return value === '16:9' || value === '9:16' || value === '1:1' ? value : undefined;
+}
+
+function parseResolution(value: unknown): VideoResolution | undefined {
+  return value === '720p' || value === '1080p' || value === '4k' ? value : undefined;
+}

--- a/src/agents/promptManager/tools/generateVideo.ts
+++ b/src/agents/promptManager/tools/generateVideo.ts
@@ -1,0 +1,182 @@
+import { App, Vault } from 'obsidian';
+import { BaseTool } from '../../baseTool';
+import { CommonParameters, CommonResult } from '../../../types';
+import { JSONSchema } from '../../../types/schema/JSONSchemaTypes';
+import { labelNamed, verbs } from '../../utils/toolStatusLabels';
+import type { ToolStatusTense } from '../../interfaces/ITool';
+import type { LLMProviderSettings } from '../../../types/llm/ProviderTypes';
+import type { VideoAspectRatio, VideoProvider, VideoResolution } from '../../../services/llm/types/VideoTypes';
+import { VideoGenerationService } from '../../../services/video/VideoGenerationService';
+import { VideoGenerationTimeoutError } from '../../../services/video/VideoGenerationTypes';
+import { ArtifactJobStore } from '../../../services/artifacts/ArtifactJobStore';
+
+export interface GenerateVideoParams extends CommonParameters {
+  prompt: string;
+  provider?: VideoProvider;
+  model?: string;
+  outputPath: string;
+  overwrite?: boolean;
+  aspectRatio?: VideoAspectRatio;
+  resolution?: VideoResolution;
+  seconds?: number;
+  referenceImage?: string;
+  generateAudio?: boolean;
+  negativePrompt?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export class GenerateVideoTool extends BaseTool<GenerateVideoParams, CommonResult> {
+  private videoService: VideoGenerationService;
+  private jobStore: ArtifactJobStore;
+
+  constructor(dependencies: {
+    app: App;
+    vault: Vault;
+    llmSettings: LLMProviderSettings | null;
+    artifactJobsPath?: string;
+  }) {
+    super(
+      'generateVideo',
+      'Generate Video',
+      'Generate text-to-video MP4 files in the vault using Google Veo or OpenRouter video models.',
+      '1.0.0'
+    );
+
+    this.videoService = new VideoGenerationService(dependencies.app, dependencies.vault, {
+      llmSettings: dependencies.llmSettings,
+    });
+    this.jobStore = new ArtifactJobStore(dependencies.vault, dependencies.artifactJobsPath);
+  }
+
+  async execute(params: GenerateVideoParams): Promise<CommonResult> {
+    try {
+      const result = await this.videoService.generate({
+        prompt: params.prompt,
+        provider: params.provider,
+        model: params.model,
+        outputPath: params.outputPath,
+        overwrite: params.overwrite,
+        aspectRatio: params.aspectRatio,
+        resolution: params.resolution,
+        seconds: params.seconds,
+        referenceImage: params.referenceImage,
+        generateAudio: params.generateAudio,
+        negativePrompt: params.negativePrompt,
+        pollIntervalMs: params.pollIntervalMs,
+        timeoutMs: params.timeoutMs,
+      });
+
+      return this.prepareResult(true, result);
+    } catch (error) {
+      if (error instanceof VideoGenerationTimeoutError) {
+        const outputPath = error.details.outputPath || params.outputPath;
+        const job = error.details.providerJobId
+          ? await this.jobStore.create({
+            kind: 'video',
+            provider: error.details.provider,
+            model: error.details.model || params.model,
+            providerJobId: error.details.providerJobId,
+            pollingUrl: error.details.pollingUrl,
+            outputPath,
+            overwrite: params.overwrite === true,
+            promptPreview: params.prompt.slice(0, 240),
+            request: error.details.request,
+          })
+          : null;
+
+        return this.prepareResult(
+          false,
+          {
+            status: 'in_progress',
+            jobId: job?.id,
+            path: outputPath,
+            provider: error.details.provider,
+            model: error.details.model || params.model,
+            providerJobId: error.details.providerJobId,
+            pollingUrl: error.details.pollingUrl,
+            timeoutMs: error.details.timeoutMs,
+            note: job
+              ? `Video generation is still running. The requested output path is ${outputPath}; call checkGeneratedArtifact with jobId ${job.id} to save the completed media there.`
+              : `Video generation is still running. The requested output path is ${outputPath}; keep the provider job details so a follow-up status check can save the completed media there.`,
+          },
+          `Video generation is still running: ${error.message}`
+        );
+      }
+
+      return this.prepareResult(
+        false,
+        undefined,
+        `Video generation failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
+    return labelNamed(verbs('Generating video', 'Generated video', 'Failed to generate video'), params, tense, ['prompt']);
+  }
+
+  getParameterSchema(): JSONSchema {
+    return this.getMergedSchema({
+      type: 'object',
+      properties: {
+        prompt: {
+          type: 'string',
+          description: 'Text description of the video to generate.',
+        },
+        provider: {
+          type: 'string',
+          enum: ['google', 'openrouter'],
+          description: 'Optional video provider. Defaults to Video generation settings.',
+        },
+        model: {
+          type: 'string',
+          description: 'Optional video model ID. Defaults to Video generation settings or the first available model for the provider.',
+        },
+        outputPath: {
+          type: 'string',
+          description: 'Vault-relative output path for the generated MP4 file, ending in .mp4.',
+        },
+        overwrite: {
+          type: 'boolean',
+          description: 'If true, replace an existing file at outputPath. Default: false.',
+        },
+        aspectRatio: {
+          type: 'string',
+          enum: ['16:9', '9:16', '1:1'],
+          description: 'Optional output aspect ratio. Defaults to Video generation settings or model default.',
+        },
+        resolution: {
+          type: 'string',
+          enum: ['720p', '1080p', '4k'],
+          description: 'Optional output resolution. Defaults to Video generation settings or model default.',
+        },
+        seconds: {
+          type: 'number',
+          description: 'Optional clip duration in seconds. Provider/model support varies.',
+        },
+        referenceImage: {
+          type: 'string',
+          description: 'Optional vault-relative image path to guide image-to-video or reference-to-video generation.',
+        },
+        generateAudio: {
+          type: 'boolean',
+          description: 'Whether to ask the provider to generate audio when the selected model supports it.',
+        },
+        negativePrompt: {
+          type: 'string',
+          description: 'Optional negative prompt for providers/models that support it.',
+        },
+        pollIntervalMs: {
+          type: 'number',
+          description: 'Optional polling interval for asynchronous jobs. Default: 10000.',
+        },
+        timeoutMs: {
+          type: 'number',
+          description: 'Optional timeout for asynchronous jobs. Default: 600000.',
+        },
+      },
+      required: ['prompt', 'outputPath'],
+    });
+  }
+}

--- a/src/agents/promptManager/tools/index.ts
+++ b/src/agents/promptManager/tools/index.ts
@@ -8,6 +8,8 @@ export { ListModelsTool } from './listModels';
 export { ExecutePromptsTool } from './executePrompts';
 export { GenerateImageTool } from './generateImage';
 export { GenerateAudioTool } from './generateAudio';
+export { GenerateVideoTool } from './generateVideo';
+export { CheckGeneratedArtifactTool } from './checkGeneratedArtifact';
 
 // Subagent tool (internal chat only - supports spawn and cancel actions)
 export { SubagentTool } from './subagent';

--- a/src/services/artifacts/ArtifactJobStore.ts
+++ b/src/services/artifacts/ArtifactJobStore.ts
@@ -1,0 +1,192 @@
+import { normalizePath, Vault } from 'obsidian';
+import { generateUUID } from '../../utils/uuid';
+import { DEFAULT_STORAGE_SETTINGS } from '../../types/plugin/PluginTypes';
+
+export type ArtifactJobKind = 'video' | 'research';
+export type ArtifactJobStatus = 'queued' | 'in_progress' | 'completed' | 'failed' | 'expired';
+
+export interface ArtifactJobRecord {
+  id: string;
+  kind: ArtifactJobKind;
+  provider: string;
+  model?: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  status: ArtifactJobStatus;
+  outputPath: string;
+  overwrite: boolean;
+  createdAt: string;
+  updatedAt: string;
+  expiresAt?: string;
+  promptPreview?: string;
+  error?: string;
+  result?: Record<string, unknown>;
+  request?: Record<string, unknown>;
+}
+
+export interface CreateArtifactJobInput {
+  kind: ArtifactJobKind;
+  provider: string;
+  model?: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  status?: ArtifactJobStatus;
+  outputPath: string;
+  overwrite?: boolean;
+  expiresAt?: string;
+  promptPreview?: string;
+  request?: Record<string, unknown>;
+}
+
+interface ArtifactJobEvent {
+  type: 'upsert';
+  id: string;
+  timestamp: string;
+  record: ArtifactJobRecord;
+}
+
+export class ArtifactJobStore {
+  private readonly path: string;
+
+  constructor(private readonly vault: Vault, path = `${DEFAULT_STORAGE_SETTINGS.rootPath}/data/artifact-jobs.jsonl`) {
+    this.path = normalizePath(path);
+  }
+
+  async create(input: CreateArtifactJobInput): Promise<ArtifactJobRecord> {
+    const now = new Date().toISOString();
+    const record: ArtifactJobRecord = {
+      id: `artifact_${generateUUID()}`,
+      kind: input.kind,
+      provider: input.provider,
+      model: input.model,
+      providerJobId: input.providerJobId,
+      pollingUrl: input.pollingUrl,
+      status: input.status ?? 'in_progress',
+      outputPath: normalizePath(input.outputPath),
+      overwrite: input.overwrite === true,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: input.expiresAt,
+      promptPreview: input.promptPreview,
+      request: input.request,
+    };
+
+    await this.appendRecord(record);
+    return record;
+  }
+
+  async update(id: string, patch: Partial<Omit<ArtifactJobRecord, 'id' | 'createdAt'>>): Promise<ArtifactJobRecord> {
+    const existing = await this.get(id);
+    if (!existing) {
+      throw new Error(`Artifact job not found: ${id}`);
+    }
+
+    const record: ArtifactJobRecord = {
+      ...existing,
+      ...patch,
+      id: existing.id,
+      createdAt: existing.createdAt,
+      outputPath: patch.outputPath ? normalizePath(patch.outputPath) : existing.outputPath,
+      updatedAt: new Date().toISOString(),
+    };
+
+    await this.appendRecord(record);
+    return record;
+  }
+
+  async get(id: string): Promise<ArtifactJobRecord | null> {
+    return (await this.readAll()).get(id) ?? null;
+  }
+
+  async list(): Promise<ArtifactJobRecord[]> {
+    return Array.from((await this.readAll()).values())
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  }
+
+  private async appendRecord(record: ArtifactJobRecord): Promise<void> {
+    await this.ensureParentDirectory();
+    const event: ArtifactJobEvent = {
+      type: 'upsert',
+      id: record.id,
+      timestamp: new Date().toISOString(),
+      record,
+    };
+    await this.vault.adapter.append(this.path, `${JSON.stringify(event)}\n`);
+  }
+
+  private async readAll(): Promise<Map<string, ArtifactJobRecord>> {
+    if (!(await this.vault.adapter.exists(this.path))) {
+      return new Map();
+    }
+
+    const content = await this.vault.adapter.read(this.path);
+    const records = new Map<string, ArtifactJobRecord>();
+
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+
+      const event = this.parseEvent(trimmed);
+      if (!event) {
+        continue;
+      }
+
+      records.set(event.id, event.record);
+    }
+
+    return records;
+  }
+
+  private parseEvent(line: string): ArtifactJobEvent | null {
+    try {
+      const value = JSON.parse(line) as unknown;
+      if (!isArtifactJobEvent(value)) {
+        return null;
+      }
+      return value;
+    } catch {
+      return null;
+    }
+  }
+
+  private async ensureParentDirectory(): Promise<void> {
+    const slashIndex = this.path.lastIndexOf('/');
+    if (slashIndex <= 0) {
+      return;
+    }
+
+    const directory = this.path.slice(0, slashIndex);
+    const parts = directory.split('/').filter(part => part.length > 0);
+    let current = '';
+
+    for (const part of parts) {
+      current = current ? `${current}/${part}` : part;
+      if (await this.vault.adapter.exists(current)) {
+        continue;
+      }
+      await this.vault.adapter.mkdir(current);
+    }
+  }
+}
+
+function isArtifactJobEvent(value: unknown): value is ArtifactJobEvent {
+  if (!isRecord(value) || value.type !== 'upsert' || typeof value.id !== 'string' || !isRecord(value.record)) {
+    return false;
+  }
+
+  const record = value.record;
+  return typeof record.id === 'string'
+    && typeof record.kind === 'string'
+    && typeof record.provider === 'string'
+    && typeof record.providerJobId === 'string'
+    && typeof record.status === 'string'
+    && typeof record.outputPath === 'string'
+    && typeof record.createdAt === 'string'
+    && typeof record.updatedAt === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/services/llm/types/VideoTypes.ts
+++ b/src/services/llm/types/VideoTypes.ts
@@ -1,0 +1,221 @@
+import type { LLMProviderSettings } from '../../../types/llm/ProviderTypes';
+
+export type VideoProvider = 'google' | 'openrouter';
+export type VideoExecution = 'long-running-operation';
+export type VideoAspectRatio = '16:9' | '9:16' | '1:1';
+export type VideoResolution = '720p' | '1080p' | '4k';
+
+export interface VideoModelDeclaration {
+  provider: VideoProvider;
+  id: string;
+  name: string;
+  execution: VideoExecution;
+  supportsReferenceImage: boolean;
+  supportsAudioPrompting: boolean;
+  aspectRatios: VideoAspectRatio[];
+  resolutions: VideoResolution[];
+  durations?: number[];
+  defaultAspectRatio: VideoAspectRatio;
+  defaultResolution: VideoResolution;
+}
+
+export interface VideoProviderAvailability {
+  provider: VideoProvider;
+  enabled: boolean;
+  configured: boolean;
+  models: VideoModelDeclaration[];
+}
+
+export interface ResolvedVideoSelection {
+  provider?: VideoProvider;
+  model?: string;
+  modelDeclaration?: VideoModelDeclaration;
+  status: 'resolved' | 'unavailable' | 'invalid';
+  reason?: string;
+}
+
+const VIDEO_MODELS: VideoModelDeclaration[] = [
+  {
+    provider: 'google',
+    id: 'veo-3.1-generate-preview',
+    name: 'Veo 3.1',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16', '1:1'],
+    resolutions: ['720p', '1080p', '4k'],
+    durations: [4, 6, 8],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p',
+  },
+  {
+    provider: 'openrouter',
+    id: 'google/veo-3.1-fast',
+    name: 'Google: Veo 3.1 Fast via OpenRouter',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16', '1:1'],
+    resolutions: ['720p', '1080p', '4k'],
+    durations: [4, 6, 8],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p',
+  },
+  {
+    provider: 'openrouter',
+    id: 'google/veo-3.1-lite',
+    name: 'Google: Veo 3.1 Lite via OpenRouter',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16'],
+    resolutions: ['720p', '1080p'],
+    durations: [4, 6, 8],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p',
+  },
+  {
+    provider: 'openrouter',
+    id: 'google/veo-3.1',
+    name: 'Google: Veo 3.1 via OpenRouter',
+    execution: 'long-running-operation',
+    supportsReferenceImage: true,
+    supportsAudioPrompting: true,
+    aspectRatios: ['16:9', '9:16'],
+    resolutions: ['720p', '1080p'],
+    durations: [4, 6, 8],
+    defaultAspectRatio: '16:9',
+    defaultResolution: '720p',
+  },
+];
+
+export const VIDEO_PROVIDER_PRIORITY: VideoProvider[] = ['google', 'openrouter'];
+
+export function getVideoProviders(): VideoProvider[] {
+  return Array.from(new Set(VIDEO_MODELS.map(model => model.provider)));
+}
+
+export function getVideoModelsForProvider(provider: string): VideoModelDeclaration[] {
+  return VIDEO_MODELS.filter(model => model.provider === provider);
+}
+
+export function getVideoModel(
+  provider: string | undefined,
+  modelId: string | undefined
+): VideoModelDeclaration | undefined {
+  if (!provider || !modelId) {
+    return undefined;
+  }
+  return VIDEO_MODELS.find(model => model.provider === provider && model.id === modelId);
+}
+
+export function buildVideoProviderAvailability(settings: LLMProviderSettings | null): VideoProviderAvailability[] {
+  return getVideoProviders().map(provider => {
+    const providerConfig = settings?.providers?.[provider];
+    const modelConfig = providerConfig?.models;
+    return {
+      provider,
+      enabled: providerConfig?.enabled === true,
+      configured: !!providerConfig?.apiKey?.trim(),
+      models: getVideoModelsForProvider(provider).filter(model => modelConfig?.[model.id]?.enabled !== false),
+    };
+  });
+}
+
+export function resolveDefaultVideoSelection(
+  settings: LLMProviderSettings | null,
+  provider?: string,
+  model?: string,
+  availability: VideoProviderAvailability[] = buildVideoProviderAvailability(settings)
+): ResolvedVideoSelection {
+  const explicit = resolveSpecificVideoSelection(provider, model, availability);
+  if (explicit.status === 'resolved' || provider || model) {
+    return explicit;
+  }
+
+  const settingsDefault = settings?.defaultVideoModel;
+  const configured = resolveSpecificVideoSelection(settingsDefault?.provider, settingsDefault?.model, availability);
+  if (configured.status === 'resolved') {
+    return configured;
+  }
+
+  for (const candidateProvider of VIDEO_PROVIDER_PRIORITY) {
+    const providerAvailability = availability.find(item => item.provider === candidateProvider);
+    const firstModel = providerAvailability?.models[0];
+    if (!providerAvailability?.enabled || !providerAvailability.configured || !firstModel) {
+      continue;
+    }
+
+    return {
+      provider: candidateProvider,
+      model: firstModel.id,
+      modelDeclaration: firstModel,
+      status: 'resolved',
+    };
+  }
+
+  return {
+    status: 'unavailable',
+    reason: 'No configured video generation provider is available.',
+  };
+}
+
+function resolveSpecificVideoSelection(
+  provider: string | undefined,
+  model: string | undefined,
+  availability: VideoProviderAvailability[]
+): ResolvedVideoSelection {
+  if (!provider && !model) {
+    return {
+      status: 'unavailable',
+      reason: 'No video provider/model selected.',
+    };
+  }
+
+  if (!provider) {
+    return {
+      model,
+      status: 'invalid',
+      reason: 'Video provider is required when a model is specified.',
+    };
+  }
+
+  if (provider !== 'google' && provider !== 'openrouter') {
+    return {
+      status: 'invalid',
+      reason: `Video provider "${provider}" is not supported.`,
+    };
+  }
+
+  const providerAvailability = availability.find(item => item.provider === provider);
+  if (!providerAvailability?.enabled || !providerAvailability.configured) {
+    return {
+      provider,
+      model,
+      status: 'invalid',
+      reason: `Video provider "${provider}" is not enabled and configured.`,
+    };
+  }
+
+  const selectedModel = model
+    ? providerAvailability.models.find(candidate => candidate.id === model)
+    : providerAvailability.models[0];
+
+  if (!selectedModel) {
+    return {
+      provider,
+      model,
+      status: 'invalid',
+      reason: model
+        ? `Video model "${model}" is not available for provider "${provider}".`
+        : `No video model is available for provider "${provider}".`,
+    };
+  }
+
+  return {
+    provider,
+    model: selectedModel.id,
+    modelDeclaration: selectedModel,
+    status: 'resolved',
+  };
+}

--- a/src/services/trace/TraceContentFormatter.ts
+++ b/src/services/trace/TraceContentFormatter.ts
@@ -60,6 +60,8 @@ const modeVerbs: Record<string, { success: string; failure: string }> = {
   promptManager_archive: { success: 'Archived prompt', failure: 'Failed to archive prompt' },
   promptManager_execute: { success: 'Executed prompt', failure: 'Failed to execute prompt' },
   generateImage: { success: 'Generated image', failure: 'Failed to generate image' },
+  generateVideo: { success: 'Generated video', failure: 'Failed to generate video' },
+  checkGeneratedArtifact: { success: 'Checked generated artifact', failure: 'Failed to check generated artifact' },
   listModels: { success: 'Listed models', failure: 'Failed to list models' },
   subagent: { success: 'Ran subagent', failure: 'Subagent failed' },
 

--- a/src/services/video/VideoGenerationService.ts
+++ b/src/services/video/VideoGenerationService.ts
@@ -1,0 +1,326 @@
+import { App, normalizePath, TFolder, Vault } from 'obsidian';
+import type { LLMProviderSettings } from '../../types/llm/ProviderTypes';
+import { isValidPath } from '../../utils/pathUtils';
+import {
+  buildVideoProviderAvailability,
+  resolveDefaultVideoSelection,
+  type VideoAspectRatio,
+  type VideoModelDeclaration,
+  type VideoProvider,
+  type VideoResolution,
+} from '../llm/types/VideoTypes';
+import { GoogleVideoAdapter } from './adapters/GoogleVideoAdapter';
+import { OpenRouterVideoAdapter } from './adapters/OpenRouterVideoAdapter';
+import { sleep } from './adapters/videoAdapterUtils';
+import type {
+  GenerateVideoRequest,
+  GenerateVideoResult,
+  PendingVideoGenerationJob,
+  ResolvedVideoGenerationRequest,
+  VideoGenerationAdapter,
+  VideoGenerationAdapterResult,
+  VideoGenerationCheckOptions,
+  VideoGenerationFinalizeResult,
+} from './VideoGenerationTypes';
+import { VideoGenerationTimeoutError } from './VideoGenerationTypes';
+
+export interface VideoGenerationServiceOptions {
+  llmSettings: LLMProviderSettings | null;
+}
+
+export class VideoGenerationService {
+  private adapters = new Map<VideoProvider, VideoGenerationAdapter>();
+
+  constructor(
+    private app: App,
+    private vault: Vault,
+    private options: VideoGenerationServiceOptions
+  ) {
+    this.initializeAdapters();
+  }
+
+  async generate(request: GenerateVideoRequest): Promise<GenerateVideoResult> {
+    const resolved = this.resolveRequest(request);
+    const adapter = this.adapters.get(resolved.provider);
+
+    if (!adapter || !adapter.isAvailable()) {
+      throw new Error(`Video provider "${resolved.provider}" is not configured or not enabled.`);
+    }
+
+    const outputPath = this.normalizeOutputPath(request.outputPath);
+    this.validateOutputExtension(outputPath);
+
+    let result: VideoGenerationAdapterResult;
+    try {
+      result = await adapter.generate(resolved);
+    } catch (error) {
+      if (error instanceof VideoGenerationTimeoutError) {
+        throw error.withOutputPath(outputPath);
+      }
+      throw error;
+    }
+
+    await this.writeVideo(outputPath, result.videoData, request.overwrite === true);
+
+    return {
+      status: 'completed',
+      path: outputPath,
+      provider: resolved.provider,
+      model: resolved.model,
+      mimeType: result.mimeType,
+      promptLength: request.prompt.length,
+      videoSize: result.videoData.byteLength,
+      durationSeconds: result.durationSeconds,
+      aspectRatio: resolved.aspectRatio,
+      resolution: resolved.resolution,
+      providerJobId: result.providerJobId,
+      pollingUrl: result.pollingUrl,
+      note: `Video generation completed and saved to ${outputPath}.`,
+    };
+  }
+
+  async finalizePendingJob(
+    job: PendingVideoGenerationJob,
+    options: VideoGenerationCheckOptions = {}
+  ): Promise<VideoGenerationFinalizeResult> {
+    const adapter = this.adapters.get(job.provider);
+    if (!adapter || !adapter.isAvailable()) {
+      throw new Error(`Video provider "${job.provider}" is not configured or not enabled.`);
+    }
+
+    const outputPath = this.normalizeOutputPath(job.outputPath);
+    this.validateOutputExtension(outputPath);
+
+    const started = Date.now();
+    const timeoutMs = options.timeoutMs ?? 30_000;
+    const pollIntervalMs = options.pollIntervalMs ?? 5_000;
+    let latestProviderJobId = job.providerJobId;
+    let latestPollingUrl = job.pollingUrl;
+
+    while (Date.now() - started <= timeoutMs) {
+      const check = await adapter.checkJob({
+        ...job,
+        outputPath,
+        providerJobId: latestProviderJobId,
+        pollingUrl: latestPollingUrl,
+      });
+
+      if (check.status === 'completed') {
+        await this.writeVideo(outputPath, check.result.videoData, job.overwrite === true);
+        return {
+          status: 'completed',
+          path: outputPath,
+          provider: job.provider,
+          model: job.model || '',
+          mimeType: check.result.mimeType,
+          promptLength: 0,
+          videoSize: check.result.videoData.byteLength,
+          durationSeconds: check.result.durationSeconds,
+          aspectRatio: job.request?.aspectRatio || '16:9',
+          resolution: job.request?.resolution || '720p',
+          providerJobId: check.result.providerJobId || latestProviderJobId,
+          pollingUrl: check.result.pollingUrl || latestPollingUrl,
+          note: `Video generation completed and saved to ${outputPath}.`,
+        };
+      }
+
+      if (check.status === 'failed') {
+        return {
+          status: 'failed',
+          path: outputPath,
+          provider: job.provider,
+          model: job.model,
+          providerJobId: check.providerJobId || latestProviderJobId,
+          pollingUrl: check.pollingUrl || latestPollingUrl,
+          error: check.error,
+          note: `Video generation failed before it could be saved to ${outputPath}.`,
+        };
+      }
+
+      latestProviderJobId = check.providerJobId || latestProviderJobId;
+      latestPollingUrl = check.pollingUrl || latestPollingUrl;
+
+      if (Date.now() - started + pollIntervalMs > timeoutMs) {
+        break;
+      }
+      await sleep(pollIntervalMs);
+    }
+
+    return {
+      status: 'in_progress',
+      path: outputPath,
+      provider: job.provider,
+      model: job.model,
+      providerJobId: latestProviderJobId,
+      pollingUrl: latestPollingUrl,
+      note: `Video generation is still running. The requested output path is ${outputPath}; check this job again later to save the completed media there.`,
+    };
+  }
+
+  hasAvailableProviders(): boolean {
+    return this.adapters.size > 0;
+  }
+
+  getInitializedProviders(): VideoProvider[] {
+    return Array.from(this.adapters.keys());
+  }
+
+  getSupportedModelIds(provider: VideoProvider): string[] {
+    return buildVideoProviderAvailability(this.options.llmSettings)
+      .find(item => item.provider === provider)
+      ?.models.map(model => model.id) ?? [];
+  }
+
+  async getModelsForProvider(provider: VideoProvider): Promise<VideoModelDeclaration[]> {
+    const adapter = this.adapters.get(provider);
+    if (provider === 'openrouter' && adapter instanceof OpenRouterVideoAdapter) {
+      return adapter.listModels();
+    }
+
+    return buildVideoProviderAvailability(this.options.llmSettings)
+      .find(item => item.provider === provider)
+      ?.models ?? [];
+  }
+
+  resolveRequest(request: GenerateVideoRequest): ResolvedVideoGenerationRequest {
+    if (!request.prompt.trim()) {
+      throw new Error('Prompt is required.');
+    }
+
+    const availability = buildVideoProviderAvailability(this.options.llmSettings);
+    const selection = resolveDefaultVideoSelection(
+      this.options.llmSettings,
+      request.provider,
+      request.model,
+      availability
+    );
+
+    if (selection.status !== 'resolved' || !selection.provider || !selection.model || !selection.modelDeclaration) {
+      throw new Error(selection.reason ?? 'No video provider/model available. Configure a video provider in default settings.');
+    }
+
+    const model = selection.modelDeclaration;
+    const aspectRatio = this.resolveAspectRatio(request.aspectRatio, model);
+    const resolution = this.resolveResolution(request.resolution, model);
+
+    if (request.seconds !== undefined && request.seconds <= 0) {
+      throw new Error('seconds must be greater than 0.');
+    }
+
+    if (request.referenceImage && !model.supportsReferenceImage) {
+      throw new Error(`Video model "${model.id}" does not support reference images.`);
+    }
+
+    return {
+      prompt: request.prompt,
+      provider: selection.provider,
+      model: selection.model,
+      aspectRatio,
+      resolution,
+      seconds: request.seconds,
+      referenceImage: request.referenceImage,
+      generateAudio: request.generateAudio,
+      negativePrompt: request.negativePrompt,
+      pollIntervalMs: request.pollIntervalMs ?? 10_000,
+      timeoutMs: request.timeoutMs ?? 10 * 60_000,
+    };
+  }
+
+  private initializeAdapters(): void {
+    const googleConfig = this.options.llmSettings?.providers?.google;
+    if (googleConfig?.enabled && googleConfig.apiKey?.trim()) {
+      this.adapters.set('google', new GoogleVideoAdapter({
+        apiKey: googleConfig.apiKey,
+        vault: this.vault,
+      }));
+    }
+
+    const openRouterConfig = this.options.llmSettings?.providers?.openrouter;
+    if (openRouterConfig?.enabled && openRouterConfig.apiKey?.trim()) {
+      this.adapters.set('openrouter', new OpenRouterVideoAdapter({
+        apiKey: openRouterConfig.apiKey,
+        vault: this.vault,
+        httpReferer: openRouterConfig.httpReferer,
+        xTitle: openRouterConfig.xTitle,
+      }));
+    }
+  }
+
+  private resolveAspectRatio(
+    requested: VideoAspectRatio | undefined,
+    model: VideoModelDeclaration
+  ): VideoAspectRatio {
+    const value = requested || this.options.llmSettings?.defaultVideoModel?.aspectRatio || model.defaultAspectRatio;
+    if (!model.aspectRatios.includes(value)) {
+      throw new Error(`Video model "${model.id}" does not support aspect ratio "${value}". Supported: ${model.aspectRatios.join(', ')}.`);
+    }
+    return value;
+  }
+
+  private resolveResolution(
+    requested: VideoResolution | undefined,
+    model: VideoModelDeclaration
+  ): VideoResolution {
+    const value = requested || this.options.llmSettings?.defaultVideoModel?.resolution || model.defaultResolution;
+    if (!model.resolutions.includes(value)) {
+      throw new Error(`Video model "${model.id}" does not support resolution "${value}". Supported: ${model.resolutions.join(', ')}.`);
+    }
+    return value;
+  }
+
+  private normalizeOutputPath(outputPath: string): string {
+    if (!outputPath.trim()) {
+      throw new Error('outputPath is required.');
+    }
+
+    if (!isValidPath(outputPath)) {
+      throw new Error(`Invalid outputPath "${outputPath}". Use a vault-relative path with no ".." or absolute path segments.`);
+    }
+
+    return normalizePath(outputPath);
+  }
+
+  private validateOutputExtension(outputPath: string): void {
+    if (!outputPath.toLowerCase().endsWith('.mp4')) {
+      throw new Error('outputPath must end with .mp4.');
+    }
+  }
+
+  private async writeVideo(outputPath: string, videoData: ArrayBuffer, overwrite: boolean): Promise<void> {
+    const existingFile = this.vault.getAbstractFileByPath(outputPath);
+    if (existingFile && !overwrite) {
+      throw new Error(`File already exists at ${outputPath}. Set overwrite: true to replace.`);
+    }
+
+    await this.ensureParentDirectory(outputPath);
+
+    if (!existingFile) {
+      await this.vault.createBinary(outputPath, videoData);
+      return;
+    }
+
+    const tempPath = `${outputPath}.generating`;
+    await this.vault.createBinary(tempPath, videoData);
+    await this.app.fileManager.trashFile(existingFile);
+    const tempFile = this.vault.getAbstractFileByPath(tempPath);
+    if (!tempFile) {
+      throw new Error(`Failed to find generated temporary file: ${tempPath}`);
+    }
+    await this.vault.rename(tempFile, outputPath);
+  }
+
+  private async ensureParentDirectory(outputPath: string): Promise<void> {
+    const dir = outputPath.substring(0, outputPath.lastIndexOf('/'));
+    if (!dir || this.vault.getAbstractFileByPath(dir) instanceof TFolder) {
+      return;
+    }
+
+    try {
+      await this.vault.createFolder(dir);
+    } catch {
+      if (!(this.vault.getAbstractFileByPath(dir) instanceof TFolder)) {
+        throw new Error(`Failed to create output directory: ${dir}`);
+      }
+    }
+  }
+}

--- a/src/services/video/VideoGenerationTypes.ts
+++ b/src/services/video/VideoGenerationTypes.ts
@@ -1,0 +1,153 @@
+import type { VideoAspectRatio, VideoProvider, VideoResolution } from '../llm/types/VideoTypes';
+
+export interface GenerateVideoRequest {
+  prompt: string;
+  provider?: string;
+  model?: string;
+  outputPath: string;
+  overwrite?: boolean;
+  aspectRatio?: VideoAspectRatio;
+  resolution?: VideoResolution;
+  seconds?: number;
+  referenceImage?: string;
+  generateAudio?: boolean;
+  negativePrompt?: string;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface ResolvedVideoGenerationRequest {
+  prompt: string;
+  provider: VideoProvider;
+  model: string;
+  aspectRatio: VideoAspectRatio;
+  resolution: VideoResolution;
+  seconds?: number;
+  referenceImage?: string;
+  generateAudio?: boolean;
+  negativePrompt?: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+}
+
+export interface VideoGenerationAdapterResult {
+  videoData: ArrayBuffer;
+  mimeType: 'video/mp4';
+  providerJobId?: string;
+  pollingUrl?: string;
+  durationSeconds?: number;
+}
+
+export interface GenerateVideoResult {
+  status: 'completed';
+  path: string;
+  provider: VideoProvider;
+  model: string;
+  mimeType: 'video/mp4';
+  promptLength: number;
+  videoSize: number;
+  durationSeconds?: number;
+  aspectRatio: VideoAspectRatio;
+  resolution: VideoResolution;
+  providerJobId?: string;
+  pollingUrl?: string;
+  note: string;
+}
+
+export interface PendingVideoGenerationJob {
+  provider: VideoProvider;
+  model?: string;
+  outputPath: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  overwrite?: boolean;
+  request?: {
+    seconds?: number;
+    aspectRatio?: VideoAspectRatio;
+    resolution?: VideoResolution;
+  };
+}
+
+export interface VideoGenerationCheckOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface PendingVideoGenerationResult {
+  status: 'in_progress';
+  path: string;
+  provider: VideoProvider;
+  model?: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  note: string;
+}
+
+export interface FailedVideoGenerationResult {
+  status: 'failed';
+  path: string;
+  provider: VideoProvider;
+  model?: string;
+  providerJobId: string;
+  pollingUrl?: string;
+  error: string;
+  note: string;
+}
+
+export type VideoGenerationFinalizeResult =
+  | GenerateVideoResult
+  | PendingVideoGenerationResult
+  | FailedVideoGenerationResult;
+
+export type VideoGenerationJobCheck =
+  | {
+    status: 'completed';
+    result: VideoGenerationAdapterResult;
+  }
+  | {
+    status: 'in_progress';
+    providerJobId?: string;
+    pollingUrl?: string;
+  }
+  | {
+    status: 'failed';
+    providerJobId?: string;
+    pollingUrl?: string;
+    error: string;
+  };
+
+export interface VideoGenerationAdapter {
+  readonly provider: VideoProvider;
+  isAvailable(): boolean;
+  generate(request: ResolvedVideoGenerationRequest): Promise<VideoGenerationAdapterResult>;
+  checkJob(job: PendingVideoGenerationJob): Promise<VideoGenerationJobCheck>;
+}
+
+export class VideoGenerationTimeoutError extends Error {
+  constructor(
+    message: string,
+    public readonly details: {
+      provider: VideoProvider;
+      model?: string;
+      providerJobId?: string;
+      pollingUrl?: string;
+      timeoutMs: number;
+      outputPath?: string;
+      request?: {
+        seconds?: number;
+        aspectRatio?: VideoAspectRatio;
+        resolution?: VideoResolution;
+      };
+    }
+  ) {
+    super(message);
+    this.name = 'VideoGenerationTimeoutError';
+  }
+
+  withOutputPath(outputPath: string): VideoGenerationTimeoutError {
+    return new VideoGenerationTimeoutError(this.message, {
+      ...this.details,
+      outputPath,
+    });
+  }
+}

--- a/src/services/video/adapters/GoogleVideoAdapter.ts
+++ b/src/services/video/adapters/GoogleVideoAdapter.ts
@@ -1,0 +1,335 @@
+import { requestUrl, Vault } from 'obsidian';
+import type {
+  PendingVideoGenerationJob,
+  ResolvedVideoGenerationRequest,
+  VideoGenerationAdapter,
+  VideoGenerationAdapterResult,
+  VideoGenerationJobCheck,
+} from '../VideoGenerationTypes';
+import { VideoGenerationTimeoutError } from '../VideoGenerationTypes';
+import type { VideoProvider } from '../../llm/types/VideoTypes';
+import {
+  getByPath,
+  getString,
+  isRecord,
+  loadReferenceImage,
+  sleep,
+} from './videoAdapterUtils';
+
+export interface GoogleVideoAdapterConfig {
+  apiKey: string;
+  vault: Vault;
+}
+
+interface GoogleOperation {
+  name?: string;
+  done?: boolean;
+  error?: {
+    message?: string;
+    code?: number;
+    status?: string;
+  };
+  response?: unknown;
+}
+
+export class GoogleVideoAdapter implements VideoGenerationAdapter {
+  readonly provider: VideoProvider = 'google';
+  private readonly baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
+
+  constructor(private config: GoogleVideoAdapterConfig) {}
+
+  isAvailable(): boolean {
+    return this.config.apiKey.trim().length > 0;
+  }
+
+  async generate(request: ResolvedVideoGenerationRequest): Promise<VideoGenerationAdapterResult> {
+    if (!this.isAvailable()) {
+      throw new Error('Google video generation is not configured.');
+    }
+
+    const started = Date.now();
+    let operation = await this.startOperation(request);
+    if (!operation.name) {
+      throw new Error('Google video generation did not return an operation name.');
+    }
+    const operationName = operation.name;
+
+    while (!operation.done) {
+      if (Date.now() - started > request.timeoutMs) {
+        throw new VideoGenerationTimeoutError(
+          `Google video generation timed out after ${Math.round(request.timeoutMs / 1000)} seconds. ` +
+          `Operation name: ${operationName}.`,
+          {
+            provider: this.provider,
+            model: request.model,
+            providerJobId: operationName,
+            timeoutMs: request.timeoutMs,
+            request: {
+              seconds: request.seconds,
+              aspectRatio: request.aspectRatio,
+              resolution: request.resolution,
+            },
+          }
+        );
+      }
+
+      await sleep(request.pollIntervalMs);
+      operation = await this.pollOperation(operationName);
+    }
+
+    if (operation.error) {
+      throw new Error(`Google video generation failed: ${operation.error.message || operation.error.status || operation.error.code || 'Unknown error'}`);
+    }
+
+    const video = await this.downloadCompletedVideo(operation);
+    return {
+      ...video,
+      providerJobId: operationName,
+      pollingUrl: `${this.baseUrl}/${operationName}`,
+      durationSeconds: request.seconds,
+    };
+  }
+
+  async checkJob(job: PendingVideoGenerationJob): Promise<VideoGenerationJobCheck> {
+    if (!this.isAvailable()) {
+      throw new Error('Google video generation is not configured.');
+    }
+
+    const operation = await this.pollOperation(job.providerJobId);
+    const pollingUrl = `${this.baseUrl}/${job.providerJobId}`;
+
+    if (!operation.done) {
+      return {
+        status: 'in_progress',
+        providerJobId: job.providerJobId,
+        pollingUrl,
+      };
+    }
+
+    if (operation.error) {
+      return {
+        status: 'failed',
+        providerJobId: job.providerJobId,
+        pollingUrl,
+        error: operation.error.message || operation.error.status || String(operation.error.code || 'Unknown error'),
+      };
+    }
+
+    const video = await this.downloadCompletedVideo(operation);
+    return {
+      status: 'completed',
+      result: {
+        ...video,
+        providerJobId: job.providerJobId,
+        pollingUrl,
+        durationSeconds: job.request?.seconds,
+      },
+    };
+  }
+
+  private async startOperation(request: ResolvedVideoGenerationRequest): Promise<GoogleOperation> {
+    const instance: Record<string, unknown> = {
+      prompt: request.prompt,
+    };
+
+    if (request.referenceImage) {
+      const image = await loadReferenceImage(this.config.vault, request.referenceImage);
+      instance.image = {
+        bytesBase64Encoded: image.data,
+        mimeType: image.mimeType,
+      };
+    }
+
+    const parameters: Record<string, unknown> = {
+      aspectRatio: request.aspectRatio,
+      resolution: request.resolution,
+    };
+
+    if (request.seconds) {
+      parameters.durationSeconds = request.seconds;
+    }
+
+    if (request.generateAudio !== undefined) {
+      parameters.generateAudio = request.generateAudio;
+    }
+
+    if (request.negativePrompt) {
+      parameters.negativePrompt = request.negativePrompt;
+    }
+
+    const response = await requestUrl({
+      url: `${this.baseUrl}/models/${encodeURIComponent(request.model)}:predictLongRunning`,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.config.apiKey,
+      },
+      body: JSON.stringify({
+        instances: [instance],
+        parameters,
+      }),
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Google video generation failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return this.asOperation(response.json);
+  }
+
+  private async pollOperation(operationName: string): Promise<GoogleOperation> {
+    const response = await requestUrl({
+      url: `${this.baseUrl}/${operationName}`,
+      method: 'GET',
+      headers: {
+        'x-goog-api-key': this.config.apiKey,
+      },
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Google video polling failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return this.asOperation(response.json);
+  }
+
+  private async downloadCompletedVideo(operation: GoogleOperation): Promise<Omit<VideoGenerationAdapterResult, 'providerJobId' | 'durationSeconds'>> {
+    const inlineData = this.findInlineVideoData(operation.response);
+    if (inlineData) {
+      return inlineData;
+    }
+
+    const uri = this.findVideoUri(operation.response);
+    if (!uri) {
+      throw new Error('Google video generation completed but no downloadable video was found.');
+    }
+
+    const response = await requestUrl({
+      url: uri,
+      method: 'GET',
+      headers: {
+        'x-goog-api-key': this.config.apiKey,
+      },
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`Google video download failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return {
+      videoData: response.arrayBuffer,
+      mimeType: 'video/mp4',
+    };
+  }
+
+  private findVideoUri(response: unknown): string | undefined {
+    const directPaths = [
+      ['generatedVideos', '0', 'video', 'uri'],
+      ['generatedVideos', '0', 'video', 'downloadUri'],
+      ['generateVideoResponse', 'generatedSamples', '0', 'video', 'uri'],
+      ['generateVideoResponse', 'generatedSamples', '0', 'video', 'downloadUri'],
+      ['videos', '0', 'uri'],
+      ['videos', '0', 'downloadUri'],
+    ];
+
+    for (const path of directPaths) {
+      const value = getString(getByPathWithArrays(response, path));
+      if (value) {
+        return value;
+      }
+    }
+
+    return this.findFirstStringKey(response, new Set(['uri', 'downloadUri', 'gcsUri']));
+  }
+
+  private findInlineVideoData(response: unknown): Omit<VideoGenerationAdapterResult, 'providerJobId' | 'durationSeconds'> | undefined {
+    const dataPaths = [
+      ['generatedVideos', '0', 'video', 'videoBytes'],
+      ['generatedVideos', '0', 'video', 'bytesBase64Encoded'],
+      ['generateVideoResponse', 'generatedSamples', '0', 'video', 'bytesBase64Encoded'],
+    ];
+
+    for (const path of dataPaths) {
+      const data = getString(getByPathWithArrays(response, path));
+      if (data) {
+        return {
+          videoData: base64ToArrayBuffer(data),
+          mimeType: 'video/mp4',
+        };
+      }
+    }
+
+    return undefined;
+  }
+
+  private findFirstStringKey(value: unknown, keys: Set<string>): string | undefined {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const found = this.findFirstStringKey(item, keys);
+        if (found) {
+          return found;
+        }
+      }
+      return undefined;
+    }
+
+    if (!isRecord(value)) {
+      return undefined;
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+      if (keys.has(key) && typeof child === 'string') {
+        return child;
+      }
+      const found = this.findFirstStringKey(child, keys);
+      if (found) {
+        return found;
+      }
+    }
+
+    return undefined;
+  }
+
+  private asOperation(value: unknown): GoogleOperation {
+    if (!isRecord(value)) {
+      throw new Error('Google video generation returned an invalid operation response.');
+    }
+
+    const operation: GoogleOperation = {
+      name: getString(value.name),
+      done: value.done === true,
+      response: value.response,
+    };
+
+    if (isRecord(value.error)) {
+      operation.error = {
+        message: getString(value.error.message),
+        code: typeof value.error.code === 'number' ? value.error.code : undefined,
+        status: getString(value.error.status),
+      };
+    }
+
+    return operation;
+  }
+}
+
+function getByPathWithArrays(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    if (Array.isArray(current)) {
+      current = current[Number(key)];
+      continue;
+    }
+    current = getByPath(current, [key]);
+  }
+  return current;
+}
+
+function base64ToArrayBuffer(data: string): ArrayBuffer {
+  const binary = atob(data);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+}

--- a/src/services/video/adapters/OpenRouterVideoAdapter.ts
+++ b/src/services/video/adapters/OpenRouterVideoAdapter.ts
@@ -1,0 +1,403 @@
+import { requestUrl, Vault } from 'obsidian';
+import { BRAND_NAME } from '../../../constants/branding';
+import {
+  getVideoModelsForProvider,
+  type VideoAspectRatio,
+  type VideoModelDeclaration,
+  type VideoProvider,
+  type VideoResolution,
+} from '../../llm/types/VideoTypes';
+import type {
+  PendingVideoGenerationJob,
+  ResolvedVideoGenerationRequest,
+  VideoGenerationAdapter,
+  VideoGenerationAdapterResult,
+  VideoGenerationJobCheck,
+} from '../VideoGenerationTypes';
+import { VideoGenerationTimeoutError } from '../VideoGenerationTypes';
+import {
+  getNumber,
+  getString,
+  isRecord,
+  loadReferenceImage,
+  sleep,
+} from './videoAdapterUtils';
+
+export interface OpenRouterVideoAdapterConfig {
+  apiKey: string;
+  vault: Vault;
+  httpReferer?: string;
+  xTitle?: string;
+}
+
+interface OpenRouterVideoModelMetadata {
+  id: string;
+  name?: string;
+  supported_resolutions?: string[];
+  supported_aspect_ratios?: string[];
+  supported_durations?: number[];
+  generate_audio?: boolean;
+}
+
+interface OpenRouterVideoJob {
+  id?: string;
+  status?: string;
+  polling_url?: string;
+  unsigned_urls?: string[];
+  output_url?: string;
+  url?: string;
+  error?: unknown;
+}
+
+export class OpenRouterVideoAdapter implements VideoGenerationAdapter {
+  readonly provider: VideoProvider = 'openrouter';
+  private readonly baseUrl = 'https://openrouter.ai/api/v1';
+  private readonly httpReferer: string;
+  private readonly xTitle: string;
+  private modelCache: OpenRouterVideoModelMetadata[] | null = null;
+  private modelCacheTimestamp = 0;
+  private readonly cacheTtlMs = 10 * 60 * 1000;
+
+  constructor(private config: OpenRouterVideoAdapterConfig) {
+    this.httpReferer = config.httpReferer?.trim() || 'https://synapticlabs.ai';
+    this.xTitle = config.xTitle?.trim() || BRAND_NAME;
+  }
+
+  isAvailable(): boolean {
+    return this.config.apiKey.trim().length > 0;
+  }
+
+  async generate(request: ResolvedVideoGenerationRequest): Promise<VideoGenerationAdapterResult> {
+    if (!this.isAvailable()) {
+      throw new Error('OpenRouter video generation is not configured.');
+    }
+
+    await this.validateAgainstModelMetadata(request);
+
+    const started = Date.now();
+    let job = await this.submitJob(request);
+    if (!job.id && !job.polling_url) {
+      throw new Error('OpenRouter video generation did not return a job ID or polling URL.');
+    }
+
+    while (!this.isTerminalStatus(job.status)) {
+      if (Date.now() - started > request.timeoutMs) {
+        throw new VideoGenerationTimeoutError(
+          `OpenRouter video generation timed out after ${Math.round(request.timeoutMs / 1000)} seconds. ` +
+          `Job ID: ${job.id || 'unknown'}. Polling URL: ${job.polling_url || 'unknown'}.`,
+          {
+            provider: this.provider,
+            model: request.model,
+            providerJobId: job.id,
+            pollingUrl: job.polling_url,
+            timeoutMs: request.timeoutMs,
+            request: {
+              seconds: request.seconds,
+              aspectRatio: request.aspectRatio,
+              resolution: request.resolution,
+            },
+          }
+        );
+      }
+
+      await sleep(request.pollIntervalMs);
+      job = await this.pollJob(job);
+    }
+
+    if (job.status !== 'completed') {
+      throw new Error(`OpenRouter video generation failed with status "${job.status || 'unknown'}": ${this.formatJobError(job.error)}`);
+    }
+
+    const videoData = await this.downloadVideo(job);
+    return {
+      videoData,
+      mimeType: 'video/mp4',
+      providerJobId: job.id,
+      pollingUrl: job.polling_url,
+      durationSeconds: request.seconds,
+    };
+  }
+
+  async checkJob(job: PendingVideoGenerationJob): Promise<VideoGenerationJobCheck> {
+    if (!this.isAvailable()) {
+      throw new Error('OpenRouter video generation is not configured.');
+    }
+
+    const providerJob: OpenRouterVideoJob = {
+      id: job.providerJobId,
+      polling_url: job.pollingUrl,
+    };
+    const current = await this.pollJob(providerJob);
+
+    if (!this.isTerminalStatus(current.status)) {
+      return {
+        status: 'in_progress',
+        providerJobId: current.id || job.providerJobId,
+        pollingUrl: current.polling_url || job.pollingUrl,
+      };
+    }
+
+    if (current.status !== 'completed') {
+      return {
+        status: 'failed',
+        providerJobId: current.id || job.providerJobId,
+        pollingUrl: current.polling_url || job.pollingUrl,
+        error: `OpenRouter video generation failed with status "${current.status || 'unknown'}": ${this.formatJobError(current.error)}`,
+      };
+    }
+
+    const videoData = await this.downloadVideo(current);
+    return {
+      status: 'completed',
+      result: {
+        videoData,
+        mimeType: 'video/mp4',
+        providerJobId: current.id || job.providerJobId,
+        pollingUrl: current.polling_url || job.pollingUrl,
+        durationSeconds: job.request?.seconds,
+      },
+    };
+  }
+
+  async listModels(): Promise<VideoModelDeclaration[]> {
+    const metadata = await this.fetchModelMetadata();
+    return metadata.map(model => ({
+      provider: 'openrouter',
+      id: model.id,
+      name: model.name || model.id,
+      execution: 'long-running-operation',
+      supportsReferenceImage: true,
+      supportsAudioPrompting: model.generate_audio === true,
+      aspectRatios: this.asAspectRatios(model.supported_aspect_ratios),
+      resolutions: this.asResolutions(model.supported_resolutions),
+      durations: model.supported_durations,
+      defaultAspectRatio: this.asAspectRatios(model.supported_aspect_ratios)[0] || '16:9',
+      defaultResolution: this.asResolutions(model.supported_resolutions)[0] || '720p',
+    }));
+  }
+
+  private async validateAgainstModelMetadata(request: ResolvedVideoGenerationRequest): Promise<void> {
+    const models = await this.fetchModelMetadata();
+    const model = models.find(candidate => candidate.id === request.model);
+    if (!model) {
+      return;
+    }
+
+    const supportedResolutions = this.asResolutions(model.supported_resolutions);
+    if (supportedResolutions.length && !supportedResolutions.includes(request.resolution)) {
+      throw new Error(`OpenRouter model "${request.model}" does not support resolution "${request.resolution}". Supported: ${supportedResolutions.join(', ')}.`);
+    }
+
+    if (model.supported_aspect_ratios?.length && !model.supported_aspect_ratios.includes(request.aspectRatio)) {
+      throw new Error(`OpenRouter model "${request.model}" does not support aspect ratio "${request.aspectRatio}". Supported: ${model.supported_aspect_ratios.join(', ')}.`);
+    }
+
+    if (request.seconds && model.supported_durations?.length && !model.supported_durations.includes(request.seconds)) {
+      throw new Error(`OpenRouter model "${request.model}" does not support ${request.seconds}-second clips. Supported durations: ${model.supported_durations.join(', ')}.`);
+    }
+  }
+
+  private async submitJob(request: ResolvedVideoGenerationRequest): Promise<OpenRouterVideoJob> {
+    const body: Record<string, unknown> = {
+      model: request.model,
+      prompt: request.prompt,
+      resolution: request.resolution,
+      aspect_ratio: request.aspectRatio,
+    };
+
+    if (request.seconds) {
+      body.duration = request.seconds;
+    }
+
+    if (request.generateAudio !== undefined) {
+      body.generate_audio = request.generateAudio;
+    }
+
+    if (request.negativePrompt) {
+      body.negative_prompt = request.negativePrompt;
+    }
+
+    if (request.referenceImage) {
+      const image = await loadReferenceImage(this.config.vault, request.referenceImage);
+      body.input_references = [
+        {
+          type: 'image_url',
+          image_url: {
+            url: `data:${image.mimeType};base64,${image.data}`,
+          },
+        },
+      ];
+    }
+
+    const response = await requestUrl({
+      url: `${this.baseUrl}/videos`,
+      method: 'POST',
+      headers: this.getHeaders(),
+      body: JSON.stringify(body),
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`OpenRouter video generation failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return this.asJob(response.json);
+  }
+
+  private async pollJob(job: OpenRouterVideoJob): Promise<OpenRouterVideoJob> {
+    const url = job.polling_url || `${this.baseUrl}/videos/${encodeURIComponent(job.id || '')}`;
+    const response = await requestUrl({
+      url,
+      method: 'GET',
+      headers: this.getHeaders(),
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`OpenRouter video polling failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return this.asJob(response.json);
+  }
+
+  private async downloadVideo(job: OpenRouterVideoJob): Promise<ArrayBuffer> {
+    const unsignedUrl = job.unsigned_urls?.find(url => url.trim().length > 0);
+    const url = unsignedUrl || job.output_url || job.url || `${this.baseUrl}/videos/${encodeURIComponent(job.id || '')}/content?index=0`;
+    const shouldAuthorize = !unsignedUrl || url.startsWith(this.baseUrl) || url.startsWith('https://openrouter.ai/api/');
+    const response = await requestUrl({
+      url,
+      method: 'GET',
+      headers: shouldAuthorize ? this.getHeaders() : undefined,
+    });
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new Error(`OpenRouter video download failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`);
+    }
+
+    return response.arrayBuffer;
+  }
+
+  private async fetchModelMetadata(): Promise<OpenRouterVideoModelMetadata[]> {
+    const now = Date.now();
+    if (this.modelCache && now - this.modelCacheTimestamp < this.cacheTtlMs) {
+      return this.modelCache;
+    }
+
+    try {
+      const response = await requestUrl({
+        url: `${this.baseUrl}/videos/models`,
+        method: 'GET',
+        headers: this.getHeaders(),
+      });
+
+      if (response.status < 200 || response.status >= 300) {
+        throw new Error(response.text || `HTTP ${response.status}`);
+      }
+
+      const data = isRecord(response.json) && Array.isArray(response.json.data) ? response.json.data : [];
+      this.modelCache = data
+        .map(item => this.asModelMetadata(item))
+        .filter((item): item is OpenRouterVideoModelMetadata => item !== null);
+      this.modelCacheTimestamp = now;
+      return this.modelCache;
+    } catch {
+      this.modelCache = getVideoModelsForProvider('openrouter').map(model => ({
+        id: model.id,
+        name: model.name,
+        supported_resolutions: model.resolutions,
+        supported_aspect_ratios: model.aspectRatios,
+        supported_durations: model.durations,
+        generate_audio: model.supportsAudioPrompting,
+      }));
+      this.modelCacheTimestamp = now;
+      return this.modelCache;
+    }
+  }
+
+  private getHeaders(): Record<string, string> {
+    return {
+      Authorization: `Bearer ${this.config.apiKey}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': this.httpReferer,
+      'X-Title': this.xTitle,
+    };
+  }
+
+  private asJob(value: unknown): OpenRouterVideoJob {
+    if (!isRecord(value)) {
+      throw new Error('OpenRouter video generation returned an invalid job response.');
+    }
+
+    const unsignedValue = value.unsigned_urls;
+    return {
+      id: getString(value.id),
+      status: getString(value.status),
+      polling_url: getString(value.polling_url),
+      unsigned_urls: Array.isArray(unsignedValue) ? unsignedValue.filter((item): item is string => typeof item === 'string') : undefined,
+      output_url: getString(value.output_url),
+      url: getString(value.url),
+      error: value.error,
+    };
+  }
+
+  private asModelMetadata(value: unknown): OpenRouterVideoModelMetadata | null {
+    if (!isRecord(value)) {
+      return null;
+    }
+
+    const id = getString(value.id);
+    if (!id) {
+      return null;
+    }
+
+    return {
+      id,
+      name: getString(value.name),
+      supported_resolutions: toStringArray(value.supported_resolutions),
+      supported_aspect_ratios: toStringArray(value.supported_aspect_ratios),
+      supported_durations: toNumberArray(value.supported_durations),
+      generate_audio: value.generate_audio === true,
+    };
+  }
+
+  private isTerminalStatus(status: string | undefined): boolean {
+    return status === 'completed' || status === 'failed' || status === 'cancelled' || status === 'canceled' || status === 'expired';
+  }
+
+  private formatJobError(error: unknown): string {
+    if (!error) {
+      return 'Unknown error';
+    }
+    if (typeof error === 'string') {
+      return error;
+    }
+    if (isRecord(error)) {
+      return getString(error.message) || JSON.stringify(error);
+    }
+    return 'Unknown error';
+  }
+
+  private asAspectRatios(values: string[] | undefined): VideoAspectRatio[] {
+    const allowed: VideoAspectRatio[] = ['16:9', '9:16', '1:1'];
+    return (values ?? []).filter((value): value is VideoAspectRatio => allowed.includes(value as VideoAspectRatio));
+  }
+
+  private asResolutions(values: string[] | undefined): VideoResolution[] {
+    const allowed: VideoResolution[] = ['720p', '1080p', '4k'];
+    return (values ?? [])
+      .map(value => value === '4K' ? '4k' : value)
+      .filter((value): value is VideoResolution => allowed.includes(value as VideoResolution));
+  }
+}
+
+function toStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.filter((item): item is string => typeof item === 'string');
+}
+
+function toNumberArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value.map(getNumber).filter((item): item is number => item !== undefined);
+}

--- a/src/services/video/adapters/videoAdapterUtils.ts
+++ b/src/services/video/adapters/videoAdapterUtils.ts
@@ -1,0 +1,74 @@
+import { TFile, Vault } from 'obsidian';
+
+export interface ReferenceImageData {
+  data: string;
+  mimeType: string;
+}
+
+export function getImageMimeType(path: string): string {
+  const ext = path.toLowerCase().split('.').pop() || '';
+  const mimeTypes: Record<string, string> = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    webp: 'image/webp',
+  };
+  return mimeTypes[ext] || 'image/png';
+}
+
+export async function loadReferenceImage(vault: Vault, path: string): Promise<ReferenceImageData> {
+  const file = vault.getAbstractFileByPath(path);
+  if (!file) {
+    throw new Error(`Reference image not found: ${path}`);
+  }
+
+  if (!(file instanceof TFile)) {
+    throw new Error(`Reference image path is not a file: ${path}`);
+  }
+
+  const data = await vault.readBinary(file);
+  return {
+    data: arrayBufferToBase64(data),
+    mimeType: getImageMimeType(path),
+  };
+}
+
+export function arrayBufferToBase64(data: ArrayBuffer): string {
+  const bytes = new Uint8Array(data);
+  let binary = '';
+  const chunkSize = 0x8000;
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    const chunk = bytes.subarray(index, index + chunkSize);
+    binary += String.fromCharCode(...Array.from(chunk));
+  }
+
+  return btoa(binary);
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function getByPath(value: unknown, path: string[]): unknown {
+  let current = value;
+  for (const key of path) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[key];
+  }
+  return current;
+}
+
+export async function sleep(ms: number): Promise<void> {
+  await new Promise(resolve => window.setTimeout(resolve, ms));
+}

--- a/src/settings/tabs/DefaultsTab.ts
+++ b/src/settings/tabs/DefaultsTab.ts
@@ -41,6 +41,13 @@ import {
   resolveDefaultRealtimeVoiceSelection,
 } from '../../services/llm/types/RealtimeVoiceTypes';
 import { VoiceCatalogService } from '../../services/readAloud/VoiceCatalogService';
+import {
+  buildVideoProviderAvailability,
+  getVideoModel,
+  type VideoAspectRatio,
+  type VideoModelDeclaration,
+  type VideoResolution,
+} from '../../services/llm/types/VideoTypes';
 import { SpeechModelCatalogService } from '../../services/readAloud/SpeechModelCatalogService';
 
 export interface DefaultsTabServices {
@@ -217,6 +224,7 @@ export class DefaultsTab {
       options: { workspaces, prompts },
       showTranscriptionSection: false,
       renderAfterImageSection: (parent) => {
+        this.renderVideoSection(parent);
         void this.renderVoiceSection(parent);
       },
       callbacks: {
@@ -252,6 +260,191 @@ export class DefaultsTab {
 
       rendererContainer.appendChild(embeddingsSection);
     }
+  }
+
+  /**
+   * Render text-to-video defaults.
+   */
+  private renderVideoSection(parentEl: HTMLElement): void {
+    const llmSettings = this.services.llmProviderSettings;
+    if (!llmSettings) return;
+
+    const section = createDiv({ cls: 'csr-section nexus-video-section' });
+    section.createDiv({ cls: 'csr-section-header', text: 'Video generation' });
+    const content = section.createDiv({ cls: 'csr-section-content' });
+    content.createDiv({
+      cls: 'csr-section-desc',
+      text: 'Defaults for generated MP4 files created by PromptManager video tools.'
+    });
+    parentEl.appendChild(section);
+
+    let modelDropdown: HTMLSelectElement | null = null;
+    let aspectRatioDropdown: HTMLSelectElement | null = null;
+    let resolutionDropdown: HTMLSelectElement | null = null;
+
+    const getAvailability = () => buildVideoProviderAvailability(llmSettings);
+    const getSelection = () => {
+      const configured = llmSettings.defaultVideoModel;
+      const availability = getAvailability();
+      const provider = configured?.provider || availability.find(item => item.enabled && item.configured && item.models.length > 0)?.provider;
+      const providerAvailability = availability.find(item => item.provider === provider);
+      const model = configured?.model && providerAvailability?.models.some(candidate => candidate.id === configured.model)
+        ? configured.model
+        : providerAvailability?.models[0]?.id;
+      const modelDeclaration = getVideoModel(provider, model) || providerAvailability?.models.find(candidate => candidate.id === model);
+      return {
+        provider,
+        model,
+        modelDeclaration,
+        aspectRatio: configured?.aspectRatio || modelDeclaration?.defaultAspectRatio,
+        resolution: configured?.resolution || modelDeclaration?.defaultResolution,
+      };
+    };
+
+    const saveVideoDefault = async (
+      model: VideoModelDeclaration,
+      aspectRatio?: VideoAspectRatio,
+      resolution?: VideoResolution
+    ): Promise<void> => {
+      llmSettings.defaultVideoModel = {
+        provider: model.provider,
+        model: model.id,
+        aspectRatio: aspectRatio || model.defaultAspectRatio,
+        resolution: resolution || model.defaultResolution,
+      };
+      await this.services.settings.saveSettings();
+    };
+
+    const updateOptionDropdowns = (): void => {
+      const selection = getSelection();
+      const model = selection.modelDeclaration;
+
+      if (aspectRatioDropdown) {
+        aspectRatioDropdown.empty();
+        if (!model) {
+          aspectRatioDropdown.createEl('option', { value: '', text: 'Select a video model first' });
+          aspectRatioDropdown.disabled = true;
+        } else {
+          model.aspectRatios.forEach(value => {
+            aspectRatioDropdown?.createEl('option', { value, text: value });
+          });
+          aspectRatioDropdown.disabled = false;
+          aspectRatioDropdown.value = selection.aspectRatio || model.defaultAspectRatio;
+        }
+      }
+
+      if (resolutionDropdown) {
+        resolutionDropdown.empty();
+        if (!model) {
+          resolutionDropdown.createEl('option', { value: '', text: 'Select a video model first' });
+          resolutionDropdown.disabled = true;
+        } else {
+          model.resolutions.forEach(value => {
+            resolutionDropdown?.createEl('option', { value, text: value });
+          });
+          resolutionDropdown.disabled = false;
+          resolutionDropdown.value = selection.resolution || model.defaultResolution;
+        }
+      }
+    };
+
+    const updateModelOptions = (): void => {
+      if (!modelDropdown) return;
+      const selection = getSelection();
+      const providerAvailability = getAvailability().find(item => item.provider === selection.provider);
+      const models = providerAvailability?.models ?? [];
+
+      modelDropdown.empty();
+      if (!selection.provider || models.length === 0) {
+        modelDropdown.createEl('option', {
+          value: '',
+          text: 'Select a video provider first'
+        });
+        modelDropdown.disabled = true;
+        updateOptionDropdowns();
+        return;
+      }
+
+      models.forEach(model => {
+        modelDropdown?.createEl('option', { value: model.id, text: model.name });
+      });
+
+      modelDropdown.disabled = providerAvailability?.enabled !== true || providerAvailability.configured !== true;
+      modelDropdown.value = selection.model || models[0]?.id || '';
+      updateOptionDropdowns();
+    };
+
+    new Setting(content)
+      .setName('Video provider')
+      .setDesc('Used by the generateVideo tool.')
+      .addDropdown(dropdown => {
+        const availability = getAvailability();
+        const selection = getSelection();
+        const usableProviders = availability.filter(item => item.enabled && item.configured && item.models.length > 0);
+
+        if (usableProviders.length === 0 && !selection.provider) {
+          dropdown.addOption('', 'No video providers available');
+          dropdown.setDisabled(true);
+          return;
+        }
+
+        usableProviders.forEach(provider => {
+          dropdown.addOption(provider.provider, this.getProviderDisplayName(provider.provider));
+        });
+
+        if (selection.provider && !usableProviders.some(provider => provider.provider === selection.provider)) {
+          dropdown.addOption(selection.provider, `${this.getProviderDisplayName(selection.provider)} (unavailable)`);
+        }
+
+        dropdown.setValue(selection.provider || usableProviders[0]?.provider || '');
+        dropdown.onChange((provider) => {
+          const providerAvailability = getAvailability().find(item => item.provider === provider);
+          const model = providerAvailability?.models[0];
+          if (model) {
+            void saveVideoDefault(model).then(updateModelOptions);
+          }
+        });
+      });
+
+    new Setting(content)
+      .setName('Video model')
+      .addDropdown(dropdown => {
+        modelDropdown = dropdown.selectEl;
+        updateModelOptions();
+        dropdown.onChange((modelId) => {
+          const selection = getSelection();
+          const model = getVideoModel(selection.provider, modelId);
+          if (model) {
+            void saveVideoDefault(model, selection.aspectRatio, selection.resolution).then(updateOptionDropdowns);
+          }
+        });
+      });
+
+    new Setting(content)
+      .setName('Aspect ratio')
+      .addDropdown(dropdown => {
+        aspectRatioDropdown = dropdown.selectEl;
+        updateOptionDropdowns();
+        dropdown.onChange((aspectRatio) => {
+          const selection = getSelection();
+          if (selection.modelDeclaration) {
+            void saveVideoDefault(selection.modelDeclaration, aspectRatio as VideoAspectRatio, selection.resolution);
+          }
+        });
+      });
+
+    new Setting(content)
+      .setName('Resolution')
+      .addDropdown(dropdown => {
+        resolutionDropdown = dropdown.selectEl;
+        updateOptionDropdowns();
+        dropdown.onChange((resolution) => {
+          const selection = getSelection();
+          if (selection.modelDeclaration) {
+            void saveVideoDefault(selection.modelDeclaration, selection.aspectRatio, resolution as VideoResolution);
+          }
+        });
+      });
   }
 
   /**

--- a/src/types/llm/ProviderTypes.ts
+++ b/src/types/llm/ProviderTypes.ts
@@ -4,6 +4,7 @@
  */
 
 import type { OAuthState } from '../../services/oauth/IOAuthProvider';
+import type { VideoAspectRatio, VideoResolution } from '../../services/llm/types/VideoTypes';
 
 /**
  * Thinking effort levels - unified across all providers
@@ -68,6 +69,13 @@ export interface DefaultImageModelSettings {
   model: string;
 }
 
+export interface DefaultVideoModelSettings {
+  provider: 'google' | 'openrouter';
+  model: string;
+  aspectRatio?: VideoAspectRatio;
+  resolution?: VideoResolution;
+}
+
 export type VoiceDefaultSelectionSource = 'auto' | 'user';
 
 export interface DefaultSpeechModelSettings {
@@ -99,6 +107,7 @@ export interface LLMProviderSettings {
   agentModel?: DefaultModelSettings; // Model for executePrompt (API-only, used when chat model is local)
   agentThinking?: DefaultThinkingSettings; // Thinking settings for agent model (separate from chat model)
   defaultImageModel?: DefaultImageModelSettings; // Default image generation model
+  defaultVideoModel?: DefaultVideoModelSettings; // Default video generation model
   defaultThinking?: DefaultThinkingSettings; // Default thinking settings for chat model
   defaultTemperature?: number; // Default temperature (0.0-1.0, default 0.5)
   monthlyBudget?: number; // Monthly budget in USD for LLM usage
@@ -200,6 +209,12 @@ export const DEFAULT_LLM_PROVIDER_SETTINGS: LLMProviderSettings = {
   defaultImageModel: {
     provider: 'google',
     model: 'gemini-2.5-flash-image'
+  },
+  defaultVideoModel: {
+    provider: 'google',
+    model: 'veo-3.1-generate-preview',
+    aspectRatio: '16:9',
+    resolution: '720p'
   },
   defaultThinking: {
     enabled: false,

--- a/tests/debug/video-generation-live-smoke.test.ts
+++ b/tests/debug/video-generation-live-smoke.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Live smoke for PromptManager generateVideo.
+ *
+ * Default:
+ *   RUN_LIVE_VIDEO_SMOKE=1 npx jest tests/debug/video-generation-live-smoke.test.ts --runInBand
+ *
+ * Paid generation:
+ *   RUN_LIVE_VIDEO_SMOKE=1 RUN_PAID_VIDEO_SMOKE=1 npx jest tests/debug/video-generation-live-smoke.test.ts --runInBand
+ */
+
+import * as fs from 'fs';
+import * as https from 'https';
+import * as os from 'os';
+import * as path from 'path';
+import type { App, Vault } from 'obsidian';
+import { TFolder, __setRequestUrlMock } from '../mocks/obsidian';
+import { GenerateVideoTool } from '../../src/agents/promptManager/tools/generateVideo';
+import { DEFAULT_LLM_PROVIDER_SETTINGS, type LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
+
+const RUN_LIVE = process.env.RUN_LIVE_VIDEO_SMOKE === '1';
+const RUN_PAID = process.env.RUN_PAID_VIDEO_SMOKE === '1';
+
+const describeLive = RUN_LIVE ? describe : describe.skip;
+
+type MockVault = Vault & {
+  getAbstractFileByPath: jest.Mock<unknown, [string]>;
+  createBinary: jest.Mock<Promise<void>, [string, ArrayBuffer]>;
+  createFolder: jest.Mock<Promise<void>, [string]>;
+  rename: jest.Mock<Promise<void>, [unknown, string]>;
+  readBinary: jest.Mock<Promise<ArrayBuffer>, [unknown]>;
+  adapter: {
+    exists: jest.Mock<Promise<boolean>, [string]>;
+    read: jest.Mock<Promise<string>, [string]>;
+    append: jest.Mock<Promise<void>, [string, string]>;
+    mkdir: jest.Mock<Promise<void>, [string]>;
+  };
+};
+
+function getEnv(name: string): string | undefined {
+  if (process.env[name]) {
+    return process.env[name];
+  }
+
+  const envPath = path.join(process.cwd(), '.env');
+  if (!fs.existsSync(envPath)) {
+    return undefined;
+  }
+
+  const line = fs.readFileSync(envPath, 'utf8')
+    .split(/\r?\n/)
+    .find(candidate => candidate.startsWith(`${name}=`));
+  return line?.slice(name.length + 1).replace(/^['"]|['"]$/g, '');
+}
+
+function makeSettings(): LLMProviderSettings {
+  return {
+    ...DEFAULT_LLM_PROVIDER_SETTINGS,
+    providers: {
+      ...DEFAULT_LLM_PROVIDER_SETTINGS.providers,
+      openrouter: {
+        ...DEFAULT_LLM_PROVIDER_SETTINGS.providers.openrouter,
+        apiKey: getEnv('OPENROUTER_API_KEY') || '',
+        enabled: true,
+      },
+    },
+    defaultVideoModel: {
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      aspectRatio: '16:9',
+      resolution: '720p',
+    },
+  };
+}
+
+function makeFileBackedVault(root: string): MockVault {
+  const entries = new Map<string, unknown>();
+
+  return {
+    getAbstractFileByPath: jest.fn((vaultPath: string) => entries.get(vaultPath) ?? null),
+    createFolder: jest.fn(async (vaultPath: string) => {
+      fs.mkdirSync(path.join(root, vaultPath), { recursive: true });
+      entries.set(vaultPath, new TFolder(vaultPath));
+    }),
+    createBinary: jest.fn(async (vaultPath: string, data: ArrayBuffer) => {
+      const outputPath = path.join(root, vaultPath);
+      fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+      fs.writeFileSync(outputPath, Buffer.from(data));
+      entries.set(vaultPath, { path: vaultPath });
+    }),
+    rename: jest.fn(async (file: unknown, vaultPath: string) => {
+      entries.set(vaultPath, file);
+    }),
+    readBinary: jest.fn(async () => new ArrayBuffer(0)),
+    adapter: {
+      exists: jest.fn(async (vaultPath: string) => fs.existsSync(path.join(root, vaultPath))),
+      read: jest.fn(async (vaultPath: string) => fs.existsSync(path.join(root, vaultPath)) ? fs.readFileSync(path.join(root, vaultPath), 'utf8') : ''),
+      append: jest.fn(async (vaultPath: string, data: string) => {
+        const outputPath = path.join(root, vaultPath);
+        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+        fs.appendFileSync(outputPath, data);
+      }),
+      mkdir: jest.fn(async (vaultPath: string) => {
+        fs.mkdirSync(path.join(root, vaultPath), { recursive: true });
+      }),
+    },
+  } as unknown as MockVault;
+}
+
+function makeApp(): App {
+  return {
+    fileManager: {
+      trashFile: jest.fn().mockResolvedValue(undefined),
+    }
+  } as unknown as App;
+}
+
+function setRealRequestUrl(): void {
+  __setRequestUrlMock(async (request) => {
+    const headers = request.headers as Record<string, string> | undefined;
+    const body = typeof request.body === 'string' ? request.body : undefined;
+    const response = await requestRaw(request.url, request.method || 'GET', headers, body);
+    const text = response.buffer.toString('utf8');
+    const contentType = response.headers['content-type'] || '';
+    const json = contentType.includes('application/json') || text.trim().startsWith('{')
+      ? safeJson(text)
+      : null;
+    return {
+      status: response.status,
+      headers: Object.fromEntries(Object.entries(response.headers).map(([key, value]) => [key, Array.isArray(value) ? value.join(', ') : String(value ?? '')])),
+      text,
+      json,
+      arrayBuffer: response.buffer.buffer.slice(response.buffer.byteOffset, response.buffer.byteOffset + response.buffer.byteLength),
+    };
+  });
+}
+
+function requestRaw(
+  url: string,
+  method: string,
+  headers: Record<string, string> | undefined,
+  body: string | undefined
+): Promise<{ status: number; headers: https.IncomingHttpHeaders; buffer: Buffer }> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method, headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      res.on('end', () => {
+        resolve({
+          status: res.statusCode || 0,
+          headers: res.headers,
+          buffer: Buffer.concat(chunks),
+        });
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(60_000, () => req.destroy(new Error('request timeout')));
+    if (body) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+function safeJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+describeLive('generateVideo live smoke', () => {
+  jest.setTimeout(10 * 60_000);
+
+  it('returns recoverable job details when polling times out', async () => {
+    __setRequestUrlMock(async (request) => {
+      if (request.url.endsWith('/videos/models')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            data: [{
+              id: 'google/veo-3.1-lite',
+              supported_resolutions: ['720p'],
+              supported_aspect_ratios: ['16:9'],
+              supported_durations: [4],
+            }]
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url.endsWith('/videos')) {
+        return {
+          status: 202,
+          headers: {},
+          text: '{}',
+          json: {
+            id: 'job-timeout-smoke',
+            status: 'queued',
+            polling_url: 'https://openrouter.ai/api/v1/videos/job-timeout-smoke',
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return {
+        status: 200,
+        headers: {},
+        text: '{}',
+        json: {
+          id: 'job-timeout-smoke',
+          status: 'queued',
+          polling_url: 'https://openrouter.ai/api/v1/videos/job-timeout-smoke',
+        },
+        arrayBuffer: new ArrayBuffer(0),
+      };
+    });
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-video-timeout-'));
+    const tool = new GenerateVideoTool({
+      app: makeApp(),
+      vault: makeFileBackedVault(root),
+      llmSettings: makeSettings(),
+    });
+
+    const result = await tool.execute({
+      prompt: 'A quiet mountain lake at sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      outputPath: 'video/timeout-smoke.mp4',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 4,
+      pollIntervalMs: 1,
+      timeoutMs: 1,
+      generateAudio: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('timed out');
+    expect(result.error).toContain('job-timeout-smoke');
+    expect(result.data).toMatchObject({
+      status: 'in_progress',
+      jobId: expect.stringMatching(/^artifact_/),
+      path: 'video/timeout-smoke.mp4',
+    });
+  });
+
+  it('generates and saves a real short OpenRouter video when paid smoke is enabled', async () => {
+    if (!RUN_PAID) {
+      console.log('Skipping paid video generation. Set RUN_PAID_VIDEO_SMOKE=1 to enable.');
+      return;
+    }
+
+    const apiKey = getEnv('OPENROUTER_API_KEY');
+    if (!apiKey) {
+      throw new Error('OPENROUTER_API_KEY is required for paid video smoke.');
+    }
+
+    setRealRequestUrl();
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'nexus-video-live-'));
+    const tool = new GenerateVideoTool({
+      app: makeApp(),
+      vault: makeFileBackedVault(root),
+      llmSettings: makeSettings(),
+    });
+
+    const result = await tool.execute({
+      prompt: 'A four second cinematic shot of a small glass prism on a desk splitting morning sunlight into a rainbow. Static camera, realistic, no text.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      outputPath: 'video/openrouter-video-smoke.mp4',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 4,
+      pollIntervalMs: 10_000,
+      timeoutMs: 8 * 60_000,
+      generateAudio: false,
+    });
+
+    if (!result.success) {
+      throw new Error(result.error || 'generateVideo tool returned failure without an error message.');
+    }
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      path: 'video/openrouter-video-smoke.mp4',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      mimeType: 'video/mp4',
+    });
+
+    const outputPath = path.join(root, 'video/openrouter-video-smoke.mp4');
+    const stat = fs.statSync(outputPath);
+    expect(stat.size).toBeGreaterThan(1000);
+    console.log(`Generated video smoke artifact: ${outputPath}`);
+  });
+});

--- a/tests/unit/ArtifactJobStore.test.ts
+++ b/tests/unit/ArtifactJobStore.test.ts
@@ -1,0 +1,97 @@
+import type { Vault } from 'obsidian';
+import { ArtifactJobStore } from '../../src/services/artifacts/ArtifactJobStore';
+
+type MockVault = Vault & {
+  adapter: {
+    exists: jest.Mock<Promise<boolean>, [string]>;
+    read: jest.Mock<Promise<string>, [string]>;
+    append: jest.Mock<Promise<void>, [string, string]>;
+    mkdir: jest.Mock<Promise<void>, [string]>;
+  };
+};
+
+function makeVault(): MockVault {
+  const files = new Map<string, string>();
+  return {
+    adapter: {
+      exists: jest.fn(async (path: string) => files.has(path)),
+      read: jest.fn(async (path: string) => files.get(path) || ''),
+      append: jest.fn(async (path: string, data: string) => {
+        files.set(path, `${files.get(path) || ''}${data}`);
+      }),
+      mkdir: jest.fn(async (path: string) => {
+        files.set(path, files.get(path) || '');
+      }),
+    },
+  } as unknown as MockVault;
+}
+
+describe('ArtifactJobStore', () => {
+  it('appends and reduces artifact job records', async () => {
+    const vault = makeVault();
+    const store = new ArtifactJobStore(vault);
+
+    const created = await store.create({
+      kind: 'video',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      providerJobId: 'job-1',
+      pollingUrl: 'https://openrouter.ai/api/v1/videos/job-1',
+      outputPath: 'video/result.mp4',
+      overwrite: true,
+      request: {
+        seconds: 4,
+        aspectRatio: '16:9',
+        resolution: '720p',
+      },
+    });
+
+    await store.update(created.id, {
+      status: 'completed',
+      result: {
+        path: 'video/result.mp4',
+      },
+    });
+
+    const loaded = await store.get(created.id);
+    expect(loaded).toMatchObject({
+      id: created.id,
+      kind: 'video',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-lite',
+      providerJobId: 'job-1',
+      status: 'completed',
+      outputPath: 'video/result.mp4',
+      overwrite: true,
+      result: {
+        path: 'video/result.mp4',
+      },
+    });
+    expect(vault.adapter.mkdir).toHaveBeenCalledWith('Nexus');
+    expect(vault.adapter.mkdir).toHaveBeenCalledWith('Nexus/data');
+    expect(vault.adapter.append).toHaveBeenCalledWith(
+      'Nexus/data/artifact-jobs.jsonl',
+      expect.any(String)
+    );
+    expect(vault.adapter.append).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses the caller-provided storage path', async () => {
+    const vault = makeVault();
+    const store = new ArtifactJobStore(vault, 'Assistant data/data/artifact-jobs.jsonl');
+
+    await store.create({
+      kind: 'video',
+      provider: 'google',
+      providerJobId: 'operations/video-1',
+      outputPath: 'video/result.mp4',
+    });
+
+    expect(vault.adapter.mkdir).toHaveBeenCalledWith('Assistant data');
+    expect(vault.adapter.mkdir).toHaveBeenCalledWith('Assistant data/data');
+    expect(vault.adapter.append).toHaveBeenCalledWith(
+      'Assistant data/data/artifact-jobs.jsonl',
+      expect.any(String)
+    );
+  });
+});

--- a/tests/unit/VideoGenerationService.test.ts
+++ b/tests/unit/VideoGenerationService.test.ts
@@ -1,0 +1,393 @@
+import type { App, Vault } from 'obsidian';
+import { TFolder, __setRequestUrlMock } from '../mocks/obsidian';
+import { VideoGenerationService } from '../../src/services/video/VideoGenerationService';
+import { VideoGenerationTimeoutError } from '../../src/services/video/VideoGenerationTypes';
+import { GoogleVideoAdapter } from '../../src/services/video/adapters/GoogleVideoAdapter';
+import { OpenRouterVideoAdapter } from '../../src/services/video/adapters/OpenRouterVideoAdapter';
+import { GenerateVideoTool } from '../../src/agents/promptManager/tools/generateVideo';
+import { CheckGeneratedArtifactTool } from '../../src/agents/promptManager/tools/checkGeneratedArtifact';
+import { DEFAULT_LLM_PROVIDER_SETTINGS, type LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
+
+type MockVault = Vault & {
+  getAbstractFileByPath: jest.Mock<unknown, [string]>;
+  createBinary: jest.Mock<Promise<void>, [string, ArrayBuffer]>;
+  createFolder: jest.Mock<Promise<void>, [string]>;
+  rename: jest.Mock<Promise<void>, [unknown, string]>;
+  adapter: {
+    exists: jest.Mock<Promise<boolean>, [string]>;
+    read: jest.Mock<Promise<string>, [string]>;
+    append: jest.Mock<Promise<void>, [string, string]>;
+    mkdir: jest.Mock<Promise<void>, [string]>;
+  };
+};
+
+function makeSettings(provider: 'google' | 'openrouter'): LLMProviderSettings {
+  return {
+    ...DEFAULT_LLM_PROVIDER_SETTINGS,
+    providers: {
+      ...DEFAULT_LLM_PROVIDER_SETTINGS.providers,
+      [provider]: {
+        ...DEFAULT_LLM_PROVIDER_SETTINGS.providers[provider],
+        apiKey: 'test-key',
+        enabled: true,
+      },
+    },
+    defaultVideoModel: provider === 'google'
+      ? {
+        provider: 'google',
+        model: 'veo-3.1-generate-preview',
+        aspectRatio: '16:9',
+        resolution: '720p',
+      }
+      : {
+        provider: 'openrouter',
+        model: 'google/veo-3.1-fast',
+        aspectRatio: '16:9',
+        resolution: '720p',
+      },
+  };
+}
+
+function makeVault(existing: Record<string, unknown> = {}): MockVault {
+  const files = new Map<string, unknown>(Object.entries(existing));
+  const adapterFiles = new Map<string, string>();
+  return {
+    getAbstractFileByPath: jest.fn((path: string) => files.get(path) ?? null),
+    createBinary: jest.fn(async (path: string, _data: ArrayBuffer) => {
+      files.set(path, { path });
+    }),
+    createFolder: jest.fn(async (path: string) => {
+      files.set(path, new TFolder(path));
+    }),
+    rename: jest.fn(async (file: unknown, path: string) => {
+      files.set(path, file);
+    }),
+    adapter: {
+      exists: jest.fn(async (path: string) => adapterFiles.has(path)),
+      read: jest.fn(async (path: string) => adapterFiles.get(path) || ''),
+      append: jest.fn(async (path: string, data: string) => {
+        adapterFiles.set(path, `${adapterFiles.get(path) || ''}${data}`);
+      }),
+      mkdir: jest.fn(async (path: string) => {
+        adapterFiles.set(path, adapterFiles.get(path) || '');
+      }),
+    },
+  } as unknown as MockVault;
+}
+
+function makeApp(): App {
+  return {
+    fileManager: {
+      trashFile: jest.fn().mockResolvedValue(undefined),
+    }
+  } as unknown as App;
+}
+
+describe('VideoGenerationService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('generates video and writes it to the vault', async () => {
+    jest.spyOn(GoogleVideoAdapter.prototype, 'generate').mockResolvedValue({
+      videoData: new Uint8Array([1, 2, 3, 4]).buffer,
+      mimeType: 'video/mp4',
+      providerJobId: 'operations/video-1',
+      durationSeconds: 8,
+    });
+
+    const vault = makeVault();
+    const service = new VideoGenerationService(makeApp(), vault, {
+      llmSettings: makeSettings('google'),
+    });
+
+    const result = await service.generate({
+      prompt: 'A calm ocean sunrise.',
+      outputPath: 'video/sunrise.mp4',
+      seconds: 8,
+    });
+
+    expect(vault.createFolder).toHaveBeenCalledWith('video');
+    expect(vault.createBinary).toHaveBeenCalledWith('video/sunrise.mp4', expect.any(ArrayBuffer));
+    expect(result).toMatchObject({
+      status: 'completed',
+      path: 'video/sunrise.mp4',
+      provider: 'google',
+      model: 'veo-3.1-generate-preview',
+      mimeType: 'video/mp4',
+      videoSize: 4,
+      providerJobId: 'operations/video-1',
+      note: 'Video generation completed and saved to video/sunrise.mp4.',
+    });
+  });
+
+  it('refuses to overwrite an existing output unless requested', async () => {
+    jest.spyOn(GoogleVideoAdapter.prototype, 'generate').mockResolvedValue({
+      videoData: new ArrayBuffer(1),
+      mimeType: 'video/mp4',
+    });
+
+    const vault = makeVault({
+      video: new TFolder('video'),
+      'video/existing.mp4': { path: 'video/existing.mp4' },
+    });
+    const service = new VideoGenerationService(makeApp(), vault, {
+      llmSettings: makeSettings('google'),
+    });
+
+    await expect(service.generate({
+      prompt: 'A calm ocean sunrise.',
+      outputPath: 'video/existing.mp4',
+    })).rejects.toThrow('File already exists at video/existing.mp4');
+
+    expect(vault.createBinary).not.toHaveBeenCalled();
+  });
+
+  it('returns structured in-progress details when the tool times out', async () => {
+    jest.spyOn(GoogleVideoAdapter.prototype, 'generate').mockRejectedValue(
+      new VideoGenerationTimeoutError(
+        'Google video generation timed out after 1 seconds. Operation name: operations/video-1.',
+        {
+          provider: 'google',
+          model: 'veo-3.1-generate-preview',
+          providerJobId: 'operations/video-1',
+          pollingUrl: 'https://generativelanguage.googleapis.com/v1beta/operations/video-1',
+          timeoutMs: 1000,
+        }
+      )
+    );
+
+    const vault = makeVault();
+    const tool = new GenerateVideoTool({
+      app: makeApp(),
+      vault,
+      llmSettings: makeSettings('google'),
+    });
+
+    const result = await tool.execute({
+      prompt: 'A calm ocean sunrise.',
+      outputPath: 'video/sunrise.mp4',
+      timeoutMs: 1000,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('still running');
+    expect(result.data).toMatchObject({
+      status: 'in_progress',
+      jobId: expect.stringMatching(/^artifact_/),
+      path: 'video/sunrise.mp4',
+      provider: 'google',
+      model: 'veo-3.1-generate-preview',
+      providerJobId: 'operations/video-1',
+      pollingUrl: 'https://generativelanguage.googleapis.com/v1beta/operations/video-1',
+      note: expect.stringContaining('video/sunrise.mp4'),
+    });
+    expect(vault.adapter.append).toHaveBeenCalledWith(
+      'Nexus/data/artifact-jobs.jsonl',
+      expect.any(String)
+    );
+  });
+
+  it('checks a saved generated artifact job and saves the completed video', async () => {
+    const vault = makeVault();
+    jest.spyOn(GoogleVideoAdapter.prototype, 'generate').mockRejectedValue(
+      new VideoGenerationTimeoutError(
+        'Google video generation timed out after 1 seconds. Operation name: operations/video-2.',
+        {
+          provider: 'google',
+          model: 'veo-3.1-generate-preview',
+          providerJobId: 'operations/video-2',
+          pollingUrl: 'https://generativelanguage.googleapis.com/v1beta/operations/video-2',
+          timeoutMs: 1000,
+          request: {
+            seconds: 8,
+            aspectRatio: '16:9',
+            resolution: '720p',
+          },
+        }
+      )
+    );
+    jest.spyOn(GoogleVideoAdapter.prototype, 'checkJob').mockResolvedValue({
+      status: 'completed',
+      result: {
+        videoData: new Uint8Array([9, 8, 7]).buffer,
+        mimeType: 'video/mp4',
+        providerJobId: 'operations/video-2',
+        pollingUrl: 'https://generativelanguage.googleapis.com/v1beta/operations/video-2',
+        durationSeconds: 8,
+      },
+    });
+
+    const generateTool = new GenerateVideoTool({
+      app: makeApp(),
+      vault,
+      llmSettings: makeSettings('google'),
+    });
+
+    const initial = await generateTool.execute({
+      prompt: 'A calm ocean sunrise.',
+      outputPath: 'video/sunrise.mp4',
+      timeoutMs: 1000,
+    });
+
+    const jobId = (initial.data as { jobId?: string }).jobId;
+    expect(jobId).toBeTruthy();
+
+    const checkTool = new CheckGeneratedArtifactTool({
+      app: makeApp(),
+      vault,
+      llmSettings: makeSettings('google'),
+    });
+    const final = await checkTool.execute({
+      jobId: jobId || '',
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(final.success).toBe(true);
+    expect(final.data).toMatchObject({
+      status: 'completed',
+      jobId,
+      path: 'video/sunrise.mp4',
+      providerJobId: 'operations/video-2',
+      note: 'Video generation completed and saved to video/sunrise.mp4.',
+    });
+    expect(vault.createBinary).toHaveBeenCalledWith('video/sunrise.mp4', expect.any(ArrayBuffer));
+  });
+});
+
+describe('OpenRouterVideoAdapter', () => {
+  beforeEach(() => {
+    __setRequestUrlMock(async () => ({
+      status: 200,
+      headers: {},
+      text: '{}',
+      json: {},
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('submits, polls, and downloads a completed video job', async () => {
+    const calls: string[] = [];
+    __setRequestUrlMock(async (request) => {
+      calls.push(request.url);
+
+      if (request.url.endsWith('/videos/models')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            data: [{
+              id: 'google/veo-3.1-fast',
+              name: 'Veo 3.1 Fast',
+              supported_resolutions: ['720p'],
+              supported_aspect_ratios: ['16:9'],
+              supported_durations: [5],
+              generate_audio: true,
+            }]
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url.endsWith('/videos')) {
+        return {
+          status: 202,
+          headers: {},
+          text: '{}',
+          json: {
+            id: 'job-1',
+            status: 'queued',
+            polling_url: 'https://openrouter.ai/api/v1/videos/job-1',
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url.endsWith('/videos/job-1')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            id: 'job-1',
+            status: 'completed',
+            unsigned_urls: ['https://cdn.example.com/video.mp4'],
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return {
+        status: 200,
+        headers: {},
+        text: '',
+        json: null,
+        arrayBuffer: new Uint8Array([5, 6, 7]).buffer,
+      };
+    });
+
+    const adapter = new OpenRouterVideoAdapter({
+      apiKey: 'test-key',
+      vault: makeVault(),
+    });
+
+    const result = await adapter.generate({
+      prompt: 'A calm ocean sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-fast',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 5,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(calls).toEqual([
+      'https://openrouter.ai/api/v1/videos/models',
+      'https://openrouter.ai/api/v1/videos',
+      'https://openrouter.ai/api/v1/videos/job-1',
+      'https://cdn.example.com/video.mp4',
+    ]);
+    expect(result.videoData.byteLength).toBe(3);
+    expect(result.providerJobId).toBe('job-1');
+  });
+
+  it('rejects unsupported model options from OpenRouter metadata', async () => {
+    __setRequestUrlMock(async () => ({
+      status: 200,
+      headers: {},
+      text: '{}',
+      json: {
+        data: [{
+          id: 'google/veo-3.1-fast',
+          supported_resolutions: ['720p'],
+          supported_aspect_ratios: ['16:9'],
+          supported_durations: [5],
+        }]
+      },
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+
+    const adapter = new OpenRouterVideoAdapter({
+      apiKey: 'test-key',
+      vault: makeVault(),
+    });
+
+    await expect(adapter.generate({
+      prompt: 'A calm ocean sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-fast',
+      aspectRatio: '16:9',
+      resolution: '1080p',
+      seconds: 5,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    })).rejects.toThrow('does not support resolution "1080p"');
+  });
+});


### PR DESCRIPTION
## Summary
- add PromptManager text-to-video generation for Google Veo and OpenRouter video models
- add generated artifact job persistence under the configured Nexus data folder, plus checkGeneratedArtifact for timeout recovery
- add video defaults settings, trace labels, plans, unit tests, and a gated live smoke test

## Validation
- npx jest tests/unit/ArtifactJobStore.test.ts tests/unit/VideoGenerationService.test.ts --runInBand
- npx tsc --noEmit --skipLibCheck
- npm run build
- RUN_LIVE_VIDEO_SMOKE=1 npx jest tests/debug/video-generation-live-smoke.test.ts --runInBand