### PR TITLE
Add live voice composer shell

### DIFF
--- a/docs/mockups/live-voice-composer.css
+++ b/docs/mockups/live-voice-composer.css
@@ -1,0 +1,671 @@
+:root {
+  color-scheme: dark;
+  --background-primary: #1f2125;
+  --background-secondary: #262a31;
+  --background-secondary-alt: #2b3038;
+  --background-modifier-border: #3a404a;
+  --background-modifier-hover: #303641;
+  --interactive-accent: #8cb8ff;
+  --interactive-accent-hover: #a8caff;
+  --text-normal: #edf1f7;
+  --text-muted: #acb5c2;
+  --text-faint: #7e8794;
+  --text-error: #ef6b73;
+  --color-red-rgb: 239, 107, 115;
+  --color-amber: #f4b86a;
+  --color-amber-rgb: 244, 184, 106;
+  --color-cyan-rgb: 123, 215, 221;
+  --color-green: #71d39a;
+  --color-green-rgb: 113, 211, 154;
+  --color-cyan: #7bd7dd;
+  --radius-s: 6px;
+  --radius-m: 8px;
+  --radius-l: 12px;
+  --font-interface: "SF Pro Text", "Segoe UI", sans-serif;
+  --shadow-l: 0 18px 48px rgba(0, 0, 0, 0.34);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+button {
+  font: inherit;
+}
+
+svg {
+  width: 18px;
+  height: 18px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.mock-page {
+  min-height: 100vh;
+  padding: 24px;
+  background: linear-gradient(180deg, #17191d 0%, #202329 100%);
+  color: var(--text-normal);
+  font-family: var(--font-interface);
+}
+
+.mock-layout {
+  width: min(1160px, 100%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 300px minmax(0, 1fr);
+  gap: 18px;
+  align-items: start;
+}
+
+.mock-panel,
+.chat-shell {
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-l);
+  background: var(--background-secondary);
+  box-shadow: var(--shadow-l);
+}
+
+.mock-panel {
+  padding: 16px;
+  position: sticky;
+  top: 24px;
+}
+
+.mock-eyebrow {
+  margin: 0 0 6px;
+  color: var(--text-faint);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: 24px;
+  line-height: 1.15;
+}
+
+.mock-summary,
+.mock-notes p {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.mock-controls,
+.mock-notes {
+  margin-top: 18px;
+  display: grid;
+  gap: 8px;
+}
+
+.mock-control-label {
+  color: var(--text-faint);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.mock-state-button {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-m);
+  background: var(--background-primary);
+  color: var(--text-normal);
+  cursor: pointer;
+  text-align: left;
+}
+
+.mock-state-button:hover {
+  background: var(--background-modifier-hover);
+}
+
+.mock-state-button.is-active {
+  border-color: var(--interactive-accent);
+  background: color-mix(in srgb, var(--interactive-accent) 18%, var(--background-primary));
+}
+
+.chat-shell {
+  min-height: calc(100vh - 48px);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr auto auto;
+}
+
+.chat-header {
+  min-height: 48px;
+  padding: 6px 10px;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid color-mix(in srgb, var(--background-modifier-border) 70%, transparent);
+}
+
+.chat-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  color: var(--text-normal);
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.chat-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.chat-header-button {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-s);
+  background: transparent;
+  color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.chat-header-button:hover,
+.chat-header-button:focus-visible {
+  color: var(--text-normal);
+  background: color-mix(in srgb, var(--background-modifier-hover) 72%, transparent);
+}
+
+.chat-live-entry {
+  color: var(--interactive-accent);
+}
+
+.message-display {
+  min-height: 0;
+  overflow: hidden;
+  background: var(--background-primary);
+}
+
+.messages-container {
+  height: 100%;
+  overflow-y: auto;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.message {
+  display: flex;
+  width: 100%;
+}
+
+.message-user {
+  justify-content: flex-end;
+}
+
+.message-assistant {
+  justify-content: flex-start;
+}
+
+.message-bubble {
+  max-width: min(78%, 640px);
+  padding: 10px 12px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-l);
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  font-size: 14px;
+  line-height: 1.48;
+}
+
+.message-user .message-bubble {
+  background: color-mix(in srgb, var(--interactive-accent) 16%, var(--background-secondary));
+  border-color: color-mix(in srgb, var(--interactive-accent) 42%, var(--background-modifier-border));
+}
+
+.message.is-partial .message-bubble::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 1em;
+  margin-left: 3px;
+  border-radius: 999px;
+  background: var(--interactive-accent);
+  vertical-align: -2px;
+  animation: partial-caret 1s steps(2, end) infinite;
+}
+
+.live-status-bar {
+  min-height: 0;
+  height: 0;
+  padding: 0 14px;
+  border-top: 0 solid transparent;
+  background: var(--background-secondary);
+  color: var(--text-faint);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  opacity: 0;
+  transition: height 160ms ease, min-height 160ms ease, padding 160ms ease, opacity 160ms ease;
+}
+
+.live-status-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+body:not([data-state="normal"]) .live-status-bar {
+  min-height: 30px;
+  height: 30px;
+  padding: 5px 14px;
+  border-top: 1px solid color-mix(in srgb, var(--background-modifier-border) 62%, transparent);
+  opacity: 1;
+}
+
+body[data-state="connecting"] .live-status-bar {
+  color: var(--color-amber);
+}
+
+body[data-state="listening"] .live-status-bar {
+  color: var(--interactive-accent);
+}
+
+body[data-state="user-speaking"] .live-status-bar {
+  color: var(--color-cyan);
+}
+
+body[data-state="assistant-speaking"] .live-status-bar {
+  color: var(--color-green);
+}
+
+body[data-state="error"] .live-status-bar {
+  color: var(--text-error);
+}
+
+.chat-input-container {
+  padding: 8px 11px 10px;
+  background: var(--background-primary);
+}
+
+.chat-input-wrapper {
+  position: relative;
+  min-height: 72px;
+}
+
+.chat-textarea,
+.chat-live-composer {
+  width: 100%;
+  min-height: 72px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: var(--radius-l);
+  background: var(--background-secondary);
+}
+
+.chat-textarea {
+  padding: 14px 56px 14px 14px;
+  color: var(--text-normal);
+  outline: none;
+  line-height: 1.5;
+}
+
+.chat-textarea:empty::before {
+  content: attr(data-placeholder);
+  color: var(--text-muted);
+}
+
+.chat-send-button,
+.chat-live-stop-button {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  width: 40px;
+  height: 40px;
+  transform: translateY(-50%);
+  border: 1px solid color-mix(in srgb, var(--interactive-accent) 36%, var(--background-modifier-border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--interactive-accent) 22%, var(--background-primary));
+  color: var(--text-normal);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.chat-send-button:hover,
+.chat-live-stop-button:hover {
+  background: color-mix(in srgb, var(--interactive-accent-hover) 28%, var(--background-primary));
+}
+
+.chat-live-composer {
+  display: none;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 58px 12px 14px;
+  overflow: hidden;
+}
+
+.chat-live-dot {
+  flex: 0 0 auto;
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--live-dot-color, var(--text-error));
+  box-shadow: 0 0 0 0 rgba(var(--live-dot-rgb, var(--color-red-rgb)), 0.36);
+  animation: live-dot-pulse 1.8s ease-in-out infinite;
+}
+
+.chat-live-waveform {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: stretch;
+  gap: 3px;
+  padding-inline: 2px;
+  position: relative;
+}
+
+.wave-bar {
+  flex: 1 1 0;
+  min-width: 2px;
+  max-width: 8px;
+  height: 30px;
+  border-radius: 999px;
+  background: var(--interactive-accent);
+  opacity: 0.54;
+  transform: scaleY(var(--listen-scale, 0.32));
+  animation: waveform-listening 1.55s ease-in-out infinite;
+  animation-delay: calc(var(--bar-index, 0) * -80ms);
+  transform-origin: center;
+}
+
+.chat-live-stop-button {
+  border-color: color-mix(in srgb, var(--text-error) 56%, var(--background-modifier-border));
+  background: color-mix(in srgb, var(--text-error) 24%, var(--background-primary));
+}
+
+.chat-live-stop-button:hover {
+  background: color-mix(in srgb, var(--text-error) 34%, var(--background-primary));
+}
+
+body:not([data-state="normal"]) .chat-live-entry {
+  background: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+}
+
+body:not([data-state="normal"]) .chat-textarea,
+body:not([data-state="normal"]) .chat-send-button {
+  display: none;
+}
+
+body:not([data-state="normal"]) .chat-live-composer {
+  display: flex;
+}
+
+body[data-state="connecting"] .wave-bar {
+  display: none;
+}
+
+body[data-state="connecting"] .chat-live-dot {
+  --live-dot-color: var(--color-amber);
+  --live-dot-rgb: var(--color-amber-rgb);
+}
+
+body[data-state="connecting"] .chat-live-waveform {
+  justify-content: center;
+}
+
+body[data-state="connecting"] .chat-live-waveform::before {
+  content: "";
+  width: 26px;
+  height: 26px;
+  border-radius: 999px;
+  border: 2px solid color-mix(in srgb, var(--color-amber) 32%, transparent);
+  border-top-color: var(--color-amber);
+  animation: live-connecting-spin 860ms linear infinite;
+}
+
+body[data-state="connecting"] .chat-live-waveform::after {
+  content: "";
+  position: absolute;
+  width: min(180px, 58%);
+  height: 1px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--color-amber) 52%, transparent), transparent);
+  transform: translateY(19px);
+  opacity: 0.68;
+}
+
+body[data-state="listening"] .wave-bar {
+  background: var(--interactive-accent);
+  animation-name: waveform-listening;
+}
+
+body[data-state="listening"] .chat-live-dot {
+  --live-dot-color: var(--text-error);
+  --live-dot-rgb: var(--color-red-rgb);
+}
+
+body[data-state="user-speaking"] .wave-bar {
+  background: var(--color-cyan);
+  opacity: 0.86;
+  animation-name: waveform-user;
+  animation-duration: 560ms;
+  animation-delay: calc(var(--bar-index, 0) * -42ms);
+}
+
+body[data-state="user-speaking"] .chat-live-dot {
+  --live-dot-color: var(--color-cyan);
+  --live-dot-rgb: var(--color-cyan-rgb);
+}
+
+body[data-state="assistant-speaking"] .wave-bar {
+  background: var(--color-green);
+  opacity: 0.9;
+  animation-name: waveform-assistant;
+  animation-duration: 1040ms;
+  animation-delay: calc(var(--bar-index, 0) * -66ms);
+}
+
+body[data-state="assistant-speaking"] .chat-live-dot {
+  --live-dot-color: var(--color-green);
+  --live-dot-rgb: var(--color-green-rgb);
+}
+
+body[data-state="error"] .chat-live-composer {
+  border-color: color-mix(in srgb, var(--text-error) 58%, var(--background-modifier-border));
+}
+
+body[data-state="error"] .wave-bar {
+  display: none;
+}
+
+body[data-state="error"] .chat-live-dot {
+  --live-dot-color: var(--text-error);
+  --live-dot-rgb: var(--color-red-rgb);
+  animation-duration: 760ms;
+}
+
+body[data-state="error"] .chat-live-waveform {
+  justify-content: center;
+}
+
+body[data-state="error"] .chat-live-waveform::before,
+body[data-state="error"] .chat-live-waveform::after {
+  content: "";
+  position: absolute;
+  width: 34px;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--text-error);
+}
+
+body[data-state="error"] .chat-live-waveform::before {
+  transform: rotate(45deg);
+}
+
+body[data-state="error"] .chat-live-waveform::after {
+  transform: rotate(-45deg);
+}
+
+@keyframes live-dot-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(var(--live-dot-rgb, var(--color-red-rgb)), 0.32);
+    opacity: 0.82;
+  }
+
+  50% {
+    box-shadow: 0 0 0 5px rgba(var(--live-dot-rgb, var(--color-red-rgb)), 0);
+    opacity: 1;
+  }
+}
+
+@keyframes waveform-listening {
+  0%,
+  100% {
+    transform: scaleY(var(--listen-min, 0.22));
+    opacity: 0.32;
+  }
+
+  50% {
+    transform: scaleY(var(--listen-max, 0.52));
+    opacity: 0.62;
+  }
+}
+
+@keyframes waveform-connecting {
+  0%,
+  100% {
+    transform: scaleY(0.22);
+    opacity: 0.32;
+  }
+
+  45%,
+  55% {
+    transform: scaleY(var(--connect-scale, 0.82));
+    opacity: 0.78;
+  }
+}
+
+@keyframes live-connecting-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes waveform-user {
+  0%,
+  100% {
+    transform: scaleY(var(--user-min, 0.28));
+  }
+
+  38% {
+    transform: scaleY(var(--user-peak, 1.16));
+  }
+
+  72% {
+    transform: scaleY(var(--user-mid, 0.55));
+  }
+}
+
+@keyframes waveform-assistant {
+  0%,
+  100% {
+    transform: scaleY(var(--assistant-min, 0.42));
+  }
+
+  25% {
+    transform: scaleY(var(--assistant-peak, 1.18));
+  }
+
+  65% {
+    transform: scaleY(var(--assistant-mid, 0.82));
+  }
+}
+
+@keyframes waveform-error {
+  0%,
+  100% {
+    transform: scaleY(0.24);
+    opacity: 0.5;
+  }
+
+  50% {
+    transform: scaleY(0.5);
+    opacity: 0.92;
+  }
+}
+
+@keyframes partial-caret {
+  0%,
+  45% {
+    opacity: 1;
+  }
+
+  46%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (max-width: 820px) {
+  .mock-page {
+    padding: 14px;
+  }
+
+  .mock-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .mock-panel {
+    position: static;
+  }
+
+  .chat-shell {
+    min-height: 720px;
+  }
+
+  .message-bubble {
+    max-width: 88%;
+  }
+
+  .chat-header {
+    grid-template-columns: 34px minmax(0, 1fr) auto;
+  }
+
+  .chat-header-actions {
+    gap: 0;
+  }
+
+  .chat-header-button {
+    width: 32px;
+  }
+
+  .chat-live-waveform {
+    gap: 2px;
+  }
+
+  .wave-bar {
+    min-width: 1px;
+  }
+}

--- a/docs/mockups/live-voice-composer.html
+++ b/docs/mockups/live-voice-composer.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nexus live voice composer mockup</title>
+  <link rel="stylesheet" href="./live-voice-composer.css">
+</head>
+<body class="mock-page theme-dark" data-state="normal">
+  <main class="mock-layout">
+    <aside class="mock-panel" aria-label="Mock controls">
+      <p class="mock-eyebrow">Nexus voice mode</p>
+      <h1>Live composer takeover</h1>
+      <p class="mock-summary">
+        This mock keeps text chat as the primary surface. Live voice only replaces the composer with a red session dot,
+        a stateful waveform, and a stop button.
+      </p>
+
+      <div class="mock-controls">
+        <div class="mock-control-label">State</div>
+        <button type="button" class="mock-state-button is-active" data-state-button="normal">
+          Normal composer
+        </button>
+        <button type="button" class="mock-state-button" data-state-button="connecting">
+          Connecting
+        </button>
+        <button type="button" class="mock-state-button" data-state-button="listening">
+          Listening
+        </button>
+        <button type="button" class="mock-state-button" data-state-button="user-speaking">
+          User speaking
+        </button>
+        <button type="button" class="mock-state-button" data-state-button="assistant-speaking">
+          Assistant speaking
+        </button>
+        <button type="button" class="mock-state-button" data-state-button="error">
+          Error
+        </button>
+      </div>
+
+      <div class="mock-notes">
+        <div class="mock-control-label">Design notes</div>
+        <p>The live composer itself intentionally has no visible text. The dot communicates that the session is active,
+        the waveform communicates who is speaking, and the square button exits live mode.</p>
+        <p>Transcript content stays in the normal message stream so live voice feels like another way to drive the same chat.</p>
+      </div>
+    </aside>
+
+    <section class="chat-shell" aria-label="Nexus chat preview">
+      <header class="chat-header">
+        <button type="button" class="chat-header-button" aria-label="Toggle conversations">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3 6h18"></path>
+            <path d="M3 12h18"></path>
+            <path d="M3 18h18"></path>
+          </svg>
+        </button>
+        <div class="chat-title">Research notes</div>
+        <div class="chat-header-actions">
+          <button type="button" class="chat-header-button chat-live-entry" aria-label="Start live voice" title="Start live voice">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 12h2"></path>
+              <path d="M7 6v12"></path>
+              <path d="M12 3v18"></path>
+              <path d="M17 8v8"></path>
+              <path d="M22 12h-2"></path>
+            </svg>
+          </button>
+          <button type="button" class="chat-header-button" aria-label="Subagents" title="Subagents">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 8V4H8"></path>
+              <rect x="4" y="8" width="16" height="12" rx="2"></rect>
+              <path d="M2 14h2"></path>
+              <path d="M20 14h2"></path>
+              <path d="M9 13h.01"></path>
+              <path d="M15 13h.01"></path>
+              <path d="M10 17h4"></path>
+            </svg>
+          </button>
+          <button type="button" class="chat-header-button" aria-label="Chat settings" title="Chat settings">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="12" cy="12" r="3"></circle>
+              <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.1V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-.4-1.1 1.7 1.7 0 0 0-1-.6 1.7 1.7 0 0 0-1.82.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.1-.4H2.8a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.1-.4 1.7 1.7 0 0 0 .6-1A1.7 1.7 0 0 0 4.26 6.4l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.7 1.7 0 0 0 9 4.6a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.1V2.8a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 .4 1.1 1.7 1.7 0 0 0 1 .6 1.7 1.7 0 0 0 1.82-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.7 1.7 0 0 0 19.4 9a1.7 1.7 0 0 0 .6 1 1.7 1.7 0 0 0 1.1.4h.1a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.1.4 1.7 1.7 0 0 0-.6 1z"></path>
+            </svg>
+          </button>
+        </div>
+      </header>
+
+      <section class="message-display" aria-label="Conversation">
+        <div class="messages-container" data-role="messages">
+          <article class="message message-user">
+            <div class="message-bubble">Can you help me think through the voice mode UX without making the composer noisy?</div>
+          </article>
+          <article class="message message-assistant">
+            <div class="message-bubble">I would keep voice mode as a composer state and let the message stream stay unchanged.</div>
+          </article>
+        </div>
+      </section>
+
+      <div class="live-status-bar" data-role="live-status-bar" role="status" aria-live="polite" aria-atomic="true">
+        <span class="live-status-text" data-role="live-status-text"></span>
+      </div>
+
+      <footer class="chat-input-container">
+        <div class="chat-input">
+          <div class="chat-input-wrapper" data-role="composer-shell">
+            <div
+              class="chat-textarea"
+              role="textbox"
+              aria-multiline="true"
+              data-placeholder="Type your message..."
+              contenteditable="true"
+            ></div>
+
+            <div class="chat-live-composer" role="group" aria-label="Live voice session">
+              <span class="chat-live-dot" aria-hidden="true"></span>
+              <div class="chat-live-waveform" data-role="live-waveform" aria-hidden="true"></div>
+              <button type="button" class="chat-live-stop-button" data-role="stop-live" aria-label="Stop live voice" title="Stop live voice">
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <rect x="7" y="7" width="10" height="10" rx="1.5"></rect>
+                </svg>
+              </button>
+            </div>
+
+            <button type="button" class="chat-send-button" aria-label="Send message">
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 19V5"></path>
+                <path d="M5 12l7-7 7 7"></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </footer>
+    </section>
+  </main>
+
+  <script src="./live-voice-composer.js"></script>
+</body>
+</html>

--- a/docs/mockups/live-voice-composer.js
+++ b/docs/mockups/live-voice-composer.js
@@ -1,0 +1,145 @@
+const stateButtons = Array.from(document.querySelectorAll('[data-state-button]'));
+const messagesEl = document.querySelector('[data-role="messages"]');
+const statusTextEl = document.querySelector('[data-role="live-status-text"]');
+const stopButton = document.querySelector('[data-role="stop-live"]');
+const liveEntryButton = document.querySelector('.chat-live-entry');
+const waveformEl = document.querySelector('[data-role="live-waveform"]');
+
+const baseMessages = [
+  {
+    role: 'user',
+    text: 'Can you help me think through the voice mode UX without making the composer noisy?'
+  },
+  {
+    role: 'assistant',
+    text: 'I would keep voice mode as a composer state and let the message stream stay unchanged.'
+  }
+];
+
+const stateMessages = {
+  normal: {
+    status: '',
+    additions: []
+  },
+  connecting: {
+    status: 'Connecting live voice...',
+    additions: []
+  },
+  listening: {
+    status: 'Listening',
+    additions: [
+      { role: 'assistant', text: 'I am ready. Start talking whenever you want to steer the conversation.' }
+    ]
+  },
+  'user-speaking': {
+    status: 'Transcribing your speech...',
+    additions: [
+      { role: 'user', text: 'What if the waveform stays in the composer and the transcript just appears here?', partial: true }
+    ]
+  },
+  'assistant-speaking': {
+    status: 'Nexus is speaking...',
+    additions: [
+      { role: 'user', text: 'What if the waveform stays in the composer and the transcript just appears here?' },
+      { role: 'assistant', text: 'That keeps the live session visible without creating a second chat surface. The composer becomes the control layer, while messages remain the record.', partial: true }
+    ]
+  },
+  error: {
+    status: 'Live voice connection failed. Stop and try again.',
+    additions: []
+  }
+};
+
+function createMessage(message) {
+  const article = document.createElement('article');
+  article.className = `message message-${message.role}`;
+  if (message.partial) {
+    article.classList.add('is-partial');
+  }
+
+  const bubble = document.createElement('div');
+  bubble.className = 'message-bubble';
+  bubble.textContent = message.text;
+  article.appendChild(bubble);
+
+  return article;
+}
+
+function renderMessages(state) {
+  if (!messagesEl) return;
+
+  messagesEl.replaceChildren();
+  const messages = [...baseMessages, ...(stateMessages[state]?.additions ?? [])];
+  messages.forEach(message => messagesEl.appendChild(createMessage(message)));
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+function buildWaveformBars() {
+  if (!waveformEl) return;
+
+  waveformEl.replaceChildren();
+
+  const barCount = 72;
+  const center = (barCount - 1) / 2;
+
+  for (let index = 0; index < barCount; index += 1) {
+    const distanceFromCenter = Math.abs(index - center) / center;
+    const sine = Math.sin((index / (barCount - 1)) * Math.PI);
+    const jagged = [0.36, 0.92, 0.52, 1.2, 0.42, 0.78, 1.34, 0.58][index % 8];
+    const assistantWave = 0.42 + (sine * 0.86);
+    const connectWave = index % 9 === 0 || index % 9 === 1 ? 1.05 : 0.34 + ((index % 5) * 0.08);
+
+    const bar = document.createElement('span');
+    bar.className = 'wave-bar';
+    bar.style.setProperty('--bar-index', String(index));
+    bar.style.setProperty('--listen-min', (0.16 + sine * 0.08).toFixed(2));
+    bar.style.setProperty('--listen-max', (0.28 + sine * 0.24).toFixed(2));
+    bar.style.setProperty('--connect-scale', connectWave.toFixed(2));
+    bar.style.setProperty('--user-min', Math.max(0.18, jagged * 0.32).toFixed(2));
+    bar.style.setProperty('--user-mid', Math.max(0.3, jagged * 0.58).toFixed(2));
+    bar.style.setProperty('--user-peak', Math.min(1.45, jagged).toFixed(2));
+    bar.style.setProperty('--assistant-min', (0.32 + (1 - distanceFromCenter) * 0.22).toFixed(2));
+    bar.style.setProperty('--assistant-mid', (0.48 + assistantWave * 0.32).toFixed(2));
+    bar.style.setProperty('--assistant-peak', (0.62 + assistantWave * 0.58).toFixed(2));
+    waveformEl.appendChild(bar);
+  }
+}
+
+function setState(state) {
+  document.body.dataset.state = state;
+
+  stateButtons.forEach(button => {
+    button.classList.toggle('is-active', button.dataset.stateButton === state);
+  });
+
+  if (statusTextEl) {
+    statusTextEl.textContent = stateMessages[state]?.status ?? '';
+  }
+
+  renderMessages(state);
+}
+
+stateButtons.forEach(button => {
+  button.addEventListener('click', () => {
+    const state = button.dataset.stateButton;
+    if (state) {
+      setState(state);
+    }
+  });
+});
+
+stopButton?.addEventListener('click', () => {
+  setState('normal');
+});
+
+liveEntryButton?.addEventListener('click', () => {
+  setState('connecting');
+  window.setTimeout(() => {
+    if (document.body.dataset.state === 'connecting') {
+      setState('listening');
+    }
+  }, 900);
+});
+
+buildWaveformBars();
+setState('normal');

--- a/docs/plans/voice-audio-read-aloud-live-plan.md
+++ b/docs/plans/voice-audio-read-aloud-live-plan.md
@@ -23,6 +23,9 @@ This plan is scope only. No production code changes are included here.
 - PDF/OCR/file conversion defaults should remain under **Ingestion**.
 - Provider/app setup still belongs in **Providers** and **Apps**. The Voice section only selects defaults from configured capabilities.
 - App-backed voice capabilities should unlock when the app is installed, enabled, and configured.
+- Live voice should use a **composer takeover**, not a full-screen replacement. The normal message stream stays visible and receives transcript/assistant text.
+- The live composer itself should stay visual: recording dot, stateful waveform/indicator, and stop button. State copy belongs in the existing chat status bar.
+- Connecting and error states must not show speech waveform bars. Connecting should use a non-speech loading indicator; error should use a non-speech error mark plus actionable status text.
 
 ## Existing Repo Context
 
@@ -79,6 +82,44 @@ Read aloud should be enabled when at least one configured speech provider is ava
 - Voice
 
 Live voice should be locked unless at least one configured realtime voice provider/app is available.
+
+## Live Voice Composer Design
+
+Reviewed mockup:
+
+- `docs/mockups/live-voice-composer.html`
+- `docs/mockups/live-voice-composer.css`
+- `docs/mockups/live-voice-composer.js`
+
+Production alignment:
+
+- `src/ui/chat/components/ChatInput.ts` owns the composer mode because it already switches between normal input, transcription recording, transcribing, send, and stop states.
+- `src/ui/chat/components/ToolStatusBar.ts` owns live voice status text because this matches existing Nexus status conventions and keeps state copy out of the composer.
+- `src/ui/chat/builders/ChatLayoutBuilder.ts` owns the header entry button because live voice is a chat mode, not a one-shot composer action.
+- `src/ui/chat/ChatView.ts` wires the entry button to the live voice controller/shell and ensures cleanup on unload.
+
+Visual states:
+
+| State | Composer visual | Status bar text |
+| --- | --- | --- |
+| Inactive | Normal text composer | none |
+| Connecting | Dot + spinner/scan indicator + stop | `Connecting live voice...` |
+| Listening | Dot + low waveform + stop | `Listening` |
+| User speaking | Dot + tighter/jagged waveform + stop | `Transcribing your speech...` |
+| Assistant speaking | Dot + fuller/smoother waveform + stop | `Nexus is speaking...` |
+| Error | Dot + error mark + stop | `Live voice connection failed. Stop and try again.` |
+
+Accessibility:
+
+- Composer visuals remain `aria-hidden`.
+- The live composer wrapper gets a stable `aria-label`.
+- The stop control uses `aria-label="Stop live voice"`.
+- Status text uses the existing status-bar live region.
+
+Phase boundary:
+
+- This UI shell does not fake provider audio. Until realtime provider adapters are wired, the header entry should show a clear status/error rather than pretending a live session is working.
+- Provider runtime work should connect real OpenAI/Google/ElevenLabs events into the same state API rather than rewriting the composer.
 
 ## Default Resolution Policy
 

--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -34,6 +34,7 @@ import { UIStateController, UIStateControllerEvents } from './controllers/UIStat
 import { StreamingController } from './controllers/StreamingController';
 import { NexusLoadingController } from './controllers/NexusLoadingController';
 import { SubagentController } from './controllers/SubagentController';
+import { ChatLiveVoiceController } from './controllers/ChatLiveVoiceController';
 
 // Coordinators
 import { ToolStatusBar } from './components/ToolStatusBar';
@@ -89,6 +90,7 @@ export class ChatView extends ItemView {
   private uiStateController!: UIStateController;
   private streamingController!: StreamingController;
   private nexusLoadingController!: NexusLoadingController;
+  private liveVoiceController: ChatLiveVoiceController | null = null;
   private toolCallStateManager!: ToolCallStateManager;
   private toolEventCoordinator!: ToolEventCoordinator;
   private toolStatusBar!: ToolStatusBar;
@@ -661,8 +663,17 @@ export class ChatView extends ItemView {
         this.sendCoordinator.handleStopGeneration();
       },
       () => this.conversationManager.getCurrentConversation() !== null,
-      this // Pass Component for registerDomEvent
+      this, // Pass Component for registerDomEvent
+      () => this.liveVoiceController?.stop()
     );
+
+    this.liveVoiceController = new ChatLiveVoiceController({
+      chatInput: this.chatInput,
+      toolStatusBar: this.toolStatusBar,
+      liveVoiceButton: this.layoutElements.liveVoiceButton,
+      getHasConversation: () => this.conversationManager.getCurrentConversation() !== null,
+      component: this,
+    });
 
     // Update conversation list if conversations were already loaded
     const conversations = this.conversationManager.getConversations();
@@ -1035,6 +1046,8 @@ export class ChatView extends ItemView {
     }
     this.conversationList?.cleanup();
     this.messageDisplay?.cleanup();
+    this.liveVoiceController?.cleanup();
+    this.liveVoiceController = null;
     this.chatInput?.cleanup();
     this.toolStatusBar?.cleanup();
     this.uiStateController?.cleanup();

--- a/src/ui/chat/builders/ChatLayoutBuilder.ts
+++ b/src/ui/chat/builders/ChatLayoutBuilder.ts
@@ -22,6 +22,7 @@ export interface ChatLayoutElements {
   conversationListContainer: HTMLElement;
   newChatButton: HTMLElement;
   settingsButton: HTMLElement;
+  liveVoiceButton: HTMLElement;
   chatTitle: HTMLElement;
   hamburgerButton: HTMLElement;
   backdrop: HTMLElement;
@@ -47,7 +48,7 @@ export class ChatLayoutBuilder {
     this.createWarningBanner(mainContainer, component);
 
     // Header
-    const { chatTitle, hamburgerButton, settingsButton } = this.createHeader(mainContainer);
+    const { chatTitle, hamburgerButton, liveVoiceButton, settingsButton } = this.createHeader(mainContainer);
 
     // Branch header container (above messages, separate from message container)
     // This ensures BranchHeader isn't clobbered when MessageDisplay.setConversation() empties the message container
@@ -72,6 +73,7 @@ export class ChatLayoutBuilder {
       conversationListContainer,
       newChatButton,
       settingsButton,
+      liveVoiceButton,
       chatTitle,
       hamburgerButton,
       backdrop,
@@ -170,6 +172,7 @@ export class ChatLayoutBuilder {
   private static createHeader(container: HTMLElement): {
     chatTitle: HTMLElement;
     hamburgerButton: HTMLElement;
+    liveVoiceButton: HTMLElement;
     settingsButton: HTMLElement;
   } {
     const chatHeader = container.createDiv('chat-header');
@@ -182,12 +185,17 @@ export class ChatLayoutBuilder {
     const chatTitle = chatHeader.createDiv('chat-title');
     chatTitle.textContent = 'Chat';
 
+    const liveVoiceButton = chatHeader.createEl('button', { cls: 'chat-live-voice-button' });
+    setIcon(liveVoiceButton, 'audio-waveform');
+    liveVoiceButton.setAttribute('aria-label', 'Start live voice');
+    liveVoiceButton.setAttribute('title', 'Start live voice');
+
     // Right: Settings gear icon
     const settingsButton = chatHeader.createEl('button', { cls: 'chat-settings-button' });
     setIcon(settingsButton, 'settings');
     settingsButton.setAttribute('aria-label', 'Chat settings');
 
-    return { chatTitle, hamburgerButton, settingsButton };
+    return { chatTitle, hamburgerButton, liveVoiceButton, settingsButton };
   }
 
   /**

--- a/src/ui/chat/components/ChatInput.ts
+++ b/src/ui/chat/components/ChatInput.ts
@@ -14,20 +14,26 @@ import { isMobile, isIOS } from '../../../utils/platform';
 import { ChatVoiceInputController, ChatVoiceInputState } from '../controllers/ChatVoiceInputController';
 import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 import { ChatKeyboardViewportController } from '../controllers/ChatKeyboardViewportController';
+import type { LiveVoiceComposerState } from '../types/LiveVoiceTypes';
 
 export class ChatInput {
   private element: HTMLElement | null = null;
   private inputElement: HTMLElement | null = null;
   private inputWrapper: HTMLElement | null = null;
   private voiceVisualElement: HTMLElement | null = null;
+  private liveVoiceComposerElement: HTMLElement | null = null;
+  private liveVoiceWaveformElement: HTMLElement | null = null;
+  private liveVoiceStopButton: HTMLButtonElement | null = null;
   private sendButton: HTMLButtonElement | null = null;
   private isLoading = false;
   private isPreSendCompacting = false;
   private hasConversation = false;
   private suggesters: SuggesterInstances | null = null;
   private voiceInputState: ChatVoiceInputState = 'idle';
+  private liveVoiceState: LiveVoiceComposerState = 'inactive';
   private voiceInputController: ChatVoiceInputController | null = null;
   private voiceVisualResizeObserver: ResizeObserver | null = null;
+  private liveVoiceResizeObserver: ResizeObserver | null = null;
   private timeouts: ManagedTimeoutTracker | null = null;
   private keyboardViewportController: ChatKeyboardViewportController | null = null;
 
@@ -42,7 +48,8 @@ export class ChatInput {
     private app?: App,
     private onStopGeneration?: () => void,
     private getHasConversation?: () => boolean,
-    private component?: Component
+    private component?: Component,
+    private onStopLiveVoice?: () => void
   ) {
     if (component) {
       this.timeouts = new ManagedTimeoutTracker(component);
@@ -103,6 +110,22 @@ export class ChatInput {
 
     this.voiceVisualElement = this.inputWrapper.createDiv('chat-voice-visual');
     this.voiceVisualElement.setAttribute('aria-hidden', 'true');
+
+    this.liveVoiceComposerElement = this.inputWrapper.createDiv('chat-live-composer');
+    this.liveVoiceComposerElement.setAttribute('role', 'group');
+    this.liveVoiceComposerElement.setAttribute('aria-label', 'Live voice session');
+    this.liveVoiceComposerElement.createSpan('chat-live-dot');
+    this.liveVoiceWaveformElement = this.liveVoiceComposerElement.createDiv('chat-live-waveform');
+    this.liveVoiceWaveformElement.setAttribute('aria-hidden', 'true');
+    this.liveVoiceStopButton = this.liveVoiceComposerElement.createEl('button', {
+      cls: 'chat-live-stop-button clickable-icon'
+    });
+    setIcon(this.liveVoiceStopButton, 'square');
+    this.liveVoiceStopButton.setAttribute('aria-label', 'Stop live voice');
+    this.liveVoiceStopButton.setAttribute('title', 'Stop live voice');
+    component?.registerDomEvent(this.liveVoiceStopButton, 'click', () => {
+      this.onStopLiveVoice?.();
+    });
 
     // Handle Enter key (send) and Shift+Enter (new line)
     const keydownHandler = (e: KeyboardEvent) => {
@@ -192,6 +215,8 @@ export class ChatInput {
 
     this.initializeVoiceVisualResizeHandling();
     this.buildVoiceBars();
+    this.initializeLiveVoiceResizeHandling();
+    this.buildLiveVoiceBars();
 
     this.element = this.container;
     this.updateUI();
@@ -337,6 +362,15 @@ export class ChatInput {
       this.sendButton.setAttribute('aria-label', 'Compacting');
       this.inputElement.contentEditable = 'false';
       this.inputElement.setAttribute('data-placeholder', 'Compacting');
+    } else if (this.liveVoiceState !== 'inactive') {
+      this.sendButton.disabled = true;
+      this.sendButton.classList.remove('stop-mode');
+      this.sendButton.classList.add('disabled-mode');
+      this.inputElement.contentEditable = 'false';
+      this.inputElement.setAttribute('data-placeholder', 'Type your message...');
+      if (this.liveVoiceStopButton) {
+        this.liveVoiceStopButton.disabled = false;
+      }
     } else if (actuallyLoading) {
       // Keep the input active so a new message can interrupt the current turn.
       this.sendButton.disabled = false;
@@ -444,6 +478,16 @@ export class ChatInput {
     }
   }
 
+  setLiveVoiceState(state: LiveVoiceComposerState): void {
+    this.liveVoiceState = state;
+    this.updateLiveVoiceVisual();
+    this.updateUI();
+  }
+
+  getLiveVoiceState(): LiveVoiceComposerState {
+    return this.liveVoiceState;
+  }
+
   /**
    * Get message enhancer (for accessing enhancements before sending)
    */
@@ -468,6 +512,8 @@ export class ChatInput {
     this.keyboardViewportController = null;
     this.voiceVisualResizeObserver?.disconnect();
     this.voiceVisualResizeObserver = null;
+    this.liveVoiceResizeObserver?.disconnect();
+    this.liveVoiceResizeObserver = null;
     this.voiceInputController?.cleanup();
     this.voiceInputController = null;
 
@@ -480,6 +526,9 @@ export class ChatInput {
     this.inputElement = null;
     this.inputWrapper = null;
     this.voiceVisualElement = null;
+    this.liveVoiceComposerElement = null;
+    this.liveVoiceWaveformElement = null;
+    this.liveVoiceStopButton = null;
     this.sendButton = null;
   }
 
@@ -508,6 +557,8 @@ export class ChatInput {
       return;
     }
 
+    this.updateLiveVoiceVisual();
+
     const isVoiceMode = this.voiceInputState === 'recording' || this.voiceInputState === 'transcribing';
     if (isVoiceMode) {
       this.inputWrapper.addClass('chat-input-voice-recording');
@@ -526,6 +577,40 @@ export class ChatInput {
     }
   }
 
+  private updateLiveVoiceVisual(): void {
+    if (!this.inputWrapper) {
+      return;
+    }
+
+    const states: LiveVoiceComposerState[] = [
+      'connecting',
+      'listening',
+      'user-speaking',
+      'assistant-speaking',
+      'error',
+    ];
+    const isLive = this.liveVoiceState !== 'inactive';
+
+    if (isLive) {
+      this.inputWrapper.addClass('chat-input-live-mode');
+    } else {
+      this.inputWrapper.removeClass('chat-input-live-mode');
+    }
+
+    states.forEach(state => {
+      const className = `chat-input-live-${state}`;
+      if (this.liveVoiceState === state) {
+        this.inputWrapper?.addClass(className);
+      } else {
+        this.inputWrapper?.removeClass(className);
+      }
+    });
+
+    if (isLive) {
+      this.buildLiveVoiceBars();
+    }
+  }
+
   private initializeVoiceVisualResizeHandling(): void {
     if (!this.voiceVisualElement) {
       return;
@@ -539,6 +624,22 @@ export class ChatInput {
 
     if (this.component && typeof window !== 'undefined') {
       this.component.registerDomEvent(window, 'resize', () => this.buildVoiceBars());
+    }
+  }
+
+  private initializeLiveVoiceResizeHandling(): void {
+    if (!this.liveVoiceWaveformElement) {
+      return;
+    }
+
+    if (typeof ResizeObserver !== 'undefined') {
+      this.liveVoiceResizeObserver = new ResizeObserver(() => this.buildLiveVoiceBars());
+      this.liveVoiceResizeObserver.observe(this.liveVoiceWaveformElement);
+      return;
+    }
+
+    if (this.component && typeof window !== 'undefined') {
+      this.component.registerDomEvent(window, 'resize', () => this.buildLiveVoiceBars());
     }
   }
 
@@ -567,6 +668,33 @@ export class ChatInput {
       const phaseIndex = index % 8;
       const delayIndex = index % 8;
       this.voiceVisualElement.createSpan(`chat-voice-bar chat-voice-bar-phase-${phaseIndex} chat-voice-bar-delay-${delayIndex}`);
+    }
+  }
+
+  private buildLiveVoiceBars(): void {
+    if (!this.liveVoiceWaveformElement || typeof window === 'undefined') {
+      return;
+    }
+
+    const computedStyle = window.getComputedStyle(this.liveVoiceWaveformElement);
+    const paddingLeft = Number.parseFloat(computedStyle.paddingLeft || '0');
+    const paddingRight = Number.parseFloat(computedStyle.paddingRight || '0');
+    const availableWidth = this.liveVoiceWaveformElement.clientWidth - paddingLeft - paddingRight;
+
+    if (availableWidth <= 0) {
+      return;
+    }
+
+    const gap = 3;
+    const barWidth = 6;
+    const barSlot = barWidth + gap;
+    const barCount = Math.max(24, Math.floor(availableWidth / barSlot));
+
+    this.liveVoiceWaveformElement.empty();
+
+    for (let index = 0; index < barCount; index += 1) {
+      const phaseIndex = index % 12;
+      this.liveVoiceWaveformElement.createSpan(`chat-live-wave-bar chat-live-wave-phase-${phaseIndex}`);
     }
   }
 }

--- a/src/ui/chat/components/ToolStatusBar.ts
+++ b/src/ui/chat/components/ToolStatusBar.ts
@@ -97,6 +97,14 @@ export class ToolStatusBar {
     this.statusLine.update(entry.text, entry.state);
   }
 
+  public pushLiveVoiceStatus(text: string, state: ToolStatusEntry['state'] = 'present'): void {
+    this.pushStatus({ text, state });
+  }
+
+  public clearLiveVoiceStatus(): void {
+    this.clearStatus();
+  }
+
   public clearStatus(): void {
     this.statusLine.clear();
   }

--- a/src/ui/chat/controllers/ChatLiveVoiceController.ts
+++ b/src/ui/chat/controllers/ChatLiveVoiceController.ts
@@ -1,0 +1,87 @@
+import type { Component } from 'obsidian';
+import type { ChatInput } from '../components/ChatInput';
+import type { ToolStatusBar } from '../components/ToolStatusBar';
+import type { LiveVoiceComposerState } from '../types/LiveVoiceTypes';
+import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
+
+export interface ChatLiveVoiceControllerOptions {
+  chatInput: ChatInput;
+  toolStatusBar: ToolStatusBar;
+  liveVoiceButton: HTMLElement;
+  getHasConversation: () => boolean;
+  component: Component;
+}
+
+const LIVE_STATUS: Record<Exclude<LiveVoiceComposerState, 'inactive'>, { text: string; state: 'present' | 'failed' }> = {
+  connecting: { text: 'Connecting live voice...', state: 'present' },
+  listening: { text: 'Listening', state: 'present' },
+  'user-speaking': { text: 'Transcribing your speech...', state: 'present' },
+  'assistant-speaking': { text: 'Nexus is speaking...', state: 'present' },
+  error: { text: 'Live voice provider is not connected yet.', state: 'failed' },
+};
+
+export class ChatLiveVoiceController {
+  private state: LiveVoiceComposerState = 'inactive';
+  private readonly timeouts: ManagedTimeoutTracker;
+
+  constructor(private readonly options: ChatLiveVoiceControllerOptions) {
+    this.timeouts = new ManagedTimeoutTracker(options.component);
+    options.component.registerDomEvent(options.liveVoiceButton, 'click', () => {
+      this.start();
+    });
+  }
+
+  start(): void {
+    if (!this.options.getHasConversation()) {
+      this.options.toolStatusBar.pushLiveVoiceStatus('Select or create a conversation to use live voice.', 'failed');
+      return;
+    }
+
+    this.setState('connecting');
+    this.timeouts.schedule(() => {
+      if (this.state === 'connecting') {
+        this.setState('error');
+      }
+    }, 700);
+  }
+
+  stop(): void {
+    this.timeouts.clear();
+    this.setState('inactive');
+    this.options.toolStatusBar.clearLiveVoiceStatus();
+  }
+
+  getState(): LiveVoiceComposerState {
+    return this.state;
+  }
+
+  setState(state: LiveVoiceComposerState): void {
+    this.state = state;
+    this.options.chatInput.setLiveVoiceState(state);
+    if (state === 'inactive') {
+      this.options.liveVoiceButton.removeClass('chat-live-voice-button-active');
+    } else {
+      this.options.liveVoiceButton.addClass('chat-live-voice-button-active');
+    }
+    this.options.liveVoiceButton.setAttribute(
+      'aria-label',
+      state === 'inactive' ? 'Start live voice' : 'Live voice active'
+    );
+    this.options.liveVoiceButton.setAttribute(
+      'title',
+      state === 'inactive' ? 'Start live voice' : 'Live voice active'
+    );
+
+    if (state === 'inactive') {
+      return;
+    }
+
+    const status = LIVE_STATUS[state];
+    this.options.toolStatusBar.pushLiveVoiceStatus(status.text, status.state);
+  }
+
+  cleanup(): void {
+    this.timeouts.clear();
+    this.options.chatInput.setLiveVoiceState('inactive');
+  }
+}

--- a/src/ui/chat/types/LiveVoiceTypes.ts
+++ b/src/ui/chat/types/LiveVoiceTypes.ts
@@ -1,0 +1,12 @@
+export type LiveVoiceComposerState =
+  | 'inactive'
+  | 'connecting'
+  | 'listening'
+  | 'user-speaking'
+  | 'assistant-speaking'
+  | 'error';
+
+export interface LiveVoiceStatus {
+  state: LiveVoiceComposerState;
+  text?: string;
+}

--- a/styles.css
+++ b/styles.css
@@ -519,6 +519,7 @@ body.theme-light .message-content {
 }
 
 .chat-header .chat-hamburger-button,
+.chat-header .chat-live-voice-button,
 .chat-header .chat-settings-button {
     padding: 4px;
 }
@@ -526,6 +527,7 @@ body.theme-light .message-content {
 /* Header buttons — flat icons matching the status bar icon style.
    No raised appearance, just the icon as the tap target. */
 .chat-hamburger-button,
+.chat-live-voice-button,
 .chat-settings-button {
     background: none;
     border: none;
@@ -541,12 +543,18 @@ body.theme-light .message-content {
 }
 
 .chat-hamburger-button:hover,
+.chat-live-voice-button:hover,
 .chat-settings-button:hover {
     background: none;
     color: var(--text-normal);
 }
 
+.chat-live-voice-button-active {
+    color: var(--interactive-accent);
+}
+
 .chat-hamburger-button:focus-visible,
+.chat-live-voice-button:focus-visible,
 .chat-settings-button:focus-visible {
     outline: 2px solid var(--interactive-accent);
     outline-offset: 2px;
@@ -1373,6 +1381,231 @@ body.theme-light .message-content {
 .chat-send-button.stop-mode:hover {
     background: var(--text-error);
     opacity: 0.9;
+}
+
+/* Live voice composer takeover. Text status lives in ToolStatusBar; the
+   composer stays visual: session dot, waveform/indicator, and stop button. */
+.chat-live-composer {
+    display: none;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 60px;
+    padding: 11px 55px 11px 13px;
+    border: 1px solid color-mix(in srgb, var(--background-modifier-border) 78%, transparent);
+    border-radius: 11px;
+    background: var(--background-primary);
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.chat-input-live-mode .chat-textarea,
+.chat-input-live-mode .chat-send-button {
+    display: none;
+}
+
+.chat-input-live-mode .chat-live-composer {
+    display: flex;
+}
+
+.chat-live-dot {
+    flex: 0 0 auto;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--text-error);
+    animation: chat-live-dot-pulse 1.8s ease-in-out infinite;
+}
+
+.chat-live-waveform {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+    height: 38px;
+    display: flex;
+    align-items: center;
+    justify-content: stretch;
+    gap: 3px;
+    padding-inline: 2px;
+}
+
+.chat-live-wave-bar {
+    flex: 1 1 0;
+    min-width: 2px;
+    max-width: 8px;
+    height: 30px;
+    border-radius: 999px;
+    background: var(--interactive-accent);
+    opacity: 0.54;
+    transform-origin: center;
+    animation: chat-live-wave-listening 1.55s ease-in-out infinite;
+}
+
+.chat-live-wave-phase-0 { animation-delay: -0ms; }
+.chat-live-wave-phase-1 { animation-delay: -80ms; }
+.chat-live-wave-phase-2 { animation-delay: -160ms; }
+.chat-live-wave-phase-3 { animation-delay: -240ms; }
+.chat-live-wave-phase-4 { animation-delay: -320ms; }
+.chat-live-wave-phase-5 { animation-delay: -400ms; }
+.chat-live-wave-phase-6 { animation-delay: -480ms; }
+.chat-live-wave-phase-7 { animation-delay: -560ms; }
+.chat-live-wave-phase-8 { animation-delay: -640ms; }
+.chat-live-wave-phase-9 { animation-delay: -720ms; }
+.chat-live-wave-phase-10 { animation-delay: -800ms; }
+.chat-live-wave-phase-11 { animation-delay: -880ms; }
+
+.chat-input-live-connecting .chat-live-wave-bar,
+.chat-input-live-error .chat-live-wave-bar {
+    display: none;
+}
+
+.chat-input-live-connecting .chat-live-dot {
+    background: var(--color-yellow);
+}
+
+.chat-input-live-listening .chat-live-dot {
+    background: var(--text-error);
+}
+
+.chat-input-live-user-speaking .chat-live-dot {
+    background: var(--color-cyan);
+}
+
+.chat-input-live-assistant-speaking .chat-live-dot {
+    background: var(--color-green);
+}
+
+.chat-input-live-error .chat-live-dot {
+    background: var(--text-error);
+    animation-duration: 760ms;
+}
+
+.chat-input-live-user-speaking .chat-live-wave-bar {
+    background: var(--color-cyan);
+    opacity: 0.86;
+    animation-name: chat-live-wave-user;
+    animation-duration: 560ms;
+}
+
+.chat-input-live-assistant-speaking .chat-live-wave-bar {
+    background: var(--color-green);
+    opacity: 0.9;
+    animation-name: chat-live-wave-assistant;
+    animation-duration: 1040ms;
+}
+
+.chat-input-live-connecting .chat-live-waveform,
+.chat-input-live-error .chat-live-waveform {
+    justify-content: center;
+}
+
+.chat-input-live-connecting .chat-live-waveform::before {
+    content: "";
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    border: 2px solid color-mix(in srgb, var(--color-yellow) 32%, transparent);
+    border-top-color: var(--color-yellow);
+    animation: chat-live-connecting-spin 860ms linear infinite;
+}
+
+.chat-input-live-connecting .chat-live-waveform::after {
+    content: "";
+    position: absolute;
+    width: min(180px, 58%);
+    height: 1px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--color-yellow) 52%, transparent), transparent);
+    transform: translateY(18px);
+    opacity: 0.68;
+}
+
+.chat-input-live-error .chat-live-composer {
+    border-color: color-mix(in srgb, var(--text-error) 58%, var(--background-modifier-border));
+}
+
+.chat-input-live-error .chat-live-waveform::before,
+.chat-input-live-error .chat-live-waveform::after {
+    content: "";
+    position: absolute;
+    width: 34px;
+    height: 2px;
+    border-radius: 999px;
+    background: var(--text-error);
+}
+
+.chat-input-live-error .chat-live-waveform::before {
+    transform: rotate(45deg);
+}
+
+.chat-input-live-error .chat-live-waveform::after {
+    transform: rotate(-45deg);
+}
+
+.chat-live-stop-button {
+    --icon-size: 12px;
+    position: absolute;
+    top: 50%;
+    right: 8px;
+    transform: translateY(-50%);
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border: 1px solid color-mix(in srgb, var(--text-error) 56%, var(--background-modifier-border));
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--text-error) 24%, var(--background-primary));
+    color: var(--text-normal);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.2s, opacity 0.2s, transform 0.15s;
+    box-shadow: inset 0 1px 0 color-mix(in srgb, var(--background-primary) 72%, var(--text-normal));
+}
+
+.chat-live-stop-button:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--text-error) 34%, var(--background-primary));
+    transform: translateY(-50%) scale(1.05);
+}
+
+@keyframes chat-live-dot-pulse {
+    0%, 100% {
+        box-shadow: 0 0 0 0 color-mix(in srgb, var(--text-error) 32%, transparent);
+        opacity: 0.82;
+    }
+    50% {
+        box-shadow: 0 0 0 5px transparent;
+        opacity: 1;
+    }
+}
+
+@keyframes chat-live-wave-listening {
+    0%, 100% {
+        transform: scaleY(0.24);
+        opacity: 0.32;
+    }
+    50% {
+        transform: scaleY(0.54);
+        opacity: 0.62;
+    }
+}
+
+@keyframes chat-live-wave-user {
+    0%, 100% { transform: scaleY(0.28); }
+    38% { transform: scaleY(1.22); }
+    72% { transform: scaleY(0.56); }
+}
+
+@keyframes chat-live-wave-assistant {
+    0%, 100% { transform: scaleY(0.42); }
+    25% { transform: scaleY(1.22); }
+    65% { transform: scaleY(0.82); }
+}
+
+@keyframes chat-live-connecting-spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 @keyframes pulse-stop {

--- a/tests/unit/ChatInputVoiceInput.test.ts
+++ b/tests/unit/ChatInputVoiceInput.test.ts
@@ -25,6 +25,8 @@ jest.mock('../../src/ui/chat/controllers/ChatVoiceInputController', () => ({
 type ChatInputInternals = ChatInput & {
   sendButton: HTMLButtonElement;
   inputWrapper: HTMLElement;
+  inputElement: HTMLElement;
+  liveVoiceStopButton: HTMLButtonElement;
 };
 
 describe('ChatInput voice input UI', () => {
@@ -97,5 +99,59 @@ describe('ChatInput voice input UI', () => {
 
     expect(inputWrapper.addClass).toHaveBeenCalledWith('chat-input-voice-recording');
     expect(sendButton.setAttribute).toHaveBeenCalledWith('aria-label', 'Stop recording');
+  });
+
+  it('switches into the live voice composer UI and disables text entry', () => {
+    mockIsAvailable.mockReturnValue(true);
+
+    const input = new ChatInput(
+      createMockElement('div'),
+      jest.fn(),
+      () => false,
+      undefined,
+      undefined,
+      () => true,
+      new Component()
+    );
+
+    const { inputElement, inputWrapper, sendButton } = input as ChatInputInternals;
+
+    input.setLiveVoiceState('assistant-speaking');
+
+    expect(input.getLiveVoiceState()).toBe('assistant-speaking');
+    expect(inputWrapper.addClass).toHaveBeenCalledWith('chat-input-live-mode');
+    expect(inputWrapper.addClass).toHaveBeenCalledWith('chat-input-live-assistant-speaking');
+    expect(sendButton.disabled).toBe(true);
+    expect(inputElement.contentEditable).toBe('false');
+  });
+
+  it('uses the embedded live voice stop button callback', () => {
+    mockIsAvailable.mockReturnValue(true);
+
+    const component = new Component();
+    const stopLiveVoice = jest.fn();
+    const registerDomEventSpy = jest.spyOn(component, 'registerDomEvent');
+
+    const input = new ChatInput(
+      createMockElement('div'),
+      jest.fn(),
+      () => false,
+      undefined,
+      undefined,
+      () => true,
+      component,
+      stopLiveVoice
+    );
+
+    const { liveVoiceStopButton } = input as ChatInputInternals;
+    const registration = registerDomEventSpy.mock.calls.find(([element, eventName]) => (
+      element === liveVoiceStopButton && eventName === 'click'
+    ));
+
+    expect(registration).toBeDefined();
+    const handler = registration?.[2] as EventListener;
+    handler(new Event('click'));
+
+    expect(stopLiveVoice).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/ChatLiveVoiceController.test.ts
+++ b/tests/unit/ChatLiveVoiceController.test.ts
@@ -1,0 +1,100 @@
+import { Component, createMockElement } from 'obsidian';
+import { ChatLiveVoiceController } from '../../src/ui/chat/controllers/ChatLiveVoiceController';
+import type { ChatInput } from '../../src/ui/chat/components/ChatInput';
+import type { ToolStatusBar } from '../../src/ui/chat/components/ToolStatusBar';
+
+describe('ChatLiveVoiceController', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  function createHarness(hasConversation = true) {
+    const chatInput = {
+      setLiveVoiceState: jest.fn(),
+    } as unknown as ChatInput;
+    const toolStatusBar = {
+      pushLiveVoiceStatus: jest.fn(),
+      clearLiveVoiceStatus: jest.fn(),
+    } as unknown as ToolStatusBar;
+    const liveVoiceButton = createMockElement('button');
+    const component = new Component();
+    const registerDomEventSpy = jest.spyOn(component, 'registerDomEvent');
+    const controller = new ChatLiveVoiceController({
+      chatInput,
+      toolStatusBar,
+      liveVoiceButton,
+      getHasConversation: () => hasConversation,
+      component,
+    });
+
+    return {
+      chatInput,
+      controller,
+      liveVoiceButton,
+      registerDomEventSpy,
+      toolStatusBar,
+    };
+  }
+
+  it('reports a clear error when no conversation is selected', () => {
+    const { chatInput, controller, toolStatusBar } = createHarness(false);
+
+    controller.start();
+
+    expect(chatInput.setLiveVoiceState).not.toHaveBeenCalled();
+    expect(toolStatusBar.pushLiveVoiceStatus).toHaveBeenCalledWith(
+      'Select or create a conversation to use live voice.',
+      'failed'
+    );
+  });
+
+  it('enters connecting state and then reports unavailable runtime wiring', () => {
+    const { chatInput, controller, liveVoiceButton, toolStatusBar } = createHarness(true);
+
+    controller.start();
+
+    expect(controller.getState()).toBe('connecting');
+    expect(chatInput.setLiveVoiceState).toHaveBeenCalledWith('connecting');
+    expect(liveVoiceButton.addClass).toHaveBeenCalledWith('chat-live-voice-button-active');
+    expect(toolStatusBar.pushLiveVoiceStatus).toHaveBeenCalledWith('Connecting live voice...', 'present');
+
+    jest.advanceTimersByTime(700);
+
+    expect(controller.getState()).toBe('error');
+    expect(chatInput.setLiveVoiceState).toHaveBeenCalledWith('error');
+    expect(toolStatusBar.pushLiveVoiceStatus).toHaveBeenCalledWith(
+      'Live voice provider is not connected yet.',
+      'failed'
+    );
+  });
+
+  it('stops the live voice UI and clears the status line', () => {
+    const { chatInput, controller, liveVoiceButton, toolStatusBar } = createHarness(true);
+
+    controller.start();
+    controller.stop();
+
+    expect(controller.getState()).toBe('inactive');
+    expect(chatInput.setLiveVoiceState).toHaveBeenLastCalledWith('inactive');
+    expect(liveVoiceButton.removeClass).toHaveBeenCalledWith('chat-live-voice-button-active');
+    expect(toolStatusBar.clearLiveVoiceStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('wires the header live voice button to start the controller', () => {
+    const { controller, liveVoiceButton, registerDomEventSpy } = createHarness(true);
+    const registration = registerDomEventSpy.mock.calls.find(([element, eventName]) => (
+      element === liveVoiceButton && eventName === 'click'
+    ));
+
+    expect(registration).toBeDefined();
+    const handler = registration?.[2] as EventListener;
+    handler(new Event('click'));
+
+    expect(controller.getState()).toBe('connecting');
+  });
+});


### PR DESCRIPTION
## Summary
- add the live voice composer takeover shell with header entry, status-bar messaging, and stop affordance
- update the voice/read-aloud/live plan with the approved code-aligned design and include the reviewed mockup assets
- add focused unit coverage for ChatInput live composer state and ChatLiveVoiceController transitions

## Validation
- npx jest tests/unit/ChatInputVoiceInput.test.ts tests/unit/ChatLiveVoiceController.test.ts
- npm run build

## Notes
- This does not fake realtime provider audio. Starting live voice currently enters connecting and then reports that the runtime provider is not connected yet, leaving the provider adapter work for the next phase.