### PR TITLE
Add live voice prior context builder

### DIFF
--- a/src/services/realtimeVoice/LiveVoiceContextBuilder.ts
+++ b/src/services/realtimeVoice/LiveVoiceContextBuilder.ts
@@ -1,0 +1,156 @@
+import type { ConversationData, ConversationMessage } from '../../types/chat/ChatTypes';
+import { ContextBudgetService } from '../chat/ContextBudgetService';
+import { ContextCompactionService, type CompactedContext } from '../chat/ContextCompactionService';
+
+export interface LiveVoiceContextBuilderOptions {
+  maxContextTokens?: number;
+  maxMessageChars?: number;
+}
+
+const DEFAULT_MAX_CONTEXT_TOKENS = 10_000;
+const DEFAULT_MAX_MESSAGE_CHARS = 2_000;
+
+export class LiveVoiceContextBuilder {
+  constructor(private readonly options: LiveVoiceContextBuilderOptions = {}) {}
+
+  build(conversation: ConversationData | null | undefined): string {
+    if (!conversation || conversation.messages.length === 0) {
+      return '';
+    }
+
+    const maxTokens = this.options.maxContextTokens ?? DEFAULT_MAX_CONTEXT_TOKENS;
+    const frontierSection = this.buildCompactionFrontierSection(conversation);
+    const recentMessages = this.getVisibleRecentMessages(conversation);
+    const recentSection = this.buildRecentMessagesSection(recentMessages);
+    const context = this.wrapContext(frontierSection, recentSection);
+
+    if (ContextBudgetService.estimateTextTokens(context) <= maxTokens) {
+      return context;
+    }
+
+    return this.buildTrimmedContext(frontierSection, recentMessages, maxTokens);
+  }
+
+  private buildTrimmedContext(
+    frontierSection: string,
+    recentMessages: ConversationMessage[],
+    maxTokens: number
+  ): string {
+    let trimmedMessages = [...recentMessages];
+
+    while (trimmedMessages.length > 0) {
+      const recentSection = this.buildRecentMessagesSection(trimmedMessages);
+      const context = this.wrapContext(frontierSection, recentSection);
+      if (ContextBudgetService.estimateTextTokens(context) <= maxTokens) {
+        return context;
+      }
+      trimmedMessages = trimmedMessages.slice(1);
+    }
+
+    const frontierOnly = this.wrapContext(frontierSection, '');
+    return ContextBudgetService.estimateTextTokens(frontierOnly) <= maxTokens
+      ? frontierOnly
+      : '';
+  }
+
+  private getVisibleRecentMessages(conversation: ConversationData): ConversationMessage[] {
+    return ContextCompactionService
+      .getMessagesAfterBoundary(conversation.messages, conversation.metadata)
+      .filter(message => (
+        !message.metadata?.hidden &&
+        (message.role === 'user' || message.role === 'assistant') &&
+        message.content.trim().length > 0
+      ));
+  }
+
+  private buildCompactionFrontierSection(conversation: ConversationData): string {
+    const frontier = this.getCompactionFrontier(conversation);
+    if (frontier.length === 0) {
+      return '';
+    }
+
+    const records = frontier
+      .filter(record => record.summary?.trim().length > 0)
+      .map((record, index) => {
+        const files = record.filesReferenced?.slice(0, 5) ?? [];
+        const topics = record.topics?.slice(0, 8) ?? [];
+        const lines = [
+          `  <record index="${index}">`,
+          `    <summary>${this.escapeXmlContent(record.summary)}</summary>`,
+        ];
+        if (files.length > 0) {
+          lines.push(`    <files>${this.escapeXmlContent(files.join(', '))}</files>`);
+        }
+        if (topics.length > 0) {
+          lines.push(`    <topics>${this.escapeXmlContent(topics.join(', '))}</topics>`);
+        }
+        lines.push('  </record>');
+        return lines.join('\n');
+      });
+
+    if (records.length === 0) {
+      return '';
+    }
+
+    return [
+      '<compaction_context>',
+      '<instruction>Compressed older conversation context. Use it for continuity, but rely on recent messages for current details.</instruction>',
+      ...records,
+      '</compaction_context>',
+    ].join('\n');
+  }
+
+  private buildRecentMessagesSection(messages: ConversationMessage[]): string {
+    if (messages.length === 0) {
+      return '';
+    }
+
+    const maxMessageChars = this.options.maxMessageChars ?? DEFAULT_MAX_MESSAGE_CHARS;
+    const renderedMessages = messages.map((message, index) => [
+      `  <message index="${index}" role="${message.role}">`,
+      this.escapeXmlContent(this.truncate(message.content, maxMessageChars)),
+      '  </message>',
+    ].join('\n'));
+
+    return [
+      '<recent_conversation>',
+      ...renderedMessages,
+      '</recent_conversation>',
+    ].join('\n');
+  }
+
+  private wrapContext(frontierSection: string, recentSection: string): string {
+    const sections = [frontierSection, recentSection].filter(section => section.trim().length > 0);
+    if (sections.length === 0) {
+      return '';
+    }
+
+    return [
+      '<conversation_context>',
+      '<instruction>This is prior text-chat context for the live voice session. Continue from it naturally; do not read or summarize this context unless asked.</instruction>',
+      ...sections,
+      '</conversation_context>',
+    ].join('\n');
+  }
+
+  private getCompactionFrontier(conversation: ConversationData): CompactedContext[] {
+    const metadataRecord = conversation.metadata as Record<string, unknown> | undefined;
+    const compaction = metadataRecord?.compaction as { frontier?: CompactedContext[] } | undefined;
+    return Array.isArray(compaction?.frontier) ? compaction.frontier : [];
+  }
+
+  private escapeXmlContent(text: string): string {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  private truncate(text: string, maxLength: number): string {
+    if (text.length <= maxLength) {
+      return text;
+    }
+
+    return `${text.slice(0, maxLength - 3).trim()}...`;
+  }
+}

--- a/src/services/realtimeVoice/OpenAIRealtimeVoiceSession.ts
+++ b/src/services/realtimeVoice/OpenAIRealtimeVoiceSession.ts
@@ -10,6 +10,10 @@ interface ClientSecretResponse {
 
 interface RealtimeServerEvent {
   type?: unknown;
+  response_id?: unknown;
+  item_id?: unknown;
+  output_index?: unknown;
+  content_index?: unknown;
   transcript?: unknown;
   delta?: unknown;
   response?: unknown;
@@ -21,7 +25,9 @@ interface RealtimeServerEvent {
 }
 
 interface RealtimeResponseWithOutput {
+  id?: unknown;
   output?: Array<{
+    id?: unknown;
     content?: Array<{
       transcript?: unknown;
     }>;
@@ -37,6 +43,7 @@ export class OpenAIRealtimeVoiceSession implements RealtimeVoiceSession {
   private mediaStream: MediaStream | null = null;
   private outputAudio: HTMLAudioElement | null = null;
   private stopped = false;
+  private completedAssistantTranscriptKeys = new Set<string>();
 
   constructor(private readonly request: ResolvedRealtimeVoiceSessionRequest) {}
 
@@ -86,6 +93,7 @@ export class OpenAIRealtimeVoiceSession implements RealtimeVoiceSession {
 
   stop(): void {
     this.stopped = true;
+    this.completedAssistantTranscriptKeys.clear();
 
     if (this.dataChannel && this.dataChannel.readyState !== 'closed') {
       this.dataChannel.close();
@@ -267,6 +275,7 @@ export class OpenAIRealtimeVoiceSession implements RealtimeVoiceSession {
       case 'response.audio_transcript.done':
       case 'response.output_audio_transcript.done':
         if (typeof event.transcript === 'string' && event.transcript.trim().length > 0) {
+          this.completedAssistantTranscriptKeys.add(this.getTranscriptEventKey(event));
           this.request.callbacks.onAssistantTranscriptCompleted?.(event.transcript.trim());
         }
         break;
@@ -280,6 +289,11 @@ export class OpenAIRealtimeVoiceSession implements RealtimeVoiceSession {
 
   private emitAssistantTranscriptFromResponseDone(event: RealtimeServerEvent): void {
     const response = event.response as RealtimeResponseWithOutput | undefined;
+    const responseId = this.getString(response?.id) || this.getString(event.response_id);
+    if (responseId && this.hasCompletedTranscriptForResponse(responseId)) {
+      return;
+    }
+
     const transcript = response?.output
       ?.flatMap(item => item.content ?? [])
       .map(content => typeof content.transcript === 'string' ? content.transcript : '')
@@ -290,6 +304,34 @@ export class OpenAIRealtimeVoiceSession implements RealtimeVoiceSession {
     if (transcript) {
       this.request.callbacks.onAssistantTranscriptCompleted?.(transcript);
     }
+  }
+
+  private getTranscriptEventKey(event: RealtimeServerEvent): string {
+    const responseId = this.getString(event.response_id) || 'unknown-response';
+    const itemId = this.getString(event.item_id) || 'unknown-item';
+    const outputIndex = this.getString(event.output_index) || 'unknown-output';
+    const contentIndex = this.getString(event.content_index) || 'unknown-content';
+    return `${responseId}:${itemId}:${outputIndex}:${contentIndex}`;
+  }
+
+  private hasCompletedTranscriptForResponse(responseId: string): boolean {
+    const prefix = `${responseId}:`;
+    for (const key of this.completedAssistantTranscriptKeys) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private getString(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      return String(value);
+    }
+    return '';
   }
 
   private formatRealtimeError(event: RealtimeServerEvent): string {

--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -35,6 +35,7 @@ import { StreamingController } from './controllers/StreamingController';
 import { NexusLoadingController } from './controllers/NexusLoadingController';
 import { SubagentController } from './controllers/SubagentController';
 import { ChatLiveVoiceController } from './controllers/ChatLiveVoiceController';
+import { LiveVoiceContextBuilder } from '../../services/realtimeVoice/LiveVoiceContextBuilder';
 
 // Coordinators
 import { ToolStatusBar } from './components/ToolStatusBar';
@@ -674,6 +675,7 @@ export class ChatView extends ItemView {
       toolStatusBar: this.toolStatusBar,
       liveVoiceButton: this.layoutElements.liveVoiceButton,
       getHasConversation: () => this.conversationManager.getCurrentConversation() !== null,
+      getConversationContext: () => new LiveVoiceContextBuilder().build(this.conversationManager.getCurrentConversation()),
       onTranscriptMessage: (role, content) => {
         void this.appendLiveVoiceTranscriptMessage(role, content);
       },

--- a/src/ui/chat/controllers/ChatLiveVoiceController.ts
+++ b/src/ui/chat/controllers/ChatLiveVoiceController.ts
@@ -22,6 +22,7 @@ export interface ChatLiveVoiceControllerOptions {
   toolStatusBar: ToolStatusBar;
   liveVoiceButton: HTMLElement;
   getHasConversation: () => boolean;
+  getConversationContext?: () => string;
   onTranscriptMessage?: (role: 'user' | 'assistant', content: string) => void | Promise<void>;
   component: Component;
 }
@@ -70,7 +71,7 @@ export class ChatLiveVoiceController {
       }
 
       const session = service.createSession({
-        instructions: 'You are Nexus, a helpful voice assistant inside Obsidian. Keep spoken responses concise and practical.',
+        instructions: this.buildSessionInstructions(),
         callbacks: {
           onStateChange: (state) => this.setState(state),
           onError: (message, error) => this.handleSessionError(message, error),
@@ -155,6 +156,19 @@ export class ChatLiveVoiceController {
 
   private normalizeTranscript(text: string): string {
     return text.replace(/\s+/g, ' ').trim();
+  }
+
+  private buildSessionInstructions(): string {
+    const context = this.options.getConversationContext?.().trim();
+    const baseInstructions = [
+      'You are Nexus, a helpful voice assistant inside Obsidian.',
+      'Keep spoken responses concise and practical.',
+      'When the user asks about prior chat context, use the provided conversation context instead of saying you cannot see it.',
+    ].join(' ');
+
+    return context
+      ? `${baseInstructions}\n\n${context}`
+      : baseInstructions;
   }
 
   setState(state: LiveVoiceComposerState, statusText?: string): void {

--- a/tests/unit/ChatLiveVoiceController.test.ts
+++ b/tests/unit/ChatLiveVoiceController.test.ts
@@ -71,6 +71,7 @@ describe('ChatLiveVoiceController', () => {
     const liveVoiceButton = createMockElement('button');
     const component = new Component();
     const onTranscriptMessage = jest.fn();
+    const getConversationContext = jest.fn(() => '<conversation_context>Prior chat</conversation_context>');
     const registerDomEventSpy = jest.spyOn(component, 'registerDomEvent');
     const controller = new ChatLiveVoiceController({
       app: app as never,
@@ -78,6 +79,7 @@ describe('ChatLiveVoiceController', () => {
       toolStatusBar,
       liveVoiceButton,
       getHasConversation: () => hasConversation,
+      getConversationContext,
       onTranscriptMessage,
       component,
     });
@@ -85,6 +87,7 @@ describe('ChatLiveVoiceController', () => {
     return {
       chatInput,
       controller,
+      getConversationContext,
       liveVoiceButton,
       onTranscriptMessage,
       registerDomEventSpy,
@@ -115,6 +118,7 @@ describe('ChatLiveVoiceController', () => {
     expect(liveVoiceButton.addClass).toHaveBeenCalledWith('chat-live-voice-button-active');
     expect(toolStatusBar.pushLiveVoiceStatus).toHaveBeenCalledWith('Connecting live voice...', 'present');
     expect(mockCreateSession).toHaveBeenCalledTimes(1);
+    expect(mockCreateSession.mock.calls[0]?.[0].instructions).toContain('<conversation_context>Prior chat</conversation_context>');
     expect(mockSessionStart).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/LiveVoiceContextBuilder.test.ts
+++ b/tests/unit/LiveVoiceContextBuilder.test.ts
@@ -1,0 +1,90 @@
+import { LiveVoiceContextBuilder } from '../../src/services/realtimeVoice/LiveVoiceContextBuilder';
+import type { ConversationData, ConversationMessage } from '../../src/types/chat/ChatTypes';
+
+function message(
+  id: string,
+  role: 'user' | 'assistant' | 'tool' | 'system',
+  content: string,
+  metadata?: Record<string, unknown>
+): ConversationMessage {
+  return {
+    id,
+    role,
+    content,
+    timestamp: Date.now(),
+    conversationId: 'conversation-1',
+    metadata,
+  };
+}
+
+function conversation(messages: ConversationMessage[], metadata: ConversationData['metadata'] = {}): ConversationData {
+  return {
+    id: 'conversation-1',
+    title: 'Conversation',
+    messages,
+    created: Date.now(),
+    updated: Date.now(),
+    metadata,
+  };
+}
+
+describe('LiveVoiceContextBuilder', () => {
+  it('returns an empty context for missing or empty conversations', () => {
+    const builder = new LiveVoiceContextBuilder();
+
+    expect(builder.build(null)).toBe('');
+    expect(builder.build(conversation([]))).toBe('');
+  });
+
+  it('includes compaction summaries and only recent visible user and assistant messages after the boundary', () => {
+    const builder = new LiveVoiceContextBuilder();
+    const context = builder.build(conversation([
+      message('old-user', 'user', 'Old user message before compaction.'),
+      message('boundary-user', 'user', 'Current user question.'),
+      message('tool-1', 'tool', 'Tool output should not appear.'),
+      message('hidden-assistant', 'assistant', 'Hidden assistant message.', { hidden: true }),
+      message('assistant-1', 'assistant', 'Current assistant answer with <special> & characters.'),
+    ], {
+      compaction: {
+        frontier: [
+          {
+            summary: 'Earlier work summarized here.',
+            messagesRemoved: 1,
+            messagesKept: 2,
+            filesReferenced: ['Project.md'],
+            topics: ['live voice'],
+            compactedAt: 123,
+            boundaryMessageId: 'boundary-user',
+          },
+        ],
+      },
+    }));
+
+    expect(context).toContain('<conversation_context>');
+    expect(context).toContain('Earlier work summarized here.');
+    expect(context).toContain('Project.md');
+    expect(context).toContain('Current user question.');
+    expect(context).toContain('Current assistant answer with &lt;special&gt; &amp; characters.');
+    expect(context).not.toContain('Old user message before compaction.');
+    expect(context).not.toContain('Tool output should not appear.');
+    expect(context).not.toContain('Hidden assistant message.');
+  });
+
+  it('drops oldest recent messages until the context fits the token budget', () => {
+    const builder = new LiveVoiceContextBuilder({
+      maxContextTokens: 120,
+      maxMessageChars: 2_000,
+    });
+    const context = builder.build(conversation([
+      message('u1', 'user', 'First old visible message '.repeat(60)),
+      message('a1', 'assistant', 'Second old visible message '.repeat(60)),
+      message('u2', 'user', 'Final user request'),
+      message('a2', 'assistant', 'Final assistant response'),
+    ]));
+
+    expect(context).not.toContain('First old visible message');
+    expect(context).not.toContain('Second old visible message');
+    expect(context).toContain('Final user request');
+    expect(context).toContain('Final assistant response');
+  });
+});

--- a/tests/unit/OpenAIRealtimeVoiceSession.test.ts
+++ b/tests/unit/OpenAIRealtimeVoiceSession.test.ts
@@ -33,14 +33,52 @@ describe('OpenAIRealtimeVoiceSession', () => {
 
     session.handleServerEvent(JSON.stringify({
       type: 'response.output_audio_transcript.delta',
+      response_id: 'response-1',
+      item_id: 'item-1',
+      output_index: 0,
+      content_index: 0,
       delta: 'Hello ',
     }));
     session.handleServerEvent(JSON.stringify({
       type: 'response.output_audio_transcript.done',
+      response_id: 'response-1',
+      item_id: 'item-1',
+      output_index: 0,
+      content_index: 0,
       transcript: 'Hello there',
     }));
 
     expect(onAssistantTranscriptDelta).toHaveBeenCalledWith('Hello ');
+    expect(onAssistantTranscriptCompleted).toHaveBeenCalledWith('Hello there');
+  });
+
+  it('does not emit response.done fallback when transcript completion already arrived for that response', () => {
+    const onAssistantTranscriptCompleted = jest.fn();
+    const session = createSession({ onAssistantTranscriptCompleted });
+
+    session.handleServerEvent(JSON.stringify({
+      type: 'response.output_audio_transcript.done',
+      response_id: 'response-1',
+      item_id: 'item-1',
+      output_index: 0,
+      content_index: 0,
+      transcript: 'Hello there',
+    }));
+    session.handleServerEvent(JSON.stringify({
+      type: 'response.done',
+      response: {
+        id: 'response-1',
+        output: [
+          {
+            content: [
+              { transcript: 'Hello there' },
+            ],
+          },
+        ],
+      },
+    }));
+
+    expect(onAssistantTranscriptCompleted).toHaveBeenCalledTimes(1);
     expect(onAssistantTranscriptCompleted).toHaveBeenCalledWith('Hello there');
   });
 


### PR DESCRIPTION
## Summary
- add LiveVoiceContextBuilder for realtime startup context using existing compaction boundary and token estimation utilities
- include bounded compaction summaries plus recent visible user/assistant turns in live voice instructions
- wire ChatView/ChatLiveVoiceController to pass prior conversation context into OpenAI realtime session startup

## Validation
- npx jest tests/unit/LiveVoiceContextBuilder.test.ts tests/unit/ChatLiveVoiceController.test.ts tests/unit/RealtimeVoiceService.test.ts tests/unit/OpenAIRealtimeVoiceSession.test.ts
- npx tsc --noEmit --skipLibCheck
- npm run build

## Notes
- Uses a conservative default 10k-token live context budget inside the 32k realtime model context window.
- Skips hidden/tool/system messages for this first pass; tool-call context should be handled separately when live tool calling is added.