### PR TITLE
Read-aloud: save + embed audio (unified UX)

### DIFF
--- a/docs/plans/read-aloud-save-embed-scoping.md
+++ b/docs/plans/read-aloud-save-embed-scoping.md
@@ -1,0 +1,183 @@
+# Read-Aloud: Save + Embed — Scoping / Design Doc
+
+**Status:** Scoping (design only, no code). Future feature — NOT part of the in-flight release.
+**Author:** PACT Architect
+**Date:** 2026-06-08
+**Related context:** Pre-release peer review of the readAloud / audio / Composer service families (architect Task #3).
+
+---
+
+## 1. Executive Summary
+
+Today, "Read aloud" synthesizes a note (or a selection) chunk-by-chunk and **plays** the audio, then discards it. This feature adds an **opt-in** capability to also:
+
+1. **Save** the synthesized audio to a user-visible folder in the vault, and
+2. **Embed** an `![[...]]` audio player into the note.
+
+There are two natural modes that already exist in the command surface — but they are the **same mechanism** (selection is just the N=1 case of whole-note):
+
+| Mode | Source | Typical size | Embed location | Concat | Mobile? |
+|------|--------|-------------|----------------|--------|---------|
+| **Selection** | `editor.getSelection()` | usually 1 chunk (≤ ~3,600 chars) | after the selected block / at cursor | none (1 buffer) | **Yes** |
+| **Whole-note** | `vault.cachedRead(file)` | many chunks (a 100K-word note → ~167 chunks) | top of note | **raw buffer join** (N → 1 file) | **Yes** |
+
+**DECIDED (user, 2026-06-08):**
+- **Single concatenated file is the only output mode.** A "playlist note" of N separate `![[chunk-NNN.mp3]]` embeds is rejected — the core use case is *listen to a whole note on a walk*, which requires one seamless file (one tap), not N players.
+- **Do NOT use the Composer app for concat.** Composer is an installable App (coupling), is desktop-only (`OfflineAudioContext`), and its encoder emits only WAV/WebM (never mp3). All three break the mobile + single-file requirement.
+- **Concat = raw format-aware `ArrayBuffer` join, no audio engine** (§4). Works identically on desktop and mobile.
+- **Mobile is a first-class target for BOTH modes**, not desktop-only.
+- **Trigger = explicit "Save as audio" action** (command + menu), separate from plain "read aloud now." Not an auto-on-play side effect.
+
+**Slicing:** one mechanism, so selection and whole-note can ship together or selection-first as a thin start — but whole-note is no longer a "hard second slice," it's the same buffer-join path with N>1.
+
+> ⚠️ **IMPLEMENTATION GUARDRAIL — storage path is SETTINGS-DERIVED, never hardcoded.** Every `Nexus/audio/` in this doc is the *default rendering* of `<rootPath>/<audioSubfolder>`. The literal string `Nexus` (or `Nexus/audio`) MUST NOT appear in code. Resolve at runtime: `rootPath = settings.settings.storage?.rootPath ?? DEFAULT_STORAGE_SETTINGS.rootPath` (precedent: `DataTab.ts:209`, `changeDataFolderPath.ts:67/82/100`), then join the configurable audio subfolder (default `'audio'`). The user changing their storage root MUST move where audio is saved. No `.nexus`, no hardcoded `Nexus`.
+
+---
+
+## 2. Current-State Ground Truth (verified)
+
+| Fact | Location |
+|------|----------|
+| Read-aloud **chunks**, doesn't truncate. Splits at ~3,600-char sentence boundaries. | `MarkdownSpeechPreprocessor.ts:10` (`preprocess`) |
+| `ReadAloudService.read()` synthesizes + **plays each chunk sequentially**, returns only `{ sourceName, chunkCount }` — **audio buffers are discarded**. | `ReadAloudService.ts:111-148` |
+| Selection vs whole-note already branch in the command surface. | `ReadAloudCommandManager.ts:122-130` (`readSelection`), `:132-135` (`readFile`) |
+| Selection command does NOT currently retain the editor reference past the read call (needed for embed insertion). | `ReadAloudCommandManager.ts:96` calls `readSelection(editor)` — editor is in scope, but not threaded to a save/embed step |
+| Each adapter returns `{ audioData: ArrayBuffer, mimeType }`. | `SpeechSynthesisTypes.ts:22-28` (`SpeechSynthesisResult`) |
+| `mimeType` differs by provider: most return `audio/mpeg` (mp3); **Google returns `audio/wav`** (PCM wrapped). | `OpenAISpeechAdapter.ts:62`, `GoogleSpeechAdapter.ts:88` |
+| Existing single-buffer vault write with temp-swap overwrite + ensureParentDirectory. | `AudioGenerationService.writeAudio()` `AudioGenerationService.ts:93-114` |
+| Embed pattern: `![[filename]]` produces an inline audio player. | `OutputNoteBuilder.buildAudioNote` `OutputNoteBuilder.ts:57-74` |
+| Positional/prepend/append insert. `startLine=1` prepends, `-1` appends, N inserts at line N (1-based, pushes content down). | `ContentManager` `InsertTool` `insert.ts:82-115` |
+
+### Storage root (CORRECTED ground truth — do NOT use `.nexus`)
+
+The save folder must derive from the **settings-derived storage root**, not a hidden folder.
+
+- **Field to pin:** `settings.settings.storage.rootPath` (type `MCPStorageSettings.rootPath`).
+- **Definition + default:** `src/types/plugin/PluginTypes.ts:21` (field), `:29` (`DEFAULT_STORAGE_SETTINGS.rootPath = 'Nexus'`).
+- **Default value origin:** `CONFIG.PLUGIN_NAME = 'Nexus'` (`src/config.ts:8`).
+- **Runtime access precedent:** `settings.settings.storage?.rootPath` with fallback to `DEFAULT_STORAGE_SETTINGS.rootPath` — see `DataTab.ts:209` and `changeDataFolderPath.ts:67/82/100`.
+
+So the audio output folder should be a subfolder of `rootPath`, e.g. `<rootPath>/audio/` (default `Nexus/audio/`), or a separately configurable subfolder (§3, open question Q3).
+
+---
+
+## 3. Requirements & The Two Modes
+
+### 3.1 Selection mode (first slice)
+
+- **Trigger:** existing `Read selection aloud` editor-menu item (`ReadAloudCommandManager.ts:91`), plus a new opt-in to save (setting or a second menu item — see Q1).
+- **Audio:** selection is usually a single chunk → a single `SpeechSynthesisResult.audioData`. **No concat.**
+- **Save:** write the single buffer via the existing `writeAudio` temp-swap pattern to `<rootPath>/<audioSubfolder>/`.
+- **Embed location:** insert `![[<savedFile>]]` **after the selected block** (at the end-of-selection line) or at the cursor. Use the editor reference already in scope at `ReadAloudCommandManager.ts:96`. Direct `editor.replaceRange` at the selection's `to` position is the simplest in-plugin path; the MCP `InsertTool` is the alternative (positional, line-based).
+- **Mobile:** fully supported — single buffer, `vault.createBinary`, no `OfflineAudioContext`.
+
+### 3.2 Whole-note mode (second slice)
+
+- **Trigger:** existing `Read note aloud` file-menu item / `read-active-note-aloud` command, plus the save opt-in.
+- **Audio:** N chunks (up to ~167 for a large note) → N separate `audioData` buffers. **Concat required** to produce ONE embeddable file (§4).
+- **Embed location:** `![[<savedFile>]]` at the **top of the note** (`InsertTool` `startLine=1`, or `vault.process` prepend).
+- **Mobile:** concat is desktop-only (§4). Mobile must fall back (§4.4).
+
+---
+
+## 4. Concat — Raw Buffer Join (no audio engine, mobile-safe)
+
+**DECISION:** concatenate the in-memory chunk buffers directly into one file, with a format-aware join. No `AudioContext`/`OfflineAudioContext`, no `MediaRecorder`, no Composer, no temp files, no re-encode. This is the only path that satisfies *mobile + single-file*.
+
+**Why it works:** within a single read-aloud run, every chunk is synthesized by ONE provider at ONE bitrate/sample-rate/channel-mode, so the buffers are format-uniform and can be joined at the container level.
+
+### 4.1 mp3 providers (OpenAI, ElevenLabs, and most others — `audio/mpeg`)
+
+MP3 is a stream of self-contained frames; decoders play concatenated frame streams fine.
+
+- **Join = byte-concatenate the `ArrayBuffer`s.** Pure JS, instant, small output, mobile-safe.
+- **Nicety:** strip any leading **ID3v2** tag and **Xing/Info VBR header** frame from chunks 2…N so metadata/VBR headers don't land mid-stream. TTS output is typically raw CBR mp3 with no ID3, so this is often a no-op — but the strip makes it robust.
+- **Known minor artifact:** the MP3 **bit reservoir** lets a frame reference up to ~2 prior frames' data; at a join boundary the first frame of chunk N+1 may reference reservoir bytes that aren't present → ~26ms of negligible artifact. **Inaudible for spoken word.** The only glitch-free alternative is decode+re-encode = the desktop-only/slow path we are deliberately rejecting.
+
+### 4.2 Google (`audio/wav` — PCM wrapped in RIFF)
+
+- **Join = header-aware:** keep chunk 1's RIFF/`fmt ` header, append only the PCM payload (bytes after each chunk's `data` sub-chunk header) from all chunks, then rewrite the `RIFF` size + `data` size fields. Pure JS, lossless, mobile-safe.
+- **Tradeoff:** WAV is large (uncompressed PCM). Only Google hits this path; if file size matters, prefer an mp3 provider. (Future option: pipe Google PCM through a pure-JS mp3 encoder — out of scope for v1.)
+
+### 4.3 Selecting the path
+
+Detect format from `SpeechSynthesisResult.mimeType` (uniform across a run). `audio/mpeg` → §4.1; `audio/wav` → §4.2. Selection mode (N=1) skips concat entirely — same code, single buffer.
+
+### 4.4 Where this lives
+
+A small pure helper, e.g. `concatAudioBuffers(buffers: ArrayBuffer[], mimeType: string): ArrayBuffer` — no Obsidian/platform deps, unit-testable in isolation, importable by the read-aloud save path. **Not** in the Composer app; **not** dependent on it. (Composer keeps its own decode/re-encode concat for its own use cases; this is a separate lightweight concern.)
+
+### 4.5 No large-note platform gate
+
+Because the join is buffer-level (no real-time encode, no `OfflineAudioContext`), there is **no chunk-count or platform ceiling** the way the Composer path had. A large note costs N synthesis API calls (the same cost as playing it aloud today) + a cheap buffer concat. Mobile and desktop run the identical path.
+
+---
+
+## 5. Integration Points & Rough Component Changes
+
+| Component | Change | Notes |
+|-----------|--------|-------|
+| `ReadAloudService` (`ReadAloudService.ts`) | Add an **opt-in persistence hook**: today `read()` discards buffers. Add an option (e.g. `read({ markdown, sourceName, capture?: 'none' \| 'buffers' })`) or a callback that yields each `SpeechSynthesisResult` as it's synthesized, so the caller can save without re-synthesizing. | Keep playback default unchanged. Don't double-synthesize. |
+| New save service / reuse | Reuse `AudioGenerationService.writeAudio`-style temp-swap write, OR extract a shared `writeMediaFile` helper. (Note: review Task #3 already flagged `writeAudio`≈`writeVideo` duplication — this feature is a good moment to extract a shared vault-write helper.) | `vault.createBinary` + `ensureParentDirectory`. |
+| Settings | New setting(s): enable save (bool), audio subfolder under `rootPath` (default e.g. `audio`), embed-on-save (bool), naming scheme. Pin to `settings.settings.storage.rootPath`. | See Q1/Q3. |
+| `ReadAloudCommandManager` | Thread the `editor`/`file` + cursor through to the save+embed step; add menu items or honor the setting. | Editor already in scope at `:96`. |
+| Embed insertion | Selection → `editor.replaceRange` at selection end (in-plugin), or `InsertTool` positional. Whole-note → prepend (`InsertTool` `startLine=1` / `vault.process`). Embed string `![[<basename>]]` per `OutputNoteBuilder` pattern. | `![[...]]` resolves by basename/shortest path — ensure unique filenames (§Q2). |
+| Concat | New pure `concatAudioBuffers(buffers, mimeType)` helper — mp3 byte-join (+ID3/Xing strip on chunks 2…N) / wav header-merge. NOT Composer. | No `AudioContext`; mobile-safe; no platform/size gate. |
+
+---
+
+## 6. Rough PR-Slice Plan
+
+One mechanism (capture buffers → format-aware join → save → embed); selection is the N=1 case. Two slices only because the insert location + trigger surface differ.
+
+**Slice 1 — "Save selection as audio" (thin start, the N=1 path).**
+- `concatAudioBuffers` helper (mp3 byte-join + ID3/Xing strip; wav header-merge) — pure, unit-tested. Handles N=1 trivially.
+- Capture hook on `ReadAloudService` so synthesis buffers aren't discarded (never double-synthesize).
+- Settings: audio subfolder under `<rootPath>` (default `audio` → `Nexus/audio/`) + naming scheme (Q2).
+- Save via temp-swap write helper; embed `![[...]]` after the selected block / at cursor (editor in scope).
+- **UI:** explicit "Save selection as audio" — command palette + **editor context menu on a selection** (desktop right-click / mobile long-press). Highlight → context menu → converts.
+- Acceptance: highlight text → context menu "Save selection as audio" → mp3 lands in `Nexus/audio/`, `![[...]]` inserted at selection end, plays inline. Works on mobile.
+
+**Slice 2 — "Save note as audio" (N>1, same join path).**
+- Synthesize all chunks, `concatAudioBuffers` → ONE file, embed one `![[...]]` at top of note.
+- **UI:** "Save note as audio" — command palette + file "⋯" menu.
+- No platform/size gate (buffer join is cheap; cost = N synth calls, same as reading aloud today). Optional progress UI for long notes.
+- Acceptance: "Save note as audio" on a large note → single seamless mp3 at top, one tap to play through. Identical on mobile + desktop.
+
+**Slice 3 (optional) — Polish.**
+- Overwrite/dedup UX, naming refinements, progress UI, optional Google-PCM→mp3 encode to shrink WAV output.
+
+---
+
+## 7. Design Questions
+
+### RESOLVED (user, 2026-06-08)
+- **Q1 — Save trigger:** ✅ Explicit "Save as audio" action (command + menu), separate from plain play. NOT an auto-save-on-play toggle.
+- **Q4 — Concat reuse vs refactor:** ✅ Neither — do not use Composer at all. New pure `concatAudioBuffers` helper, raw buffer join (§4).
+- **Q5 — Large whole-note policy:** ✅ Single file always; no size/platform gate. Buffer join has no real-time-encode cost.
+- **Q6 — Output format:** ✅ Preserve provider-native mp3 via raw frame concat (small). WAV only for Google; single seamless file either way. Playlist rejected.
+- **Q7 — Mobile:** ✅ Mobile is first-class for BOTH modes. The buffer-join path is platform-agnostic.
+- **UI for selection:** ✅ Editor context menu on a highlight (desktop right-click / mobile long-press) → "Save selection as audio" → converts. Plus command palette.
+
+### RESOLVED (user, 2026-06-08, cont.)
+- **Q2 — File naming & dedup:** ✅ **Timestamped, always new** (no overwrite — every render is kept; the freshly-inserted `![[...]]` points at the new file).
+  - **Whole-note:** `<note-basename> - <timestamp>.mp3`
+  - **Selection:** `<note-basename> - <first few words of selection> - <timestamp>.mp3` (human-identifiable which selection it was)
+  - Implementation notes: sanitize the snippet + basename for filename-illegal chars (`normalizePath` does NOT strip these), cap snippet length (~first 3–5 words / ~40 chars), pick a sortable timestamp format (e.g. `YYYYMMDD-HHmmss`). Accepted tradeoff: audio files accumulate in the folder (user is fine with this).
+- **Q3 — Folder layout:** ✅ **Flat `<rootPath>/audio/`** (default `Nexus/audio/`). Subfolder name (`audio`) configurable in settings. No source-folder mirroring.
+
+### STILL OPEN
+- _None. Spec is complete and buildable._
+
+---
+
+## 8. Risks Summary
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| `ReadAloudService` currently discards buffers — naive impl could double-synthesize (2× cost/latency) | Medium | Add a capture hook in the existing synth loop; never re-synthesize for save |
+| `![[...]]` embed resolves by basename — name collisions break the embed (wrong file plays) | Medium | Unique/predictable naming scheme (Q2) |
+| mp3 raw concat: ~26ms bit-reservoir artifact at chunk boundaries | Low | Inaudible for speech; accepted vs the desktop-only decode/re-encode alternative |
+| ID3v2 / Xing header mid-stream if not stripped from chunks 2…N | Low | Strip leading metadata/VBR header on non-first mp3 chunks |
+| Google WAV output is large (uncompressed PCM) | Low | Single provider only; recommend mp3 providers; optional future PCM→mp3 encode |
+| Mode parity confusion (selection vs whole-note insert location) | Low | Selection→after-block/cursor; whole-note→top of note |

--- a/docs/plans/read-aloud-save-embed-scoping.md
+++ b/docs/plans/read-aloud-save-embed-scoping.md
@@ -34,6 +34,21 @@ There are two natural modes that already exist in the command surface — but th
 
 ---
 
+## 1b. v2 UX REDESIGN — supersedes the v1 trigger/feedback design (user manual-test feedback, 2026-06-08)
+
+The v1 build (commits 89f65a8e CODE / f526adbc TEST) shipped **two separate explicit actions** ("Save selection/note as audio") that synthesized WITHOUT playback. Manual testing rejected that surface. The engine (`concatAudioBuffers`, settings-derived path, naming, embed-below-frontmatter) is RETAINED; the **trigger + feedback + playback coupling** is redesigned:
+
+**DECIDED (user, 2026-06-08):**
+1. **Unify to ONE action.** REMOVE the two separate "Save selection as audio" / "Save note as audio" commands AND their context/file-menu items. There is a single **"Read aloud"** entry (selection via editor context menu + palette; note via file ⋯ menu + palette). Save is no longer its own command.
+2. **Save-prompt modal.** On invoking read-aloud → an Obsidian `Modal` asks **save-or-not** (e.g. [Save & read] / [Just read], + Cancel). This replaces the silent-synth behavior.
+3. **Animated reading-aloud modal (either choice).** After the prompt, show a progress modal with a **live animation REUSED from the live-voice/transcript UI** (the pulsing dot `.chat-live-dot` + waveform bars `.chat-live-wave-bar` / `ChatInput.buildLiveVoiceBars`) so it's visually clear it's synthesizing/reading. These styles already carry `prefers-reduced-motion` handling (FE-MINOR-1) — reuse inherits it.
+4. **Read-aloud now PLAYS.** This REVERSES the v1 "synth-only, no playback" decision. The action plays audio aloud; saving is captured ALONGSIDE playback (single synth pass — never double-synthesize: play + capture from the same synthesized buffers).
+5. **Background-continue on dismiss (save case).** If Save was chosen and the user dismisses/leaves the modal: **playback STOPS, but synthesis + save CONTINUE in the background**, inserting the `![[...]]` embed when done. Implication: the save's synth pass must complete ALL chunks even after playback is cancelled mid-way (play until stopped, then synth-only for remaining chunks — one pass, no double-synth). If "Just read" was chosen, dismiss simply stops playback (nothing saved).
+
+**Engine reuse (unchanged):** `concatAudioBuffers`, `ReadAloudSaveService` file-write + naming + sanitization + embed-below-frontmatter, settings-derived path. The capture source shifts from a synth-only pass to a **play-and-capture pass with cancellable playback but non-cancellable save**.
+
+---
+
 ## 2. Current-State Ground Truth (verified)
 
 | Fact | Location |

--- a/src/core/commands/ReadAloudCommandManager.ts
+++ b/src/core/commands/ReadAloudCommandManager.ts
@@ -155,14 +155,65 @@ export class ReadAloudCommandManager {
   private getReadAloudService(): ReadAloudService {
     const llmSettings = this.config.plugin.settings?.settings.llmProviders ?? null;
     const appsSettings = this.config.plugin.settings?.settings.apps;
-    const fingerprint = JSON.stringify(llmSettings?.defaultSpeechModel ?? {}) +
-      JSON.stringify(llmSettings?.providers?.openai ?? {}) +
-      JSON.stringify(appsSettings?.apps.elevenlabs ?? {});
+    const fingerprint = this.computeSettingsFingerprint(llmSettings, appsSettings);
     if (!this.readAloudService || this.settingsFingerprint !== fingerprint) {
       this.readAloudService?.stop();
       this.readAloudService = new ReadAloudService(llmSettings, appsSettings);
       this.settingsFingerprint = fingerprint;
     }
     return this.readAloudService;
+  }
+
+  /**
+   * Build a change-detection fingerprint for the read-aloud settings WITHOUT
+   * retaining any raw API key. The fingerprint stays in memory only (never
+   * logged or persisted) and is used solely to decide whether the cached
+   * ReadAloudService must be rebuilt.
+   *
+   * SEC-m2: the previous implementation JSON.stringify'd the full provider/app
+   * configs (which include `apiKey`/`credentials.apiKey`) into this long-lived
+   * field, leaving a plaintext key copy in memory. We now compose only
+   * non-secret fields (provider/model/voice + enabled) plus a non-reversible
+   * hash of each key. Hashing the key (rather than dropping it) preserves
+   * change-detection across same-provider key rotation, which a plain
+   * presence boolean would miss.
+   */
+  private computeSettingsFingerprint(
+    llmSettings: Settings['settings']['llmProviders'] | null,
+    appsSettings: Settings['settings']['apps'] | undefined
+  ): string {
+    const speech = llmSettings?.defaultSpeechModel;
+    const openai = llmSettings?.providers?.openai;
+    const elevenlabs = appsSettings?.apps.elevenlabs;
+
+    const parts = [
+      speech?.provider ?? '',
+      speech?.model ?? '',
+      speech?.voice ?? '',
+      openai?.enabled ? '1' : '0',
+      this.hashSecret(openai?.apiKey),
+      elevenlabs?.enabled ? '1' : '0',
+      this.hashSecret(elevenlabs?.credentials.apiKey),
+    ];
+
+    return parts.join('|');
+  }
+
+  /**
+   * Non-cryptographic djb2 hash of a secret. Returns a short hex digest that
+   * changes when the secret changes but never exposes the plaintext. Empty/
+   * absent secrets collapse to a stable sentinel so an unset key is
+   * distinguishable from a set one.
+   */
+  private hashSecret(secret: string | undefined): string {
+    if (!secret) {
+      return '0';
+    }
+
+    let hash = 5381;
+    for (let index = 0; index < secret.length; index += 1) {
+      hash = ((hash << 5) + hash + secret.charCodeAt(index)) | 0;
+    }
+    return (hash >>> 0).toString(16);
   }
 }

--- a/src/core/commands/ReadAloudCommandManager.ts
+++ b/src/core/commands/ReadAloudCommandManager.ts
@@ -12,7 +12,10 @@ import {
 } from 'obsidian';
 import type { Settings } from '../../settings';
 import { ReadAloudService } from '../../services/readAloud/ReadAloudService';
+import type { ReadAloudSession } from '../../services/readAloud/ReadAloudService';
 import { ReadAloudSaveService } from '../../services/readAloud/ReadAloudSaveService';
+import { SavePromptModal, SavePromptChoice } from '../../ui/readAloud/SavePromptModal';
+import { ReadAloudProgressModal } from '../../ui/readAloud/ReadAloudProgressModal';
 
 declare module 'obsidian' {
   interface Workspace extends Events {
@@ -30,6 +33,8 @@ export interface ReadAloudCommandManagerConfig {
   app: App;
 }
 
+type ReadAloudTarget = { mode: 'selection' | 'note'; file: TFile; editor?: Editor };
+
 export class ReadAloudCommandManager {
   private readAloudService: ReadAloudService | null = null;
   private settingsFingerprint: string | null = null;
@@ -39,8 +44,7 @@ export class ReadAloudCommandManager {
 
   registerCommands(): void {
     this.registerReadActiveNoteCommand();
-    this.registerSaveActiveNoteCommand();
-    this.registerSaveSelectionCommand();
+    this.registerReadSelectionCommand();
     this.registerStopCommand();
     this.registerEditorMenu();
     this.registerFileMenu();
@@ -49,7 +53,7 @@ export class ReadAloudCommandManager {
   private registerReadActiveNoteCommand(): void {
     this.config.plugin.addCommand({
       id: 'read-active-note-aloud',
-      name: 'Read active note aloud',
+      name: 'Read note aloud',
       checkCallback: (checking) => {
         const view = this.config.app.workspace.getActiveViewOfType(MarkdownView);
         if (!view?.file) {
@@ -57,7 +61,7 @@ export class ReadAloudCommandManager {
         }
 
         if (!checking) {
-          void this.readFile(view.file);
+          this.promptAndRead({ mode: 'note', file: view.file });
         }
 
         return true;
@@ -65,29 +69,10 @@ export class ReadAloudCommandManager {
     });
   }
 
-  private registerSaveActiveNoteCommand(): void {
+  private registerReadSelectionCommand(): void {
     this.config.plugin.addCommand({
-      id: 'save-active-note-as-audio',
-      name: 'Save note as audio',
-      checkCallback: (checking) => {
-        const view = this.config.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!view?.file) {
-          return false;
-        }
-
-        if (!checking) {
-          void this.saveNoteAsAudio(view.file);
-        }
-
-        return true;
-      }
-    });
-  }
-
-  private registerSaveSelectionCommand(): void {
-    this.config.plugin.addCommand({
-      id: 'save-selection-as-audio',
-      name: 'Save selection as audio',
+      id: 'read-selection-aloud',
+      name: 'Read selection aloud',
       editorCheckCallback: (checking, editor, ctx) => {
         const file = ctx.file;
         if (!file || !editor.somethingSelected()) {
@@ -95,7 +80,7 @@ export class ReadAloudCommandManager {
         }
 
         if (!checking) {
-          void this.saveSelectionAsAudio(editor, file);
+          this.promptAndRead({ mode: 'selection', file, editor });
         }
 
         return true;
@@ -130,26 +115,19 @@ export class ReadAloudCommandManager {
           return;
         }
 
+        const file = info.file;
+        if (!(file instanceof TFile) || file.extension !== 'md') {
+          return;
+        }
+
         menu.addItem((item) => {
           item
             .setTitle('Read selection aloud')
             .setIcon('volume-2')
             .onClick(() => {
-              void this.readSelection(editor);
+              this.promptAndRead({ mode: 'selection', file, editor });
             });
         });
-
-        const file = info.file;
-        if (file instanceof TFile && file.extension === 'md') {
-          menu.addItem((item) => {
-            item
-              .setTitle('Save selection as audio')
-              .setIcon('save')
-              .onClick(() => {
-                void this.saveSelectionAsAudio(editor, file);
-              });
-          });
-        }
       })
     );
   }
@@ -166,109 +144,115 @@ export class ReadAloudCommandManager {
             .setTitle('Read note aloud')
             .setIcon('volume-2')
             .onClick(() => {
-              void this.readFile(file);
-            });
-        });
-
-        menu.addItem((item) => {
-          item
-            .setTitle('Save note as audio')
-            .setIcon('save')
-            .onClick(() => {
-              void this.saveNoteAsAudio(file);
+              this.promptAndRead({ mode: 'note', file });
             });
         });
       })
     );
   }
 
-  private async readSelection(editor: Editor): Promise<void> {
-    const selectedText = editor.getSelection();
-    if (!selectedText.trim()) {
-      new Notice('Please select text to read aloud.');
+  /**
+   * The single v2 read-aloud entry point. Asks save-or-not, then runs an
+   * animated reading-aloud session. "Save & read" plays AND saves+embeds (the
+   * save continues in the background even if the modal is dismissed mid-play);
+   * "Just read" plays only; dismissing the progress modal stops playback.
+   */
+  private promptAndRead(target: ReadAloudTarget): void {
+    new SavePromptModal(this.config.app, (choice: SavePromptChoice) => {
+      if (choice === 'cancel') {
+        return;
+      }
+      void this.runReadAloudSession(target, choice === 'save');
+    }).open();
+  }
+
+  /**
+   * Resolve the text to synthesize: the live selection (selection mode) or the
+   * whole note (note mode). Returns null with a Notice if there's nothing to read.
+   */
+  private async resolveMarkdown(target: ReadAloudTarget): Promise<string | null> {
+    if (target.mode === 'selection') {
+      const selection = target.editor?.getSelection() ?? '';
+      if (!selection.trim()) {
+        new Notice('Please select text to read aloud.');
+        return null;
+      }
+      return selection;
+    }
+
+    const content = await this.config.app.vault.cachedRead(target.file);
+    if (!content.trim()) {
+      new Notice('There is no readable text in this note.');
+      return null;
+    }
+    return content;
+  }
+
+  /**
+   * Start a read-aloud session and drive the progress modal. Wiring rules:
+   * - onProgress updates the modal until the modal is closed (listener detached).
+   * - User-dismissing the modal stops playback; a chosen save keeps running in
+   *   the background (the backend session is modal-agnostic).
+   * - session.completed resolves with a savedPath on save, resolves empty on
+   *   just-read, and rejects on synth/write failure (-> error Notice).
+   */
+  private async runReadAloudSession(target: ReadAloudTarget, save: boolean): Promise<void> {
+    const markdown = await this.resolveMarkdown(target);
+    if (markdown === null) {
       return;
     }
 
-    await this.startReadAloud(selectedText, 'Selection');
-  }
-
-  private async readFile(file: TFile): Promise<void> {
-    const content = await this.config.app.vault.cachedRead(file);
-    await this.startReadAloud(content, file.basename);
-  }
-
-  /**
-   * Explicit "Save selection as audio": synthesize the current selection, save
-   * it as a single audio file, and embed an ![[...]] player after the selection.
-   * The backend ReadAloudSaveService owns the synth/concat/write/embed; this
-   * handler only triggers it and surfaces progress + errors to the user.
-   */
-  private async saveSelectionAsAudio(editor: Editor, file: TFile): Promise<void> {
-    if (!editor.somethingSelected()) {
-      new Notice('Please select text to save as audio.');
+    let session: ReadAloudSession;
+    try {
+      session = this.getReadAloudService().startReadAloudSession({
+        mode: target.mode,
+        file: target.file,
+        markdown,
+        editor: target.editor,
+        selection: target.mode === 'selection' ? markdown : undefined,
+        save,
+        saveService: save ? this.getReadAloudSaveService() : undefined
+      });
+    } catch (error) {
+      new Notice(`Read aloud failed: ${this.errorMessage(error)}`);
       return;
     }
 
-    await this.runSaveAsAudio(
-      file.basename,
-      (service) => service.saveSelectionAsAudio(editor, file)
-    );
-  }
-
-  /**
-   * Explicit "Save note as audio": synthesize the whole note, save it as one
-   * concatenated audio file, and embed an ![[...]] player at the top of the
-   * note. Backend owns the work; this handler triggers + reports.
-   */
-  private async saveNoteAsAudio(file: TFile): Promise<void> {
-    await this.runSaveAsAudio(
-      file.basename,
-      (service) => service.saveNoteAsAudio(file)
-    );
-  }
-
-  /**
-   * Shared trigger/progress/error wrapper for the two save-as-audio actions.
-   * Mirrors startReadAloud's progress-Notice + stopped/failure handling so the
-   * save actions feel consistent with plain read-aloud.
-   */
-  private async runSaveAsAudio(
-    sourceName: string,
-    run: (service: ReadAloudSaveService) => Promise<void>
-  ): Promise<void> {
-    const service = this.getReadAloudSaveService();
-    const notice = new Notice(`Saving ${sourceName} as audio...`, 0);
-
-    try {
-      await run(service);
-      notice.hide();
-      new Notice(`Saved ${sourceName} as audio.`);
-    } catch (error) {
-      notice.hide();
-      const message = error instanceof Error ? error.message : String(error);
-      if (message === 'Read aloud playback was stopped.') {
-        return;
+    let listening = true;
+    const modal = new ReadAloudProgressModal(
+      this.config.app,
+      target.file.basename,
+      () => {
+        // User dismissed: stop playback, stop reacting to progress. A chosen
+        // save continues in the background and inserts its embed on completion.
+        listening = false;
+        session.stopPlayback();
       }
-      new Notice(`Save as audio failed: ${message}`);
-    }
+    );
+
+    session.onProgress((done, total) => {
+      if (listening) {
+        modal.setProgress(done, total);
+      }
+    });
+
+    modal.open();
+
+    void session.completed
+      .then((result) => {
+        modal.finish();
+        if (result.savedPath) {
+          new Notice(`Saved read-aloud audio to ${result.savedPath}`);
+        }
+      })
+      .catch((error) => {
+        modal.finish();
+        new Notice(`Read aloud save failed: ${this.errorMessage(error)}`);
+      });
   }
 
-  private async startReadAloud(markdown: string, sourceName: string): Promise<void> {
-    const service = this.getReadAloudService();
-    const notice = new Notice(`Reading ${sourceName} aloud...`, 0);
-
-    try {
-      const result = await service.read({ markdown, sourceName });
-      notice.hide();
-      new Notice(`Finished reading ${result.sourceName ?? 'text'} aloud.`);
-    } catch (error) {
-      notice.hide();
-      const message = error instanceof Error ? error.message : String(error);
-      if (message === 'Read aloud playback was stopped.') {
-        return;
-      }
-      new Notice(`Read aloud failed: ${message}`);
-    }
+  private errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
   }
 
   private getReadAloudService(): ReadAloudService {
@@ -284,11 +268,10 @@ export class ReadAloudCommandManager {
   }
 
   /**
-   * Lazily build the backend ReadAloudSaveService. It holds the live Settings
-   * object and resolves the LLM/apps/storage config (incl. the audio-subfolder,
-   * settings-derived and never hardcoded) on each call, so a single instance
-   * stays correct across settings changes — no fingerprint rebuild needed.
-   * Requires plugin settings to be available.
+   * Lazily build the backend ReadAloudSaveService (the save tail passed to the
+   * session when saving). It holds the live Settings object and resolves the
+   * storage config (incl. the settings-derived audio subfolder, never hardcoded)
+   * on each call, so one cached instance stays correct across settings changes.
    */
   private getReadAloudSaveService(): ReadAloudSaveService {
     if (!this.readAloudSaveService) {

--- a/src/core/commands/ReadAloudCommandManager.ts
+++ b/src/core/commands/ReadAloudCommandManager.ts
@@ -12,6 +12,7 @@ import {
 } from 'obsidian';
 import type { Settings } from '../../settings';
 import { ReadAloudService } from '../../services/readAloud/ReadAloudService';
+import { ReadAloudSaveService } from '../../services/readAloud/ReadAloudSaveService';
 
 declare module 'obsidian' {
   interface Workspace extends Events {
@@ -32,11 +33,14 @@ export interface ReadAloudCommandManagerConfig {
 export class ReadAloudCommandManager {
   private readAloudService: ReadAloudService | null = null;
   private settingsFingerprint: string | null = null;
+  private readAloudSaveService: ReadAloudSaveService | null = null;
 
   constructor(private config: ReadAloudCommandManagerConfig) {}
 
   registerCommands(): void {
     this.registerReadActiveNoteCommand();
+    this.registerSaveActiveNoteCommand();
+    this.registerSaveSelectionCommand();
     this.registerStopCommand();
     this.registerEditorMenu();
     this.registerFileMenu();
@@ -54,6 +58,44 @@ export class ReadAloudCommandManager {
 
         if (!checking) {
           void this.readFile(view.file);
+        }
+
+        return true;
+      }
+    });
+  }
+
+  private registerSaveActiveNoteCommand(): void {
+    this.config.plugin.addCommand({
+      id: 'save-active-note-as-audio',
+      name: 'Save note as audio',
+      checkCallback: (checking) => {
+        const view = this.config.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view?.file) {
+          return false;
+        }
+
+        if (!checking) {
+          void this.saveNoteAsAudio(view.file);
+        }
+
+        return true;
+      }
+    });
+  }
+
+  private registerSaveSelectionCommand(): void {
+    this.config.plugin.addCommand({
+      id: 'save-selection-as-audio',
+      name: 'Save selection as audio',
+      editorCheckCallback: (checking, editor, ctx) => {
+        const file = ctx.file;
+        if (!file || !editor.somethingSelected()) {
+          return false;
+        }
+
+        if (!checking) {
+          void this.saveSelectionAsAudio(editor, file);
         }
 
         return true;
@@ -83,7 +125,7 @@ export class ReadAloudCommandManager {
 
   private registerEditorMenu(): void {
     this.config.plugin.registerEvent(
-      this.config.app.workspace.on('editor-menu', (menu, editor) => {
+      this.config.app.workspace.on('editor-menu', (menu, editor, info) => {
         if (!editor.somethingSelected()) {
           return;
         }
@@ -96,6 +138,18 @@ export class ReadAloudCommandManager {
               void this.readSelection(editor);
             });
         });
+
+        const file = info.file;
+        if (file instanceof TFile && file.extension === 'md') {
+          menu.addItem((item) => {
+            item
+              .setTitle('Save selection as audio')
+              .setIcon('save')
+              .onClick(() => {
+                void this.saveSelectionAsAudio(editor, file);
+              });
+          });
+        }
       })
     );
   }
@@ -115,6 +169,15 @@ export class ReadAloudCommandManager {
               void this.readFile(file);
             });
         });
+
+        menu.addItem((item) => {
+          item
+            .setTitle('Save note as audio')
+            .setIcon('save')
+            .onClick(() => {
+              void this.saveNoteAsAudio(file);
+            });
+        });
       })
     );
   }
@@ -132,6 +195,62 @@ export class ReadAloudCommandManager {
   private async readFile(file: TFile): Promise<void> {
     const content = await this.config.app.vault.cachedRead(file);
     await this.startReadAloud(content, file.basename);
+  }
+
+  /**
+   * Explicit "Save selection as audio": synthesize the current selection, save
+   * it as a single audio file, and embed an ![[...]] player after the selection.
+   * The backend ReadAloudSaveService owns the synth/concat/write/embed; this
+   * handler only triggers it and surfaces progress + errors to the user.
+   */
+  private async saveSelectionAsAudio(editor: Editor, file: TFile): Promise<void> {
+    if (!editor.somethingSelected()) {
+      new Notice('Please select text to save as audio.');
+      return;
+    }
+
+    await this.runSaveAsAudio(
+      file.basename,
+      (service) => service.saveSelectionAsAudio(editor, file)
+    );
+  }
+
+  /**
+   * Explicit "Save note as audio": synthesize the whole note, save it as one
+   * concatenated audio file, and embed an ![[...]] player at the top of the
+   * note. Backend owns the work; this handler triggers + reports.
+   */
+  private async saveNoteAsAudio(file: TFile): Promise<void> {
+    await this.runSaveAsAudio(
+      file.basename,
+      (service) => service.saveNoteAsAudio(file)
+    );
+  }
+
+  /**
+   * Shared trigger/progress/error wrapper for the two save-as-audio actions.
+   * Mirrors startReadAloud's progress-Notice + stopped/failure handling so the
+   * save actions feel consistent with plain read-aloud.
+   */
+  private async runSaveAsAudio(
+    sourceName: string,
+    run: (service: ReadAloudSaveService) => Promise<void>
+  ): Promise<void> {
+    const service = this.getReadAloudSaveService();
+    const notice = new Notice(`Saving ${sourceName} as audio...`, 0);
+
+    try {
+      await run(service);
+      notice.hide();
+      new Notice(`Saved ${sourceName} as audio.`);
+    } catch (error) {
+      notice.hide();
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === 'Read aloud playback was stopped.') {
+        return;
+      }
+      new Notice(`Save as audio failed: ${message}`);
+    }
   }
 
   private async startReadAloud(markdown: string, sourceName: string): Promise<void> {
@@ -162,6 +281,28 @@ export class ReadAloudCommandManager {
       this.settingsFingerprint = fingerprint;
     }
     return this.readAloudService;
+  }
+
+  /**
+   * Lazily build the backend ReadAloudSaveService. It holds the live Settings
+   * object and resolves the LLM/apps/storage config (incl. the audio-subfolder,
+   * settings-derived and never hardcoded) on each call, so a single instance
+   * stays correct across settings changes — no fingerprint rebuild needed.
+   * Requires plugin settings to be available.
+   */
+  private getReadAloudSaveService(): ReadAloudSaveService {
+    if (!this.readAloudSaveService) {
+      const settings = this.config.plugin.settings;
+      if (!settings) {
+        throw new Error('Read aloud settings are not available yet.');
+      }
+      this.readAloudSaveService = new ReadAloudSaveService(
+        this.config.app,
+        this.config.app.vault,
+        settings
+      );
+    }
+    return this.readAloudSaveService;
   }
 
   /**

--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -258,6 +258,19 @@ export class SyncCoordinator {
    * NOTE: Uses smaller batch size (25) to avoid OOM errors with sql.js asm.js version.
    * Saves once after replay and FTS rebuild so cold-start cache rebuilds do not
    * repeatedly export and rewrite the full SQLite blob.
+   *
+   * Error handling distinguishes two error classes so a single bad input file
+   * never permanently breaks cold-start:
+   * - Per-file / per-event errors (a malformed JSONL file, an event an applier
+   *   rejects) are RECOVERABLE: the offending file is skipped, accumulated in
+   *   `errors` as a warning, and the rebuild continues. The good cache is still
+   *   indexed, saved, and the sync state advanced, so cold-start does NOT re-run
+   *   the rebuild on every launch. The completed result is `success: true` and
+   *   `errors` carries the skipped-file warnings.
+   * - Fatal errors (clearAllData / rebuildFTSIndexes / updateSyncState / save
+   *   throwing — i.e. the rebuild engine itself failing) are NOT recoverable.
+   *   They propagate to the catch below, which returns `success: false` WITHOUT
+   *   saving, preserving the "never persist a half-built index" guarantee.
    */
   async fullRebuild(options: SyncOptions = {}): Promise<SyncResult> {
     const startTime = Date.now();
@@ -286,11 +299,21 @@ export class SyncCoordinator {
       eventsApplied += taskResult.applied;
       filesProcessed.push(...taskResult.files);
 
+      // Surface skipped files so a persistent bad input file is visible in the
+      // console, but do NOT abort: per-file errors are recoverable. Aborting
+      // here (the previous behavior) discarded the entire good rebuild and never
+      // saved, so cold-start re-ran fullRebuild on every launch — a permanent
+      // loop on a single malformed file.
       if (errors.length > 0) {
-        return this.createResult(false, eventsApplied, 0, errors, startTime, filesProcessed);
+        console.warn(
+          `[SyncCoordinator] Full rebuild skipped ${errors.length} file(s)/event(s); ` +
+          `continuing with the good cache: ${errors.join('; ')}`
+        );
       }
 
-      // Rebuild FTS and save
+      // Rebuild FTS and save. Reaching here means the rebuild engine itself
+      // succeeded, so the cache is valid and MUST be persisted (even if some
+      // input files were skipped above).
       options.onProgress?.('Rebuilding search indexes', 0, 1);
       await this.sqliteCache.rebuildFTSIndexes();
       await this.sqliteCache.updateSyncState(this.deviceId, Date.now(), {});
@@ -298,8 +321,13 @@ export class SyncCoordinator {
 
       options.onProgress?.('Complete', 1, 1);
 
-      return this.createResult(errors.length === 0, eventsApplied, 0, errors, startTime, filesProcessed);
+      // success: true even when `errors` is non-empty — those are skipped-file
+      // warnings, not a failed rebuild. Callers throw only on `!success`, so
+      // this persists the good cache and prevents the cold-start rebuild loop.
+      return this.createResult(true, eventsApplied, 0, errors, startTime, filesProcessed);
     } catch (error) {
+      // Fatal: the rebuild engine failed. Do not save — never persist a
+      // half-built index. success: false makes callers surface the failure.
       console.error('[SyncCoordinator] Full rebuild failed:', error);
       return this.createResult(false, eventsApplied, 0, [...errors, `Rebuild failed: ${String(error)}`], startTime, filesProcessed);
     }

--- a/src/services/audio/AudioGenerationService.ts
+++ b/src/services/audio/AudioGenerationService.ts
@@ -7,6 +7,20 @@ import type { SpeechSynthesisRequest } from '../readAloud/SpeechSynthesisTypes';
 
 export type AudioGenerationMode = 'voice';
 
+/**
+ * Maps a synthesized-audio mimeType to its canonical file extension (no dot).
+ * Single source of truth for both the upfront allowed-extension check and the
+ * post-synthesis mimeType↔extension consistency check, so the two never drift.
+ * Speech adapters currently emit only audio/mpeg (OpenAI/OpenRouter/Mistral/
+ * ElevenLabs, all response_format mp3) and audio/wav (Google).
+ */
+const AUDIO_MIME_TO_EXTENSION: Readonly<Record<string, string>> = {
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+};
+
+const ALLOWED_AUDIO_EXTENSIONS: readonly string[] = Object.values(AUDIO_MIME_TO_EXTENSION);
+
 export interface GenerateAudioRequest {
   mode?: AudioGenerationMode;
   prompt: string;
@@ -57,6 +71,7 @@ export class AudioGenerationService {
     }
 
     const outputPath = this.normalizeOutputPath(request.outputPath);
+    this.validateOutputExtension(outputPath);
     const speechRequest: SpeechSynthesisRequest = {
       text: request.prompt,
       provider: request.provider,
@@ -64,6 +79,7 @@ export class AudioGenerationService {
       voice: request.voice,
     };
     const speechResult = await this.speechService.synthesize(speechRequest);
+    this.assertExtensionMatchesMime(outputPath, speechResult.mimeType);
     await this.writeAudio(outputPath, speechResult.audioData, request.overwrite === true);
 
     return {
@@ -88,6 +104,52 @@ export class AudioGenerationService {
     }
 
     return normalizePath(outputPath);
+  }
+
+  /**
+   * Fail fast (before synthesis) when the outputPath does not end in a supported
+   * audio extension. Mirrors VideoGenerationService.validateOutputExtension,
+   * generalized to the allowed audio set instead of a single .mp4.
+   */
+  private validateOutputExtension(outputPath: string): void {
+    const extension = this.extensionOf(outputPath);
+    if (!extension || !ALLOWED_AUDIO_EXTENSIONS.includes(extension)) {
+      throw new Error(
+        `outputPath must end with one of: ${ALLOWED_AUDIO_EXTENSIONS.map(ext => `.${ext}`).join(', ')}.`
+      );
+    }
+  }
+
+  /**
+   * Reject a write whose path extension does not match the actually synthesized
+   * audio format, so e.g. Google's audio/wav bytes can never be written to a
+   * .mp3 path (BE-m1). An unmapped mimeType fails with a clear error rather than
+   * silently passing — covers any future adapter that returns a new format.
+   */
+  private assertExtensionMatchesMime(outputPath: string, mimeType: string): void {
+    const expectedExtension = AUDIO_MIME_TO_EXTENSION[mimeType.toLowerCase()];
+    if (!expectedExtension) {
+      throw new Error(
+        `Synthesized audio has an unsupported mimeType "${mimeType}". Supported: ${Object.keys(AUDIO_MIME_TO_EXTENSION).join(', ')}.`
+      );
+    }
+
+    const actualExtension = this.extensionOf(outputPath);
+    if (actualExtension !== expectedExtension) {
+      throw new Error(
+        `outputPath extension ".${actualExtension}" does not match the synthesized audio format "${mimeType}" (expected ".${expectedExtension}").`
+      );
+    }
+  }
+
+  /** Lowercased file extension without the leading dot, or '' if none. */
+  private extensionOf(path: string): string {
+    const lastDot = path.lastIndexOf('.');
+    const lastSlash = path.lastIndexOf('/');
+    if (lastDot <= lastSlash + 1) {
+      return '';
+    }
+    return path.substring(lastDot + 1).toLowerCase();
   }
 
   private async writeAudio(outputPath: string, audioData: ArrayBuffer, overwrite: boolean): Promise<void> {

--- a/src/services/readAloud/ReadAloudSaveService.ts
+++ b/src/services/readAloud/ReadAloudSaveService.ts
@@ -1,19 +1,24 @@
 /**
  * Location: src/services/readAloud/ReadAloudSaveService.ts
  *
- * Backend engine for the read-aloud "save as audio" feature. Synthesizes a
- * selection or a whole note to audio (capturing buffers, never playing),
- * concatenates them into ONE file via the pure {@link concatAudioBuffers}
- * helper, writes the file to the SETTINGS-DERIVED audio folder, and inserts a
- * single `![[...]]` embed into the note.
+ * Backend SAVE-TAIL for the read-aloud "save as audio" feature: given the
+ * per-chunk synthesis buffers, concatenates them into ONE file via the pure
+ * {@link concatAudioBuffers} helper, writes the file to the SETTINGS-DERIVED
+ * audio folder, and inserts a single `![[...]]` embed into the note.
  *
- * Public contract (called by ReadAloudCommandManager / UI — frontend-coder):
- * - saveSelectionAsAudio(editor, file): synth selection, embed after selection.
- * - saveNoteAsAudio(file): synth whole note, embed at top of body.
- * Both return Promise<void> and THROW on failure (caller catches + Notices).
+ * v2 contract (called by ReadAloudService.startReadAloudSession during the
+ * play-and-capture session — synthesis happens ONCE, in the session loop):
+ * - saveCapturedSelection(results, editor, file, selection): write + embed after selection.
+ * - saveCapturedNote(results, file): write + embed at top of body (below frontmatter).
+ * Both return the saved vault-relative path and THROW on failure (the session's
+ * `completed` promise rejects; the UI catches + Notices).
+ *
+ * The synthesize-then-save methods {@link saveSelectionAsAudio} /
+ * {@link saveNoteAsAudio} are RETAINED as test seams that drive the full
+ * capture→write→embed pipeline; production traffic goes through the session.
  *
  * Mobile-safe: no AudioContext family, no Node built-ins, no Composer. See
- * docs/plans/read-aloud-save-embed-scoping.md.
+ * docs/plans/read-aloud-save-embed-scoping.md §1b.
  */
 
 import { App, Editor, normalizePath, TFile, TFolder, Vault } from 'obsidian';
@@ -44,9 +49,52 @@ export class ReadAloudSaveService {
   ) {}
 
   /**
-   * Synthesize the current editor selection to a single audio file and insert an
-   * `![[...]]` embed immediately after the selection. Selection is usually one
-   * chunk (N=1), so concat is a no-op pass-through.
+   * Persist ALREADY-captured selection buffers (from the v2 play-and-capture
+   * session) to one audio file and insert the `![[...]]` embed after the selection.
+   * No synthesis happens here — the session synthesized each chunk exactly once.
+   * Selection is usually one chunk (N=1), so concat is a no-op pass-through.
+   * Returns the saved vault-relative path; throws on failure.
+   */
+  async saveCapturedSelection(
+    results: SpeechSynthesisResult[],
+    editor: Editor,
+    file: TFile,
+    selection: string
+  ): Promise<string> {
+    const { filename, outputPath } = await this.writeCaptured(
+      results,
+      this.buildSelectionFilenameStem(file.basename, selection)
+    );
+
+    // Insert the embed on its own line after the selection's end.
+    const to = editor.getCursor('to');
+    const embed = `\n\n${this.buildEmbed(filename)}\n`;
+    editor.replaceRange(embed, to);
+    return outputPath;
+  }
+
+  /**
+   * Persist ALREADY-captured whole-note buffers (from the v2 session) to one
+   * concatenated audio file and insert the `![[...]]` embed at the top of the note
+   * body (below YAML frontmatter, if any). No synthesis happens here. Returns the
+   * saved vault-relative path; throws on failure.
+   */
+  async saveCapturedNote(results: SpeechSynthesisResult[], file: TFile): Promise<string> {
+    const { filename, outputPath } = await this.writeCaptured(
+      results,
+      this.buildNoteFilenameStem(file.basename)
+    );
+
+    const embed = this.buildEmbed(filename);
+    await this.vault.process(file, (content) => this.prependBelowFrontmatter(content, embed));
+    return outputPath;
+  }
+
+  /**
+   * RETAINED test seam: synthesize the current editor selection (capturing, no
+   * playback) and persist it via {@link saveCapturedSelection}. The v2 session
+   * does NOT call this — it captures during play-and-capture so synthesis happens
+   * once. Kept to exercise the full capture→write→embed pipeline in unit tests.
    */
   async saveSelectionAsAudio(editor: Editor, file: TFile): Promise<void> {
     const selection = editor.getSelection();
@@ -54,49 +102,39 @@ export class ReadAloudSaveService {
       throw new Error('Select text to save as audio.');
     }
 
-    const { basename, mimeType } = await this.synthesizeAndWrite(
-      selection,
-      this.buildSelectionFilenameStem(file.basename, selection),
-      undefined
-    );
-    void mimeType;
-
-    // Insert the embed on its own line after the selection's end.
-    const to = editor.getCursor('to');
-    const embed = `\n\n${this.buildEmbed(basename)}\n`;
-    editor.replaceRange(embed, to);
+    const results = await this.captureResults(selection);
+    await this.saveCapturedSelection(results, editor, file, selection);
   }
 
   /**
-   * Synthesize a whole note to a single concatenated audio file and insert one
-   * `![[...]]` embed at the top of the note body (below YAML frontmatter, if any).
+   * RETAINED test seam: synthesize a whole note (capturing, no playback) and
+   * persist it via {@link saveCapturedNote}. See {@link saveSelectionAsAudio}.
    */
   async saveNoteAsAudio(file: TFile): Promise<void> {
     const markdown = await this.vault.cachedRead(file);
-
-    const { basename } = await this.synthesizeAndWrite(
-      markdown,
-      this.buildNoteFilenameStem(file.basename),
-      undefined
-    );
-
-    const embed = this.buildEmbed(basename);
-    await this.vault.process(file, (content) => this.prependBelowFrontmatter(content, embed));
+    const results = await this.captureResults(markdown);
+    await this.saveCapturedNote(results, file);
   }
 
   /**
-   * Shared pipeline: capture-synthesize the text (no playback), concat to one
-   * buffer, derive the settings-rooted output path with the provider-native
-   * extension, and write it via the temp-swap pattern. Returns the saved file's
-   * basename (for the embed) and the audio mimeType.
+   * Capture-synthesize text chunk-by-chunk (no playback) and return the per-chunk
+   * results. Used only by the retained synthesize-then-save seams; the v2 session
+   * supplies its own captured results.
    */
-  private async synthesizeAndWrite(
-    text: string,
-    filenameStem: string,
-    onProgress?: (completed: number, total: number) => void
-  ): Promise<{ basename: string; mimeType: string }> {
+  private async captureResults(text: string): Promise<SpeechSynthesisResult[]> {
     const service = this.buildCaptureService();
-    const results = await service.synthesizeForCapture({ markdown: text }, onProgress);
+    return service.synthesizeForCapture({ markdown: text });
+  }
+
+  /**
+   * Shared write tail: validate + concat the captured buffers to one buffer, derive
+   * the settings-rooted output path with the provider-native extension, and write
+   * it. Returns the saved file's basename (for the embed) and the vault path.
+   */
+  private async writeCaptured(
+    results: SpeechSynthesisResult[],
+    filenameStem: string
+  ): Promise<{ filename: string; mimeType: string; outputPath: string }> {
     if (results.length === 0) {
       throw new Error('There is no readable text to save as audio.');
     }
@@ -113,13 +151,13 @@ export class ReadAloudSaveService {
     const outputPath = this.resolveOutputPath(filename);
     await this.writeAudio(outputPath, merged);
 
-    return { basename: filename, mimeType };
+    return { filename, mimeType, outputPath };
   }
 
   /**
-   * Normalize a SpeechSynthesisResult's audioData to a true ArrayBuffer. Adapters
-   * return ArrayBuffer today, but guard against a typed-array slice so concat
-   * never sees a SharedArrayBuffer/typed-array view.
+   * Extract a SpeechSynthesisResult's audioData. Adapters already return a true
+   * ArrayBuffer (see SpeechSynthesisResult.audioData), so this is a direct
+   * pass-through used as the map projection into concatAudioBuffers.
    */
   private toAudioBuffer = (result: SpeechSynthesisResult): ArrayBuffer => {
     return result.audioData;

--- a/src/services/readAloud/ReadAloudSaveService.ts
+++ b/src/services/readAloud/ReadAloudSaveService.ts
@@ -1,0 +1,262 @@
+/**
+ * Location: src/services/readAloud/ReadAloudSaveService.ts
+ *
+ * Backend engine for the read-aloud "save as audio" feature. Synthesizes a
+ * selection or a whole note to audio (capturing buffers, never playing),
+ * concatenates them into ONE file via the pure {@link concatAudioBuffers}
+ * helper, writes the file to the SETTINGS-DERIVED audio folder, and inserts a
+ * single `![[...]]` embed into the note.
+ *
+ * Public contract (called by ReadAloudCommandManager / UI — frontend-coder):
+ * - saveSelectionAsAudio(editor, file): synth selection, embed after selection.
+ * - saveNoteAsAudio(file): synth whole note, embed at top of body.
+ * Both return Promise<void> and THROW on failure (caller catches + Notices).
+ *
+ * Mobile-safe: no AudioContext family, no Node built-ins, no Composer. See
+ * docs/plans/read-aloud-save-embed-scoping.md.
+ */
+
+import { App, Editor, normalizePath, TFile, TFolder, Vault } from 'obsidian';
+import type { Settings } from '../../settings';
+import { DEFAULT_STORAGE_SETTINGS } from '../../types/plugin/PluginTypes';
+import { isValidPath } from '../../utils/pathUtils';
+import { concatAudioBuffers } from './concatAudioBuffers';
+import { ReadAloudService } from './ReadAloudService';
+import type { SpeechSynthesisResult } from './SpeechSynthesisTypes';
+
+/** Default audio subfolder under the storage root when none is configured. */
+const DEFAULT_AUDIO_SUBFOLDER = 'audio';
+
+/** Maps a synthesized mimeType to its file extension (mirrors AudioGenerationService). */
+const MIME_TO_EXTENSION: Readonly<Record<string, string>> = {
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+};
+
+/** Max characters kept from a selection snippet in the filename. */
+const MAX_SNIPPET_CHARS = 40;
+
+export class ReadAloudSaveService {
+  constructor(
+    private readonly app: App,
+    private readonly vault: Vault,
+    private readonly settings: Settings
+  ) {}
+
+  /**
+   * Synthesize the current editor selection to a single audio file and insert an
+   * `![[...]]` embed immediately after the selection. Selection is usually one
+   * chunk (N=1), so concat is a no-op pass-through.
+   */
+  async saveSelectionAsAudio(editor: Editor, file: TFile): Promise<void> {
+    const selection = editor.getSelection();
+    if (!selection.trim()) {
+      throw new Error('Select text to save as audio.');
+    }
+
+    const { basename, mimeType } = await this.synthesizeAndWrite(
+      selection,
+      this.buildSelectionFilenameStem(file.basename, selection),
+      undefined
+    );
+    void mimeType;
+
+    // Insert the embed on its own line after the selection's end.
+    const to = editor.getCursor('to');
+    const embed = `\n\n${this.buildEmbed(basename)}\n`;
+    editor.replaceRange(embed, to);
+  }
+
+  /**
+   * Synthesize a whole note to a single concatenated audio file and insert one
+   * `![[...]]` embed at the top of the note body (below YAML frontmatter, if any).
+   */
+  async saveNoteAsAudio(file: TFile): Promise<void> {
+    const markdown = await this.vault.cachedRead(file);
+
+    const { basename } = await this.synthesizeAndWrite(
+      markdown,
+      this.buildNoteFilenameStem(file.basename),
+      undefined
+    );
+
+    const embed = this.buildEmbed(basename);
+    await this.vault.process(file, (content) => this.prependBelowFrontmatter(content, embed));
+  }
+
+  /**
+   * Shared pipeline: capture-synthesize the text (no playback), concat to one
+   * buffer, derive the settings-rooted output path with the provider-native
+   * extension, and write it via the temp-swap pattern. Returns the saved file's
+   * basename (for the embed) and the audio mimeType.
+   */
+  private async synthesizeAndWrite(
+    text: string,
+    filenameStem: string,
+    onProgress?: (completed: number, total: number) => void
+  ): Promise<{ basename: string; mimeType: string }> {
+    const service = this.buildCaptureService();
+    const results = await service.synthesizeForCapture({ markdown: text }, onProgress);
+    if (results.length === 0) {
+      throw new Error('There is no readable text to save as audio.');
+    }
+
+    const mimeType = results[0].mimeType;
+    const extension = MIME_TO_EXTENSION[mimeType.toLowerCase()];
+    if (!extension) {
+      throw new Error(`Synthesized audio has an unsupported format "${mimeType}".`);
+    }
+
+    const merged = concatAudioBuffers(results.map(this.toAudioBuffer), mimeType);
+
+    const filename = `${filenameStem}.${extension}`;
+    const outputPath = this.resolveOutputPath(filename);
+    await this.writeAudio(outputPath, merged);
+
+    return { basename: filename, mimeType };
+  }
+
+  /**
+   * Normalize a SpeechSynthesisResult's audioData to a true ArrayBuffer. Adapters
+   * return ArrayBuffer today, but guard against a typed-array slice so concat
+   * never sees a SharedArrayBuffer/typed-array view.
+   */
+  private toAudioBuffer = (result: SpeechSynthesisResult): ArrayBuffer => {
+    return result.audioData;
+  };
+
+  private buildCaptureService(): ReadAloudService {
+    const llmSettings = this.settings.settings.llmProviders ?? null;
+    const appsSettings = this.settings.settings.apps;
+    return new ReadAloudService(llmSettings, appsSettings);
+  }
+
+  // ── Path resolution (SETTINGS-DERIVED — never hardcode the root) ──────────
+
+  /**
+   * Build the vault-relative output path `<rootPath>/<audioSubfolder>/<filename>`.
+   * rootPath + audioSubfolder are read from settings with defaults; the literal
+   * storage-root name is NEVER hardcoded so audio follows the user's configured
+   * storage root.
+   */
+  private resolveOutputPath(filename: string): string {
+    const storage = this.settings.settings.storage as
+      | { rootPath?: string; audioSubfolder?: string }
+      | undefined;
+    const rootPath = storage?.rootPath ?? DEFAULT_STORAGE_SETTINGS.rootPath;
+    const subfolder = storage?.audioSubfolder?.trim() || DEFAULT_AUDIO_SUBFOLDER;
+
+    const path = normalizePath(`${rootPath}/${subfolder}/${filename}`);
+    if (!isValidPath(path)) {
+      throw new Error(`Resolved an invalid audio output path "${path}".`);
+    }
+    return path;
+  }
+
+  // ── Filenames (timestamped, always-new, sanitized) ────────────────────────
+
+  private buildNoteFilenameStem(noteBasename: string): string {
+    return `${this.sanitize(noteBasename)} - ${this.timestamp()}`;
+  }
+
+  private buildSelectionFilenameStem(noteBasename: string, selection: string): string {
+    const snippet = this.sanitize(this.snippetOf(selection));
+    const base = this.sanitize(noteBasename);
+    return snippet
+      ? `${base} - ${snippet} - ${this.timestamp()}`
+      : `${base} - ${this.timestamp()}`;
+  }
+
+  /** First few words of the selection, capped at MAX_SNIPPET_CHARS. */
+  private snippetOf(selection: string): string {
+    const words = selection.trim().split(/\s+/).slice(0, 5).join(' ');
+    return words.length > MAX_SNIPPET_CHARS ? words.slice(0, MAX_SNIPPET_CHARS).trim() : words;
+  }
+
+  /**
+   * Strip filename-illegal characters. normalizePath does NOT remove these, so a
+   * raw note basename like "A/B: C?" would corrupt the path. Collapse runs of
+   * removed/whitespace chars to single spaces and trim.
+   */
+  private sanitize(value: string): string {
+    return value
+      .replace(/[\\/:*?"<>|[\]#^]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  /** Sortable local timestamp `YYYYMMDD-HHmmss`. */
+  private timestamp(): string {
+    const now = new Date();
+    const pad = (n: number): string => String(n).padStart(2, '0');
+    return (
+      `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}` +
+      `-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`
+    );
+  }
+
+  // ── Embed insertion ───────────────────────────────────────────────────────
+
+  private buildEmbed(basename: string): string {
+    return `![[${basename}]]`;
+  }
+
+  /**
+   * Prepend the embed at the top of the note BODY: after a leading YAML
+   * frontmatter block if present (so the embed never lands inside/above
+   * frontmatter and corrupts it), otherwise at the very top.
+   */
+  private prependBelowFrontmatter(content: string, embed: string): string {
+    const block = `${embed}\n\n`;
+    if (!content.startsWith('---')) {
+      return `${block}${content}`;
+    }
+
+    // Find the closing '---' of the frontmatter block.
+    const lines = content.split('\n');
+    if (lines[0].trim() !== '---') {
+      return `${block}${content}`;
+    }
+    for (let index = 1; index < lines.length; index += 1) {
+      if (lines[index].trim() === '---') {
+        const head = lines.slice(0, index + 1).join('\n');
+        const rest = lines.slice(index + 1).join('\n');
+        const separator = rest.startsWith('\n') ? '\n' : '\n\n';
+        return `${head}${separator}${block}${rest.replace(/^\n+/, '')}`;
+      }
+    }
+    // Unterminated frontmatter — treat the whole thing as body to be safe.
+    return `${block}${content}`;
+  }
+
+  // ── Vault write (ensureParentDirectory + createBinary; mirrors the
+  //    AudioGenerationService.writeAudio pattern) ────────────────────────────
+
+  private async writeAudio(outputPath: string, audioData: ArrayBuffer): Promise<void> {
+    await this.ensureParentDirectory(outputPath);
+
+    // Timestamped filenames are always-new, so a collision should not happen;
+    // if it does, fail rather than silently overwrite a prior render.
+    const existing = this.vault.getAbstractFileByPath(outputPath);
+    if (existing) {
+      throw new Error(`An audio file already exists at ${outputPath}.`);
+    }
+
+    await this.vault.createBinary(outputPath, audioData);
+  }
+
+  private async ensureParentDirectory(outputPath: string): Promise<void> {
+    const dir = outputPath.substring(0, outputPath.lastIndexOf('/'));
+    if (!dir || this.vault.getAbstractFileByPath(dir) instanceof TFolder) {
+      return;
+    }
+
+    try {
+      await this.vault.createFolder(dir);
+    } catch {
+      if (!(this.vault.getAbstractFileByPath(dir) instanceof TFolder)) {
+        throw new Error(`Failed to create audio output directory: ${dir}`);
+      }
+    }
+  }
+}

--- a/src/services/readAloud/ReadAloudService.ts
+++ b/src/services/readAloud/ReadAloudService.ts
@@ -2,6 +2,7 @@ import type { LLMProviderSettings } from '../../types/llm/ProviderTypes';
 import type { AppsSettings } from '../../types/apps/AppTypes';
 import { MarkdownSpeechPreprocessor, SpeechTextChunk } from './MarkdownSpeechPreprocessor';
 import { SpeechSynthesisService } from './SpeechSynthesisService';
+import type { SpeechSynthesisResult } from './SpeechSynthesisTypes';
 
 export interface ReadAloudRequest {
   markdown: string;
@@ -134,6 +135,36 @@ export class ReadAloudService {
         this.activePlayback = null;
       }
     }
+  }
+
+  /**
+   * Synthesize the markdown chunk-by-chunk and RETURN every
+   * SpeechSynthesisResult WITHOUT playing any audio. This is the capture path
+   * for "save as audio": it reuses the same preprocessor + speech service as
+   * {@link read} but never touches playback, so saving does not force the user
+   * to listen (and never double-synthesizes — each chunk is synthesized once).
+   *
+   * Results are returned in chunk order so the caller can concatenate them into
+   * a single file. Throws if there is no readable text.
+   *
+   * @param onProgress optional callback after each chunk synthesizes (e.g. for a
+   *   long-note progress UI). Index is 0-based; total is the chunk count.
+   */
+  async synthesizeForCapture(
+    request: ReadAloudRequest,
+    onProgress?: (completed: number, total: number) => void
+  ): Promise<SpeechSynthesisResult[]> {
+    const chunks = MarkdownSpeechPreprocessor.preprocess(request.markdown);
+    if (chunks.length === 0) {
+      throw new Error('There is no readable text in this note.');
+    }
+
+    const results: SpeechSynthesisResult[] = [];
+    for (let index = 0; index < chunks.length; index += 1) {
+      results.push(await this.speechService.synthesize({ text: chunks[index].text }));
+      onProgress?.(index + 1, chunks.length);
+    }
+    return results;
   }
 
   private async playChunk(chunk: SpeechTextChunk, runId: number): Promise<void> {

--- a/src/services/readAloud/ReadAloudService.ts
+++ b/src/services/readAloud/ReadAloudService.ts
@@ -1,3 +1,4 @@
+import type { Editor, TFile } from 'obsidian';
 import type { LLMProviderSettings } from '../../types/llm/ProviderTypes';
 import type { AppsSettings } from '../../types/apps/AppTypes';
 import { MarkdownSpeechPreprocessor, SpeechTextChunk } from './MarkdownSpeechPreprocessor';
@@ -12,6 +13,56 @@ export interface ReadAloudRequest {
 export interface ReadAloudResult {
   sourceName?: string;
   chunkCount: number;
+}
+
+/**
+ * The buffer-driven save tail the v2 session depends on. ReadAloudSaveService
+ * structurally satisfies this; declaring it as a local interface (rather than
+ * importing the class) breaks the ReadAloudService ⇄ ReadAloudSaveService import
+ * cycle. The session captures buffers itself, then hands them here — so synthesis
+ * happens exactly once, in the session loop.
+ */
+export interface ReadAloudSaveTail {
+  saveCapturedSelection(
+    results: SpeechSynthesisResult[],
+    editor: Editor,
+    file: TFile,
+    selection: string
+  ): Promise<string>;
+  saveCapturedNote(results: SpeechSynthesisResult[], file: TFile): Promise<string>;
+}
+
+/**
+ * Options for {@link ReadAloudService.startReadAloudSession}. `saveService` is
+ * REQUIRED when `save` is true (it persists the captured buffers); ignored when
+ * `save` is false. `editor` is REQUIRED when `mode` is 'selection' (for the
+ * embed insert) and `selection` carries the selected text for the filename snippet.
+ */
+export interface ReadAloudSessionOptions {
+  mode: 'selection' | 'note';
+  file: TFile;
+  /** Markdown to synthesize: the selection (selection mode) or whole note (note mode). */
+  markdown: string;
+  save: boolean;
+  editor?: Editor;
+  /** The raw selected text (selection mode, save case) — used for the filename snippet. */
+  selection?: string;
+  saveService?: ReadAloudSaveTail;
+}
+
+/**
+ * A running play-and-capture read-aloud session. Playback is cancellable via
+ * {@link stopPlayback}; the SAVE (when requested) is NOT — after playback stops,
+ * the remaining chunks are still synthesized (synth-only) so the saved file is
+ * complete. {@link onProgress} ticks per chunk synthesized, INCLUDING the
+ * post-stopPlayback synth-only phase. {@link completed} resolves once playback
+ * finishes naturally OR (save case) once the background save + embed completes;
+ * it REJECTS on a synth/write failure.
+ */
+export interface ReadAloudSession {
+  onProgress(cb: (done: number, total: number) => void): void;
+  stopPlayback(): void;
+  completed: Promise<{ savedPath?: string }>;
 }
 
 export interface AudioPlaybackHandle {
@@ -165,6 +216,171 @@ export class ReadAloudService {
       onProgress?.(index + 1, chunks.length);
     }
     return results;
+  }
+
+  /**
+   * Start a v2 PLAY-AND-CAPTURE read-aloud session: synthesize each chunk ONCE,
+   * play it while playback is active, and (save case) capture the SAME buffer for
+   * saving — a single synth pass, never double-synthesized.
+   *
+   * Cancellable playback / non-cancellable save: {@link ReadAloudSession.stopPlayback}
+   * halts current + further PLAYBACK, but when `save` is true the loop CONTINUES
+   * synthesizing the remaining chunks (synth-only) so the saved file is complete.
+   * On loop end (save case) the captured buffers are concatenated and persisted via
+   * the injected save tail, and `completed` resolves with the saved path. With
+   * `save` false, `completed` resolves once playback ends (or is stopped) with no
+   * path. `completed` REJECTS on a synth or write failure.
+   *
+   * `onProgress` fires after each chunk is synthesized, INCLUDING the post-stopPlayback
+   * synth-only phase — the caller detaches its listener when its UI closes.
+   *
+   * S2: this method orchestrates synth+playback+capture; the actual file write +
+   * embed live in the {@link ReadAloudSaveTail} (ReadAloudSaveService), reused
+   * unchanged.
+   */
+  startReadAloudSession(options: ReadAloudSessionOptions): ReadAloudSession {
+    if (options.save && !options.saveService) {
+      throw new Error('A save service is required to save read-aloud audio.');
+    }
+    if (options.save && options.mode === 'selection' && !options.editor) {
+      throw new Error('An editor is required to save a selection as audio.');
+    }
+
+    // Playback is cancellable independently of the synth loop: stopPlayback flips
+    // this flag (so remaining chunks skip play()) and stops the active handle (so
+    // the in-flight chunk's play() promise rejects with the stop sentinel, which
+    // the loop swallows). The synth loop itself is never aborted by a stop.
+    let playbackStopped = false;
+    let activePlayback: AudioPlaybackHandle | null = null;
+    let progressCb: ((done: number, total: number) => void) | null = null;
+
+    const stopPlayback = (): void => {
+      playbackStopped = true;
+      activePlayback?.stop();
+      activePlayback = null;
+    };
+
+    const completed = this.runSession(options, {
+      isPlaybackStopped: () => playbackStopped,
+      setActivePlayback: (handle) => {
+        activePlayback = handle;
+      },
+      clearActivePlayback: () => {
+        activePlayback = null;
+      },
+      emitProgress: (done, total) => progressCb?.(done, total),
+    });
+
+    return {
+      onProgress: (cb) => {
+        progressCb = cb;
+      },
+      stopPlayback,
+      completed,
+    };
+  }
+
+  /**
+   * Drives the single synth pass for a session. Synthesizes each chunk once;
+   * plays it if playback is still active; collects it if saving. Swallows the
+   * playback stop sentinel so a mid-run stop never aborts the save's synth loop.
+   */
+  private async runSession(
+    options: ReadAloudSessionOptions,
+    hooks: {
+      isPlaybackStopped: () => boolean;
+      setActivePlayback: (handle: AudioPlaybackHandle | null) => void;
+      clearActivePlayback: () => void;
+      emitProgress: (done: number, total: number) => void;
+    }
+  ): Promise<{ savedPath?: string }> {
+    const chunks = MarkdownSpeechPreprocessor.preprocess(options.markdown);
+    if (chunks.length === 0) {
+      throw new Error('There is no readable text in this note.');
+    }
+
+    // Yield one microtask so the synchronous caller can register its onProgress
+    // listener (startReadAloudSession returns BEFORE this body runs), then emit an
+    // initial (0, total) tick so a progress UI can show "0 of N" before chunk 1.
+    await Promise.resolve();
+    hooks.emitProgress(0, chunks.length);
+
+    const captured: SpeechSynthesisResult[] = [];
+
+    for (let index = 0; index < chunks.length; index += 1) {
+      // ONE synthesis per chunk — the buffer is reused for both play and save.
+      const result = await this.speechService.synthesize({ text: chunks[index].text });
+      if (options.save) {
+        captured.push(result);
+      }
+
+      if (!hooks.isPlaybackStopped()) {
+        await this.playSessionChunk(result, hooks);
+      }
+
+      hooks.emitProgress(index + 1, chunks.length);
+    }
+
+    hooks.clearActivePlayback();
+
+    if (!options.save) {
+      return {};
+    }
+
+    const savedPath = await this.persistCaptured(options, captured);
+    return { savedPath };
+  }
+
+  /**
+   * Play a single already-synthesized chunk. If playback is stopped mid-chunk the
+   * handle rejects with the stop sentinel; we SWALLOW that one sentinel so the
+   * surrounding synth loop continues (for the save). Any other playback error
+   * propagates and rejects the session's `completed`.
+   */
+  private async playSessionChunk(
+    result: SpeechSynthesisResult,
+    hooks: {
+      isPlaybackStopped: () => boolean;
+      setActivePlayback: (handle: AudioPlaybackHandle | null) => void;
+    }
+  ): Promise<void> {
+    const playback = this.playbackFactory.create();
+    hooks.setActivePlayback(playback);
+    try {
+      await playback.play(result.audioData, result.mimeType);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === 'Read aloud playback was stopped.') {
+        return; // expected cancel — continue the loop (synth-only) for the save
+      }
+      throw error;
+    } finally {
+      hooks.setActivePlayback(null);
+    }
+  }
+
+  /** Persist the captured session buffers via the injected save tail. */
+  private async persistCaptured(
+    options: ReadAloudSessionOptions,
+    captured: SpeechSynthesisResult[]
+  ): Promise<string> {
+    const saveService = options.saveService;
+    if (!saveService) {
+      throw new Error('A save service is required to save read-aloud audio.');
+    }
+
+    if (options.mode === 'selection') {
+      if (!options.editor) {
+        throw new Error('An editor is required to save a selection as audio.');
+      }
+      return saveService.saveCapturedSelection(
+        captured,
+        options.editor,
+        options.file,
+        options.selection ?? options.markdown
+      );
+    }
+    return saveService.saveCapturedNote(captured, options.file);
   }
 
   private async playChunk(chunk: SpeechTextChunk, runId: number): Promise<void> {

--- a/src/services/readAloud/concatAudioBuffers.ts
+++ b/src/services/readAloud/concatAudioBuffers.ts
@@ -1,0 +1,292 @@
+/**
+ * Location: src/services/readAloud/concatAudioBuffers.ts
+ *
+ * Pure, format-aware audio buffer concatenation for the read-aloud "save as
+ * audio" feature. Joins the N per-chunk synthesis buffers from a single
+ * read-aloud run into ONE embeddable file WITHOUT any audio engine
+ * (no AudioContext/OfflineAudioContext/MediaRecorder) and without re-encoding,
+ * so the whole path runs identically on desktop and mobile.
+ *
+ * Used by: ReadAloudSaveService (save selection / save note as audio). The
+ * helper has zero Obsidian/platform dependencies and is unit-testable in
+ * isolation.
+ *
+ * Why a raw join works: within one read-aloud run every chunk is synthesized by
+ * ONE provider at ONE bitrate / sample-rate / channel mode, so the buffers are
+ * format-uniform and can be joined at the container level. See
+ * docs/plans/read-aloud-save-embed-scoping.md §4.
+ */
+
+/** mimeType emitted by mp3 speech adapters (OpenAI/OpenRouter/Mistral/ElevenLabs). */
+const MIME_MPEG = 'audio/mpeg';
+/** mimeType emitted by the Google speech adapter (PCM wrapped in RIFF/WAV). */
+const MIME_WAV = 'audio/wav';
+
+const WAV_RIFF_HEADER_BYTES = 12; // 'RIFF' + size(4) + 'WAVE'
+const WAV_SUBCHUNK_HEADER_BYTES = 8; // id(4) + size(4)
+
+/**
+ * Concatenate per-chunk audio buffers (all of one `mimeType`) into a single
+ * buffer. `audio/mpeg` → frame byte-join with ID3/Xing strip on chunks 2…N;
+ * `audio/wav` → header-aware PCM merge. N=1 returns the single buffer unchanged.
+ *
+ * @throws if `buffers` is empty or the mimeType is not a supported audio format.
+ */
+export function concatAudioBuffers(buffers: ArrayBuffer[], mimeType: string): ArrayBuffer {
+  if (buffers.length === 0) {
+    throw new Error('concatAudioBuffers requires at least one buffer.');
+  }
+
+  // N=1 is the common case (selection) — return the single buffer untouched so
+  // no format-specific logic can ever corrupt a pristine single chunk.
+  if (buffers.length === 1) {
+    return buffers[0];
+  }
+
+  const normalizedMime = mimeType.toLowerCase();
+  if (normalizedMime === MIME_MPEG) {
+    return concatMp3(buffers);
+  }
+  if (normalizedMime === MIME_WAV) {
+    return concatWav(buffers);
+  }
+
+  throw new Error(
+    `concatAudioBuffers does not support mimeType "${mimeType}". Supported: ${MIME_MPEG}, ${MIME_WAV}.`
+  );
+}
+
+/**
+ * MP3 is a stream of self-contained frames, so concatenated frame streams play
+ * fine. We byte-join the buffers, stripping any leading ID3v2 tag and Xing/Info
+ * VBR header frame from chunks 2…N so metadata/VBR headers never land
+ * mid-stream. Chunk 1 keeps whatever leading bytes it has.
+ */
+function concatMp3(buffers: ArrayBuffer[]): ArrayBuffer {
+  const cleaned: Uint8Array[] = buffers.map((buffer, index) => {
+    const bytes = new Uint8Array(buffer);
+    if (index === 0) {
+      return bytes;
+    }
+    return stripXingHeader(stripId3v2(bytes));
+  });
+
+  return toArrayBuffer(concatUint8Arrays(cleaned));
+}
+
+/**
+ * Strip a leading ID3v2 tag if present. ID3v2 header = "ID3" + 2 version bytes
+ * + 1 flags byte + 4 synchsafe size bytes (7 bits each); total tag length =
+ * 10 + size. Returns the input unchanged when no ID3v2 tag is present (the
+ * common case for raw TTS output).
+ */
+function stripId3v2(bytes: Uint8Array): Uint8Array {
+  if (
+    bytes.length < 10 ||
+    bytes[0] !== 0x49 || // 'I'
+    bytes[1] !== 0x44 || // 'D'
+    bytes[2] !== 0x33 // '3'
+  ) {
+    return bytes;
+  }
+
+  // Synchsafe integer: 4 bytes, low 7 bits each.
+  const size =
+    (bytes[6] & 0x7f) * 0x200000 +
+    (bytes[7] & 0x7f) * 0x4000 +
+    (bytes[8] & 0x7f) * 0x80 +
+    (bytes[9] & 0x7f);
+  const tagLength = 10 + size;
+  if (tagLength >= bytes.length) {
+    return bytes;
+  }
+  return bytes.subarray(tagLength);
+}
+
+/**
+ * Strip a leading Xing/Info VBR header frame if present. After any ID3 tag, an
+ * mp3 may begin with a single empty frame carrying a "Xing" or "Info" tag
+ * describing VBR stats; appended mid-stream it would be decoded as silence /
+ * confuse seeking. We detect the tag within the first frame and drop that whole
+ * frame. Returns the input unchanged when no Xing/Info tag is found.
+ */
+function stripXingHeader(bytes: Uint8Array): Uint8Array {
+  if (bytes.length < 4 || (bytes[0] !== 0xff || (bytes[1] & 0xe0) !== 0xe0)) {
+    // Not an mp3 frame sync at offset 0 — nothing to strip.
+    return bytes;
+  }
+
+  const frameLength = mp3FrameLength(bytes);
+  if (frameLength <= 0 || frameLength > bytes.length) {
+    return bytes;
+  }
+
+  // Xing/Info tag lives a small variable offset into the frame; scan the frame
+  // body for the 4-char marker rather than hardcoding the side-info offset.
+  const marker = findAsciiMarker(bytes, frameLength, ['Xing', 'Info']);
+  if (marker === -1) {
+    return bytes;
+  }
+  return bytes.subarray(frameLength);
+}
+
+/**
+ * Compute the byte length of the mp3 frame starting at offset 0, from its
+ * 4-byte header. Returns 0 if the header is unparseable. Supports MPEG-1/2/2.5
+ * Layer III (the layer TTS providers emit).
+ */
+function mp3FrameLength(bytes: Uint8Array): number {
+  const versionBits = (bytes[1] >> 3) & 0x03; // 00=MPEG2.5, 10=MPEG2, 11=MPEG1
+  const layerBits = (bytes[1] >> 1) & 0x03; // 01=Layer III
+  const bitrateIndex = (bytes[2] >> 4) & 0x0f;
+  const sampleRateIndex = (bytes[2] >> 2) & 0x03;
+  const padding = (bytes[2] >> 1) & 0x01;
+
+  if (layerBits !== 0x01 || bitrateIndex === 0 || bitrateIndex === 0x0f || sampleRateIndex === 0x03) {
+    return 0;
+  }
+
+  const isMpeg1 = versionBits === 0x03;
+  const bitrate = (isMpeg1 ? MPEG1_L3_BITRATES : MPEG2_L3_BITRATES)[bitrateIndex];
+  const sampleRate = SAMPLE_RATES[versionBits][sampleRateIndex];
+  if (!bitrate || !sampleRate) {
+    return 0;
+  }
+
+  // Layer III: MPEG1 = 144 * br / sr; MPEG2/2.5 = 72 * br / sr (half samples/frame).
+  const coefficient = isMpeg1 ? 144000 : 72000;
+  return Math.floor((coefficient * bitrate) / sampleRate) + padding;
+}
+
+const MPEG1_L3_BITRATES = [0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0];
+const MPEG2_L3_BITRATES = [0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0];
+// Indexed by versionBits (00=2.5, 01=reserved, 10=2, 11=1), then sampleRateIndex.
+const SAMPLE_RATES: Record<number, number[]> = {
+  0x00: [11025, 12000, 8000, 0],
+  0x02: [22050, 24000, 16000, 0],
+  0x03: [44100, 48000, 32000, 0],
+};
+
+/**
+ * WAV merge: keep chunk 1's full RIFF/`fmt ` header, append only the PCM payload
+ * (the bytes inside each chunk's `data` sub-chunk) from every chunk, then
+ * rewrite the RIFF size and data size fields. The `data` sub-chunk is located by
+ * SCANNING the RIFF sub-chunk list rather than assuming a fixed 44-byte header,
+ * so non-canonical files (extra `LIST`/`fact` sub-chunks before `data`) merge
+ * correctly. All chunks share one format (single provider per run), so chunk 1's
+ * `fmt ` is authoritative.
+ */
+function concatWav(buffers: ArrayBuffer[]): ArrayBuffer {
+  const first = new Uint8Array(buffers[0]);
+  const firstData = locateDataSubchunk(first);
+  if (!firstData) {
+    throw new Error('concatAudioBuffers: first WAV buffer has no "data" sub-chunk.');
+  }
+
+  // Header = everything in chunk 1 up to and including the 8-byte `data`
+  // sub-chunk header (id + size). PCM payloads follow.
+  const headerEnd = firstData.offset; // offset of PCM payload start in chunk 1
+  const header = first.subarray(0, headerEnd);
+
+  const payloads: Uint8Array[] = [];
+  for (const buffer of buffers) {
+    const bytes = new Uint8Array(buffer);
+    const data = locateDataSubchunk(bytes);
+    if (!data) {
+      throw new Error('concatAudioBuffers: a WAV buffer has no "data" sub-chunk.');
+    }
+    payloads.push(bytes.subarray(data.offset, data.offset + data.size));
+  }
+
+  const totalPayload = payloads.reduce((sum, payload) => sum + payload.byteLength, 0);
+  const merged = new Uint8Array(header.byteLength + totalPayload);
+  merged.set(header, 0);
+  let cursor = header.byteLength;
+  for (const payload of payloads) {
+    merged.set(payload, cursor);
+    cursor += payload.byteLength;
+  }
+
+  // Rewrite size fields (little-endian).
+  const view = new DataView(merged.buffer);
+  // RIFF chunk size = total file size - 8 (the 'RIFF' id + this size field).
+  view.setUint32(4, merged.byteLength - 8, true);
+  // data sub-chunk size = total PCM payload, written at (headerEnd - 4).
+  view.setUint32(headerEnd - 4, totalPayload, true);
+
+  return toArrayBuffer(merged);
+}
+
+/**
+ * Return a freshly-allocated Uint8Array's backing store as a true ArrayBuffer.
+ * `Uint8Array.prototype.buffer` is typed `ArrayBufferLike` (could be a
+ * SharedArrayBuffer); since we always allocate with `new Uint8Array(n)` the
+ * store is a plain ArrayBuffer, so a narrowing copy-free assertion is safe and
+ * keeps the public return type `ArrayBuffer`.
+ */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer as ArrayBuffer;
+}
+
+/**
+ * Locate the `data` sub-chunk in a RIFF/WAVE buffer by walking the sub-chunk
+ * list. Returns the PCM payload `offset` (first byte after the `data` sub-chunk
+ * header) and its declared `size`, or null if no `data` sub-chunk is found.
+ */
+function locateDataSubchunk(bytes: Uint8Array): { offset: number; size: number } | null {
+  if (bytes.byteLength < WAV_RIFF_HEADER_BYTES || !matchesAscii(bytes, 0, 'RIFF') || !matchesAscii(bytes, 8, 'WAVE')) {
+    return null;
+  }
+
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let cursor = WAV_RIFF_HEADER_BYTES;
+  while (cursor + WAV_SUBCHUNK_HEADER_BYTES <= bytes.byteLength) {
+    const size = view.getUint32(cursor + 4, true);
+    const payloadOffset = cursor + WAV_SUBCHUNK_HEADER_BYTES;
+    if (matchesAscii(bytes, cursor, 'data')) {
+      // Clamp size to the actual remaining bytes to tolerate a truncated/over-
+      // declared size field.
+      const available = bytes.byteLength - payloadOffset;
+      return { offset: payloadOffset, size: Math.min(size, available) };
+    }
+    // Sub-chunks are word-aligned: advance by header + size + pad-to-even.
+    cursor = payloadOffset + size + (size % 2);
+  }
+  return null;
+}
+
+function matchesAscii(bytes: Uint8Array, offset: number, ascii: string): boolean {
+  if (offset + ascii.length > bytes.byteLength) {
+    return false;
+  }
+  for (let index = 0; index < ascii.length; index += 1) {
+    if (bytes[offset + index] !== ascii.charCodeAt(index)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/** Find the first occurrence of any of `markers` within bytes[0, limit). */
+function findAsciiMarker(bytes: Uint8Array, limit: number, markers: string[]): number {
+  const end = Math.min(limit, bytes.byteLength);
+  for (let offset = 0; offset < end; offset += 1) {
+    for (const marker of markers) {
+      if (matchesAscii(bytes, offset, marker)) {
+        return offset;
+      }
+    }
+  }
+  return -1;
+}
+
+function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, array) => sum + array.byteLength, 0);
+  const merged = new Uint8Array(total);
+  let cursor = 0;
+  for (const array of arrays) {
+    merged.set(array, cursor);
+    cursor += array.byteLength;
+  }
+  return merged;
+}

--- a/src/services/video/adapters/GoogleVideoAdapter.ts
+++ b/src/services/video/adapters/GoogleVideoAdapter.ts
@@ -32,6 +32,19 @@ interface GoogleOperation {
   response?: unknown;
 }
 
+/**
+ * Hosts that legitimately serve a Google video/file download URL which REQUIRES
+ * the user's API key (`x-goog-api-key`). The Gemini/Veo Files API returns a
+ * download URI on `generativelanguage.googleapis.com` that must be fetched with
+ * the key. Any other host (e.g. a pre-signed `storage.googleapis.com` URL) does
+ * NOT need the key, so the credential is dropped there — this both blocks
+ * credential exfiltration to an attacker-controlled host scraped from the
+ * response body (SEC-M1) and remains safe for legitimate pre-signed downloads.
+ */
+const GOOGLE_CREDENTIALED_DOWNLOAD_HOSTS = new Set<string>([
+  'generativelanguage.googleapis.com',
+]);
+
 export class GoogleVideoAdapter implements VideoGenerationAdapter {
   readonly provider: VideoProvider = 'google';
   private readonly baseUrl = 'https://generativelanguage.googleapis.com/v1beta';
@@ -204,12 +217,16 @@ export class GoogleVideoAdapter implements VideoGenerationAdapter {
       throw new Error('Google video generation completed but no downloadable video was found.');
     }
 
+    // Only attach the API key when the resolved download host is a Google host
+    // that requires it. For any other host the credential is dropped (SEC-M1) —
+    // a malicious or unexpected URL never receives the key, and legitimate
+    // pre-signed URLs download fine without it.
     const response = await requestUrl({
       url: uri,
       method: 'GET',
-      headers: {
-        'x-goog-api-key': this.config.apiKey,
-      },
+      headers: this.shouldAttachApiKey(uri)
+        ? { 'x-goog-api-key': this.config.apiKey }
+        : undefined,
     });
 
     if (response.status < 200 || response.status >= 300) {
@@ -239,7 +256,25 @@ export class GoogleVideoAdapter implements VideoGenerationAdapter {
       }
     }
 
-    return this.findFirstStringKey(response, new Set(['uri', 'downloadUri', 'gcsUri']));
+    // Intentionally NO recursive key-scrape fallback: previously a recursive
+    // search returned ANY string under uri/downloadUri/gcsUri anywhere in the
+    // response, which let a poisoned response point the credentialed download
+    // GET at an arbitrary host (SEC-M1). Parse only the documented paths above.
+    return undefined;
+  }
+
+  /**
+   * Whether the user's API key should be attached when downloading from `url`.
+   * Returns true only when the resolved host is on the Google credentialed-host
+   * allowlist; an unparseable URL is treated as off-allowlist (no credential).
+   */
+  private shouldAttachApiKey(url: string): boolean {
+    try {
+      const host = new URL(url).hostname;
+      return GOOGLE_CREDENTIALED_DOWNLOAD_HOSTS.has(host);
+    } catch {
+      return false;
+    }
   }
 
   private findInlineVideoData(response: unknown): Omit<VideoGenerationAdapterResult, 'providerJobId' | 'durationSeconds'> | undefined {
@@ -256,34 +291,6 @@ export class GoogleVideoAdapter implements VideoGenerationAdapter {
           videoData: base64ToArrayBuffer(data),
           mimeType: 'video/mp4',
         };
-      }
-    }
-
-    return undefined;
-  }
-
-  private findFirstStringKey(value: unknown, keys: Set<string>): string | undefined {
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        const found = this.findFirstStringKey(item, keys);
-        if (found) {
-          return found;
-        }
-      }
-      return undefined;
-    }
-
-    if (!isRecord(value)) {
-      return undefined;
-    }
-
-    for (const [key, child] of Object.entries(value)) {
-      if (keys.has(key) && typeof child === 'string') {
-        return child;
-      }
-      const found = this.findFirstStringKey(child, keys);
-      if (found) {
-        return found;
       }
     }
 

--- a/src/services/video/adapters/OpenRouterVideoAdapter.ts
+++ b/src/services/video/adapters/OpenRouterVideoAdapter.ts
@@ -245,10 +245,15 @@ export class OpenRouterVideoAdapter implements VideoGenerationAdapter {
 
   private async pollJob(job: OpenRouterVideoJob): Promise<OpenRouterVideoJob> {
     const url = job.polling_url || `${this.baseUrl}/videos/${encodeURIComponent(job.id || '')}`;
+    // polling_url is taken verbatim from the provider response body. Only attach
+    // the Bearer key when the resolved URL is an OpenRouter API endpoint; any
+    // other host is fetched without the credential (SEC-M2). Mirrors the
+    // allowlist used by downloadVideo below.
+    const shouldAuthorize = this.isOpenRouterUrl(url);
     const response = await requestUrl({
       url,
       method: 'GET',
-      headers: this.getHeaders(),
+      headers: shouldAuthorize ? this.getHeaders() : undefined,
     });
 
     if (response.status < 200 || response.status >= 300) {
@@ -261,7 +266,9 @@ export class OpenRouterVideoAdapter implements VideoGenerationAdapter {
   private async downloadVideo(job: OpenRouterVideoJob): Promise<ArrayBuffer> {
     const unsignedUrl = job.unsigned_urls?.find(url => url.trim().length > 0);
     const url = unsignedUrl || job.output_url || job.url || `${this.baseUrl}/videos/${encodeURIComponent(job.id || '')}/content?index=0`;
-    const shouldAuthorize = !unsignedUrl || url.startsWith(this.baseUrl) || url.startsWith('https://openrouter.ai/api/');
+    // Attach the key only for OpenRouter API endpoints; when no unsigned_url was
+    // returned the fallback URL is always OpenRouter-hosted, so authorize it too.
+    const shouldAuthorize = !unsignedUrl || this.isOpenRouterUrl(url);
     const response = await requestUrl({
       url,
       method: 'GET',
@@ -319,6 +326,28 @@ export class OpenRouterVideoAdapter implements VideoGenerationAdapter {
       'HTTP-Referer': this.httpReferer,
       'X-Title': this.xTitle,
     };
+  }
+
+  /**
+   * Whether `url` is an OpenRouter API endpoint that should receive the Bearer
+   * key. Used to gate credential attachment on URLs taken from the provider
+   * response body (polling_url, output_url) so the key is never sent to an
+   * arbitrary host.
+   *
+   * Matches by URL ORIGIN (https + exact hostname), not substring, so neither a
+   * suffix host (`openrouter.ai.evil.com`) nor a userinfo trick
+   * (`https://openrouter.ai/api/v1@evil.com/`) can smuggle the credential to an
+   * attacker host. An unparseable URL is treated as off-allowlist.
+   */
+  private isOpenRouterUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'https:'
+        && parsed.hostname === 'openrouter.ai'
+        && parsed.pathname.startsWith('/api/');
+    } catch {
+      return false;
+    }
   }
 
   private asJob(value: unknown): OpenRouterVideoJob {

--- a/src/settings/tabs/DefaultsTab.ts
+++ b/src/settings/tabs/DefaultsTab.ts
@@ -12,6 +12,7 @@ import {
   LLMProviderSettings
 } from '../../types/llm/ProviderTypes';
 import { Settings } from '../../settings';
+import { DEFAULT_STORAGE_SETTINGS } from '../../types/plugin/PluginTypes';
 import { WorkspaceService } from '../../services/WorkspaceService';
 import { CustomPromptStorageService } from '../../agents/promptManager/services/CustomPromptStorageService';
 import { ChatSettingsRenderer, ChatSettings } from '../../components/shared/ChatSettingsRenderer';
@@ -515,6 +516,7 @@ export class DefaultsTab {
 
     this.renderVoiceGroupLabel(content, 'Read aloud');
     this.renderSpeechSettings(content, llmSettings, () => updateVoiceWarning());
+    this.renderAudioSaveSettings(content);
 
     this.renderVoiceGroupLabel(content, 'Live voice');
     this.renderRealtimeVoiceSettings(content, llmSettings, () => updateVoiceWarning());
@@ -533,6 +535,49 @@ export class DefaultsTab {
 
   private renderVoiceGroupLabel(parentEl: HTMLElement, label: string): void {
     parentEl.createDiv({ cls: 'nexus-voice-group-label', text: label });
+  }
+
+  /**
+   * Render the "Save as audio" subfolder field. Controls the subfolder under
+   * the storage root where saved read-aloud audio is written. The value is a
+   * plain folder NAME (not a path) joined under the configured storage root by
+   * the backend, so changing the storage root relocates saved audio. Never a
+   * hardcoded root.
+   */
+  private renderAudioSaveSettings(parentEl: HTMLElement): void {
+    const pluginSettings = this.services.settings.settings;
+    const defaultSubfolder = DEFAULT_STORAGE_SETTINGS.audioSubfolder ?? 'audio';
+
+    new Setting(parentEl)
+      .setName('Saved audio subfolder')
+      .setDesc('Folder name, under your storage root, where saved read-aloud audio (mp3/wav) is written.')
+      .addText(text => {
+        const current = pluginSettings.storage?.audioSubfolder ?? defaultSubfolder;
+        text
+          .setPlaceholder(defaultSubfolder)
+          .setValue(current)
+          .onChange(async (value) => {
+            const sanitized = this.sanitizeSubfolderName(value);
+            const storage = pluginSettings.storage ?? { ...DEFAULT_STORAGE_SETTINGS };
+            storage.audioSubfolder = sanitized || defaultSubfolder;
+            pluginSettings.storage = storage;
+            await this.services.settings.saveSettings();
+          });
+      });
+  }
+
+  /**
+   * Reduce free-text input to a safe single folder NAME: trim, collapse path
+   * separators and leading dots so the value can never escape the storage root
+   * or become a nested path. Returns '' for empty/invalid input so the caller
+   * can fall back to the default.
+   */
+  private sanitizeSubfolderName(value: string): string {
+    return value
+      .trim()
+      .replace(/[\\/]+/g, '')
+      .replace(/^\.+/, '')
+      .trim();
   }
 
   private renderSpeechSettings(

--- a/src/types/plugin/PluginTypes.ts
+++ b/src/types/plugin/PluginTypes.ts
@@ -22,12 +22,20 @@ export interface MCPStorageSettings {
   maxShardBytes: number;
   /** Root paths from previous configurations, used as legacy read sources on next startup */
   previousRootPaths?: string[];
+  /**
+   * Subfolder under `rootPath` where saved read-aloud audio files are written
+   * (e.g. `<rootPath>/<audioSubfolder>/`). Just a folder name, never a full
+   * path — the root is resolved from `rootPath` so changing the storage root
+   * relocates saved audio. Defaults to `audio`.
+   */
+  audioSubfolder?: string;
 }
 
 export const DEFAULT_STORAGE_SETTINGS: MCPStorageSettings = {
   schemaVersion: 2,
   rootPath: 'Nexus',
-  maxShardBytes: 4 * 1024 * 1024
+  maxShardBytes: 4 * 1024 * 1024,
+  audioSubfolder: 'audio'
 };
 
 /**

--- a/src/ui/readAloud/ReadAloudProgressModal.ts
+++ b/src/ui/readAloud/ReadAloudProgressModal.ts
@@ -36,6 +36,10 @@ export class ReadAloudProgressModal extends Modal {
   onOpen(): void {
     this.modalEvents = new Component();
     const { contentEl } = this;
+    // Scope the FRAME (not just contentEl) so the modal renders at a sensible
+    // centered width instead of full-screen-wide; the waveform fill rules below
+    // are anchored under .read-aloud-progress.
+    this.modalEl.addClass('read-aloud-progress-modal');
     contentEl.addClass('read-aloud-progress');
 
     contentEl.createEl('h2', { text: 'Reading aloud…' });

--- a/src/ui/readAloud/ReadAloudProgressModal.ts
+++ b/src/ui/readAloud/ReadAloudProgressModal.ts
@@ -1,0 +1,94 @@
+/**
+ * ReadAloudProgressModal - Animated "reading aloud" progress modal.
+ *
+ * Reuses the live-voice visual language: a pulsing dot (.chat-live-dot) and a
+ * row of waveform bars (.chat-live-wave-bar + .chat-live-wave-phase-N). The
+ * animations are pure CSS (class-driven), so replicating the markup here with
+ * the existing classes animates correctly without importing ChatInput — and
+ * inherits the prefers-reduced-motion handling already in styles.css (FE-MINOR-1).
+ *
+ * The modal owns only its own display. The caller drives progress via
+ * setProgress() and is notified of user dismissal via onDismiss — wiring the
+ * dismiss to the backend session (stopPlayback + listener detach) lives in the
+ * command manager, keeping this component free of session/backend coupling.
+ */
+
+import { App, Component, Modal } from 'obsidian';
+
+// Number of waveform bars to render. Matches the phase-class cycle (0..11) used
+// by the live-voice waveform; bars beyond 12 reuse the cycle via index % 12.
+const WAVE_BAR_COUNT = 24;
+const WAVE_PHASE_COUNT = 12;
+
+export class ReadAloudProgressModal extends Modal {
+  private modalEvents: Component | null = null;
+  private statusEl: HTMLElement | null = null;
+  private dismissed = true;
+
+  constructor(
+    app: App,
+    private readonly title: string,
+    private readonly onDismiss: () => void
+  ) {
+    super(app);
+  }
+
+  onOpen(): void {
+    this.modalEvents = new Component();
+    const { contentEl } = this;
+    contentEl.addClass('read-aloud-progress');
+
+    contentEl.createEl('h2', { text: 'Reading aloud…' });
+
+    const visual = contentEl.createDiv('read-aloud-progress-visual');
+    visual.createSpan('chat-live-dot');
+
+    const waveform = visual.createDiv('chat-live-waveform');
+    waveform.setAttribute('aria-hidden', 'true');
+    for (let index = 0; index < WAVE_BAR_COUNT; index += 1) {
+      const phase = index % WAVE_PHASE_COUNT;
+      waveform.createSpan(`chat-live-wave-bar chat-live-wave-phase-${phase}`);
+    }
+
+    this.statusEl = contentEl.createDiv({
+      cls: 'read-aloud-progress-status',
+      text: this.title
+    });
+  }
+
+  /**
+   * Update the progress line. Called by the caller on each session progress
+   * tick. No-op once the modal has been closed.
+   */
+  setProgress(done: number, total: number): void {
+    if (!this.statusEl) {
+      return;
+    }
+    this.statusEl.setText(
+      total > 0 ? `${this.title} — ${done} of ${total}` : this.title
+    );
+  }
+
+  /**
+   * Close the modal programmatically without firing the user-dismiss callback
+   * (e.g. when the session completes on its own).
+   */
+  finish(): void {
+    this.dismissed = false;
+    this.close();
+  }
+
+  onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.modalEvents?.unload();
+    this.modalEvents = null;
+    this.statusEl = null;
+
+    // Only a USER dismissal (Esc / click-outside / close button) triggers the
+    // stop-playback path; a programmatic finish() does not.
+    if (this.dismissed) {
+      this.onDismiss();
+    }
+  }
+}

--- a/src/ui/readAloud/SavePromptModal.ts
+++ b/src/ui/readAloud/SavePromptModal.ts
@@ -1,0 +1,71 @@
+/**
+ * SavePromptModal - Asks whether to save a read-aloud rendering to the note.
+ *
+ * Shown when the user invokes "Read aloud". Offers three outcomes:
+ *   - 'save'  → [Save & read]  : play AND save the audio + insert the embed
+ *   - 'read'  → [Just read]    : play only, nothing saved
+ *   - 'cancel'→ [Cancel] / dismiss : do nothing
+ */
+
+import { App, Component, Modal } from 'obsidian';
+
+export type SavePromptChoice = 'save' | 'read' | 'cancel';
+
+export class SavePromptModal extends Modal {
+  private choice: SavePromptChoice = 'cancel';
+  private modalEvents: Component | null = null;
+
+  constructor(app: App, private onChoose: (choice: SavePromptChoice) => void) {
+    super(app);
+  }
+
+  onOpen(): void {
+    this.modalEvents = new Component();
+    const { contentEl } = this;
+    contentEl.addClass('read-aloud-save-prompt');
+
+    contentEl.createEl('h2', { text: 'Read aloud' });
+    contentEl.createEl('p', { text: 'Save this read-aloud to the note?' });
+
+    const buttonContainer = contentEl.createDiv('modal-button-container');
+    buttonContainer.addClass('modal-button-container-flex');
+
+    const cancelBtn = buttonContainer.createEl('button', {
+      text: 'Cancel',
+      cls: 'mod-cancel'
+    });
+    this.modalEvents.registerDomEvent(cancelBtn, 'click', () => {
+      this.choice = 'cancel';
+      this.close();
+    });
+
+    const justReadBtn = buttonContainer.createEl('button', {
+      text: 'Just read'
+    });
+    this.modalEvents.registerDomEvent(justReadBtn, 'click', () => {
+      this.choice = 'read';
+      this.close();
+    });
+
+    const saveReadBtn = buttonContainer.createEl('button', {
+      text: 'Save & read',
+      cls: 'mod-cta'
+    });
+    this.modalEvents.registerDomEvent(saveReadBtn, 'click', () => {
+      this.choice = 'save';
+      this.close();
+    });
+
+    window.setTimeout(() => {
+      saveReadBtn.focus();
+    }, 0);
+  }
+
+  onClose(): void {
+    const { contentEl } = this;
+    contentEl.empty();
+    this.modalEvents?.unload();
+    this.modalEvents = null;
+    this.onChoose(this.choice);
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -8250,6 +8250,17 @@ body.is-mobile .nexus-task-board-shell {
   .context-badge-danger {
     animation: none;
   }
+
+  /* Live voice composer: disable the continuous dot pulse, waveform bars,
+     and connecting spinner for motion-sensitive users. The session dot
+     keeps its color and the ToolStatusBar text + button aria-label carry
+     the state meaning, so motion is a reinforcement, not the sole indicator
+     (WCAG 1.4.1). */
+  .chat-live-dot,
+  .chat-live-wave-bar,
+  .chat-input-live-connecting .chat-live-waveform::before {
+    animation: none;
+  }
 }
 
 .tool-status-text-failed {

--- a/styles.css
+++ b/styles.css
@@ -9190,10 +9190,19 @@ body.is-mobile .nexus-task-board-shell {
 /* Read-aloud progress modal. Reuses the live-voice .chat-live-dot +
    .chat-live-waveform / .chat-live-wave-bar visuals (animations + their
    prefers-reduced-motion handling are defined with those classes). */
+
+/* Give the modal content a sensible target width so the waveform reads as a
+   full-width player rather than shrink-wrapping to a small cluster. min() caps
+   it to the viewport on narrow/mobile screens so it never overflows. */
+.read-aloud-progress {
+    width: min(420px, 100%);
+}
+
 .read-aloud-progress-visual {
     display: flex;
     align-items: center;
     gap: 12px;
+    width: 100%;
     margin: var(--space-m) 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -9189,13 +9189,16 @@ body.is-mobile .nexus-task-board-shell {
 
 /* Read-aloud progress modal. Reuses the live-voice .chat-live-dot +
    .chat-live-waveform / .chat-live-wave-bar visuals (animations + their
-   prefers-reduced-motion handling are defined with those classes). */
+   prefers-reduced-motion handling are defined with those classes). All width
+   overrides are SCOPED to the read-aloud context so the shared live-voice
+   rules used elsewhere are untouched. */
 
-/* Give the modal content a sensible target width so the waveform reads as a
-   full-width player rather than shrink-wrapping to a small cluster. min() caps
-   it to the viewport on narrow/mobile screens so it never overflows. */
-.read-aloud-progress {
-    width: min(420px, 100%);
+/* Constrain the modal FRAME (not just contentEl) so it renders at a sensible
+   centered width instead of full-screen-wide. min() caps it to the viewport on
+   narrow/mobile screens so it never overflows. */
+.read-aloud-progress-modal {
+    width: min(520px, 100%);
+    max-width: 100%;
 }
 
 .read-aloud-progress-visual {
@@ -9204,6 +9207,18 @@ body.is-mobile .nexus-task-board-shell {
     gap: 12px;
     width: 100%;
     margin: var(--space-m) 0;
+}
+
+/* Make the 24 bars span the waveform edge-to-edge. The shared
+   .chat-live-wave-bar caps growth at max-width:8px (fine for the narrow chat
+   input), so in this wider modal we spread the bars (space-between) AND raise
+   the per-bar cap so they thicken into a proper full-width waveform. */
+.read-aloud-progress .chat-live-waveform {
+    justify-content: space-between;
+}
+
+.read-aloud-progress .chat-live-wave-bar {
+    max-width: 12px;
 }
 
 .read-aloud-progress-status {

--- a/styles.css
+++ b/styles.css
@@ -9186,3 +9186,18 @@ body.is-mobile .nexus-task-board-shell {
         overflow: visible;
     }
 }
+
+/* Read-aloud progress modal. Reuses the live-voice .chat-live-dot +
+   .chat-live-waveform / .chat-live-wave-bar visuals (animations + their
+   prefers-reduced-motion handling are defined with those classes). */
+.read-aloud-progress-visual {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: var(--space-m) 0;
+}
+
+.read-aloud-progress-status {
+    color: var(--text-muted);
+    font-size: 13px;
+}

--- a/tests/unit/AudioGenerationService.test.ts
+++ b/tests/unit/AudioGenerationService.test.ts
@@ -89,4 +89,88 @@ describe('AudioGenerationService', () => {
 
     expect(vault.createBinary).not.toHaveBeenCalled();
   });
+
+  describe('output-extension validation (BE-m1)', () => {
+    it('rejects a disallowed extension before synthesizing', async () => {
+      const synth = jest.spyOn(SpeechSynthesisService.prototype, 'synthesize');
+      const vault = makeVault();
+      const service = new AudioGenerationService(makeApp(), vault, {
+        llmSettings: DEFAULT_LLM_PROVIDER_SETTINGS,
+      });
+
+      await expect(service.generate({
+        prompt: 'Read this.',
+        outputPath: 'audio/read-this.txt',
+      })).rejects.toThrow('outputPath must end with one of: .mp3, .wav.');
+
+      // Fail-fast: synthesis is never invoked for an invalid extension.
+      expect(synth).not.toHaveBeenCalled();
+      expect(vault.createBinary).not.toHaveBeenCalled();
+    });
+
+    it('rejects writing audio/wav bytes to a .mp3 path', async () => {
+      jest.spyOn(SpeechSynthesisService.prototype, 'synthesize').mockResolvedValue({
+        provider: 'google',
+        model: 'gemini-tts',
+        voice: 'kore',
+        audioData: new Uint8Array([1, 2, 3]).buffer,
+        mimeType: 'audio/wav',
+      });
+      const vault = makeVault();
+      const service = new AudioGenerationService(makeApp(), vault, {
+        llmSettings: DEFAULT_LLM_PROVIDER_SETTINGS,
+      });
+
+      await expect(service.generate({
+        prompt: 'Read this.',
+        outputPath: 'audio/read-this.mp3',
+      })).rejects.toThrow('does not match the synthesized audio format "audio/wav" (expected ".wav")');
+
+      // The mismatched file must never be written.
+      expect(vault.createBinary).not.toHaveBeenCalled();
+    });
+
+    it('accepts a .wav path for audio/wav output', async () => {
+      jest.spyOn(SpeechSynthesisService.prototype, 'synthesize').mockResolvedValue({
+        provider: 'google',
+        model: 'gemini-tts',
+        voice: 'kore',
+        audioData: new Uint8Array([1, 2, 3]).buffer,
+        mimeType: 'audio/wav',
+      });
+      const vault = makeVault();
+      const service = new AudioGenerationService(makeApp(), vault, {
+        llmSettings: DEFAULT_LLM_PROVIDER_SETTINGS,
+      });
+
+      const result = await service.generate({
+        prompt: 'Read this.',
+        outputPath: 'audio/read-this.wav',
+      });
+
+      expect(vault.createBinary).toHaveBeenCalledWith('audio/read-this.wav', expect.any(ArrayBuffer));
+      expect(result).toMatchObject({ path: 'audio/read-this.wav', mimeType: 'audio/wav' });
+    });
+
+    it('rejects an unmapped synthesized mimeType with a clear error', async () => {
+      jest.spyOn(SpeechSynthesisService.prototype, 'synthesize').mockResolvedValue({
+        provider: 'future',
+        model: 'future-tts',
+        voice: 'x',
+        audioData: new Uint8Array([1]).buffer,
+        mimeType: 'audio/opus',
+      });
+      const vault = makeVault();
+      const service = new AudioGenerationService(makeApp(), vault, {
+        llmSettings: DEFAULT_LLM_PROVIDER_SETTINGS,
+      });
+
+      await expect(service.generate({
+        prompt: 'Read this.',
+        outputPath: 'audio/read-this.mp3',
+      })).rejects.toThrow('unsupported mimeType "audio/opus"');
+
+      expect(vault.createBinary).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/ReadAloudCommandManager.test.ts
+++ b/tests/unit/ReadAloudCommandManager.test.ts
@@ -1,0 +1,169 @@
+import { App, Editor, MarkdownView, TFile } from 'obsidian';
+import { ReadAloudCommandManager } from '../../src/core/commands/ReadAloudCommandManager';
+import { ReadAloudSaveService } from '../../src/services/readAloud/ReadAloudSaveService';
+
+// Mock the backend save service — frontend only CALLS its two pinned methods
+// (S2 boundary), so we assert the calls without exercising backend internals.
+jest.mock('../../src/services/readAloud/ReadAloudSaveService');
+
+const MockedSaveService = ReadAloudSaveService as jest.MockedClass<typeof ReadAloudSaveService>;
+
+interface CapturedCommand {
+  id: string;
+  name: string;
+  checkCallback?: (checking: boolean) => boolean;
+  editorCheckCallback?: (checking: boolean, editor: Editor, ctx: { file: TFile | null }) => boolean;
+}
+
+interface CapturedMenuItem {
+  title: string;
+  icon: string;
+  onClick: () => void;
+}
+
+class FakeMenu {
+  items: CapturedMenuItem[] = [];
+
+  addItem(cb: (item: MenuItemBuilder) => void): this {
+    const builder = new MenuItemBuilder();
+    cb(builder);
+    this.items.push({ title: builder.title, icon: builder.icon, onClick: builder.clickHandler });
+    return this;
+  }
+}
+
+class MenuItemBuilder {
+  title = '';
+  icon = '';
+  clickHandler: () => void = () => undefined;
+
+  setTitle(title: string): this { this.title = title; return this; }
+  setIcon(icon: string): this { this.icon = icon; return this; }
+  onClick(handler: () => void): this { this.clickHandler = handler; return this; }
+}
+
+/**
+ * Build a plugin/app harness that captures registered commands and the
+ * editor-menu / file-menu callbacks so a test can fire them directly.
+ */
+function buildHarness(activeFile: TFile | null = new TFile('My Note.md', 'My Note.md')) {
+  const commands: CapturedCommand[] = [];
+  const menuCallbacks: Record<string, (...args: unknown[]) => void> = {};
+
+  const app = new App();
+  app.workspace.getActiveViewOfType = (() => {
+    return activeFile ? ({ file: activeFile } as MarkdownView) : null;
+  }) as App['workspace']['getActiveViewOfType'];
+  app.workspace.on = ((name: string, cb: (...args: unknown[]) => void) => {
+    menuCallbacks[name] = cb;
+    return { id: name };
+  }) as unknown as App['workspace']['on'];
+
+  const plugin = {
+    addCommand: (command: CapturedCommand) => { commands.push(command); },
+    registerEvent: () => undefined,
+    settings: {
+      settings: {
+        llmProviders: { providers: {} },
+        apps: { apps: {} },
+        storage: { rootPath: 'Nexus', audioSubfolder: 'audio', maxShardBytes: 1 }
+      }
+    }
+  };
+
+  const manager = new ReadAloudCommandManager({
+    plugin: plugin as never,
+    app
+  });
+  manager.registerCommands();
+
+  return { manager, commands, menuCallbacks, app, activeFile };
+}
+
+describe('ReadAloudCommandManager — save as audio', () => {
+  beforeEach(() => {
+    MockedSaveService.mockClear();
+    MockedSaveService.prototype.saveSelectionAsAudio = jest.fn().mockResolvedValue(undefined);
+    MockedSaveService.prototype.saveNoteAsAudio = jest.fn().mockResolvedValue(undefined);
+  });
+
+  it('registers both save commands', () => {
+    const { commands } = buildHarness();
+    const ids = commands.map(c => c.id);
+    expect(ids).toContain('save-active-note-as-audio');
+    expect(ids).toContain('save-selection-as-audio');
+  });
+
+  it('"Save note as audio" command is gated on an active file', () => {
+    const withFile = buildHarness(new TFile('Note.md', 'Note.md'));
+    const cmd = withFile.commands.find(c => c.id === 'save-active-note-as-audio');
+    expect(cmd?.checkCallback?.(true)).toBe(true);
+
+    const noFile = buildHarness(null);
+    const cmdNoFile = noFile.commands.find(c => c.id === 'save-active-note-as-audio');
+    expect(cmdNoFile?.checkCallback?.(true)).toBe(false);
+  });
+
+  it('"Save note as audio" calls backend saveNoteAsAudio when executed', async () => {
+    const file = new TFile('Note.md', 'Note.md');
+    const { commands } = buildHarness(file);
+    const cmd = commands.find(c => c.id === 'save-active-note-as-audio');
+
+    cmd?.checkCallback?.(false);
+    await Promise.resolve();
+
+    expect(MockedSaveService.prototype.saveNoteAsAudio).toHaveBeenCalledWith(file);
+  });
+
+  it('"Save selection as audio" command requires a selection AND a file', () => {
+    const { commands } = buildHarness();
+    const cmd = commands.find(c => c.id === 'save-selection-as-audio');
+    const file = new TFile('Note.md', 'Note.md');
+
+    const noSelection = new Editor();
+    expect(cmd?.editorCheckCallback?.(true, noSelection, { file })).toBe(false);
+
+    const withSelection = new Editor();
+    withSelection.setSelection('hello world');
+    expect(cmd?.editorCheckCallback?.(true, withSelection, { file })).toBe(true);
+
+    expect(cmd?.editorCheckCallback?.(true, withSelection, { file: null })).toBe(false);
+  });
+
+  it('"Save selection as audio" calls backend saveSelectionAsAudio when executed', async () => {
+    const { commands } = buildHarness();
+    const cmd = commands.find(c => c.id === 'save-selection-as-audio');
+    const file = new TFile('Note.md', 'Note.md');
+    const editor = new Editor();
+    editor.setSelection('read this');
+
+    cmd?.editorCheckCallback?.(false, editor, { file });
+    await Promise.resolve();
+
+    expect(MockedSaveService.prototype.saveSelectionAsAudio).toHaveBeenCalledWith(editor, file);
+  });
+
+  it('editor context menu offers "Save selection as audio" only on a md file with a selection', () => {
+    const { menuCallbacks } = buildHarness();
+    const editor = new Editor();
+    editor.setSelection('some text');
+    const file = new TFile('Note.md', 'Note.md');
+
+    const menu = new FakeMenu();
+    menuCallbacks['editor-menu'](menu, editor, { file });
+
+    const titles = menu.items.map(i => i.title);
+    expect(titles).toContain('Save selection as audio');
+  });
+
+  it('file menu offers "Save note as audio" on a markdown file', () => {
+    const { menuCallbacks } = buildHarness();
+    const file = new TFile('Note.md', 'Note.md');
+
+    const menu = new FakeMenu();
+    menuCallbacks['file-menu'](menu, file, 'more-options');
+
+    const titles = menu.items.map(i => i.title);
+    expect(titles).toContain('Save note as audio');
+  });
+});

--- a/tests/unit/ReadAloudCommandManager.test.ts
+++ b/tests/unit/ReadAloudCommandManager.test.ts
@@ -1,12 +1,19 @@
 import { App, Editor, MarkdownView, TFile } from 'obsidian';
 import { ReadAloudCommandManager } from '../../src/core/commands/ReadAloudCommandManager';
-import { ReadAloudSaveService } from '../../src/services/readAloud/ReadAloudSaveService';
+import { ReadAloudService } from '../../src/services/readAloud/ReadAloudService';
+import { SavePromptModal } from '../../src/ui/readAloud/SavePromptModal';
+import { ReadAloudProgressModal } from '../../src/ui/readAloud/ReadAloudProgressModal';
 
-// Mock the backend save service — frontend only CALLS its two pinned methods
-// (S2 boundary), so we assert the calls without exercising backend internals.
+// Mock the backend session API and both modals — frontend only DRIVES them
+// (S2 boundary), so we assert the wiring without exercising backend/modal DOM.
+jest.mock('../../src/services/readAloud/ReadAloudService');
 jest.mock('../../src/services/readAloud/ReadAloudSaveService');
+jest.mock('../../src/ui/readAloud/SavePromptModal');
+jest.mock('../../src/ui/readAloud/ReadAloudProgressModal');
 
-const MockedSaveService = ReadAloudSaveService as jest.MockedClass<typeof ReadAloudSaveService>;
+const MockedReadAloudService = ReadAloudService as jest.MockedClass<typeof ReadAloudService>;
+const MockedSavePromptModal = SavePromptModal as jest.MockedClass<typeof SavePromptModal>;
+const MockedProgressModal = ReadAloudProgressModal as jest.MockedClass<typeof ReadAloudProgressModal>;
 
 interface CapturedCommand {
   id: string;
@@ -15,155 +22,171 @@ interface CapturedCommand {
   editorCheckCallback?: (checking: boolean, editor: Editor, ctx: { file: TFile | null }) => boolean;
 }
 
-interface CapturedMenuItem {
-  title: string;
-  icon: string;
-  onClick: () => void;
-}
-
 class FakeMenu {
-  items: CapturedMenuItem[] = [];
-
+  items: { title: string; onClick: () => void }[] = [];
   addItem(cb: (item: MenuItemBuilder) => void): this {
     const builder = new MenuItemBuilder();
     cb(builder);
-    this.items.push({ title: builder.title, icon: builder.icon, onClick: builder.clickHandler });
+    this.items.push({ title: builder.title, onClick: builder.clickHandler });
     return this;
   }
 }
 
 class MenuItemBuilder {
   title = '';
-  icon = '';
   clickHandler: () => void = () => undefined;
-
   setTitle(title: string): this { this.title = title; return this; }
-  setIcon(icon: string): this { this.icon = icon; return this; }
+  setIcon(): this { return this; }
   onClick(handler: () => void): this { this.clickHandler = handler; return this; }
 }
 
-/**
- * Build a plugin/app harness that captures registered commands and the
- * editor-menu / file-menu callbacks so a test can fire them directly.
- */
+let startSessionSpy: jest.Mock;
+let sessionCompleted: Promise<{ savedPath?: string }>;
+
 function buildHarness(activeFile: TFile | null = new TFile('My Note.md', 'My Note.md')) {
   const commands: CapturedCommand[] = [];
   const menuCallbacks: Record<string, (...args: unknown[]) => void> = {};
 
   const app = new App();
-  app.workspace.getActiveViewOfType = (() => {
-    return activeFile ? ({ file: activeFile } as MarkdownView) : null;
-  }) as App['workspace']['getActiveViewOfType'];
+  app.workspace.getActiveViewOfType = (() =>
+    activeFile ? ({ file: activeFile } as MarkdownView) : null
+  ) as App['workspace']['getActiveViewOfType'];
   app.workspace.on = ((name: string, cb: (...args: unknown[]) => void) => {
     menuCallbacks[name] = cb;
     return { id: name };
   }) as unknown as App['workspace']['on'];
+  app.vault.cachedRead = (async () => 'note body text') as App['vault']['cachedRead'];
 
   const plugin = {
     addCommand: (command: CapturedCommand) => { commands.push(command); },
     registerEvent: () => undefined,
-    settings: {
-      settings: {
-        llmProviders: { providers: {} },
-        apps: { apps: {} },
-        storage: { rootPath: 'Nexus', audioSubfolder: 'audio', maxShardBytes: 1 }
-      }
-    }
+    settings: { settings: { llmProviders: { providers: {} }, apps: { apps: {} }, storage: {} } }
   };
 
-  const manager = new ReadAloudCommandManager({
-    plugin: plugin as never,
-    app
-  });
+  const manager = new ReadAloudCommandManager({ plugin: plugin as never, app });
   manager.registerCommands();
-
-  return { manager, commands, menuCallbacks, app, activeFile };
+  return { manager, commands, menuCallbacks };
 }
 
-describe('ReadAloudCommandManager — save as audio', () => {
+/** Drive the SavePromptModal mock to invoke its callback with a given choice. */
+function resolveSavePrompt(choice: 'save' | 'read' | 'cancel'): void {
+  const lastCall = MockedSavePromptModal.mock.calls[MockedSavePromptModal.mock.calls.length - 1];
+  const onChoose = lastCall[1] as (c: 'save' | 'read' | 'cancel') => void;
+  onChoose(choice);
+}
+
+describe('ReadAloudCommandManager — v2 unified read-aloud', () => {
   beforeEach(() => {
-    MockedSaveService.mockClear();
-    MockedSaveService.prototype.saveSelectionAsAudio = jest.fn().mockResolvedValue(undefined);
-    MockedSaveService.prototype.saveNoteAsAudio = jest.fn().mockResolvedValue(undefined);
+    MockedReadAloudService.mockClear();
+    MockedSavePromptModal.mockClear();
+    MockedProgressModal.mockClear();
+
+    sessionCompleted = Promise.resolve({});
+    startSessionSpy = jest.fn(() => ({
+      onProgress: jest.fn(),
+      stopPlayback: jest.fn(),
+      completed: sessionCompleted
+    }));
+    MockedReadAloudService.prototype.startReadAloudSession = startSessionSpy as never;
+    MockedReadAloudService.prototype.isPlaying = jest.fn(() => false);
+    MockedReadAloudService.prototype.stop = jest.fn();
+
+    MockedSavePromptModal.prototype.open = jest.fn();
+    MockedProgressModal.prototype.open = jest.fn();
+    MockedProgressModal.prototype.setProgress = jest.fn();
+    MockedProgressModal.prototype.finish = jest.fn();
   });
 
-  it('registers both save commands', () => {
+  it('registers the unified read-aloud commands and NOT the v1 save commands', () => {
     const { commands } = buildHarness();
     const ids = commands.map(c => c.id);
-    expect(ids).toContain('save-active-note-as-audio');
-    expect(ids).toContain('save-selection-as-audio');
+    expect(ids).toContain('read-active-note-aloud');
+    expect(ids).toContain('read-selection-aloud');
+    expect(ids).toContain('stop-read-aloud');
+    // v1 commands removed
+    expect(ids).not.toContain('save-active-note-as-audio');
+    expect(ids).not.toContain('save-selection-as-audio');
   });
 
-  it('"Save note as audio" command is gated on an active file', () => {
-    const withFile = buildHarness(new TFile('Note.md', 'Note.md'));
-    const cmd = withFile.commands.find(c => c.id === 'save-active-note-as-audio');
-    expect(cmd?.checkCallback?.(true)).toBe(true);
-
-    const noFile = buildHarness(null);
-    const cmdNoFile = noFile.commands.find(c => c.id === 'save-active-note-as-audio');
-    expect(cmdNoFile?.checkCallback?.(true)).toBe(false);
-  });
-
-  it('"Save note as audio" calls backend saveNoteAsAudio when executed', async () => {
-    const file = new TFile('Note.md', 'Note.md');
-    const { commands } = buildHarness(file);
-    const cmd = commands.find(c => c.id === 'save-active-note-as-audio');
-
-    cmd?.checkCallback?.(false);
-    await Promise.resolve();
-
-    expect(MockedSaveService.prototype.saveNoteAsAudio).toHaveBeenCalledWith(file);
-  });
-
-  it('"Save selection as audio" command requires a selection AND a file', () => {
-    const { commands } = buildHarness();
-    const cmd = commands.find(c => c.id === 'save-selection-as-audio');
-    const file = new TFile('Note.md', 'Note.md');
-
-    const noSelection = new Editor();
-    expect(cmd?.editorCheckCallback?.(true, noSelection, { file })).toBe(false);
-
-    const withSelection = new Editor();
-    withSelection.setSelection('hello world');
-    expect(cmd?.editorCheckCallback?.(true, withSelection, { file })).toBe(true);
-
-    expect(cmd?.editorCheckCallback?.(true, withSelection, { file: null })).toBe(false);
-  });
-
-  it('"Save selection as audio" calls backend saveSelectionAsAudio when executed', async () => {
-    const { commands } = buildHarness();
-    const cmd = commands.find(c => c.id === 'save-selection-as-audio');
-    const file = new TFile('Note.md', 'Note.md');
-    const editor = new Editor();
-    editor.setSelection('read this');
-
-    cmd?.editorCheckCallback?.(false, editor, { file });
-    await Promise.resolve();
-
-    expect(MockedSaveService.prototype.saveSelectionAsAudio).toHaveBeenCalledWith(editor, file);
-  });
-
-  it('editor context menu offers "Save selection as audio" only on a md file with a selection', () => {
+  it('editor menu offers ONE "Read selection aloud" entry (no separate save item)', () => {
     const { menuCallbacks } = buildHarness();
     const editor = new Editor();
-    editor.setSelection('some text');
-    const file = new TFile('Note.md', 'Note.md');
-
+    editor.setSelection('hello');
     const menu = new FakeMenu();
-    menuCallbacks['editor-menu'](menu, editor, { file });
+    menuCallbacks['editor-menu'](menu, editor, { file: new TFile('Note.md', 'Note.md') });
 
     const titles = menu.items.map(i => i.title);
-    expect(titles).toContain('Save selection as audio');
+    expect(titles).toEqual(['Read selection aloud']);
+    expect(titles).not.toContain('Save selection as audio');
   });
 
-  it('file menu offers "Save note as audio" on a markdown file', () => {
+  it('file menu offers ONE "Read note aloud" entry (no separate save item)', () => {
     const { menuCallbacks } = buildHarness();
-    const file = new TFile('Note.md', 'Note.md');
-
     const menu = new FakeMenu();
-    menuCallbacks['file-menu'](menu, file, 'more-options');
+    menuCallbacks['file-menu'](menu, new TFile('Note.md', 'Note.md'), 'more-options');
 
     const titles = menu.items.map(i => i.title);
-    expect(titles).toContain('Save note as audio');
+    expect(titles).toEqual(['Read note aloud']);
+    expect(titles).not.toContain('Save note as audio');
+  });
+
+  it('invoking read-aloud opens the SavePromptModal', () => {
+    const { commands } = buildHarness();
+    commands.find(c => c.id === 'read-active-note-aloud')?.checkCallback?.(false);
+    expect(MockedSavePromptModal).toHaveBeenCalledTimes(1);
+    expect(MockedSavePromptModal.prototype.open).toHaveBeenCalled();
+  });
+
+  it('choosing "Just read" starts a session with save=false', async () => {
+    const { commands } = buildHarness();
+    commands.find(c => c.id === 'read-active-note-aloud')?.checkCallback?.(false);
+    resolveSavePrompt('read');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startSessionSpy).toHaveBeenCalledTimes(1);
+    expect(startSessionSpy.mock.calls[0][0]).toMatchObject({ mode: 'note', save: false });
+    expect(startSessionSpy.mock.calls[0][0].saveService).toBeUndefined();
+  });
+
+  it('choosing "Save & read" starts a session with save=true and a saveService', async () => {
+    const { commands } = buildHarness();
+    const editor = new Editor();
+    editor.setSelection('read this selection');
+    const cmd = commands.find(c => c.id === 'read-selection-aloud');
+    cmd?.editorCheckCallback?.(false, editor, { file: new TFile('Note.md', 'Note.md') });
+    resolveSavePrompt('save');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(startSessionSpy).toHaveBeenCalledTimes(1);
+    const opts = startSessionSpy.mock.calls[0][0];
+    expect(opts).toMatchObject({ mode: 'selection', save: true });
+    expect(opts.saveService).toBeDefined();
+    expect(opts.markdown).toBe('read this selection');
+  });
+
+  it('choosing "Cancel" starts no session', async () => {
+    const { commands } = buildHarness();
+    commands.find(c => c.id === 'read-active-note-aloud')?.checkCallback?.(false);
+    resolveSavePrompt('cancel');
+    await Promise.resolve();
+
+    expect(startSessionSpy).not.toHaveBeenCalled();
+    expect(MockedProgressModal).not.toHaveBeenCalled();
+  });
+
+  it('selection command is gated on a selection + file', () => {
+    const { commands } = buildHarness();
+    const cmd = commands.find(c => c.id === 'read-selection-aloud');
+    const file = new TFile('Note.md', 'Note.md');
+
+    const empty = new Editor();
+    expect(cmd?.editorCheckCallback?.(true, empty, { file })).toBe(false);
+
+    const withSel = new Editor();
+    withSel.setSelection('x');
+    expect(cmd?.editorCheckCallback?.(true, withSel, { file })).toBe(true);
+    expect(cmd?.editorCheckCallback?.(true, withSel, { file: null })).toBe(false);
   });
 });

--- a/tests/unit/ReadAloudSaveService.test.ts
+++ b/tests/unit/ReadAloudSaveService.test.ts
@@ -1,0 +1,506 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { App, Editor, TFile, TFolder, Vault } from 'obsidian';
+import { ReadAloudSaveService } from '../../src/services/readAloud/ReadAloudSaveService';
+import { ReadAloudService } from '../../src/services/readAloud/ReadAloudService';
+import type { SpeechSynthesisResult } from '../../src/services/readAloud/SpeechSynthesisTypes';
+
+/**
+ * ReadAloudSaveService is the CRITICAL-tier engine for "save read-aloud as audio":
+ * it captures synthesis buffers (never plays), concatenates them, writes a binary
+ * file to a SETTINGS-DERIVED path, and inserts an ![[...]] embed. The filename is
+ * derived from user content (note basename + selection snippet), so path
+ * resolution + sanitization are a path-traversal / frontmatter-corruption surface.
+ *
+ * The service constructs ReadAloudService INTERNALLY (buildCaptureService), so we
+ * jest.mock that module to inject synthesizeForCapture results and assert the
+ * no-double-synth contract — same S2-boundary mocking the CommandManager test uses.
+ */
+jest.mock('../../src/services/readAloud/ReadAloudService');
+
+const MockedReadAloudService = ReadAloudService as jest.MockedClass<typeof ReadAloudService>;
+
+/** A single synthesized chunk result with `bytes` worth of payload filled with `fill`. */
+function makeResult(bytes: number, fill: number, mimeType = 'audio/mpeg'): SpeechSynthesisResult {
+  const data = new Uint8Array(bytes);
+  data.fill(fill);
+  return {
+    provider: 'openai' as SpeechSynthesisResult['provider'],
+    model: 'gpt-4o-mini-tts',
+    voice: 'alloy',
+    audioData: data.buffer as ArrayBuffer,
+    mimeType,
+  };
+}
+
+/**
+ * Build a fake Vault that records every binary write + folder create and lets a
+ * test seed the set of paths that already "exist". `process` applies the mutator
+ * to seeded note content and records the resulting content.
+ */
+function buildFakeVault(options: {
+  existingPaths?: string[];
+  noteContent?: string;
+} = {}) {
+  const existing = new Set(options.existingPaths ?? []);
+  const writes: Array<{ path: string; data: ArrayBuffer }> = [];
+  const createdFolders: string[] = [];
+  let processedContent: string | undefined;
+
+  const vault = {
+    cachedRead: jest.fn(async () => options.noteContent ?? ''),
+    getAbstractFileByPath: jest.fn((path: string) => {
+      if (!existing.has(path)) return null;
+      // Seeded folder paths return a TFolder; seeded file paths return a TFile.
+      return path.endsWith('.mp3') || path.endsWith('.wav')
+        ? new TFile(path.split('/').pop(), path)
+        : new TFolder(path);
+    }),
+    createFolder: jest.fn(async (dir: string) => {
+      createdFolders.push(dir);
+      existing.add(dir);
+    }),
+    createBinary: jest.fn(async (path: string, data: ArrayBuffer) => {
+      writes.push({ path, data });
+      existing.add(path);
+    }),
+    process: jest.fn(async (_file: TFile, mutator: (content: string) => string) => {
+      processedContent = mutator(options.noteContent ?? '');
+      return processedContent;
+    }),
+  };
+
+  return {
+    vault: vault as unknown as Vault,
+    writes,
+    createdFolders,
+    getProcessed: () => processedContent,
+    seedExists: (p: string) => existing.add(p),
+    raw: vault,
+  };
+}
+
+/** Build a Settings-shaped fake exposing only the fields the service reads. */
+function buildSettings(storage?: { rootPath?: string; audioSubfolder?: string }) {
+  return {
+    settings: {
+      llmProviders: { providers: {} },
+      apps: { apps: {} },
+      storage: storage ?? { rootPath: 'Nexus', audioSubfolder: 'audio' },
+    },
+  } as never;
+}
+
+/** An Editor fake with a controllable selection + recorded replaceRange calls. */
+function buildEditor(selection: string) {
+  const replaceRange = jest.fn();
+  const editor = {
+    getSelection: () => selection,
+    getCursor: (_which?: string) => ({ line: 5, ch: 0 }),
+    replaceRange,
+  } as unknown as Editor;
+  return { editor, replaceRange };
+}
+
+/** Install a synthesizeForCapture impl on the mocked ReadAloudService. */
+function stubSynthesis(results: SpeechSynthesisResult[], spy?: jest.Mock) {
+  const impl = spy ?? jest.fn(async () => results);
+  MockedReadAloudService.prototype.synthesizeForCapture = impl as never;
+  return impl;
+}
+
+describe('ReadAloudSaveService', () => {
+  beforeEach(() => {
+    MockedReadAloudService.mockClear();
+  });
+
+  // ── Settings-derived path resolution (NO hardcoded root) ───────────────────
+  describe('path resolution', () => {
+    it('writes to <rootPath>/<audioSubfolder>/<file> using DEFAULT settings', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+
+      expect(fake.writes).toHaveLength(1);
+      expect(fake.writes[0].path).toMatch(/^Nexus\/audio\/Note - \d{8}-\d{6}\.mp3$/);
+    });
+
+    it('honors a CUSTOM rootPath (root is never hardcoded)', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(
+        new App(),
+        fake.vault,
+        buildSettings({ rootPath: 'MyVaultRoot', audioSubfolder: 'audio' })
+      );
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+
+      expect(fake.writes[0].path.startsWith('MyVaultRoot/audio/')).toBe(true);
+      expect(fake.writes[0].path.includes('Nexus')).toBe(false);
+    });
+
+    it('honors a custom audioSubfolder', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(
+        new App(),
+        fake.vault,
+        buildSettings({ rootPath: 'Nexus', audioSubfolder: 'voice-clips' })
+      );
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(fake.writes[0].path.startsWith('Nexus/voice-clips/')).toBe(true);
+    });
+
+    it('falls back to "audio" when audioSubfolder is blank or whitespace', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(
+        new App(),
+        fake.vault,
+        buildSettings({ rootPath: 'Nexus', audioSubfolder: '   ' })
+      );
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(fake.writes[0].path.startsWith('Nexus/audio/')).toBe(true);
+    });
+
+    it('falls back to the default rootPath ("Nexus") when storage is absent', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      // storage omitted entirely
+      const settings = { settings: { llmProviders: {}, apps: {} } } as never;
+      const svc = new ReadAloudSaveService(new App(), fake.vault, settings);
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(fake.writes[0].path.startsWith('Nexus/audio/')).toBe(true);
+    });
+  });
+
+  // ── Adversarial: path traversal must be neutralized ────────────────────────
+  describe('path-traversal safety', () => {
+    it('strips wikilink/path-illegal chars from a malicious note basename so no traversal occurs', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      // A hostile basename packed with separators + wikilink breakers.
+      await svc.saveNoteAsAudio(new TFile('A/B: C? [[x]] #t.md', 'A/B: C? [[x]] #t.md'));
+
+      const path = fake.writes[0].path;
+      // Must stay under the configured audio folder — no parent escape, no abs path.
+      expect(path.startsWith('Nexus/audio/')).toBe(true);
+      expect(path.includes('..')).toBe(false);
+      // The filename segment must contain none of the stripped illegal chars.
+      const filename = path.slice('Nexus/audio/'.length);
+      expect(filename).not.toMatch(/[\\/:*?"<>|[\]#^]/);
+    });
+
+    it('rejects (throws) a basename whose ".." survives sanitize and would escape the folder', async () => {
+      // sanitize() does NOT strip '.', so a ".." basename passes through to
+      // isValidPath, which must reject it — proving the layered guard holds.
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await expect(
+        svc.saveNoteAsAudio(new TFile('..', '..'))
+      ).rejects.toThrow(/invalid audio output path/);
+      expect(fake.writes).toHaveLength(0);
+    });
+  });
+
+  // ── Filename builder ───────────────────────────────────────────────────────
+  describe('filename builder', () => {
+    it('note filename = "<sanitized base> - <timestamp>.<ext>"', async () => {
+      stubSynthesis([makeResult(8, 0x11, 'audio/wav')]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Daily Note.md', 'Daily Note.md'));
+      const filename = fake.writes[0].path.split('/').pop() as string;
+      expect(filename).toMatch(/^Daily Note - \d{8}-\d{6}\.wav$/);
+    });
+
+    it('selection filename includes a snippet capped at 40 chars / 5 words', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      const { editor } = buildEditor(
+        'alpha beta gamma delta epsilon zeta eta theta iota'
+      );
+
+      await svc.saveSelectionAsAudio(editor, new TFile('Src.md', 'Src.md'));
+      const filename = fake.writes[0].path.split('/').pop() as string;
+      // Stem = "Src - <snippet> - <ts>.mp3". Snippet is <=5 words AND <=40 chars.
+      const snippet = filename.replace(/^Src - /, '').replace(/ - \d{8}-\d{6}\.mp3$/, '');
+      expect(snippet.split(/\s+/).length).toBeLessThanOrEqual(5);
+      expect(snippet.length).toBeLessThanOrEqual(40);
+      // First word preserved, 6th word ("zeta") excluded by the 5-word cap.
+      expect(snippet.startsWith('alpha')).toBe(true);
+      expect(snippet.includes('zeta')).toBe(false);
+    });
+
+    it('selection with no usable snippet falls back to "<base> - <ts>"', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      // Selection of only illegal/wikilink chars → snippet sanitizes to empty.
+      const { editor } = buildEditor('[[ ]] ## :: //');
+
+      await svc.saveSelectionAsAudio(editor, new TFile('Src.md', 'Src.md'));
+      const filename = fake.writes[0].path.split('/').pop() as string;
+      expect(filename).toMatch(/^Src - \d{8}-\d{6}\.mp3$/);
+    });
+  });
+
+  // ── Embed insertion ────────────────────────────────────────────────────────
+  describe('embed insertion', () => {
+    it('selection: inserts ![[basename]] after the selection end via replaceRange', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      const { editor, replaceRange } = buildEditor('read me aloud');
+
+      await svc.saveSelectionAsAudio(editor, new TFile('Src.md', 'Src.md'));
+
+      expect(replaceRange).toHaveBeenCalledTimes(1);
+      const [text, pos] = replaceRange.mock.calls[0];
+      expect(text).toContain('![[');
+      expect(text).toContain('.mp3]]');
+      expect(pos).toEqual({ line: 5, ch: 0 }); // the getCursor('to') position
+    });
+
+    it('whole-note (no frontmatter): prepends the embed at top of body', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault({ noteContent: 'First line\nSecond line' });
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      const out = fake.getProcessed() as string;
+      expect(out.startsWith('![[')).toBe(true);
+      expect(out).toContain('First line');
+      expect(out.indexOf('![[')).toBeLessThan(out.indexOf('First line'));
+    });
+
+    it('whole-note (with YAML frontmatter): inserts embed BELOW the closing ---', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const content = '---\ntitle: Hi\ntags: [a]\n---\nBody starts here';
+      const fake = buildFakeVault({ noteContent: content });
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      const out = fake.getProcessed() as string;
+
+      // Frontmatter block stays intact at the very top.
+      expect(out.startsWith('---\ntitle: Hi')).toBe(true);
+      // Embed lands after the SECOND '---' (closing fence), before the body.
+      const closingIdx = out.indexOf('---', 3);
+      const embedIdx = out.indexOf('![[');
+      const bodyIdx = out.indexOf('Body starts here');
+      expect(embedIdx).toBeGreaterThan(closingIdx);
+      expect(embedIdx).toBeLessThan(bodyIdx);
+    });
+
+    it('whole-note (UNTERMINATED frontmatter): treats whole content as body (safe fallback)', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      // Opens with --- but never closes it.
+      const content = '---\ntitle: Hi\nstill frontmatter never closed';
+      const fake = buildFakeVault({ noteContent: content });
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      const out = fake.getProcessed() as string;
+      // Embed prepended at the very top rather than risking corruption of the
+      // unterminated block.
+      expect(out.startsWith('![[')).toBe(true);
+    });
+  });
+
+  // ── No-double-synth + capture contract ─────────────────────────────────────
+  describe('synthesizeForCapture (no double synth, ordering, progress)', () => {
+    it('calls synthesizeForCapture exactly once and never plays audio', async () => {
+      const spy = jest.fn(async () => [makeResult(8, 0x11)]);
+      stubSynthesis([], spy);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(spy).toHaveBeenCalledTimes(1);
+      // The capture path takes { markdown } — never a playback request.
+      expect(spy.mock.calls[0][0]).toHaveProperty('markdown');
+    });
+
+    it('concatenates multi-chunk results in ORDER (chunk 1 payload precedes chunk 2)', async () => {
+      // Two WAV chunks: payload of chunk1 = 0xa1, chunk2 = 0xb2. After merge the
+      // a1 bytes must come before the b2 bytes.
+      const chunk1 = makeResult(20, 0xa1, 'audio/wav');
+      const chunk2 = makeResult(30, 0xb2, 'audio/wav');
+      // Wrap raw payloads in real WAV containers so concatWav can parse them.
+      stubSynthesis([wrapWav(chunk1), wrapWav(chunk2)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      const merged = new Uint8Array(fake.writes[0].data);
+      const firstA1 = merged.indexOf(0xa1);
+      const firstB2 = merged.indexOf(0xb2);
+      expect(firstA1).toBeGreaterThan(-1);
+      expect(firstB2).toBeGreaterThan(-1);
+      expect(firstA1).toBeLessThan(firstB2);
+    });
+  });
+
+  // ── Error paths ────────────────────────────────────────────────────────────
+  describe('error paths', () => {
+    it('throws when the selection is empty/whitespace (no synth, no write)', async () => {
+      const spy = jest.fn(async () => [makeResult(8, 0x11)]);
+      stubSynthesis([], spy);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      const { editor } = buildEditor('   ');
+
+      await expect(
+        svc.saveSelectionAsAudio(editor, new TFile('Src.md', 'Src.md'))
+      ).rejects.toThrow(/Select text/);
+      expect(spy).not.toHaveBeenCalled();
+      expect(fake.writes).toHaveLength(0);
+    });
+
+    it('throws when synthesis yields no results', async () => {
+      stubSynthesis([]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await expect(
+        svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'))
+      ).rejects.toThrow(/no readable text/);
+      expect(fake.writes).toHaveLength(0);
+    });
+
+    it('throws on an unsupported synthesized mimeType', async () => {
+      stubSynthesis([makeResult(8, 0x11, 'audio/ogg')]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await expect(
+        svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'))
+      ).rejects.toThrow(/unsupported format/);
+      expect(fake.writes).toHaveLength(0);
+    });
+
+    it('throws (does not overwrite) when the output path already exists', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      // Pre-seed the audio dir as an existing folder AND seed the would-be output.
+      // We can't know the timestamp, so intercept createBinary's first arg by
+      // seeding once getAbstractFileByPath is asked: simplest is to make EVERY
+      // .mp3 path appear to exist.
+      fake.raw.getAbstractFileByPath = jest.fn((path: string) => {
+        if (path.endsWith('.mp3')) return new TFile(path.split('/').pop(), path);
+        return new TFolder(path); // parent dir exists
+      }) as never;
+
+      await expect(
+        svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'))
+      ).rejects.toThrow(/already exists/);
+    });
+  });
+
+  // ── Mobile-safety: the feature path must use no desktop-only audio/Node APIs ─
+  // The feature ships on Obsidian mobile (isDesktopOnly: false). A static scan of
+  // the source guards against a future edit reintroducing AudioContext /
+  // MediaRecorder / Node built-ins that crash module init on mobile. Comments are
+  // stripped before scanning so the "no AudioContext" JSDoc lines don't false-fire.
+  describe('mobile-safety (static source scan)', () => {
+    const featureFiles = [
+      'src/services/readAloud/concatAudioBuffers.ts',
+      'src/services/readAloud/ReadAloudSaveService.ts',
+      'src/services/readAloud/ReadAloudService.ts',
+      'src/core/commands/ReadAloudCommandManager.ts',
+    ];
+
+    const stripComments = (src: string): string =>
+      src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+
+    it.each(featureFiles)('%s uses no AudioContext/MediaRecorder/Node built-ins', (rel) => {
+      const code = stripComments(readFileSync(join(__dirname, '..', '..', rel), 'utf8'));
+      expect(code).not.toMatch(/\bAudioContext\b/);
+      expect(code).not.toMatch(/\bOfflineAudioContext\b/);
+      expect(code).not.toMatch(/\bMediaRecorder\b/);
+      expect(code).not.toMatch(/from ['"]node:/);
+      expect(code).not.toMatch(/from ['"](fs|path|stream|crypto|buffer|os|http|events)['"]/);
+      expect(code).not.toMatch(/\brequire\(/);
+    });
+  });
+
+  // ── Auditor focus (A): toAudioBuffer behavior is harmless ───────────────────
+  // The JSDoc claims a typed-array slice guard, but the body just returns
+  // result.audioData. Adapters already return ArrayBuffer, so the pass-through is
+  // correct end-to-end; we verify the buffer reaches createBinary intact.
+  describe('toAudioBuffer pass-through (auditor focus A)', () => {
+    it('forwards the synthesized ArrayBuffer to the write unchanged for N=1', async () => {
+      const result = makeResult(12, 0x7e);
+      stubSynthesis([result]);
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      // N=1 concat is a pass-through, so the written bytes equal the synth payload.
+      const written = new Uint8Array(fake.writes[0].data);
+      expect(written.byteLength).toBe(12);
+      expect(Array.from(written).every((b) => b === 0x7e)).toBe(true);
+    });
+  });
+
+  // ── Directory creation ─────────────────────────────────────────────────────
+  describe('ensureParentDirectory', () => {
+    it('creates the audio folder when it is missing', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault(); // nothing seeded → folder missing
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(fake.createdFolders).toContain('Nexus/audio');
+    });
+
+    it('does NOT create the folder when it already exists', async () => {
+      stubSynthesis([makeResult(8, 0x11)]);
+      const fake = buildFakeVault({ existingPaths: ['Nexus/audio'] });
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+
+      await svc.saveNoteAsAudio(new TFile('Note.md', 'Note.md'));
+      expect(fake.createdFolders).toHaveLength(0);
+    });
+  });
+});
+
+/** Wrap a raw-payload result's bytes inside a canonical WAV container. */
+function wrapWav(result: SpeechSynthesisResult): SpeechSynthesisResult {
+  const payload = new Uint8Array(result.audioData);
+  const dataSize = payload.byteLength;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+  const writeAscii = (offset: number, ascii: string): void => {
+    for (let i = 0; i < ascii.length; i += 1) view.setUint8(offset + i, ascii.charCodeAt(i));
+  };
+  writeAscii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, 44100, true);
+  view.setUint32(28, 88200, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  new Uint8Array(buffer).set(payload, 44);
+  return { ...result, audioData: buffer, mimeType: 'audio/wav' };
+}

--- a/tests/unit/ReadAloudSaveService.test.ts
+++ b/tests/unit/ReadAloudSaveService.test.ts
@@ -354,6 +354,97 @@ describe('ReadAloudSaveService', () => {
     });
   });
 
+  // ── v2 buffer-driven save tail (the ACTUAL v2 entry points) ────────────────
+  // The v2 session captures buffers during play-and-capture and calls these
+  // directly — they perform NO synthesis. The synth-then-save methods above are
+  // retained test seams; these tests cover the v2 surface (ReadAloudSaveTail)
+  // with N>1 captured buffers so concat + embed + settings-path are exercised
+  // without going through synthesizeForCapture.
+  describe('v2 buffer-driven saveCaptured* (N>1, no synthesis)', () => {
+    it('saveCapturedNote: concatenates N buffers, writes to settings path, embeds below frontmatter, returns path', async () => {
+      const fake = buildFakeVault({ noteContent: '---\ntitle: T\n---\nBody' });
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      // 3 WAV chunks with distinct fills to verify ordered concat.
+      const results = [
+        wrapWav(makeResult(10, 0xa1, 'audio/wav')),
+        wrapWav(makeResult(10, 0xb2, 'audio/wav')),
+        wrapWav(makeResult(10, 0xc3, 'audio/wav')),
+      ];
+
+      const returnedPath = await svc.saveCapturedNote(results, new TFile('Note.md', 'Note.md'));
+
+      // ONE write, settings-derived path, returns that path.
+      expect(fake.writes).toHaveLength(1);
+      expect(fake.writes[0].path).toMatch(/^Nexus\/audio\/Note - \d{8}-\d{6}\.wav$/);
+      expect(returnedPath).toBe(fake.writes[0].path);
+      // Ordered concat of all 3 payloads.
+      const merged = new Uint8Array(fake.writes[0].data);
+      expect(merged.indexOf(0xa1)).toBeLessThan(merged.indexOf(0xb2));
+      expect(merged.indexOf(0xb2)).toBeLessThan(merged.indexOf(0xc3));
+      // Embed inserted below the YAML frontmatter.
+      const out = fake.getProcessed() as string;
+      expect(out.startsWith('---\ntitle: T')).toBe(true);
+      expect(out.indexOf('![[')).toBeGreaterThan(out.indexOf('---', 3));
+    });
+
+    it('saveCapturedSelection: concatenates N buffers, inserts embed at selection end, returns path', async () => {
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      const { editor, replaceRange } = buildEditor('the selected text');
+      const results = [
+        wrapWav(makeResult(8, 0xd4, 'audio/wav')),
+        wrapWav(makeResult(8, 0xe5, 'audio/wav')),
+      ];
+
+      const returnedPath = await svc.saveCapturedSelection(
+        results,
+        editor,
+        new TFile('Src.md', 'Src.md'),
+        'the selected text'
+      );
+
+      expect(fake.writes).toHaveLength(1);
+      expect(returnedPath).toBe(fake.writes[0].path);
+      expect(fake.writes[0].path).toMatch(/^Nexus\/audio\/Src - the selected text - \d{8}-\d{6}\.wav$/);
+      // Embed inserted at the selection end (getCursor('to')).
+      expect(replaceRange).toHaveBeenCalledTimes(1);
+      const [text, pos] = replaceRange.mock.calls[0];
+      expect(text).toContain('![[');
+      expect(pos).toEqual({ line: 5, ch: 0 });
+      // Ordered concat.
+      const merged = new Uint8Array(fake.writes[0].data);
+      expect(merged.indexOf(0xd4)).toBeLessThan(merged.indexOf(0xe5));
+    });
+
+    it('saveCapturedNote: throws on empty buffer array (no write)', async () => {
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      await expect(
+        svc.saveCapturedNote([], new TFile('Note.md', 'Note.md'))
+      ).rejects.toThrow(/no readable text/);
+      expect(fake.writes).toHaveLength(0);
+    });
+
+    it('saveCapturedNote: throws on unsupported captured mimeType (no write)', async () => {
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      await expect(
+        svc.saveCapturedNote([makeResult(8, 0x01, 'audio/ogg')], new TFile('Note.md', 'Note.md'))
+      ).rejects.toThrow(/unsupported format/);
+      expect(fake.writes).toHaveLength(0);
+    });
+
+    it('saveCapturedNote: N=1 passthrough writes the single buffer unchanged', async () => {
+      const fake = buildFakeVault();
+      const svc = new ReadAloudSaveService(new App(), fake.vault, buildSettings());
+      const only = makeResult(12, 0x7f); // audio/mpeg, N=1 → concat passthrough
+      await svc.saveCapturedNote([only], new TFile('Note.md', 'Note.md'));
+      const written = new Uint8Array(fake.writes[0].data);
+      expect(written.byteLength).toBe(12);
+      expect(Array.from(written).every((b) => b === 0x7f)).toBe(true);
+    });
+  });
+
   // ── Error paths ────────────────────────────────────────────────────────────
   describe('error paths', () => {
     it('throws when the selection is empty/whitespace (no synth, no write)', async () => {

--- a/tests/unit/ReadAloudService.test.ts
+++ b/tests/unit/ReadAloudService.test.ts
@@ -1,5 +1,12 @@
-import { ReadAloudService, type AudioPlaybackFactory, type AudioPlaybackHandle } from '../../src/services/readAloud/ReadAloudService';
+import type { Editor, TFile } from 'obsidian';
+import {
+  ReadAloudService,
+  type AudioPlaybackFactory,
+  type AudioPlaybackHandle,
+  type ReadAloudSaveTail
+} from '../../src/services/readAloud/ReadAloudService';
 import { SpeechSynthesisService } from '../../src/services/readAloud/SpeechSynthesisService';
+import type { SpeechSynthesisResult } from '../../src/services/readAloud/SpeechSynthesisTypes';
 import {
   DEFAULT_LLM_PROVIDER_SETTINGS,
   type LLMProviderConfig,
@@ -94,5 +101,257 @@ describe('ReadAloudService', () => {
     expect(playbackFactory.handles).toHaveLength(1);
     expect(playbackFactory.handles[0].played).toHaveLength(1);
     expect(playbackFactory.handles[0].stopped).toBe(true);
+  });
+});
+
+// ── v2 play-and-capture session ───────────────────────────────────────────────
+
+/** A playback handle whose play() can be made to block until stopped. */
+class ControllablePlaybackHandle implements AudioPlaybackHandle {
+  played: Array<{ audioData: ArrayBuffer; mimeType: string }> = [];
+  stopped = false;
+  private rejectPlay: ((e: Error) => void) | null = null;
+
+  constructor(private readonly block: boolean) {}
+
+  play(audioData: ArrayBuffer, mimeType: string): Promise<void> {
+    this.played.push({ audioData, mimeType });
+    if (!this.block) {
+      return Promise.resolve();
+    }
+    // Block until stop() rejects with the canonical sentinel (mirrors BrowserAudioPlaybackHandle).
+    return new Promise<void>((_resolve, reject) => {
+      this.rejectPlay = reject;
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.rejectPlay?.(new Error('Read aloud playback was stopped.'));
+    this.rejectPlay = null;
+  }
+}
+
+class ControllablePlaybackFactory implements AudioPlaybackFactory {
+  handles: ControllablePlaybackHandle[] = [];
+  /** Indices (0-based chunk) whose play() should block until stopPlayback. */
+  constructor(private readonly blockingIndices: Set<number> = new Set()) {}
+
+  create(): AudioPlaybackHandle {
+    const handle = new ControllablePlaybackHandle(this.blockingIndices.has(this.handles.length));
+    this.handles.push(handle);
+    return handle;
+  }
+}
+
+function makeSessionService(
+  playbackFactory: AudioPlaybackFactory,
+  audioMime = 'audio/mpeg'
+): { service: ReadAloudService; synthSpy: jest.SpyInstance } {
+  const synthSpy = jest
+    .spyOn(SpeechSynthesisService.prototype, 'synthesize')
+    .mockImplementation(async ({ text }: { text: string }) => ({
+      provider: 'openai',
+      model: 'gpt-4o-mini-tts',
+      voice: 'marin',
+      audioData: new Uint8Array([text.length & 0xff]).buffer,
+      mimeType: audioMime
+    } as SpeechSynthesisResult));
+
+  const service = new ReadAloudService(
+    makeSettings({
+      providers: { ...DEFAULT_LLM_PROVIDER_SETTINGS.providers, openai: providerConfig() },
+      defaultSpeechModel: { provider: 'openai', model: 'gpt-4o-mini-tts', source: 'user' }
+    }),
+    playbackFactory
+  );
+  return { service, synthSpy };
+}
+
+/** A markdown long enough to split into N chunks (each ~one sentence per maxChunkChars). */
+function multiChunkMarkdown(): string {
+  // MarkdownSpeechPreprocessor splits at ~3,600 chars. Build 3 long paragraphs.
+  const para = 'This sentence is repeated many times to fill a chunk. '.repeat(80);
+  return [para, para, para].join('\n\n');
+}
+
+function fakeFile(name = 'Note.md'): TFile {
+  return { basename: name.replace(/\.md$/, ''), path: name, name } as unknown as TFile;
+}
+
+describe('ReadAloudService.startReadAloudSession', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('save=false: plays each chunk once, never double-synths, resolves with no savedPath', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service, synthSpy } = makeSessionService(playbackFactory);
+    const markdown = multiChunkMarkdown();
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown,
+      save: false
+    });
+
+    const progress: Array<[number, number]> = [];
+    session.onProgress((d, t) => progress.push([d, t]));
+
+    const out = await session.completed;
+    expect(out).toEqual({}); // no savedPath
+    // One synth per chunk (no double-synth) and one playback per chunk.
+    expect(synthSpy).toHaveBeenCalledTimes(playbackFactory.handles.length);
+    expect(playbackFactory.handles.length).toBeGreaterThan(1);
+    playbackFactory.handles.forEach((h) => expect(h.played).toHaveLength(1));
+    // Progress: an initial (0, total) tick, then once per chunk, ending at total.
+    const total = playbackFactory.handles.length;
+    expect(progress[0]).toEqual([0, total]);
+    expect(progress.length).toBe(total + 1);
+    expect(progress[progress.length - 1]).toEqual([total, total]);
+  });
+
+  it('save=true with stopPlayback mid-run: continues synth-only and still saves all chunks (no double-synth)', async () => {
+    // First chunk's play() blocks; we stopPlayback while it's in flight. The loop
+    // must continue synthesizing the remaining chunks WITHOUT playing them, then save.
+    const playbackFactory = new ControllablePlaybackFactory(new Set([0]));
+    const { service, synthSpy } = makeSessionService(playbackFactory, 'audio/mpeg');
+
+    const captured: SpeechSynthesisResult[][] = [];
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async (results) => {
+        captured.push(results);
+        return 'Nexus/audio/Note - 20260608-000000.mp3';
+      }),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const markdown = multiChunkMarkdown();
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown,
+      save: true,
+      saveService
+    });
+
+    const progress: Array<[number, number]> = [];
+    session.onProgress((d, t) => progress.push([d, t]));
+
+    // Let the first chunk synthesize + start playing, then stop playback.
+    await new Promise((r) => setTimeout(r, 0));
+    session.stopPlayback();
+
+    const out = await session.completed;
+
+    // Save completed despite the cancel.
+    expect(out.savedPath).toMatch(/\.mp3$/);
+    expect(saveService.saveCapturedNote).toHaveBeenCalledTimes(1);
+
+    const totalChunks = synthSpy.mock.calls.length;
+    expect(totalChunks).toBeGreaterThan(1);
+    // Exactly ONE synth per chunk — no double-synthesis for the save tail.
+    expect(captured[0]).toHaveLength(totalChunks);
+    // Only the first chunk was played (the rest were synth-only after stop).
+    expect(playbackFactory.handles[0].played).toHaveLength(1);
+    expect(playbackFactory.handles).toHaveLength(1);
+    // Progress kept ticking through the synth-only phase, ending at total.
+    expect(progress[progress.length - 1]).toEqual([totalChunks, totalChunks]);
+  });
+
+  it('save=true to completion: saves and resolves with the saved path', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'Nexus/audio/Note - 20260608-000000.mp3'),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+
+    const out = await session.completed;
+    expect(out.savedPath).toBe('Nexus/audio/Note - 20260608-000000.mp3');
+    expect(saveService.saveCapturedNote).toHaveBeenCalledTimes(1);
+  });
+
+  it('completed REJECTS when the save tail throws', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => {
+        throw new Error('An audio file already exists at Nexus/audio/x.mp3.');
+      }),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+
+    await expect(session.completed).rejects.toThrow(/already exists/);
+  });
+
+  it('completed REJECTS when there is no readable text', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: '---\ntitle: only metadata\n---',
+      save: false
+    });
+
+    await expect(session.completed).rejects.toThrow(/no readable text/);
+  });
+
+  it('throws synchronously when save=true without a save service', () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+
+    expect(() =>
+      service.startReadAloudSession({
+        mode: 'note',
+        file: fakeFile(),
+        markdown: 'hello world',
+        save: true
+      })
+    ).toThrow(/save service is required/);
+  });
+
+  it('selection save routes to saveCapturedSelection with the editor + selection text', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+    const editor = { getCursor: () => ({ line: 0, ch: 0 }), replaceRange: jest.fn() } as unknown as Editor;
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'unused'),
+      saveCapturedSelection: jest.fn(async () => 'Nexus/audio/Src - hi - 20260608-000000.mp3')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'selection',
+      file: fakeFile('Src.md'),
+      markdown: 'hi there reader',
+      selection: 'hi there reader',
+      save: true,
+      editor,
+      saveService
+    });
+
+    const out = await session.completed;
+    expect(out.savedPath).toMatch(/^Nexus\/audio\/Src/);
+    expect(saveService.saveCapturedSelection).toHaveBeenCalledTimes(1);
+    const args = (saveService.saveCapturedSelection as jest.Mock).mock.calls[0];
+    expect(args[1]).toBe(editor);
+    expect(args[3]).toBe('hi there reader');
   });
 });

--- a/tests/unit/ReadAloudService.test.ts
+++ b/tests/unit/ReadAloudService.test.ts
@@ -355,3 +355,283 @@ describe('ReadAloudService.startReadAloudSession', () => {
     expect(args[3]).toBe('hi there reader');
   });
 });
+
+/**
+ * A playback handle whose play() REJECTS with a chosen error on a chosen 0-based
+ * chunk index — used to drive the non-sentinel-error propagation path. Default
+ * message is a NON-sentinel error so it must propagate (not be swallowed).
+ */
+class ErroringPlaybackHandle implements AudioPlaybackHandle {
+  played: Array<{ audioData: ArrayBuffer; mimeType: string }> = [];
+  stopped = false;
+  constructor(private readonly shouldReject: boolean, private readonly message: string) {}
+
+  play(audioData: ArrayBuffer, mimeType: string): Promise<void> {
+    this.played.push({ audioData, mimeType });
+    return this.shouldReject ? Promise.reject(new Error(this.message)) : Promise.resolve();
+  }
+
+  stop(): void {
+    this.stopped = true;
+  }
+}
+
+class ErroringPlaybackFactory implements AudioPlaybackFactory {
+  handles: ErroringPlaybackHandle[] = [];
+  constructor(
+    private readonly failIndex: number,
+    private readonly message = 'Audio playback failed.'
+  ) {}
+
+  create(): AudioPlaybackHandle {
+    const handle = new ErroringPlaybackHandle(this.handles.length === this.failIndex, this.message);
+    this.handles.push(handle);
+    return handle;
+  }
+}
+
+describe('ReadAloudService.startReadAloudSession — v2 edge hardening', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  // (b) NON-sentinel playback error PROPAGATES and rejects completed.
+  it('completed REJECTS when a NON-sentinel playback error occurs mid-run', async () => {
+    const playbackFactory = new ErroringPlaybackFactory(1, 'Audio playback failed.');
+    const { service, synthSpy } = makeSessionService(playbackFactory);
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: false
+    });
+
+    await expect(session.completed).rejects.toThrow('Audio playback failed.');
+    // The loop aborted on the unhandled throw at chunk 1 (0-based) — chunk 2 (index 2)
+    // was never synthesized. So synth ran for chunks 0 and 1 only.
+    expect(synthSpy.mock.calls.length).toBe(2);
+  });
+
+  // (b) sentinel contract guard: the EXACT stop sentinel must be SWALLOWED (no reject).
+  // Pairs with the test above — if the sentinel wording ever drifts, one of these fails.
+  it('does NOT reject when play() rejects with the EXACT stop sentinel (swallowed)', async () => {
+    // failIndex 0 rejects chunk 0's play with the canonical stop sentinel.
+    const playbackFactory = new ErroringPlaybackFactory(0, 'Read aloud playback was stopped.');
+    const { service, synthSpy } = makeSessionService(playbackFactory);
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: false
+    });
+
+    // Resolves (no reject) — the sentinel is swallowed and the loop continues
+    // synth-only through ALL chunks.
+    const out = await session.completed;
+    expect(out).toEqual({});
+    expect(synthSpy.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  // (2, backend target) SYNTH failure mid-loop rejects completed AND (save case)
+  // writes NO partial file — the save tail is never reached.
+  it('completed REJECTS when synthesize() throws mid-loop and writes NO partial file', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    // Make synth succeed for chunk 0, throw on chunk 1.
+    let call = 0;
+    const synthSpy = jest
+      .spyOn(SpeechSynthesisService.prototype, 'synthesize')
+      .mockImplementation(async ({ text }: { text: string }) => {
+        call += 1;
+        if (call === 2) {
+          throw new Error('Speech synthesis failed (HTTP 500).');
+        }
+        return {
+          provider: 'openai',
+          model: 'gpt-4o-mini-tts',
+          voice: 'marin',
+          audioData: new Uint8Array([text.length & 0xff]).buffer,
+          mimeType: 'audio/mpeg'
+        } as SpeechSynthesisResult;
+      });
+    const service = new ReadAloudService(
+      makeSettings({
+        providers: { ...DEFAULT_LLM_PROVIDER_SETTINGS.providers, openai: providerConfig() },
+        defaultSpeechModel: { provider: 'openai', model: 'gpt-4o-mini-tts', source: 'user' }
+      }),
+      playbackFactory
+    );
+
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'should-not-be-called'),
+      saveCapturedSelection: jest.fn(async () => 'should-not-be-called')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+
+    await expect(session.completed).rejects.toThrow(/HTTP 500/);
+    // No partial file: the save tail is never reached on a mid-loop synth failure.
+    expect(saveService.saveCapturedNote).not.toHaveBeenCalled();
+    expect(synthSpy.mock.calls.length).toBe(2); // chunk 0 ok, chunk 1 threw, stopped
+  });
+
+  // (1, backend target) Single-synth invariant when stopped AFTER chunk K plays:
+  // chunk 0 plays, stop after it, remaining chunks synth-only, exactly N synth calls.
+  it('stop AFTER chunk 0 plays: only chunk 0 played, all chunks synth-only saved, N synths', async () => {
+    // Block chunk 0 so we can stop while it is the active playback.
+    const playbackFactory = new ControllablePlaybackFactory(new Set([0]));
+    const { service, synthSpy } = makeSessionService(playbackFactory, 'audio/mpeg');
+    const captured: SpeechSynthesisResult[][] = [];
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async (results) => {
+        captured.push(results);
+        return 'Nexus/audio/Note - 20260608-000000.mp3';
+      }),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+
+    await new Promise((r) => setTimeout(r, 0)); // let chunk 0 synth + begin blocking play
+    session.stopPlayback();
+
+    const out = await session.completed;
+    expect(out.savedPath).toMatch(/\.mp3$/);
+
+    const n = synthSpy.mock.calls.length;
+    expect(n).toBeGreaterThan(1);
+    expect(captured[0]).toHaveLength(n); // exactly one synth per chunk → N captured
+    // Only chunk 0 created a playback handle and played once; rest were synth-only.
+    expect(playbackFactory.handles).toHaveLength(1);
+    expect(playbackFactory.handles[0].played).toHaveLength(1);
+  });
+
+  // (1) stop BEFORE any chunk plays: a stop issued before the first play still
+  // saves all chunks synth-only, with zero playback handles created.
+  it('stop BEFORE chunk 0 plays: zero playback, all chunks synth-only saved', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service, synthSpy } = makeSessionService(playbackFactory);
+    const captured: SpeechSynthesisResult[][] = [];
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async (results) => {
+        captured.push(results);
+        return 'Nexus/audio/Note - 20260608-000000.mp3';
+      }),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+    // Stop synchronously, before the async loop body runs its first play().
+    session.stopPlayback();
+
+    const out = await session.completed;
+    expect(out.savedPath).toMatch(/\.mp3$/);
+    const n = synthSpy.mock.calls.length;
+    expect(captured[0]).toHaveLength(n); // every chunk synthesized exactly once
+    // No chunk ever played → no handle created.
+    expect(playbackFactory.handles).toHaveLength(0);
+  });
+
+  // (a/3) onProgress: initial (0,total) tick + monotonic per-chunk ticks through the
+  // post-stop synth-only phase. Asserted timing-robust (monotonic + endpoints), not
+  // by exact array identity.
+  it('onProgress emits (0,total) then monotonic ticks to (total,total) incl. post-stop phase', async () => {
+    const playbackFactory = new ControllablePlaybackFactory(new Set([0]));
+    const { service } = makeSessionService(playbackFactory, 'audio/mpeg');
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'Nexus/audio/Note - 20260608-000000.mp3'),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: true,
+      saveService
+    });
+
+    const progress: Array<[number, number]> = [];
+    session.onProgress((d, t) => progress.push([d, t]));
+
+    await new Promise((r) => setTimeout(r, 0));
+    session.stopPlayback();
+    await session.completed;
+
+    const total = progress[0][1];
+    // Initial tick is (0, total).
+    expect(progress[0]).toEqual([0, total]);
+    // Last tick is (total, total).
+    expect(progress[progress.length - 1]).toEqual([total, total]);
+    // `done` is monotonically non-decreasing and `total` is constant throughout
+    // (robust to exact scheduling — no order-fragile equality on the whole array).
+    for (let i = 1; i < progress.length; i += 1) {
+      expect(progress[i][1]).toBe(total);
+      expect(progress[i][0]).toBeGreaterThanOrEqual(progress[i - 1][0]);
+    }
+    // One tick per chunk synthesized plus the initial tick — covers the post-stop
+    // synth-only chunks too.
+    expect(progress.length).toBe(total + 1);
+  });
+
+  // (5) save=true selection without an editor throws synchronously.
+  it('throws synchronously when save=true selection without an editor', () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'unused'),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    expect(() =>
+      service.startReadAloudSession({
+        mode: 'selection',
+        file: fakeFile('Src.md'),
+        markdown: 'hi',
+        selection: 'hi',
+        save: true,
+        saveService
+        // editor omitted
+      })
+    ).toThrow(/editor is required/);
+  });
+
+  // (d) save=false NEVER touches the save service.
+  it('save=false never calls saveService methods', async () => {
+    const playbackFactory = new ControllablePlaybackFactory();
+    const { service } = makeSessionService(playbackFactory);
+    const saveService: ReadAloudSaveTail = {
+      saveCapturedNote: jest.fn(async () => 'unused'),
+      saveCapturedSelection: jest.fn(async () => 'unused')
+    };
+
+    const session = service.startReadAloudSession({
+      mode: 'note',
+      file: fakeFile(),
+      markdown: multiChunkMarkdown(),
+      save: false,
+      saveService // present but must be ignored when save=false
+    });
+
+    await session.completed;
+    expect(saveService.saveCapturedNote).not.toHaveBeenCalled();
+    expect(saveService.saveCapturedSelection).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/Settings.test.ts
+++ b/tests/unit/Settings.test.ts
@@ -28,7 +28,8 @@ describe('Settings', () => {
     expect(settings.settings.storage).toEqual({
       schemaVersion: 2,
       rootPath: 'Nexus',
-      maxShardBytes: 4 * 1024 * 1024
+      maxShardBytes: 4 * 1024 * 1024,
+      audioSubfolder: 'audio'
     });
   });
 
@@ -49,7 +50,8 @@ describe('Settings', () => {
     expect(settings.settings.storage).toEqual({
       schemaVersion: 2,
       rootPath: 'storage/assistant-data',
-      maxShardBytes: 4 * 1024 * 1024
+      maxShardBytes: 4 * 1024 * 1024,
+      audioSubfolder: 'audio'
     });
   });
 

--- a/tests/unit/SyncCoordinator.test.ts
+++ b/tests/unit/SyncCoordinator.test.ts
@@ -152,15 +152,18 @@ describe('SyncCoordinator', () => {
     expect(sqliteCache.save).toHaveBeenCalledTimes(1);
   });
 
-  it('does not persist sync state or save a partial cache when full rebuild replay fails', async () => {
-    const failingEvent: StorageEvent = {
-      id: 'workspace-event-fails',
+  it('does not persist sync state or save a partial cache when a fatal rebuild step throws', async () => {
+    // Fatal error = the rebuild ENGINE itself fails (here: rebuildFTSIndexes()
+    // throws). Unlike a per-file parse error, this is not recoverable, so the
+    // rebuild must NOT persist a half-built index and must report failure.
+    const workspaceEvent: StorageEvent = {
+      id: 'workspace-event-1',
       type: 'workspace_created',
       deviceId: 'desktop-device',
       timestamp: 1_000,
       data: {
-        id: 'workspace-fails',
-        name: 'Workspace fails',
+        id: 'workspace-1',
+        name: 'Workspace one',
         rootFolder: '',
         created: 1_000
       }
@@ -169,10 +172,10 @@ describe('SyncCoordinator', () => {
     const jsonlWriter: IJSONLWriter = {
       getDeviceId: jest.fn(() => 'mobile-device'),
       listFiles: jest.fn(async (category) => {
-        return category === 'workspaces' ? ['workspaces/ws_fails.jsonl'] : [];
+        return category === 'workspaces' ? ['workspaces/ws_one.jsonl'] : [];
       }),
       getFileModTime: jest.fn(async () => null),
-      readEvents: jest.fn(async <T extends StorageEvent>(): Promise<T[]> => [failingEvent as T]),
+      readEvents: jest.fn(async <T extends StorageEvent>(): Promise<T[]> => [workspaceEvent as T]),
       getEventsNotFromDevice: jest.fn(async () => [])
     };
 
@@ -181,8 +184,89 @@ describe('SyncCoordinator', () => {
       updateSyncState: jest.fn(async () => undefined),
       isEventApplied: jest.fn(async () => false),
       markEventApplied: jest.fn(async () => undefined),
-      run: jest.fn(async () => {
-        throw new Error('workspace insert failed');
+      run: jest.fn(async () => ({ changes: 1, lastInsertRowid: 1 })),
+      query: jest.fn(async () => []),
+      queryOne: jest.fn(async () => null),
+      clearAllData: jest.fn(async () => undefined),
+      rebuildFTSIndexes: jest.fn(async () => {
+        throw new Error('FTS rebuild failed');
+      }),
+      save: jest.fn(async () => undefined)
+    };
+
+    const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
+    const result = await coordinator.fullRebuild();
+
+    expect(result.success).toBe(false);
+    expect(result.errors.some(error => error.includes('FTS rebuild failed'))).toBe(true);
+    // The engine failed before persistence, so neither sync state nor the blob
+    // is written — the "never persist a half-built index" guarantee holds.
+    // success:false makes callers (HybridStorageAdapter) surface the failure,
+    // and with no blob written the next launch is still a cold start free to
+    // retry the rebuild.
+    expect(sqliteCache.updateSyncState).not.toHaveBeenCalled();
+    expect(sqliteCache.save).not.toHaveBeenCalled();
+  });
+
+  it('skips a malformed file but still saves the good cache and advances sync state', async () => {
+    // Regression for the cold-cache rebuild loop: one bad file among good ones
+    // used to abort the entire rebuild and save nothing, so cold-start re-ran
+    // the rebuild on every launch. Now the bad file is skipped (quarantined as
+    // a warning) and the good cache is indexed, saved, and sync state advanced.
+    const now = 1_000;
+    const goodEvent: StorageEvent = {
+      id: 'workspace-event-good',
+      type: 'workspace_created',
+      deviceId: 'desktop-device',
+      timestamp: now,
+      data: {
+        id: 'workspace-good',
+        name: 'Workspace good',
+        rootFolder: '',
+        created: now
+      }
+    };
+    const eventsByFile: Record<string, StorageEvent[]> = {
+      'workspaces/ws_good.jsonl': [goodEvent],
+      'workspaces/ws_bad.jsonl': [{
+        id: 'workspace-event-bad',
+        type: 'workspace_created',
+        deviceId: 'desktop-device',
+        timestamp: now + 1,
+        data: {
+          id: 'workspace-bad',
+          name: 'Workspace bad',
+          rootFolder: '',
+          created: now + 1
+        }
+      }]
+    };
+
+    const jsonlWriter: IJSONLWriter = {
+      getDeviceId: jest.fn(() => 'mobile-device'),
+      listFiles: jest.fn(async (category) => {
+        return category === 'workspaces'
+          ? ['workspaces/ws_good.jsonl', 'workspaces/ws_bad.jsonl']
+          : [];
+      }),
+      getFileModTime: jest.fn(async () => null),
+      readEvents: jest.fn(async <T extends StorageEvent>(file: string): Promise<T[]> => {
+        return (eventsByFile[file] ?? []) as T[];
+      }),
+      getEventsNotFromDevice: jest.fn(async () => [])
+    };
+
+    const sqliteCache: ISQLiteCacheManager = {
+      getSyncState: jest.fn(async () => null),
+      updateSyncState: jest.fn(async () => undefined),
+      isEventApplied: jest.fn(async () => false),
+      markEventApplied: jest.fn(async () => undefined),
+      // Only the bad workspace's insert fails — a recoverable per-event error.
+      run: jest.fn(async (sql: string, params: unknown[] = []) => {
+        if (sql.includes('INTO workspaces') && String(params[0]) === 'workspace-bad') {
+          throw new Error('malformed workspace row');
+        }
+        return { changes: 1, lastInsertRowid: 1 };
       }),
       query: jest.fn(async () => []),
       queryOne: jest.fn(async () => null),
@@ -194,11 +278,18 @@ describe('SyncCoordinator', () => {
     const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
     const result = await coordinator.fullRebuild();
 
-    expect(result.success).toBe(false);
-    expect(result.errors.some(error => error.includes('workspace insert failed'))).toBe(true);
-    expect(sqliteCache.rebuildFTSIndexes).not.toHaveBeenCalled();
-    expect(sqliteCache.updateSyncState).not.toHaveBeenCalled();
-    expect(sqliteCache.save).not.toHaveBeenCalled();
+    // Good cache persisted: success despite the skipped file...
+    expect(result.success).toBe(true);
+    // ...with the bad file surfaced as a warning in errors (not a hard failure).
+    expect(result.errors.some(error => error.includes('malformed workspace row'))).toBe(true);
+    // ...and the good event was applied.
+    expect(result.eventsApplied).toBe(1);
+    expect(sqliteCache.markEventApplied).toHaveBeenCalledWith('workspace-event-good');
+    // The save + sync-state advance MUST happen so cold-start does not re-fire
+    // the rebuild on the next launch.
+    expect(sqliteCache.rebuildFTSIndexes).toHaveBeenCalledTimes(1);
+    expect(sqliteCache.updateSyncState).toHaveBeenCalledTimes(1);
+    expect(sqliteCache.save).toHaveBeenCalledTimes(1);
   });
 
   it('replays events from newly arrived files even when event timestamps are older than the last sync', async () => {

--- a/tests/unit/VideoGenerationService.test.ts
+++ b/tests/unit/VideoGenerationService.test.ts
@@ -2,6 +2,7 @@ import type { App, Vault } from 'obsidian';
 import { TFolder, __setRequestUrlMock } from '../mocks/obsidian';
 import { VideoGenerationService } from '../../src/services/video/VideoGenerationService';
 import { VideoGenerationTimeoutError } from '../../src/services/video/VideoGenerationTypes';
+import type { PendingVideoGenerationJob } from '../../src/services/video/VideoGenerationTypes';
 import { GoogleVideoAdapter } from '../../src/services/video/adapters/GoogleVideoAdapter';
 import { OpenRouterVideoAdapter } from '../../src/services/video/adapters/OpenRouterVideoAdapter';
 import { GenerateVideoTool } from '../../src/agents/promptManager/tools/generateVideo';
@@ -358,6 +359,202 @@ describe('OpenRouterVideoAdapter', () => {
     expect(result.providerJobId).toBe('job-1');
   });
 
+  it('does not attach the Bearer key when polling an off-allowlist polling_url', async () => {
+    const authByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      authByUrl[request.url] = request.headers?.Authorization;
+
+      if (request.url.endsWith('/videos/models')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            data: [{
+              id: 'google/veo-3.1-fast',
+              supported_resolutions: ['720p'],
+              supported_aspect_ratios: ['16:9'],
+              supported_durations: [5],
+            }]
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      // submitJob → return a poisoned, attacker-controlled polling_url.
+      if (request.url.endsWith('/videos')) {
+        return {
+          status: 202,
+          headers: {},
+          text: '{}',
+          json: {
+            id: 'job-1',
+            status: 'queued',
+            polling_url: 'https://evil.example.com/steal',
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      // pollJob hits the poisoned URL → report completed so generate() finishes.
+      if (request.url === 'https://evil.example.com/steal') {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            id: 'job-1',
+            status: 'completed',
+            unsigned_urls: ['https://cdn.example.com/video.mp4'],
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return {
+        status: 200,
+        headers: {},
+        text: '',
+        json: null,
+        arrayBuffer: new Uint8Array([1]).buffer,
+      };
+    });
+
+    const adapter = new OpenRouterVideoAdapter({
+      apiKey: 'test-key',
+      vault: makeVault(),
+    });
+
+    await adapter.generate({
+      prompt: 'A calm ocean sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-fast',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 5,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    // The off-allowlist polling host must NOT receive the credential.
+    expect(authByUrl['https://evil.example.com/steal']).toBeUndefined();
+    // The legitimate OpenRouter submit endpoint still gets the key.
+    expect(authByUrl['https://openrouter.ai/api/v1/videos']).toBe('Bearer test-key');
+    // The unsigned CDN download is also fetched without the credential.
+    expect(authByUrl['https://cdn.example.com/video.mp4']).toBeUndefined();
+  });
+
+  it('attaches the Bearer key when polling an OpenRouter polling_url', async () => {
+    const authByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      authByUrl[request.url] = request.headers?.Authorization;
+
+      if (request.url.endsWith('/videos/models')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: { data: [{ id: 'google/veo-3.1-fast', supported_resolutions: ['720p'], supported_aspect_ratios: ['16:9'], supported_durations: [5] }] },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url.endsWith('/videos')) {
+        return {
+          status: 202,
+          headers: {},
+          text: '{}',
+          json: { id: 'job-1', status: 'queued', polling_url: 'https://openrouter.ai/api/v1/videos/job-1' },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url === 'https://openrouter.ai/api/v1/videos/job-1') {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: { id: 'job-1', status: 'completed', unsigned_urls: ['https://cdn.example.com/video.mp4'] },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1]).buffer };
+    });
+
+    const adapter = new OpenRouterVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+
+    await adapter.generate({
+      prompt: 'A calm ocean sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-fast',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 5,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(authByUrl['https://openrouter.ai/api/v1/videos/job-1']).toBe('Bearer test-key');
+  });
+
+  it('does not attach the Bearer key to a userinfo-trick polling_url', async () => {
+    // Resolves to host evil.com (the openrouter.ai before @ is userinfo) — the
+    // hostname-equality check must reject it; a naive prefix check would not.
+    const trickUrl = 'https://openrouter.ai@evil.com/api/v1/steal';
+    const authByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      authByUrl[request.url] = request.headers?.Authorization;
+
+      if (request.url.endsWith('/videos/models')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: { data: [{ id: 'google/veo-3.1-fast', supported_resolutions: ['720p'], supported_aspect_ratios: ['16:9'], supported_durations: [5] }] },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url.endsWith('/videos')) {
+        return {
+          status: 202,
+          headers: {},
+          text: '{}',
+          json: { id: 'job-1', status: 'queued', polling_url: trickUrl },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      if (request.url === trickUrl) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: { id: 'job-1', status: 'completed', unsigned_urls: ['https://cdn.example.com/video.mp4'] },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1]).buffer };
+    });
+
+    const adapter = new OpenRouterVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+
+    await adapter.generate({
+      prompt: 'A calm ocean sunrise.',
+      provider: 'openrouter',
+      model: 'google/veo-3.1-fast',
+      aspectRatio: '16:9',
+      resolution: '720p',
+      seconds: 5,
+      pollIntervalMs: 1,
+      timeoutMs: 1000,
+    });
+
+    expect(authByUrl[trickUrl]).toBeUndefined();
+  });
+
   it('rejects unsupported model options from OpenRouter metadata', async () => {
     __setRequestUrlMock(async () => ({
       status: 200,
@@ -389,5 +586,138 @@ describe('OpenRouterVideoAdapter', () => {
       pollIntervalMs: 1,
       timeoutMs: 1000,
     })).rejects.toThrow('does not support resolution "1080p"');
+  });
+});
+
+describe('GoogleVideoAdapter credential allowlist', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function makeJob(): PendingVideoGenerationJob {
+    return {
+      provider: 'google',
+      providerJobId: 'operations/video-1',
+      pollingUrl: 'https://generativelanguage.googleapis.com/v1beta/operations/video-1',
+      request: { seconds: 8, aspectRatio: '16:9', resolution: '720p' },
+    } as unknown as PendingVideoGenerationJob;
+  }
+
+  it('does not attach x-goog-api-key when the download URI is off-allowlist', async () => {
+    const keyByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      keyByUrl[request.url] = request.headers?.['x-goog-api-key'];
+
+      // pollOperation → completed, with a poisoned attacker-controlled download URI.
+      if (request.url.endsWith('/operations/video-1')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            name: 'operations/video-1',
+            done: true,
+            response: { generatedVideos: [{ video: { uri: 'https://evil.example.com/steal.mp4' } }] },
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1, 2, 3]).buffer };
+    });
+
+    const adapter = new GoogleVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+    await adapter.checkJob(makeJob());
+
+    // The poll endpoint (generativelanguage.googleapis.com) legitimately gets the key.
+    expect(keyByUrl['https://generativelanguage.googleapis.com/v1beta/operations/video-1']).toBe('test-key');
+    // The off-allowlist download host must NOT receive the credential.
+    expect(keyByUrl['https://evil.example.com/steal.mp4']).toBeUndefined();
+  });
+
+  it('attaches x-goog-api-key when the download URI is on generativelanguage.googleapis.com', async () => {
+    const downloadUrl = 'https://generativelanguage.googleapis.com/v1beta/files/abc:download?alt=media';
+    const keyByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      keyByUrl[request.url] = request.headers?.['x-goog-api-key'];
+
+      if (request.url.endsWith('/operations/video-1')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            name: 'operations/video-1',
+            done: true,
+            response: { generatedVideos: [{ video: { uri: downloadUrl } }] },
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1, 2, 3]).buffer };
+    });
+
+    const adapter = new GoogleVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+    await adapter.checkJob(makeJob());
+
+    expect(keyByUrl[downloadUrl]).toBe('test-key');
+  });
+
+  it('ignores a download URI hidden in an undocumented response location', async () => {
+    __setRequestUrlMock(async (request) => {
+      if (request.url.endsWith('/operations/video-1')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          // uri buried under an undocumented key — previously the recursive
+          // findFirstStringKey scrape would have picked this up.
+          json: {
+            name: 'operations/video-1',
+            done: true,
+            response: { metadata: { attacker: { uri: 'https://evil.example.com/steal.mp4' } } },
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1]).buffer };
+    });
+
+    const adapter = new GoogleVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+
+    await expect(adapter.checkJob(makeJob())).rejects.toThrow('no downloadable video was found');
+  });
+
+  it('does not attach x-goog-api-key to a userinfo-trick download URI', async () => {
+    // Resolves to host evil.com despite the generativelanguage prefix; the
+    // hostname-equality check must reject it (substring/startsWith would not).
+    const trickUrl = 'https://generativelanguage.googleapis.com@evil.com/steal.mp4';
+    const keyByUrl: Record<string, string | undefined> = {};
+    __setRequestUrlMock(async (request) => {
+      keyByUrl[request.url] = request.headers?.['x-goog-api-key'];
+
+      if (request.url.endsWith('/operations/video-1')) {
+        return {
+          status: 200,
+          headers: {},
+          text: '{}',
+          json: {
+            name: 'operations/video-1',
+            done: true,
+            response: { generatedVideos: [{ video: { uri: trickUrl } }] },
+          },
+          arrayBuffer: new ArrayBuffer(0),
+        };
+      }
+
+      return { status: 200, headers: {}, text: '', json: null, arrayBuffer: new Uint8Array([1]).buffer };
+    });
+
+    const adapter = new GoogleVideoAdapter({ apiKey: 'test-key', vault: makeVault() });
+    await adapter.checkJob(makeJob());
+
+    expect(keyByUrl[trickUrl]).toBeUndefined();
   });
 });

--- a/tests/unit/concatAudioBuffers.test.ts
+++ b/tests/unit/concatAudioBuffers.test.ts
@@ -1,0 +1,143 @@
+import { concatAudioBuffers } from '../../src/services/readAloud/concatAudioBuffers';
+
+/**
+ * Build a minimal valid MPEG-1 Layer III frame (128 kbps, 44100 Hz, no padding)
+ * whose body is filled with `fill`. Frame length = 144000 * 128 / 44100 = 417 bytes.
+ * Optionally injects a leading ID3v2 tag and/or a "Xing" marker in the body so the
+ * mp3 strip logic can be exercised on chunks 2..N.
+ */
+function makeMp3Frame(options: { fill?: number; id3?: boolean; xing?: boolean } = {}): ArrayBuffer {
+  const fill = options.fill ?? 0xaa;
+  const FRAME_LEN = 417;
+  const frame = new Uint8Array(FRAME_LEN);
+  // 4-byte header: FF FB 90 00 = sync + MPEG1 LayerIII + 128kbps + 44100 + no pad.
+  frame[0] = 0xff;
+  frame[1] = 0xfb;
+  frame[2] = 0x90;
+  frame[3] = 0x00;
+  for (let i = 4; i < FRAME_LEN; i += 1) {
+    frame[i] = fill;
+  }
+  if (options.xing) {
+    // Place the ASCII "Xing" marker inside the frame body (after side info).
+    const marker = 'Xing';
+    for (let i = 0; i < marker.length; i += 1) {
+      frame[36 + i] = marker.charCodeAt(i);
+    }
+  }
+
+  if (!options.id3) {
+    return frame.buffer as ArrayBuffer;
+  }
+
+  // Prepend a 10-byte (empty body) ID3v2 tag: "ID3" + ver + flags + synchsafe size 0.
+  const id3 = new Uint8Array([0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  const withTag = new Uint8Array(id3.length + frame.length);
+  withTag.set(id3, 0);
+  withTag.set(frame, id3.length);
+  return withTag.buffer as ArrayBuffer;
+}
+
+/** Build a canonical 44-byte-header WAV with `samples` bytes of PCM payload `fill`. */
+function makeWav(samples: number, fill: number): ArrayBuffer {
+  const dataSize = samples;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+  const writeAscii = (offset: number, ascii: string): void => {
+    for (let i = 0; i < ascii.length; i += 1) {
+      view.setUint8(offset + i, ascii.charCodeAt(i));
+    }
+  };
+  writeAscii(0, 'RIFF');
+  view.setUint32(4, 36 + dataSize, true);
+  writeAscii(8, 'WAVE');
+  writeAscii(12, 'fmt ');
+  view.setUint32(16, 16, true); // fmt chunk size
+  view.setUint16(20, 1, true); // PCM
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, 44100, true);
+  view.setUint32(28, 88200, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(36, 'data');
+  view.setUint32(40, dataSize, true);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 44; i < 44 + dataSize; i += 1) {
+    bytes[i] = fill;
+  }
+  return buffer;
+}
+
+describe('concatAudioBuffers', () => {
+  it('throws when given no buffers', () => {
+    expect(() => concatAudioBuffers([], 'audio/mpeg')).toThrow(/at least one buffer/);
+  });
+
+  it('throws on an unsupported mimeType when concatenating multiple buffers', () => {
+    const a = new ArrayBuffer(8);
+    const b = new ArrayBuffer(8);
+    expect(() => concatAudioBuffers([a, b], 'audio/ogg')).toThrow(/does not support mimeType/);
+  });
+
+  describe('N=1 passthrough', () => {
+    it('returns the single mp3 buffer unchanged (identity)', () => {
+      const only = makeMp3Frame({ fill: 0x11, id3: true, xing: true });
+      const result = concatAudioBuffers([only], 'audio/mpeg');
+      expect(result).toBe(only); // exact same reference — no copy, no strip
+    });
+
+    it('returns the single wav buffer unchanged regardless of mimeType casing', () => {
+      const only = makeWav(16, 0x22);
+      expect(concatAudioBuffers([only], 'AUDIO/WAV')).toBe(only);
+    });
+  });
+
+  describe('N>1 mp3 join', () => {
+    it('byte-joins frames and strips ID3 + Xing from chunks 2..N', () => {
+      const first = makeMp3Frame({ fill: 0x11 }); // 417 bytes, kept whole
+      const second = makeMp3Frame({ fill: 0x22, id3: true, xing: true }); // 10 ID3 + 417 frame
+      const third = makeMp3Frame({ fill: 0x33, id3: true }); // 10 ID3 + 417 frame
+
+      const result = new Uint8Array(concatAudioBuffers([first, second, third], 'audio/mpeg'));
+
+      // first kept whole (417); second's Xing frame stripped (entire 417 frame dropped,
+      // ID3 already stripped) → 0 bytes from second; third's ID3 stripped → 417 bytes.
+      // first(417) + second(0) + third(417) = 834.
+      expect(result.byteLength).toBe(417 + 0 + 417);
+      // First frame's sync header preserved at offset 0.
+      expect(result[0]).toBe(0xff);
+      expect(result[1]).toBe(0xfb);
+      // First byte of the third frame's body follows the first frame.
+      expect(result[417]).toBe(0xff); // third frame sync header
+    });
+
+    it('joins plain frames (no ID3/Xing) end to end', () => {
+      const first = makeMp3Frame({ fill: 0x11 });
+      const second = makeMp3Frame({ fill: 0x22 });
+      const result = new Uint8Array(concatAudioBuffers([first, second], 'audio/mpeg'));
+      expect(result.byteLength).toBe(417 * 2);
+      expect(result[417]).toBe(0xff); // second frame begins right after the first
+    });
+  });
+
+  describe('N>1 wav merge', () => {
+    it('keeps one header and concatenates PCM payloads, rewriting size fields', () => {
+      const a = makeWav(20, 0xa1);
+      const b = makeWav(30, 0xb2);
+
+      const merged = concatAudioBuffers([a, b], 'audio/wav');
+      const bytes = new Uint8Array(merged);
+      const view = new DataView(merged);
+
+      // Header (44) + 20 + 30 = 94 bytes total.
+      expect(merged.byteLength).toBe(44 + 20 + 30);
+      // RIFF size = total - 8.
+      expect(view.getUint32(4, true)).toBe(merged.byteLength - 8);
+      // data sub-chunk size = combined PCM payload.
+      expect(view.getUint32(40, true)).toBe(50);
+      // Payload ordering: first chunk's fill then second chunk's fill.
+      expect(bytes[44]).toBe(0xa1);
+      expect(bytes[44 + 20]).toBe(0xb2);
+    });
+  });
+});

--- a/tests/unit/concatAudioBuffers.test.ts
+++ b/tests/unit/concatAudioBuffers.test.ts
@@ -68,6 +68,90 @@ function makeWav(samples: number, fill: number): ArrayBuffer {
   return buffer;
 }
 
+/**
+ * Build an MPEG-2 Layer III frame (64 kbps, 22050 Hz, no padding).
+ * frameLen = floor(72000 * 64 / 22050) = 208 bytes.
+ * Header FF F3 80 00: sync(11) + version=10(MPEG2) + layer=01(III) + 64kbps + 22050.
+ */
+function makeMpeg2Frame(options: { fill?: number; xing?: boolean } = {}): ArrayBuffer {
+  const fill = options.fill ?? 0xaa;
+  const FRAME_LEN = 208;
+  const frame = new Uint8Array(FRAME_LEN);
+  frame[0] = 0xff;
+  frame[1] = 0xf3; // 1111 0011: sync(11111) + MPEG2(10) + LayerIII(01) + protection(1)
+  frame[2] = 0x80; // 1000 0000: bitrateIdx=1000(64k MPEG2) + sampleIdx=00(22050) + pad=0
+  frame[3] = 0x00;
+  for (let i = 4; i < FRAME_LEN; i += 1) frame[i] = fill;
+  if (options.xing) {
+    const marker = 'Xing';
+    for (let i = 0; i < marker.length; i += 1) frame[20 + i] = marker.charCodeAt(i);
+  }
+  return frame.buffer as ArrayBuffer;
+}
+
+/** WAV with an extra sub-chunk (`id`, `pad` payload bytes) inserted BEFORE `data`. */
+function makeWavWithLeadingSubchunk(samples: number, fill: number, id: string, pad: number): ArrayBuffer {
+  const fmtBytes = 8 + 16; // 'fmt ' header + 16-byte body
+  const extraBytes = 8 + pad; // leading sub-chunk header + payload
+  const headerBytes = 12 + fmtBytes + extraBytes + 8; // RIFF + fmt + extra + 'data' header
+  const buffer = new ArrayBuffer(headerBytes + samples);
+  const view = new DataView(buffer);
+  const w = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i += 1) view.setUint8(o + i, s.charCodeAt(i));
+  };
+  w(0, 'RIFF');
+  view.setUint32(4, buffer.byteLength - 8, true);
+  w(8, 'WAVE');
+  // fmt
+  w(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, 44100, true);
+  view.setUint32(28, 88200, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  // leading extra sub-chunk
+  const extraOff = 36;
+  w(extraOff, id);
+  view.setUint32(extraOff + 4, pad, true);
+  // data
+  const dataOff = extraOff + 8 + pad;
+  w(dataOff, 'data');
+  view.setUint32(dataOff + 4, samples, true);
+  const bytes = new Uint8Array(buffer);
+  for (let i = dataOff + 8; i < dataOff + 8 + samples; i += 1) bytes[i] = fill;
+  return buffer;
+}
+
+/** A valid RIFF/WAVE with a `fmt ` sub-chunk but NO `data` sub-chunk. */
+function makeWavNoData(): ArrayBuffer {
+  const buffer = new ArrayBuffer(12 + 8 + 16);
+  const view = new DataView(buffer);
+  const w = (o: number, s: string): void => {
+    for (let i = 0; i < s.length; i += 1) view.setUint8(o + i, s.charCodeAt(i));
+  };
+  w(0, 'RIFF');
+  view.setUint32(4, buffer.byteLength - 8, true);
+  w(8, 'WAVE');
+  w(12, 'fmt ');
+  view.setUint32(16, 16, true);
+  return buffer;
+}
+
+/** Walk the RIFF sub-chunk list and return the `data` payload offset + size. */
+function findDataSubchunk(bytes: Uint8Array): { offset: number; size: number } {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let cursor = 12;
+  while (cursor + 8 <= bytes.byteLength) {
+    const id = String.fromCharCode(bytes[cursor], bytes[cursor + 1], bytes[cursor + 2], bytes[cursor + 3]);
+    const size = view.getUint32(cursor + 4, true);
+    if (id === 'data') return { offset: cursor + 8, size };
+    cursor += 8 + size + (size % 2);
+  }
+  throw new Error('test helper: no data sub-chunk found');
+}
+
 describe('concatAudioBuffers', () => {
   it('throws when given no buffers', () => {
     expect(() => concatAudioBuffers([], 'audio/mpeg')).toThrow(/at least one buffer/);
@@ -138,6 +222,83 @@ describe('concatAudioBuffers', () => {
       // Payload ordering: first chunk's fill then second chunk's fill.
       expect(bytes[44]).toBe(0xa1);
       expect(bytes[44 + 20]).toBe(0xb2);
+    });
+
+    it('locates "data" by SCANNING sub-chunks (non-canonical layout: LIST before data)', () => {
+      // Chunk 1 has an extra `LIST` sub-chunk BEFORE `data`, so the PCM payload
+      // is NOT at the fixed 44-byte offset. locateDataSubchunk must walk the
+      // sub-chunk list to find it.
+      const a = makeWavWithLeadingSubchunk(20, 0xc3, 'LIST', 8);
+      const b = makeWav(10, 0xd4);
+
+      const merged = concatAudioBuffers([a, b], 'audio/wav');
+      const bytes = new Uint8Array(merged);
+      const dataInfo = findDataSubchunk(bytes);
+
+      // The merged data payload = 20 + 10 and begins right after chunk 1's
+      // (preserved) header incl. the LIST sub-chunk.
+      expect(dataInfo.size).toBe(30);
+      expect(bytes[dataInfo.offset]).toBe(0xc3); // chunk 1 PCM first
+      expect(bytes[dataInfo.offset + 20]).toBe(0xd4); // chunk 2 PCM follows
+    });
+
+    it('clamps an over-declared data size to the bytes actually present', () => {
+      // Chunk 1 lies: declares data size 100 but only carries 20 PCM bytes.
+      const a = makeWav(20, 0xe5);
+      new DataView(a).setUint32(40, 100, true); // over-declare
+      const b = makeWav(10, 0xf6);
+
+      // Must not read past chunk 1's buffer; merged payload = 20 (clamped) + 10.
+      const merged = concatAudioBuffers([a, b], 'audio/wav');
+      const view = new DataView(merged);
+      expect(view.getUint32(40, true)).toBe(30);
+      expect(merged.byteLength).toBe(44 + 30);
+    });
+
+    it('throws when the first WAV buffer has no "data" sub-chunk', () => {
+      const noData = makeWavNoData();
+      const ok = makeWav(8, 0x01);
+      expect(() => concatAudioBuffers([noData, ok], 'audio/wav')).toThrow(/no "data" sub-chunk/);
+    });
+
+    it('throws when a LATER WAV buffer has no "data" sub-chunk', () => {
+      const ok = makeWav(8, 0x01);
+      const noData = makeWavNoData();
+      expect(() => concatAudioBuffers([ok, noData], 'audio/wav')).toThrow(/no "data" sub-chunk/);
+    });
+  });
+
+  describe('mp3 frame-length parsing across MPEG versions', () => {
+    it('parses an MPEG-2 Layer III frame (72000 coefficient) when stripping Xing on chunk 2', () => {
+      // MPEG-2 LayerIII, 64 kbps, 22050 Hz: frameLen = floor(72000*64/22050) = 209.
+      const first = makeMpeg2Frame({ fill: 0x11 });
+      const second = makeMpeg2Frame({ fill: 0x22, xing: true });
+      const result = new Uint8Array(concatAudioBuffers([first, second], 'audio/mpeg'));
+      // Chunk 2 is a single Xing frame → stripped entirely (0 bytes). Only chunk 1 (208) remains.
+      expect(result.byteLength).toBe(208);
+      expect(result[0]).toBe(0xff);
+    });
+  });
+
+  describe('ID3 strip guards', () => {
+    it('leaves chunk 2 unchanged when its declared ID3 tag length exceeds the buffer', () => {
+      const first = makeMp3Frame({ fill: 0x11 });
+      // Build a chunk 2 whose ID3 header declares a size larger than the buffer
+      // (synchsafe size = 0x7F in the last byte → 127, +10 header = 137 > frame).
+      const frame = new Uint8Array(makeMp3Frame({ fill: 0x22 }));
+      const id3 = new Uint8Array([0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x7f, 0x7f, 0x7f, 0x7f]);
+      const tagged = new Uint8Array(id3.length + frame.length);
+      tagged.set(id3, 0);
+      tagged.set(frame, id3.length);
+
+      const result = new Uint8Array(
+        concatAudioBuffers([first, tagged.buffer as ArrayBuffer], 'audio/mpeg')
+      );
+      // ID3 NOT stripped (tagLength >= length guard), so chunk 2 kept whole incl. its ID3.
+      // first(417) + tagged(10 + 417) = 844.
+      expect(result.byteLength).toBe(417 + 10 + 417);
+      // The ID3 'I' byte is preserved at the chunk-2 boundary.
+      expect(result[417]).toBe(0x49);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a **Read aloud → optionally save as audio + embed** feature to Nexus, working on **desktop and mobile**.

One unified **"Read aloud"** action per surface (editor context menu, file menu, command palette) →
**SavePromptModal** (save-or-not) → animated **ReadAloudProgressModal** (reuses the live-voice dot+waveform) → playback.
If the user chooses **Save & read** and then dismisses the modal, playback stops but the save's synth loop **continues in the background** and inserts a single `![[...]]` embed when done.

## How it works

- **`concatAudioBuffers(buffers, mimeType)`** — pure, mobile-safe helper: mp3 frame byte-join (+ID3/Xing strip on chunks 2…N) / WAV RIFF header-merge. **No AudioContext, no MediaRecorder, no Composer** — single concatenated file.
- **`ReadAloudService.startReadAloudSession()`** — single synth pass: each chunk synthesized **exactly once**, the same buffer feeds both playback and capture (no double-synth). `stopPlayback()` cancels playback only (swallows the exact `'Read aloud playback was stopped.'` sentinel); the save's synth loop runs to completion → concat → save → embed.
- **Settings-derived storage path** — `settings.settings.storage?.rootPath ?? DEFAULT_STORAGE_SETTINGS.rootPath` + configurable audio subfolder (default `audio`). **Never hardcodes `Nexus`.**
- Naming (timestamped, always-new): whole-note `<basename> - <ts>.mp3`, selection `<basename> - <first few words> - <ts>.mp3`.

## Quality

- **Auditor: GREEN** (7/7 watch points — no double-synth, background-save-survives-cancel, no hardcoded path, mobile-safe, animation reuse, old commands removed, S2 boundary).
- **Full suite: 3379 passed / 0 failed** (+13 net-new edge-case tests incl. a sentinel-string-drift counter-test proving the stop-contract is load-bearing; direct `ReadAloudSaveTail` N>1 buffer-driven coverage).
- Build + lint clean. **Manually tested in Obsidian** — read-aloud, save+embed, background-save-after-dismiss, and full-width waveform render all confirmed.

## Notes

- Bundle impact: **+12 KiB** on `main.js`.
- Reuses live-voice waveform classes (inherits reduced-motion handling); modal overrides scoped to `.read-aloud-progress` — shared live-voice rules untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)