### PR TITLE
[codex] Slim YAML frontmatter parsing bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "streaming-markdown": "^0.2.15",
         "tough-cookie": "^4.1.4",
         "uuid": "^11.1.1",
-        "winston": "^3.19.0",
-        "yaml": "^2.9.0"
+        "winston": "^3.19.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -55,7 +54,8 @@
         "obsidian": "^1.12.3",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.58.0"
+        "typescript-eslint": "^8.58.0",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -12181,6 +12181,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "obsidian": "^1.12.3",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.58.0"
+    "typescript-eslint": "^8.58.0",
+    "yaml": "^2.9.0"
   },
   "dependencies": {
     "@dao-xyz/sqlite3-vec": "^0.0.19",
@@ -74,7 +75,6 @@
     "streaming-markdown": "^0.2.15",
     "tough-cookie": "^4.1.4",
     "uuid": "^11.1.1",
-    "winston": "^3.19.0",
-    "yaml": "^2.9.0"
+    "winston": "^3.19.0"
   }
 }

--- a/src/agents/apps/composer/services/TextComposer.ts
+++ b/src/agents/apps/composer/services/TextComposer.ts
@@ -8,7 +8,7 @@
  * Used by: compose.ts tool when format='markdown'.
  */
 
-import { Vault } from 'obsidian';
+import { Vault, parseYaml, stringifyYaml } from 'obsidian';
 import { IFormatComposer, ComposeInput, ComposeOptions, ComposerError } from '../types';
 
 export class TextComposer implements IFormatComposer {
@@ -37,7 +37,7 @@ export class TextComposer implements IFormatComposer {
     for (const file of files) {
       let content = await vault.read(file);
 
-      const fmResult = await extractFrontmatter(content);
+      const fmResult = extractFrontmatter(content);
 
       switch (frontmatterHandling) {
         case 'first':
@@ -72,7 +72,7 @@ export class TextComposer implements IFormatComposer {
     let result = sections.join(separator);
 
     if (frontmatterHandling === 'merge' && Object.keys(mergedFrontmatter).length > 0) {
-      const fmYaml = await serializeFrontmatter(mergedFrontmatter);
+      const fmYaml = serializeFrontmatter(mergedFrontmatter);
       result = fmYaml + '\n' + result;
     }
 
@@ -82,13 +82,12 @@ export class TextComposer implements IFormatComposer {
 
 /**
  * Extract YAML frontmatter from markdown content.
- * Uses the 'yaml' package for robust parsing of nested structures,
- * arrays, and multi-line values.
+ * Uses Obsidian's YAML helpers for nested structures, arrays, and multi-line values.
  */
-async function extractFrontmatter(content: string): Promise<{
+function extractFrontmatter(content: string): {
   frontmatter: Record<string, unknown> | null;
   body: string;
-}> {
+} {
   // Strip BOM if present
   const trimmed = content.replace(/^\uFEFF/, '');
 
@@ -98,8 +97,7 @@ async function extractFrontmatter(content: string): Promise<{
   const body = trimmed.slice(match[0].length);
 
   try {
-    const { parse: yamlParse } = await import('yaml');
-    const parsed: unknown = yamlParse(match[1]);
+    const parsed: unknown = parseYaml(match[1]);
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
       return { frontmatter: parsed as Record<string, unknown>, body };
     }
@@ -113,7 +111,6 @@ async function extractFrontmatter(content: string): Promise<{
 /**
  * Serialize a frontmatter object back to YAML format.
  */
-async function serializeFrontmatter(fm: Record<string, unknown>): Promise<string> {
-  const { stringify: yamlStringify } = await import('yaml');
-  return '---\n' + yamlStringify(fm).trimEnd() + '\n---';
+function serializeFrontmatter(fm: Record<string, unknown>): string {
+  return '---\n' + stringifyYaml(fm).trimEnd() + '\n---';
 }

--- a/src/agents/apps/skills/services/SkillScanner.ts
+++ b/src/agents/apps/skills/services/SkillScanner.ts
@@ -71,7 +71,7 @@ export class SkillScanner {
           }
 
           const content = await this.adapter.read(skillMdPath);
-          const frontmatter = await parseSkillFrontmatter(content);
+          const frontmatter = parseSkillFrontmatter(content);
 
           // The (provider, name) index key is the on-disk FOLDER identity —
           // the same identity vaultPath/originPath are built from. The

--- a/src/agents/apps/skills/services/SkillSyncService.ts
+++ b/src/agents/apps/skills/services/SkillSyncService.ts
@@ -175,7 +175,7 @@ export class SkillSyncService {
             result.archived.push(archived);
           }
 
-          const fm = await parseSkillFrontmatter(content);
+          const fm = parseSkillFrontmatter(content);
           const description =
             typeof fm.description === 'string' && fm.description.trim().length > 0
               ? fm.description.trim()

--- a/src/agents/apps/skills/services/SkillValidator.ts
+++ b/src/agents/apps/skills/services/SkillValidator.ts
@@ -1,9 +1,8 @@
 /**
  * SkillValidator — pure, dependency-free validation of SKILL.md formatting conventions.
  *
- * No Obsidian imports, no Node imports. Pure TypeScript so it is trivially
- * unit-testable and mobile-safe. The only external dependency (`yaml`) is loaded
- * via a DYNAMIC import inside the async path so module init stays mobile-safe.
+ * Uses Obsidian's YAML helper for frontmatter parsing so no production YAML
+ * parser dependency is bundled.
  *
  * Validation rules (from docs/plans/skills-protocol-integration-plan.md §7):
  *   - `name` is required, non-empty, and lowercase-hyphenated.
@@ -17,6 +16,7 @@
  * All errors are collected (validation does not short-circuit at the first error).
  */
 
+import { parseYaml } from 'obsidian';
 import type { SkillValidationResult, SkillFrontmatterInput } from '../types';
 
 // Re-exported so callers can import the result/input shapes alongside the validator.
@@ -105,9 +105,9 @@ export class SkillValidator {
    *
    * The content must begin with a YAML frontmatter block delimited by `---`
    * lines. The `name`/`description` are extracted from it and validated via the
-   * same rules as {@link validate}. Async because YAML is dynamically imported.
+   * same rules as {@link validate}.
    */
-  async validateSkillMd(content: string): Promise<SkillValidationResult> {
+  validateSkillMd(content: string): SkillValidationResult {
     const errors: string[] = [];
     const raw = typeof content === 'string' ? content : '';
 
@@ -119,8 +119,7 @@ export class SkillValidator {
 
     let parsed: unknown;
     try {
-      const { parse } = await import('yaml');
-      parsed = parse(frontmatter);
+      parsed = parseYaml(frontmatter);
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       errors.push(`SKILL.md frontmatter is not valid YAML: ${message}`);

--- a/src/agents/apps/skills/services/SkillWriteService.ts
+++ b/src/agents/apps/skills/services/SkillWriteService.ts
@@ -11,11 +11,9 @@
  *     into a co-located `_archive/<ts>/` before any overwrite (last-writer-wins).
  *   - The CRUA `is_archived` soft-delete lives in the SQLite index, NOT here.
  *
- * `yaml` is dynamically imported inside {@link composeSkillMd} so module init
- * stays mobile-safe (no Node API at import time).
  */
 
-import { normalizePath } from 'obsidian';
+import { normalizePath, stringifyYaml } from 'obsidian';
 import type { DataAdapter } from 'obsidian';
 import { SnapshotArchiveService } from '../../../../services/storage/SnapshotArchiveService';
 
@@ -67,11 +65,10 @@ export class SkillWriteService {
 
   /**
    * Build a well-formed SKILL.md string: `name`/`description` frontmatter (YAML)
-   * followed by the trimmed body. `yaml` is dynamically imported (mobile-safe).
+   * followed by the trimmed body.
    */
-  async composeSkillMd(name: string, description: string, body: string): Promise<string> {
-    const { stringify } = await import('yaml');
-    const frontmatter = stringify({ name, description });
+  composeSkillMd(name: string, description: string, body: string): string {
+    const frontmatter = stringifyYaml({ name, description });
     return `---\n${frontmatter}---\n\n${body.trim()}\n`;
   }
 

--- a/src/agents/apps/skills/services/skillFrontmatter.ts
+++ b/src/agents/apps/skills/services/skillFrontmatter.ts
@@ -4,8 +4,8 @@
  * Located at: src/agents/apps/skills/services/skillFrontmatter.ts
  * Extracted so the scanner, the CRUA tools, and the SkillSyncService share ONE
  * implementation of "split a SKILL.md into its leading `---` YAML block + body".
- * `yaml` is dynamically imported (mobile-safe — no Node API at module init).
  */
+import { parseYaml } from 'obsidian';
 
 /**
  * Parse a SKILL.md: leading `---\nYAML\n---` block + trailing body.
@@ -18,9 +18,9 @@
  * (e.g. the scanner) must do so themselves — this util reports only what the
  * frontmatter actually contains.
  */
-export async function parseSkillFrontmatter(
+export function parseSkillFrontmatter(
   content: string
-): Promise<{ name?: string; description?: string; body: string }> {
+): { name?: string; description?: string; body: string } {
   const normalized = content.replace(/\r\n/g, '\n');
   const match = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(normalized);
   if (!match) {
@@ -30,8 +30,7 @@ export async function parseSkillFrontmatter(
   let name: string | undefined;
   let description: string | undefined;
   try {
-    const { parse } = await import('yaml');
-    const parsed: unknown = parse(match[1]);
+    const parsed: unknown = parseYaml(match[1]);
     if (parsed && typeof parsed === 'object') {
       const fields = parsed as Record<string, unknown>;
       if (typeof fields.name === 'string') {

--- a/src/agents/apps/skills/tools/createSkill.ts
+++ b/src/agents/apps/skills/tools/createSkill.ts
@@ -83,7 +83,7 @@ export class CreateSkillTool extends BaseTool<CreateSkillParams, CommonResult> {
       return this.prepareResult(false, undefined, `Skill already exists: ${provider}/${params.name}`);
     }
 
-    const skillMd = await write.composeSkillMd(params.name, params.description, params.body);
+    const skillMd = write.composeSkillMd(params.name, params.description, params.body);
     await write.writeSkill(folder, skillMd);
 
     await r.rt.index.upsertOne({

--- a/src/agents/apps/skills/tools/updateSkill.ts
+++ b/src/agents/apps/skills/tools/updateSkill.ts
@@ -66,7 +66,7 @@ export class UpdateSkillTool extends BaseTool<UpdateSkillParams, CommonResult> {
       return this.prepareResult(false, undefined,
         `Could not read SKILL.md for skill "${existing.name}" (${provider}) at ${existing.vaultPath}/SKILL.md`);
     }
-    const current = await parseSkillFrontmatter(currentContent);
+    const current = parseSkillFrontmatter(currentContent);
 
     // Merge: caller values win, else fall back to the current on-disk values.
     const newName = params.rename ?? existing.name;
@@ -102,7 +102,7 @@ export class UpdateSkillTool extends BaseTool<UpdateSkillParams, CommonResult> {
       return this.prepareResult(false, undefined, `Skill already exists: ${provider}/${newName}`);
     }
 
-    const skillMd = await write.composeSkillMd(newName, newDescription, newBody);
+    const skillMd = write.composeSkillMd(newName, newDescription, newBody);
 
     let archivedVersion: string | null;
     if (isRename) {

--- a/src/agents/contentManager/tools/write.ts
+++ b/src/agents/contentManager/tools/write.ts
@@ -1,4 +1,4 @@
-import { App, TFile } from 'obsidian';
+import { App, TFile, parseYaml } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { WriteParams, WriteResult } from '../types';
 import { ContentOperations } from '../utils/ContentOperations';
@@ -17,7 +17,7 @@ interface YamlParseError {
  * lists, and scalar document roots are rejected because Obsidian properties
  * are map-shaped.
  */
-async function validateFrontmatter(content: string): Promise<string | null> {
+function validateFrontmatter(content: string): string | null {
   const withoutBom = content.replace(/^\uFEFF/, '');
   const match = withoutBom.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
 
@@ -28,8 +28,7 @@ async function validateFrontmatter(content: string): Promise<string | null> {
   const frontmatterBody = match[1];
 
   try {
-    const { parse } = await import('yaml');
-    const parsed: unknown = parse(frontmatterBody);
+    const parsed: unknown = parseYaml(frontmatterBody);
 
     if (parsed === null || parsed === undefined) {
       return null;
@@ -131,7 +130,7 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
         return this.prepareResult(false, undefined, 'Content is required');
       }
 
-      const frontmatterError = await validateFrontmatter(content);
+      const frontmatterError = validateFrontmatter(content);
       if (frontmatterError) {
         return this.prepareResult(false, undefined, frontmatterError);
       }

--- a/src/components/skills/SkillsSectionRenderer.ts
+++ b/src/components/skills/SkillsSectionRenderer.ts
@@ -362,7 +362,7 @@ export class SkillsSectionRenderer {
                     new Notice(`A skill named "${name}" already exists for provider "nexus".`);
                     return false;
                 }
-                const skillMd = await bundle.write.composeSkillMd(name, description, body);
+                const skillMd = bundle.write.composeSkillMd(name, description, body);
                 await bundle.write.writeSkill(folder, skillMd);
                 await bundle.index.upsertOne({
                     provider: 'nexus',
@@ -382,7 +382,7 @@ export class SkillsSectionRenderer {
         // Edit mode — prefill from the current SKILL.md.
         void (async () => {
             const raw = await bundle.write.readSkillMd(skill.vaultPath);
-            const parsed = raw ? await parseSkillFrontmatter(raw) : { body: '' };
+            const parsed = raw ? parseSkillFrontmatter(raw) : { body: '' };
             const modal = new SkillEditModal(
                 this.app,
                 {
@@ -392,7 +392,7 @@ export class SkillsSectionRenderer {
                     body: parsed.body
                 },
                 async ({ description, body }) => {
-                    const skillMd = await bundle.write.composeSkillMd(skill.name, description, body);
+                    const skillMd = bundle.write.composeSkillMd(skill.name, description, body);
                     // Reuse the same archive-then-replace path as updateSkill.
                     await bundle.write.archiveThenReplace(
                         skill.vaultPath,

--- a/tests/mocks/obsidian/core.ts
+++ b/tests/mocks/obsidian/core.ts
@@ -1,6 +1,7 @@
 /**
  * Core Obsidian API mocks: Editor, files, App, Vault, Workspace, Platform.
  */
+import { parse, stringify } from 'yaml';
 
 // EditorPosition type
 export interface EditorPosition {
@@ -187,6 +188,14 @@ export function requestUrl(request: RequestUrlRequest): Promise<RequestUrlRespon
 
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/');
+}
+
+export function parseYaml(yaml: string): unknown {
+  return parse(yaml);
+}
+
+export function stringifyYaml(obj: unknown): string {
+  return stringify(obj);
 }
 
 // Events / EventRef mocks

--- a/tests/mocks/obsidian/index.ts
+++ b/tests/mocks/obsidian/index.ts
@@ -21,6 +21,8 @@ export {
   requestUrl,
   __setRequestUrlMock,
   normalizePath,
+  parseYaml,
+  stringifyYaml,
   Events,
   EventRef,
   MarkdownFileInfo,

--- a/tests/unit/SkillWriteService.test.ts
+++ b/tests/unit/SkillWriteService.test.ts
@@ -94,8 +94,8 @@ describe('SkillWriteService', () => {
       const match = /^---\n([\s\S]*?)\n---\n\n([\s\S]*)$/.exec(content);
       expect(match).not.toBeNull();
 
-      const { parse } = await import('yaml');
-      const fm = parse(match![1]) as Record<string, unknown>;
+      const { parseYaml } = await import('obsidian');
+      const fm = parseYaml(match![1]) as Record<string, unknown>;
       expect(fm.name).toBe('essay-editor');
       expect(fm.description).toBe('Edit essays for clarity.');
       expect(match![2].trim()).toBe('# Body\nText.');


### PR DESCRIPTION
## Summary
- Replace production yaml package imports with Obsidian parseYaml/stringifyYaml helpers
- Convert affected helpers and callsites back to synchronous flows
- Move yaml from dependencies to devDependencies for test/mock usage

## Validation
- npm run build passed in the primary workspace
- npx jest tests/unit/SkillWriteService.test.ts tests/unit/SkillValidator.test.ts --runInBand passed in the primary workspace
- Production bundle analysis dropped yaml bytes to 0 and reduced main.js by about 116 KB