### PR TITLE
Add Google Gemini live voice support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "test": "jest",
     "test:coverage": "jest --coverage --coverageThreshold='{\"global\":{\"branches\":80,\"functions\":80,\"lines\":80,\"statements\":80}}'",
+    "smoke:google-live": "node scripts/smoke-google-live.mjs",
     "lint": "npm run lint:obsidian",
     "lint:obsidian": "eslint .",
     "deploy": "npm run build && powershell.exe -ExecutionPolicy Bypass -File .\\postbuild.ps1",

--- a/scripts/smoke-google-live.mjs
+++ b/scripts/smoke-google-live.mjs
@@ -1,0 +1,281 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const GOOGLE_LIVE_ENDPOINT = 'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+const DEFAULT_MODEL = 'gemini-3.1-flash-live-preview';
+const DEFAULT_PROMPT = 'Reply with exactly the single word pong.';
+const DEFAULT_TIMEOUT_MS = 30000;
+
+loadEnvFiles(process.cwd(), ['.env.local', '.env']);
+
+const apiKey = firstNonEmpty(process.env.GOOGLE_API_KEY, process.env.GEMINI_API_KEY);
+if (!apiKey) {
+  console.error('Missing GOOGLE_API_KEY or GEMINI_API_KEY. Add one to your shell or repo .env before running this smoke test.');
+  process.exit(1);
+}
+
+if (typeof WebSocket === 'undefined') {
+  console.error('Global WebSocket is unavailable in this Node runtime.');
+  process.exit(1);
+}
+
+const model = firstNonEmpty(process.env.GOOGLE_LIVE_MODEL, process.env.GEMINI_LIVE_MODEL) ?? DEFAULT_MODEL;
+const prompt = process.env.GOOGLE_LIVE_SMOKE_PROMPT?.trim() || DEFAULT_PROMPT;
+const voice = firstNonEmpty(process.env.GOOGLE_LIVE_SMOKE_VOICE, process.env.GOOGLE_LIVE_VOICE) ?? 'Kore';
+const timeoutMs = parsePositiveInteger(process.env.GOOGLE_LIVE_SMOKE_TIMEOUT_MS) ?? DEFAULT_TIMEOUT_MS;
+
+const url = `${GOOGLE_LIVE_ENDPOINT}?key=${encodeURIComponent(apiKey)}`;
+const websocket = new WebSocket(url);
+
+const summary = {
+  opened: false,
+  setupComplete: false,
+  generationComplete: false,
+  turnComplete: false,
+  audioChunkCount: 0,
+  audioBytes: 0,
+  outputTranscript: '',
+  closeCode: null,
+  firstMessageType: null,
+  firstServerFrame: null,
+};
+
+let settled = false;
+
+const timeout = setTimeout(() => {
+  finish(new Error(`Timed out after ${timeoutMs}ms waiting for Gemini Live response.`));
+}, timeoutMs);
+
+websocket.addEventListener('open', () => {
+  summary.opened = true;
+  websocket.send(JSON.stringify({
+    setup: {
+      model: `models/${model}`,
+      generationConfig: {
+        responseModalities: ['AUDIO'],
+        speechConfig: {
+          voiceConfig: {
+            prebuiltVoiceConfig: {
+              voiceName: voice,
+            },
+          },
+        },
+      },
+      outputAudioTranscription: {},
+    },
+  }));
+});
+
+websocket.addEventListener('message', async (event) => {
+  try {
+    const rawText = await coerceMessageText(event.data);
+    if (!rawText) {
+      return;
+    }
+
+    if (!summary.firstMessageType) {
+      summary.firstMessageType = describeMessagePayload(event.data);
+      summary.firstServerFrame = rawText.slice(0, 500);
+    }
+
+    const message = JSON.parse(rawText);
+    if (message.setupComplete !== undefined) {
+      summary.setupComplete = true;
+      websocket.send(JSON.stringify({
+        clientContent: {
+          turns: [
+            {
+              role: 'user',
+              parts: [{ text: prompt }],
+            },
+          ],
+          turnComplete: true,
+        },
+      }));
+      return;
+    }
+
+    if (message.serverContent) {
+      const { serverContent } = message;
+      if (typeof serverContent.outputTranscription?.text === 'string') {
+        summary.outputTranscript = serverContent.outputTranscription.text.trim();
+      }
+
+      const parts = Array.isArray(serverContent.modelTurn?.parts) ? serverContent.modelTurn.parts : [];
+      for (const part of parts) {
+        const data = part?.inlineData?.data;
+        if (typeof data !== 'string' || data.length === 0) {
+          continue;
+        }
+        summary.audioChunkCount += 1;
+        summary.audioBytes += estimateBase64Bytes(data);
+      }
+
+      if (serverContent.generationComplete === true) {
+        summary.generationComplete = true;
+      }
+
+      if (serverContent.turnComplete === true) {
+        summary.turnComplete = true;
+      }
+
+      if (summary.turnComplete && (summary.audioChunkCount > 0 || summary.outputTranscript.length > 0)) {
+        finish();
+      }
+      return;
+    }
+
+    if (message.goAway) {
+      finish(new Error('Gemini Live sent goAway before the smoke test completed.'));
+      return;
+    }
+
+    if (message.toolCall) {
+      finish(new Error('Gemini Live requested a tool call during the smoke test, which this harness does not handle.'));
+    }
+  } catch (error) {
+    finish(error);
+  }
+});
+
+websocket.addEventListener('error', () => {
+  finish(new Error('Gemini Live WebSocket failed. Check network access and API key configuration.'));
+});
+
+websocket.addEventListener('close', (event) => {
+  summary.closeCode = event.code;
+  if (!settled) {
+    finish(new Error(`Gemini Live WebSocket closed before completion (code ${event.code}${event.reason ? `, reason: ${event.reason}` : ''}).`));
+  }
+});
+
+function finish(error) {
+  if (settled) {
+    return;
+  }
+  settled = true;
+  clearTimeout(timeout);
+
+  if (websocket.readyState === WebSocket.OPEN || websocket.readyState === WebSocket.CONNECTING) {
+    websocket.close();
+  }
+
+  if (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(JSON.stringify(summary, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(JSON.stringify({
+    status: 'ok',
+    model,
+    voice,
+    prompt,
+    ...summary,
+  }, null, 2));
+}
+
+function loadEnvFiles(rootDir, fileNames) {
+  for (const fileName of fileNames) {
+    const filePath = path.join(rootDir, fileName);
+    if (!fs.existsSync(filePath)) {
+      continue;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    for (const line of content.split(/\r?\n/)) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/);
+      if (!match) {
+        continue;
+      }
+
+      const [, key, rawValue] = match;
+      if (process.env[key]) {
+        continue;
+      }
+
+      process.env[key] = stripMatchingQuotes(rawValue);
+    }
+  }
+}
+
+function stripMatchingQuotes(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+    || (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function parsePositiveInteger(value) {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function estimateBase64Bytes(base64) {
+  const normalized = base64.replace(/=+$/, '');
+  return Math.floor(normalized.length * 3 / 4);
+}
+
+async function coerceMessageText(data) {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return await data.text();
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+  }
+
+  return null;
+}
+
+function describeMessagePayload(data) {
+  if (typeof data === 'string') {
+    return 'string';
+  }
+
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return 'blob';
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return 'arraybuffer';
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return data.constructor?.name ?? 'typed-array';
+  }
+
+  return typeof data;
+}

--- a/src/services/llm/types/RealtimeVoiceTypes.ts
+++ b/src/services/llm/types/RealtimeVoiceTypes.ts
@@ -74,6 +74,39 @@ const OPENAI_REALTIME_VOICES: RealtimeVoiceDeclaration[] = [
   { id: 'cedar', name: 'Cedar' }
 ];
 
+const GOOGLE_REALTIME_VOICES: RealtimeVoiceDeclaration[] = [
+  { id: 'Zephyr', name: 'Zephyr', description: 'Bright' },
+  { id: 'Puck', name: 'Puck', description: 'Upbeat' },
+  { id: 'Charon', name: 'Charon', description: 'Informative' },
+  { id: 'Kore', name: 'Kore', description: 'Firm' },
+  { id: 'Fenrir', name: 'Fenrir', description: 'Excitable' },
+  { id: 'Leda', name: 'Leda', description: 'Youthful' },
+  { id: 'Orus', name: 'Orus', description: 'Firm' },
+  { id: 'Aoede', name: 'Aoede', description: 'Breezy' },
+  { id: 'Callirrhoe', name: 'Callirrhoe', description: 'Easy-going' },
+  { id: 'Autonoe', name: 'Autonoe', description: 'Bright' },
+  { id: 'Enceladus', name: 'Enceladus', description: 'Breathy' },
+  { id: 'Iapetus', name: 'Iapetus', description: 'Clear' },
+  { id: 'Umbriel', name: 'Umbriel', description: 'Easy-going' },
+  { id: 'Algieba', name: 'Algieba', description: 'Smooth' },
+  { id: 'Despina', name: 'Despina', description: 'Smooth' },
+  { id: 'Erinome', name: 'Erinome', description: 'Clear' },
+  { id: 'Algenib', name: 'Algenib', description: 'Gravelly' },
+  { id: 'Rasalgethi', name: 'Rasalgethi', description: 'Informative' },
+  { id: 'Laomedeia', name: 'Laomedeia', description: 'Upbeat' },
+  { id: 'Achernar', name: 'Achernar', description: 'Soft' },
+  { id: 'Alnilam', name: 'Alnilam', description: 'Firm' },
+  { id: 'Schedar', name: 'Schedar', description: 'Even' },
+  { id: 'Gacrux', name: 'Gacrux', description: 'Mature' },
+  { id: 'Pulcherrima', name: 'Pulcherrima', description: 'Forward' },
+  { id: 'Achird', name: 'Achird', description: 'Friendly' },
+  { id: 'Zubenelgenubi', name: 'Zubenelgenubi', description: 'Casual' },
+  { id: 'Vindemiatrix', name: 'Vindemiatrix', description: 'Gentle' },
+  { id: 'Sadachbia', name: 'Sadachbia', description: 'Lively' },
+  { id: 'Sadaltager', name: 'Sadaltager', description: 'Knowledgeable' },
+  { id: 'Sulafat', name: 'Sulafat', description: 'Warm' },
+];
+
 const REALTIME_VOICE_MODELS: RealtimeVoiceModelDeclaration[] = [
   {
     provider: 'openai',
@@ -102,6 +135,8 @@ const REALTIME_VOICE_MODELS: RealtimeVoiceModelDeclaration[] = [
     id: 'gemini-3.1-flash-live-preview',
     name: 'Gemini 3.1 Flash Live Preview',
     transport: 'websocket',
+    defaultVoice: 'Kore',
+    voices: GOOGLE_REALTIME_VOICES,
     supportsTools: true,
     supportsTranscripts: true
   },

--- a/src/services/realtimeVoice/GoogleRealtimeVoiceSession.ts
+++ b/src/services/realtimeVoice/GoogleRealtimeVoiceSession.ts
@@ -1,0 +1,585 @@
+import type {
+  RealtimeVoiceSession,
+  ResolvedGoogleRealtimeVoiceSessionRequest,
+} from './RealtimeVoiceSessionTypes';
+
+interface GoogleInlineData {
+  data?: unknown;
+  mimeType?: unknown;
+}
+
+interface GooglePart {
+  inlineData?: GoogleInlineData;
+  text?: unknown;
+}
+
+interface GoogleServerContent {
+  generationComplete?: unknown;
+  turnComplete?: unknown;
+  interrupted?: unknown;
+  inputTranscription?: {
+    text?: unknown;
+  };
+  outputTranscription?: {
+    text?: unknown;
+  };
+  modelTurn?: {
+    parts?: GooglePart[];
+  };
+}
+
+interface GoogleServerMessage {
+  setupComplete?: unknown;
+  serverContent?: GoogleServerContent;
+  goAway?: {
+    timeLeft?: unknown;
+  };
+}
+
+const GOOGLE_SAMPLE_RATE_IN = 16000;
+const GOOGLE_SAMPLE_RATE_OUT = 24000;
+const GOOGLE_LIVE_ENDPOINT = 'wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent';
+
+export class GoogleRealtimeVoiceSession implements RealtimeVoiceSession {
+  private websocket: WebSocket | null = null;
+  private mediaStream: MediaStream | null = null;
+  private captureAudioContext: AudioContext | null = null;
+  private playbackAudioContext: AudioContext | null = null;
+  private captureSource: MediaStreamAudioSourceNode | null = null;
+  // Obsidian/Electron still relies on the simpler ScriptProcessor path here until
+  // we add a dedicated AudioWorklet processor bundle for live voice capture.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  private captureProcessor: ScriptProcessorNode | null = null;
+  private captureSink: GainNode | null = null;
+  private queuedSources = new Set<AudioBufferSourceNode>();
+  private playbackCursorTime = 0;
+  private currentState: 'connecting' | 'listening' | 'user-speaking' | 'assistant-speaking' | null = null;
+  private assistantTurnFinishing = false;
+  private configured = false;
+  private stopped = false;
+  private pendingUserTranscript = '';
+  private lastCommittedUserTranscript = '';
+  private currentAssistantTranscript = '';
+
+  constructor(private readonly request: ResolvedGoogleRealtimeVoiceSessionRequest) {}
+
+  async start(): Promise<void> {
+    this.assertRuntimeSupport();
+    this.stopped = false;
+    this.configured = false;
+    this.currentState = null;
+    this.assistantTurnFinishing = false;
+    this.emitStateChange('connecting');
+
+    const url = `${GOOGLE_LIVE_ENDPOINT}?key=${encodeURIComponent(this.request.apiKey)}`;
+    const websocket = new WebSocket(url);
+    this.websocket = websocket;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      const rejectOnce = (error: unknown): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.stop();
+        const normalized = error instanceof Error ? error : new Error(String(error));
+        reject(normalized);
+      };
+
+      const resolveOnce = (): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        resolve();
+      };
+
+      websocket.onopen = () => {
+        if (this.stopped) {
+          return;
+        }
+
+        this.sendMessage({
+          setup: {
+            model: `models/${this.request.model}`,
+            generationConfig: {
+              responseModalities: ['AUDIO'],
+              speechConfig: {
+                voiceConfig: {
+                  prebuiltVoiceConfig: {
+                    voiceName: this.request.voice,
+                  },
+                },
+              },
+            },
+            systemInstruction: this.request.instructions
+              ? { parts: [{ text: this.request.instructions }] }
+              : undefined,
+            inputAudioTranscription: {},
+            outputAudioTranscription: {},
+          },
+        });
+      };
+
+      websocket.onerror = (event) => {
+        rejectOnce(new Error(`Google live voice WebSocket failed.${event ? ' Check network or API key configuration.' : ''}`));
+      };
+
+      websocket.onclose = (event) => {
+        if (this.stopped) {
+          return;
+        }
+
+        const reason = event.reason?.trim();
+        const message = reason
+          ? `Google live voice connection closed: ${reason}`
+          : `Google live voice connection closed (code ${event.code}).`;
+
+        if (!settled) {
+          rejectOnce(new Error(message));
+          return;
+        }
+
+        this.request.callbacks.onError(message);
+      };
+
+      websocket.onmessage = async (event) => {
+        try {
+          await this.handleServerMessage(event.data);
+          if (this.configured) {
+            resolveOnce();
+          }
+        } catch (error) {
+          if (!settled) {
+            rejectOnce(error);
+            return;
+          }
+
+          this.request.callbacks.onError(
+            error instanceof Error ? error.message : 'Google live voice session failed.',
+            error
+          );
+        }
+      };
+    });
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.configured = false;
+    this.currentState = null;
+    this.pendingUserTranscript = '';
+    this.currentAssistantTranscript = '';
+    this.assistantTurnFinishing = false;
+    this.clearPlaybackQueue();
+
+    if (this.captureProcessor) {
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      this.captureProcessor.onaudioprocess = null;
+      this.captureProcessor.disconnect();
+      this.captureProcessor = null;
+    }
+    this.captureSource?.disconnect();
+    this.captureSource = null;
+    this.captureSink?.disconnect();
+    this.captureSink = null;
+
+    this.mediaStream?.getTracks().forEach(track => track.stop());
+    this.mediaStream = null;
+
+    if (this.captureAudioContext) {
+      void this.captureAudioContext.close();
+      this.captureAudioContext = null;
+    }
+
+    if (this.playbackAudioContext) {
+      void this.playbackAudioContext.close();
+      this.playbackAudioContext = null;
+      this.playbackCursorTime = 0;
+    }
+
+    if (this.websocket && this.websocket.readyState === WebSocket.OPEN) {
+      this.websocket.close();
+    }
+    this.websocket = null;
+  }
+
+  private assertRuntimeSupport(): void {
+    if (typeof WebSocket === 'undefined') {
+      throw new Error('WebSocket is not available in this Obsidian environment.');
+    }
+
+    if (typeof AudioContext === 'undefined') {
+      throw new Error('AudioContext is not available in this Obsidian environment.');
+    }
+
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      throw new Error('Microphone capture is not available in this Obsidian environment.');
+    }
+  }
+
+  private async startAudioCapture(): Promise<void> {
+    this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.captureAudioContext = new AudioContext({ sampleRate: GOOGLE_SAMPLE_RATE_IN });
+    this.playbackAudioContext = new AudioContext();
+
+    await Promise.all([
+      this.captureAudioContext.resume(),
+      this.playbackAudioContext.resume(),
+    ]);
+
+    const source = this.captureAudioContext.createMediaStreamSource(this.mediaStream);
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const processor = this.captureAudioContext.createScriptProcessor(2048, 1, 1);
+    const sink = this.captureAudioContext.createGain();
+    sink.gain.value = 0;
+
+    source.connect(processor);
+    processor.connect(sink);
+    sink.connect(this.captureAudioContext.destination);
+
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    processor.onaudioprocess = (event) => {
+      if (this.stopped || !this.configured || !this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+        return;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      const inputBuffer = event.inputBuffer;
+      const channelData = inputBuffer.getChannelData(0);
+      const audioBase64 = encodeFloatPcm16Base64(channelData, inputBuffer.sampleRate, GOOGLE_SAMPLE_RATE_IN);
+      if (!audioBase64) {
+        return;
+      }
+
+      this.emitStateChange('user-speaking');
+
+      this.sendMessage({
+        realtimeInput: {
+          audio: {
+            data: audioBase64,
+            mimeType: 'audio/pcm;rate=16000',
+          },
+        },
+      });
+    };
+
+    this.captureSource = source;
+    this.captureProcessor = processor;
+    this.captureSink = sink;
+  }
+
+  private sendMessage(payload: Record<string, unknown>): void {
+    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.websocket.send(JSON.stringify(payload));
+  }
+
+  private async handleServerMessage(rawData: unknown): Promise<void> {
+    if (this.stopped) {
+      return;
+    }
+
+    const messageText = await coerceMessageText(rawData);
+    if (!messageText) {
+      return;
+    }
+
+    const message = JSON.parse(messageText) as GoogleServerMessage;
+
+    if (message.setupComplete !== undefined) {
+      this.configured = true;
+      void this.startAudioCapture()
+        .then(() => {
+          if (!this.stopped) {
+            this.emitStateChange('listening');
+          }
+        })
+        .catch((error) => {
+          this.request.callbacks.onError(
+            error instanceof Error ? error.message : 'Failed to start Google live audio capture.',
+            error
+          );
+          this.stop();
+        });
+      return;
+    }
+
+    if (message.goAway && !this.stopped) {
+      this.request.callbacks.onError('Google live voice session is ending soon. Stop and restart the session if needed.');
+      return;
+    }
+
+    const serverContent = message.serverContent;
+    if (!serverContent) {
+      return;
+    }
+
+    const userTranscript = normalizeText(serverContent.inputTranscription?.text);
+    if (userTranscript) {
+      this.pendingUserTranscript = mergeTranscriptFragments(this.pendingUserTranscript, userTranscript).merged;
+      this.emitStateChange('user-speaking');
+    }
+
+    const assistantTranscript = normalizeText(serverContent.outputTranscription?.text);
+    if (assistantTranscript) {
+      this.flushPendingUserTranscript();
+      this.emitStateChange('assistant-speaking');
+      const mergedTranscript = mergeTranscriptFragments(this.currentAssistantTranscript, assistantTranscript);
+      this.currentAssistantTranscript = mergedTranscript.merged;
+      if (mergedTranscript.delta) {
+        this.request.callbacks.onAssistantTranscriptDelta?.(mergedTranscript.delta);
+      }
+    }
+
+    const parts = serverContent.modelTurn?.parts;
+    if (Array.isArray(parts)) {
+      for (const part of parts) {
+        const data = part.inlineData?.data;
+        if (typeof data !== 'string' || data.length === 0) {
+          continue;
+        }
+        this.flushPendingUserTranscript();
+        this.emitStateChange('assistant-speaking');
+        this.playAudioChunk(data);
+      }
+    }
+
+    if (serverContent.interrupted === true) {
+      this.assistantTurnFinishing = false;
+      this.clearPlaybackQueue();
+      this.emitStateChange('listening');
+      return;
+    }
+
+    if (serverContent.turnComplete === true || serverContent.generationComplete === true) {
+      this.finishAssistantTurn();
+    }
+  }
+
+  private emitStateChange(state: 'connecting' | 'listening' | 'user-speaking' | 'assistant-speaking'): void {
+    if (this.currentState === state) {
+      return;
+    }
+
+    this.currentState = state;
+    this.request.callbacks.onStateChange(state);
+  }
+
+  private finishAssistantTurn(): void {
+    this.flushPendingUserTranscript();
+    this.flushAssistantTranscript();
+
+    if (this.queuedSources.size === 0) {
+      this.assistantTurnFinishing = false;
+      this.emitStateChange('listening');
+      return;
+    }
+
+    this.assistantTurnFinishing = true;
+  }
+
+  private playAudioChunk(base64Data: string): void {
+    if (!this.playbackAudioContext) {
+      return;
+    }
+
+    const samples = decodeBase64Pcm16(base64Data);
+    if (samples.length === 0) {
+      return;
+    }
+
+    const buffer = this.playbackAudioContext.createBuffer(1, samples.length, GOOGLE_SAMPLE_RATE_OUT);
+    const channelSamples = new Float32Array(samples.length);
+    channelSamples.set(samples);
+    buffer.copyToChannel(channelSamples, 0);
+
+    const source = this.playbackAudioContext.createBufferSource();
+    source.buffer = buffer;
+    source.connect(this.playbackAudioContext.destination);
+
+    const startTime = Math.max(this.playbackAudioContext.currentTime, this.playbackCursorTime);
+    source.start(startTime);
+    this.playbackCursorTime = startTime + buffer.duration;
+    this.queuedSources.add(source);
+    source.onended = () => {
+      this.queuedSources.delete(source);
+      if (this.queuedSources.size === 0 && this.playbackAudioContext) {
+        this.playbackCursorTime = this.playbackAudioContext.currentTime;
+      }
+      if (this.queuedSources.size === 0 && this.assistantTurnFinishing && !this.stopped) {
+        this.assistantTurnFinishing = false;
+        this.emitStateChange('listening');
+      }
+    };
+  }
+
+  private clearPlaybackQueue(): void {
+    for (const source of this.queuedSources) {
+      try {
+        source.stop();
+      } catch {
+        // Ignore already-stopped sources.
+      }
+      source.disconnect();
+    }
+    this.queuedSources.clear();
+    if (this.playbackAudioContext) {
+      this.playbackCursorTime = this.playbackAudioContext.currentTime;
+    } else {
+      this.playbackCursorTime = 0;
+    }
+  }
+
+  private flushPendingUserTranscript(): void {
+    if (!this.pendingUserTranscript || this.pendingUserTranscript === this.lastCommittedUserTranscript) {
+      return;
+    }
+
+    this.request.callbacks.onUserTranscript?.(this.pendingUserTranscript);
+    this.lastCommittedUserTranscript = this.pendingUserTranscript;
+    this.pendingUserTranscript = '';
+  }
+
+  private flushAssistantTranscript(): void {
+    const transcript = this.currentAssistantTranscript.trim();
+    this.currentAssistantTranscript = '';
+    if (!transcript) {
+      return;
+    }
+
+    this.request.callbacks.onAssistantTranscriptCompleted?.(transcript);
+  }
+}
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
+}
+
+function mergeTranscriptFragments(previous: string, incoming: string): { merged: string; delta: string } {
+  if (!previous) {
+    return { merged: incoming, delta: incoming };
+  }
+
+  if (!incoming || incoming === previous) {
+    return { merged: previous, delta: '' };
+  }
+
+  if (incoming.startsWith(previous)) {
+    return { merged: incoming, delta: incoming.slice(previous.length) };
+  }
+
+  if (previous.startsWith(incoming)) {
+    return { merged: previous, delta: '' };
+  }
+
+  const overlap = findTranscriptOverlap(previous, incoming);
+  if (overlap >= 3) {
+    const delta = incoming.slice(overlap);
+    return {
+      merged: previous + delta,
+      delta,
+    };
+  }
+
+  const joiner = needsTranscriptSpace(previous, incoming) ? ' ' : '';
+  return {
+    merged: `${previous}${joiner}${incoming}`,
+    delta: `${joiner}${incoming}`,
+  };
+}
+
+function findTranscriptOverlap(previous: string, incoming: string): number {
+  const maxOverlap = Math.min(previous.length, incoming.length);
+  for (let size = maxOverlap; size > 0; size -= 1) {
+    if (previous.slice(-size) === incoming.slice(0, size)) {
+      return size;
+    }
+  }
+
+  return 0;
+}
+
+function needsTranscriptSpace(previous: string, incoming: string): boolean {
+  return !/[\s([{'"-]$/.test(previous) && !/^[\s,.;:!?)}'"-]/.test(incoming);
+}
+
+function encodeFloatPcm16Base64(samples: Float32Array, inputRate: number, targetRate: number): string {
+  const resampled = inputRate === targetRate
+    ? samples
+    : resampleLinear(samples, inputRate, targetRate);
+
+  if (resampled.length === 0) {
+    return '';
+  }
+
+  const pcm = new Int16Array(resampled.length);
+  for (let index = 0; index < resampled.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, resampled[index]));
+    pcm[index] = sample < 0 ? Math.round(sample * 0x8000) : Math.round(sample * 0x7fff);
+  }
+
+  const bytes = new Uint8Array(pcm.buffer);
+  let binary = '';
+  for (let index = 0; index < bytes.length; index += 1) {
+    binary += String.fromCharCode(bytes[index]);
+  }
+  return btoa(binary);
+}
+
+function resampleLinear(samples: Float32Array, inputRate: number, targetRate: number): Float32Array {
+  const targetLength = Math.max(1, Math.round(samples.length * targetRate / inputRate));
+  const result = new Float32Array(targetLength);
+  const scale = inputRate / targetRate;
+
+  for (let index = 0; index < targetLength; index += 1) {
+    const position = index * scale;
+    const left = Math.floor(position);
+    const right = Math.min(left + 1, samples.length - 1);
+    const weight = position - left;
+    result[index] = samples[left] + (samples[right] - samples[left]) * weight;
+  }
+
+  return result;
+}
+
+function decodeBase64Pcm16(base64Data: string): Float32Array {
+  const binary = atob(base64Data);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  const sampleCount = Math.floor(bytes.byteLength / 2);
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const samples = new Float32Array(sampleCount);
+  for (let index = 0; index < sampleCount; index += 1) {
+    samples[index] = view.getInt16(index * 2, true) / 0x8000;
+  }
+
+  return samples;
+}
+
+async function coerceMessageText(data: unknown): Promise<string | null> {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return data.text();
+  }
+
+  if (data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(new Uint8Array(data));
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+  }
+
+  return null;
+}

--- a/src/services/realtimeVoice/RealtimeVoiceService.ts
+++ b/src/services/realtimeVoice/RealtimeVoiceService.ts
@@ -5,10 +5,12 @@ import {
   resolveDefaultRealtimeVoiceSelection,
 } from '../llm/types/RealtimeVoiceTypes';
 import { OpenAIRealtimeVoiceSession } from './OpenAIRealtimeVoiceSession';
+import { GoogleRealtimeVoiceSession } from './GoogleRealtimeVoiceSession';
 import type {
   RealtimeVoiceAvailability,
   RealtimeVoiceSession,
   RealtimeVoiceSessionRequest,
+  RealtimeVoiceSelection,
   ResolvedRealtimeVoiceSessionRequest,
 } from './RealtimeVoiceSessionTypes';
 
@@ -21,30 +23,15 @@ export class RealtimeVoiceService {
       return { available: false, reason: 'No realtime voice provider/model is configured.' };
     }
 
-    if (selection.provider !== 'openai') {
-      return {
-        available: false,
-        reason: `Realtime voice provider "${selection.provider}" is configured, but only OpenAI WebRTC is wired in this build.`,
-      };
-    }
-
-    if (!this.getOpenAIApiKey()) {
-      return { available: false, reason: 'OpenAI is not enabled and configured for live voice.' };
-    }
-
-    if (typeof RTCPeerConnection === 'undefined') {
-      return { available: false, reason: 'WebRTC is not available in this Obsidian environment.' };
-    }
-
-    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
-      return { available: false, reason: 'Microphone capture is not available in this Obsidian environment.' };
-    }
-
-    return { available: true };
+    return this.getProviderAvailability(selection);
   }
 
   createSession(request: Omit<RealtimeVoiceSessionRequest, 'llmSettings'>): RealtimeVoiceSession {
     const resolved = this.resolveRequest(request);
+    if (resolved.provider === 'google') {
+      return new GoogleRealtimeVoiceSession(resolved);
+    }
+
     return new OpenAIRealtimeVoiceSession(resolved);
   }
 
@@ -56,26 +43,37 @@ export class RealtimeVoiceService {
       throw new Error('No realtime voice provider/model is configured.');
     }
 
-    if (selection.provider !== 'openai') {
-      throw new Error(`Realtime voice provider "${selection.provider}" is not wired yet.`);
+    const availability = this.getProviderAvailability(selection);
+    if (!availability.available) {
+      throw new Error(availability.reason ?? `Realtime voice provider "${selection.provider}" is unavailable.`);
     }
 
-    const apiKey = this.getOpenAIApiKey();
-    if (!apiKey) {
-      throw new Error('OpenAI is not enabled and configured for live voice.');
+    if (selection.provider === 'google') {
+      return {
+        provider: 'google',
+        model: selection.model,
+        voice: selection.voice,
+        apiKey: this.getGoogleApiKey(),
+        instructions: request.instructions,
+        callbacks: request.callbacks,
+      };
+    }
+
+    if (selection.provider !== 'openai') {
+      throw new Error(`Realtime voice provider "${selection.provider}" is not wired yet.`);
     }
 
     return {
       provider: 'openai',
       model: selection.model,
       voice: selection.voice,
-      apiKey,
+      apiKey: this.getOpenAIApiKey(),
       instructions: request.instructions,
       callbacks: request.callbacks,
     };
   }
 
-  private resolveSelection(): { provider: string; model: string; voice: string } | null {
+  private resolveSelection(): RealtimeVoiceSelection | null {
     const availability = buildRealtimeVoiceProviderAvailability(this.llmSettings);
     const selection = resolveDefaultRealtimeVoiceSelection(this.llmSettings, availability);
     if (selection.status !== 'resolved' || !selection.provider || !selection.model) {
@@ -90,8 +88,56 @@ export class RealtimeVoiceService {
     };
   }
 
+  private getProviderAvailability(selection: RealtimeVoiceSelection): RealtimeVoiceAvailability {
+    if (typeof navigator === 'undefined' || !navigator.mediaDevices?.getUserMedia) {
+      return { available: false, reason: 'Microphone capture is not available in this Obsidian environment.' };
+    }
+
+    if (selection.provider === 'elevenlabs') {
+      return {
+        available: false,
+        reason: 'Realtime voice provider "elevenlabs" is configured, but only OpenAI WebRTC and Google Live are wired in this build.',
+      };
+    }
+
+    if (selection.provider === 'google') {
+      if (!this.getGoogleApiKey()) {
+        return { available: false, reason: 'Google is not enabled and configured for live voice.' };
+      }
+
+      if (typeof WebSocket === 'undefined') {
+        return { available: false, reason: 'WebSocket is not available in this Obsidian environment.' };
+      }
+
+      if (typeof AudioContext === 'undefined') {
+        return { available: false, reason: 'AudioContext is not available in this Obsidian environment.' };
+      }
+
+      return { available: true };
+    }
+
+    if (!this.getOpenAIApiKey()) {
+      return { available: false, reason: 'OpenAI is not enabled and configured for live voice.' };
+    }
+
+    if (typeof RTCPeerConnection === 'undefined') {
+      return { available: false, reason: 'WebRTC is not available in this Obsidian environment.' };
+    }
+
+    return { available: true };
+  }
+
   private getOpenAIApiKey(): string {
     const config = this.llmSettings?.providers.openai;
+    if (!config?.enabled) {
+      return '';
+    }
+
+    return config.apiKey?.trim() ?? '';
+  }
+
+  private getGoogleApiKey(): string {
+    const config = this.llmSettings?.providers.google;
     if (!config?.enabled) {
       return '';
     }

--- a/src/services/realtimeVoice/RealtimeVoiceSessionTypes.ts
+++ b/src/services/realtimeVoice/RealtimeVoiceSessionTypes.ts
@@ -20,13 +20,31 @@ export interface RealtimeVoiceSessionRequest {
   callbacks: RealtimeVoiceSessionCallbacks;
 }
 
-export interface ResolvedRealtimeVoiceSessionRequest {
-  provider: 'openai';
+interface BaseResolvedRealtimeVoiceSessionRequest {
+  provider: 'openai' | 'google';
   model: string;
   voice: string;
   apiKey: string;
   instructions?: string;
   callbacks: RealtimeVoiceSessionCallbacks;
+}
+
+export interface ResolvedOpenAIRealtimeVoiceSessionRequest extends BaseResolvedRealtimeVoiceSessionRequest {
+  provider: 'openai';
+}
+
+export interface ResolvedGoogleRealtimeVoiceSessionRequest extends BaseResolvedRealtimeVoiceSessionRequest {
+  provider: 'google';
+}
+
+export type ResolvedRealtimeVoiceSessionRequest =
+  | ResolvedOpenAIRealtimeVoiceSessionRequest
+  | ResolvedGoogleRealtimeVoiceSessionRequest;
+
+export interface RealtimeVoiceSelection {
+  provider: 'openai' | 'google' | 'elevenlabs';
+  model: string;
+  voice: string;
 }
 
 export interface RealtimeVoiceAvailability {

--- a/tests/unit/GoogleRealtimeVoiceSession.test.ts
+++ b/tests/unit/GoogleRealtimeVoiceSession.test.ts
@@ -1,0 +1,129 @@
+import { GoogleRealtimeVoiceSession } from '../../src/services/realtimeVoice/GoogleRealtimeVoiceSession';
+import type { ResolvedGoogleRealtimeVoiceSessionRequest } from '../../src/services/realtimeVoice/RealtimeVoiceSessionTypes';
+
+type TestableGoogleRealtimeVoiceSession = GoogleRealtimeVoiceSession & {
+  handleServerMessage: (rawData: unknown) => Promise<void>;
+  startAudioCapture: () => Promise<void>;
+};
+
+describe('GoogleRealtimeVoiceSession', () => {
+  function createSession(callbacks: Partial<ResolvedGoogleRealtimeVoiceSessionRequest['callbacks']> = {}) {
+    return new GoogleRealtimeVoiceSession({
+      provider: 'google',
+      model: 'gemini-3.1-flash-live-preview',
+      voice: 'Kore',
+      apiKey: 'test-key',
+      callbacks: {
+        onStateChange: jest.fn(),
+        onError: jest.fn(),
+        onUserTranscript: jest.fn(),
+        onAssistantTranscriptDelta: jest.fn(),
+        onAssistantTranscriptCompleted: jest.fn(),
+        ...callbacks,
+      },
+    }) as TestableGoogleRealtimeVoiceSession;
+  }
+
+  it('buffers the user transcript until assistant output begins', async () => {
+    const onUserTranscript = jest.fn();
+    const onAssistantTranscriptDelta = jest.fn();
+    const session = createSession({
+      onUserTranscript,
+      onAssistantTranscriptDelta,
+    });
+
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        inputTranscription: { text: 'Hello Nexus' },
+      },
+    }));
+
+    expect(onUserTranscript).not.toHaveBeenCalled();
+
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'Hi there' },
+      },
+    }));
+
+    expect(onUserTranscript).toHaveBeenCalledWith('Hello Nexus');
+    expect(onAssistantTranscriptDelta).toHaveBeenCalledWith('Hi there');
+  });
+
+  it('emits only the incremental assistant delta and completes on turnComplete', async () => {
+    const onAssistantTranscriptDelta = jest.fn();
+    const onAssistantTranscriptCompleted = jest.fn();
+    const session = createSession({
+      onAssistantTranscriptDelta,
+      onAssistantTranscriptCompleted,
+    });
+
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'Hi' },
+      },
+    }));
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'Hi there' },
+      },
+    }));
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        turnComplete: true,
+      },
+    }));
+
+    expect(onAssistantTranscriptDelta).toHaveBeenNthCalledWith(1, 'Hi');
+    expect(onAssistantTranscriptDelta).toHaveBeenNthCalledWith(2, ' there');
+    expect(onAssistantTranscriptCompleted).toHaveBeenCalledWith('Hi there');
+  });
+
+  it('accumulates non-cumulative assistant transcript fragments instead of replacing them', async () => {
+    const onAssistantTranscriptDelta = jest.fn();
+    const onAssistantTranscriptCompleted = jest.fn();
+    const session = createSession({
+      onAssistantTranscriptDelta,
+      onAssistantTranscriptCompleted,
+    });
+
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'This' },
+      },
+    }));
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'is' },
+      },
+    }));
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        outputTranscription: { text: 'working' },
+      },
+    }));
+    await session.handleServerMessage(JSON.stringify({
+      serverContent: {
+        turnComplete: true,
+      },
+    }));
+
+    expect(onAssistantTranscriptDelta).toHaveBeenNthCalledWith(1, 'This');
+    expect(onAssistantTranscriptDelta).toHaveBeenNthCalledWith(2, ' is');
+    expect(onAssistantTranscriptDelta).toHaveBeenNthCalledWith(3, ' working');
+    expect(onAssistantTranscriptCompleted).toHaveBeenCalledWith('This is working');
+  });
+
+  it('accepts blob setup frames and transitions to listening', async () => {
+    const onStateChange = jest.fn();
+    const session = createSession({ onStateChange });
+    jest.spyOn(session, 'startAudioCapture').mockResolvedValue(undefined);
+
+    await session.handleServerMessage(new Blob([JSON.stringify({ setupComplete: {} })], {
+      type: 'application/json',
+    }));
+    await Promise.resolve();
+
+    expect(onStateChange).toHaveBeenCalledWith('listening');
+  });
+});

--- a/tests/unit/RealtimeVoiceService.test.ts
+++ b/tests/unit/RealtimeVoiceService.test.ts
@@ -4,9 +4,19 @@ import type { LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
 describe('RealtimeVoiceService', () => {
   const originalRTCPeerConnection = globalThis.RTCPeerConnection;
   const originalNavigator = globalThis.navigator;
+  const originalWebSocket = globalThis.WebSocket;
+  const originalAudioContext = globalThis.AudioContext;
 
   beforeEach(() => {
     Object.defineProperty(globalThis, 'RTCPeerConnection', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      value: jest.fn(),
+    });
+    Object.defineProperty(globalThis, 'AudioContext', {
       configurable: true,
       value: jest.fn(),
     });
@@ -24,6 +34,14 @@ describe('RealtimeVoiceService', () => {
     Object.defineProperty(globalThis, 'RTCPeerConnection', {
       configurable: true,
       value: originalRTCPeerConnection,
+    });
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      value: originalWebSocket,
+    });
+    Object.defineProperty(globalThis, 'AudioContext', {
+      configurable: true,
+      value: originalAudioContext,
     });
     Object.defineProperty(globalThis, 'navigator', {
       configurable: true,
@@ -72,7 +90,7 @@ describe('RealtimeVoiceService', () => {
     });
   });
 
-  it('reports configured providers that are not wired yet', () => {
+  it('is available when Google live voice is configured and browser APIs exist', () => {
     const service = new RealtimeVoiceService(buildSettings({
       providers: {
         openai: {
@@ -92,8 +110,7 @@ describe('RealtimeVoiceService', () => {
     }));
 
     expect(service.getAvailability()).toEqual({
-      available: false,
-      reason: 'Realtime voice provider "google" is configured, but only OpenAI WebRTC is wired in this build.',
+      available: true,
     });
   });
 });

--- a/tests/unit/VoiceAudioCapabilityTypes.test.ts
+++ b/tests/unit/VoiceAudioCapabilityTypes.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../src/services/llm/types/SpeechTypes';
 import {
   buildRealtimeVoiceProviderAvailability,
+  getRealtimeVoiceModel,
   getRealtimeVoiceModelsForProvider,
   resolveDefaultRealtimeVoiceSelection
 } from '../../src/services/llm/types/RealtimeVoiceTypes';
@@ -193,6 +194,15 @@ describe('RealtimeVoiceTypes', () => {
   it('declares realtime models separately from speech models', () => {
     expect(getRealtimeVoiceModelsForProvider('openai').map(model => model.id)).toContain('gpt-realtime-2');
     expect(getRealtimeVoiceModelsForProvider('openrouter')).toEqual([]);
+  });
+
+  it('uses a Google-native default voice for Google live models', () => {
+    const model = getRealtimeVoiceModel('google', 'gemini-3.1-flash-live-preview');
+
+    expect(model).toEqual(expect.objectContaining({
+      defaultVoice: 'Kore',
+    }));
+    expect(model?.voices?.some(voice => voice.id === 'Kore')).toBe(true);
   });
 
   it('auto-selects OpenAI before Google when both realtime providers are configured', () => {


### PR DESCRIPTION
## Summary
- add provider-aware realtime voice dispatch and a Google Gemini Live session implementation
- add Google realtime voice defaults and focused regression coverage for provider availability and transcript fragment handling
- add a smoke script for live Gemini endpoint verification

## Validation
- npm test -- --runTestsByPath tests/unit/VoiceAudioCapabilityTypes.test.ts tests/unit/RealtimeVoiceService.test.ts tests/unit/GoogleRealtimeVoiceSession.test.ts
- npm run build
- npm run smoke:google-live