### PR TITLE
Fix chat voice settings sync

### DIFF
--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -16,7 +16,26 @@ import { App, Setting, EventRef } from 'obsidian';
 import { LLMProviderManager } from '../../services/llm/providers/ProviderManager';
 import { StaticModelsService } from '../../services/StaticModelsService';
 import { ImageGenerationService } from '../../services/llm/ImageGenerationService';
-import { LLMProviderSettings, ThinkingEffort } from '../../types/llm/ProviderTypes';
+import {
+  buildSpeechProviderAvailability,
+  getSpeechModel,
+  resolveDefaultSpeechSelection,
+  type SpeechProvider,
+  type SpeechProviderAvailability,
+} from '../../services/llm/types/SpeechTypes';
+import {
+  buildRealtimeVoiceProviderAvailability,
+  getRealtimeVoiceModel,
+  resolveDefaultRealtimeVoiceSelection,
+  type RealtimeVoiceProviderAvailability,
+} from '../../services/llm/types/RealtimeVoiceTypes';
+import {
+  DefaultRealtimeVoiceModelSettings,
+  DefaultSpeechModelSettings,
+  LLMProviderSettings,
+  ThinkingEffort
+} from '../../types/llm/ProviderTypes';
+import type { AppsSettings } from '../../types/apps/AppTypes';
 import { FilePickerRenderer } from '../workspace/FilePickerRenderer';
 import { isDesktop, isProviderCompatible } from '../../utils/platform';
 import { LLMSettingsNotifier } from '../../services/llm/LLMSettingsNotifier';
@@ -26,6 +45,10 @@ import {
   normalizeIngestSelection
 } from '../../agents/ingestManager/tools/services/IngestCapabilityService';
 import { renderIngestModelDropdowns } from './IngestModelDropdownRenderer';
+import { VoiceCatalogService } from '../../services/readAloud/VoiceCatalogService';
+import { SpeechModelCatalogService } from '../../services/readAloud/SpeechModelCatalogService';
+import { ProviderUtils } from '../../ui/chat/utils/ProviderUtils';
+import { getNexusPlugin } from '../../utils/pluginLocator';
 
 /**
  * Current settings state
@@ -48,6 +71,12 @@ export interface ChatSettings {
   temperature: number; // 0.0-1.0, controls randomness
   imageProvider: 'google' | 'openrouter';
   imageModel: string;
+  speechProvider?: DefaultSpeechModelSettings['provider'];
+  speechModel?: DefaultSpeechModelSettings['model'];
+  speechVoice?: DefaultSpeechModelSettings['voice'];
+  realtimeVoiceProvider?: DefaultRealtimeVoiceModelSettings['provider'];
+  realtimeVoiceModel?: DefaultRealtimeVoiceModelSettings['model'];
+  realtimeVoiceVoice?: DefaultRealtimeVoiceModelSettings['voice'];
   transcriptionProvider?: string;
   transcriptionModel?: string;
   workspaceId: string | null;
@@ -93,8 +122,17 @@ export interface ChatSettingsRendererConfig {
   initialSettings: ChatSettings;
   options: ChatSettingsOptions;
   callbacks: ChatSettingsCallbacks;
+  showVoiceSection?: boolean;
   showTranscriptionSection?: boolean;
   renderAfterImageSection?: (parent: HTMLElement) => void;
+}
+
+interface PluginWithAppSettings {
+  settings?: {
+    settings?: {
+      apps?: AppsSettings;
+    };
+  };
 }
 
 const EFFORT_LEVELS: ThinkingEffort[] = ['low', 'medium', 'high'];
@@ -158,7 +196,9 @@ export class ChatSettingsRenderer {
     this.renderAgentModelSection(this.container);
     this.renderImageSection(this.container);
     this.config.renderAfterImageSection?.(this.container);
-    if (this.config.showTranscriptionSection !== false) {
+    if (this.config.showVoiceSection !== false) {
+      this.renderVoiceSection(this.container);
+    } else if (this.config.showTranscriptionSection !== false) {
       this.renderTranscriptionSection(this.container);
     }
     this.renderTemperatureSection(this.container);
@@ -541,6 +581,11 @@ export class ChatSettingsRenderer {
     const section = parent.createDiv('csr-section');
     section.createDiv('csr-section-header').setText('Transcription model');
     const content = section.createDiv('csr-section-content');
+    this.renderTranscriptionControls(content);
+  }
+
+  private renderTranscriptionControls(parent: HTMLElement): void {
+    const content = parent.createDiv('csr-transcription-controls');
     content.createDiv({
       cls: 'setting-item-description',
       text: 'Loading transcription models...'
@@ -589,6 +634,470 @@ export class ChatSettingsRenderer {
         text: 'Transcription models are not available.'
       });
     });
+  }
+
+  private renderVoiceSection(parent: HTMLElement): void {
+    const section = parent.createDiv('csr-section');
+    section.createDiv('csr-section-header').setText('Voice');
+    const content = section.createDiv('csr-section-content');
+    content.createDiv({
+      cls: 'csr-section-desc nexus-voice-section-desc',
+      text: 'Defaults for microphone input, read aloud, and live voice in this chat.'
+    });
+
+    let updateVoiceWarning = (): void => undefined;
+
+    this.renderVoiceGroupLabel(content, 'Voice input');
+    this.renderTranscriptionControls(content);
+
+    this.renderVoiceGroupLabel(content, 'Read aloud');
+    this.renderSpeechSettings(content, () => updateVoiceWarning());
+
+    this.renderVoiceGroupLabel(content, 'Live voice');
+    this.renderRealtimeVoiceSettings(content, () => updateVoiceWarning());
+
+    const warningEl = content.createDiv({ cls: 'nexus-voice-warning is-hidden' });
+    updateVoiceWarning = (): void => {
+      const messages = this.getVoiceWarningMessages();
+      warningEl.empty();
+      warningEl.toggleClass('is-hidden', messages.length === 0);
+      messages.forEach(message => {
+        warningEl.createDiv({ text: message });
+      });
+    };
+    updateVoiceWarning();
+  }
+
+  private renderVoiceGroupLabel(parentEl: HTMLElement, label: string): void {
+    parentEl.createDiv({ cls: 'nexus-voice-group-label', text: label });
+  }
+
+  private renderSpeechSettings(parent: HTMLElement, onSelectionChange: () => void): void {
+    let modelDropdown: HTMLSelectElement | null = null;
+    let voiceDropdown: HTMLSelectElement | null = null;
+    let modelRequestId = 0;
+    let voiceRequestId = 0;
+    const voiceCatalogService = new VoiceCatalogService();
+    const speechModelCatalogService = new SpeechModelCatalogService();
+
+    const getAvailability = (): SpeechProviderAvailability[] =>
+      buildSpeechProviderAvailability(this.config.llmProviderSettings, this.getSpeechAppStates());
+
+    const getSelection = (): DefaultSpeechModelSettings => {
+      const availability = getAvailability();
+      const configuredProvider = this.settings.speechProvider;
+      const provider = configuredProvider
+        || availability.find(item => item.enabled && item.configured && (item.models?.length ?? 0) > 0)?.provider;
+      const providerAvailability = availability.find(item => item.provider === provider);
+      const model = this.settings.speechModel && providerAvailability?.models?.some(candidate => candidate.id === this.settings.speechModel)
+        ? this.settings.speechModel
+        : providerAvailability?.models?.[0]?.id;
+
+      return {
+        provider,
+        model,
+        voice: this.settings.speechVoice,
+        source: 'user'
+      };
+    };
+
+    const updateVoiceOptions = async (): Promise<void> => {
+      if (!voiceDropdown) return;
+      const requestId = ++voiceRequestId;
+      const selection = getSelection();
+
+      voiceDropdown.empty();
+      if (selection.provider === 'elevenlabs') {
+        voiceDropdown.createEl('option', { value: '', text: 'Loading voices...' });
+        voiceDropdown.disabled = true;
+      }
+
+      const voices = await voiceCatalogService.getVoices(selection.provider, selection.model, {
+        llmSettings: this.config.llmProviderSettings,
+        appsSettings: this.getAppsSettings()
+      }).catch(() => []);
+
+      if (requestId !== voiceRequestId || !voiceDropdown) {
+        return;
+      }
+
+      voiceDropdown.empty();
+      voiceDropdown.createEl('option', { value: '', text: 'Provider default' });
+      voices.forEach(voice => {
+        voiceDropdown?.createEl('option', { value: voice.id, text: voice.name });
+      });
+
+      if (selection.voice && !voices.some(voice => voice.id === selection.voice)) {
+        voiceDropdown.createEl('option', {
+          value: selection.voice,
+          text: `${selection.voice} (unavailable)`
+        });
+      }
+
+      voiceDropdown.disabled = !selection.provider || !selection.model;
+      voiceDropdown.value = selection.voice || '';
+    };
+
+    const updateModelOptions = async (): Promise<void> => {
+      if (!modelDropdown) return;
+      const requestId = ++modelRequestId;
+      const selection = getSelection();
+      const availability = getAvailability();
+      const providerAvailability = availability.find(item => item.provider === selection.provider);
+      const providerUsable = providerAvailability?.enabled === true && providerAvailability.configured === true;
+
+      modelDropdown.empty();
+      if (!selection.provider) {
+        modelDropdown.createEl('option', {
+          value: '',
+          text: 'Select a speech provider first'
+        });
+        modelDropdown.disabled = true;
+        void updateVoiceOptions();
+        return;
+      }
+
+      if (selection.provider === 'openrouter') {
+        modelDropdown.createEl('option', { value: '', text: 'Loading OpenRouter speech models...' });
+        modelDropdown.disabled = true;
+      }
+
+      const models = await speechModelCatalogService.getModels(
+        selection.provider as SpeechProvider,
+        this.config.llmProviderSettings
+      ).catch(() => providerAvailability?.models ?? []);
+
+      if (requestId !== modelRequestId || !modelDropdown) {
+        return;
+      }
+
+      modelDropdown.empty();
+      if (models.length === 0) {
+        modelDropdown.createEl('option', {
+          value: '',
+          text: 'No speech models available'
+        });
+        modelDropdown.disabled = true;
+        void updateVoiceOptions();
+        return;
+      }
+
+      models.forEach(model => {
+        modelDropdown?.createEl('option', { value: model.id, text: model.name });
+      });
+
+      if (selection.model && !models.some(model => model.id === selection.model)) {
+        modelDropdown.createEl('option', {
+          value: selection.model,
+          text: `${selection.model} (unavailable)`
+        });
+      }
+
+      const selectedModelExists = models.some(model => model.id === selection.model);
+      const nextModel = selection.model && selectedModelExists
+        ? selection.model
+        : models[0]?.id || '';
+
+      this.settings.speechProvider = selection.provider;
+      this.settings.speechModel = nextModel || undefined;
+      modelDropdown.disabled = !providerUsable;
+      modelDropdown.value = nextModel;
+      this.notifyChange();
+      void updateVoiceOptions();
+    };
+
+    new Setting(parent)
+      .setName('Speech provider')
+      .setDesc('Normal text-to-speech models for reading chat content aloud.')
+      .addDropdown(dropdown => {
+        const availability = getAvailability();
+        const selection = getSelection();
+        const usableProviders = availability.filter(item => item.enabled && item.configured && (item.models?.length ?? 0) > 0);
+
+        if (usableProviders.length === 0 && !selection.provider) {
+          dropdown.addOption('', 'No speech providers available');
+          dropdown.setDisabled(true);
+          return;
+        }
+
+        usableProviders.forEach(provider => {
+          dropdown.addOption(provider.provider, this.getProviderDisplayName(provider.provider));
+        });
+
+        if (selection.provider && !usableProviders.some(provider => provider.provider === selection.provider)) {
+          dropdown.addOption(
+            selection.provider,
+            `${this.getProviderDisplayName(selection.provider)} (unavailable)`
+          );
+        }
+
+        dropdown.setValue(selection.provider || usableProviders[0]?.provider || '');
+        dropdown.onChange((provider) => {
+          const providerAvailability = getAvailability().find(item => item.provider === provider);
+          const model = providerAvailability?.models?.[0];
+          this.settings.speechProvider = provider || undefined;
+          this.settings.speechModel = model?.id;
+          this.settings.speechVoice = model?.defaultVoice;
+          this.notifyChange();
+          void updateModelOptions().then(onSelectionChange);
+        });
+      });
+
+    new Setting(parent)
+      .setName('Speech model')
+      .addDropdown(dropdown => {
+        modelDropdown = dropdown.selectEl;
+        void updateModelOptions();
+        dropdown.onChange((modelId) => {
+          const selection = getSelection();
+          const model = getSpeechModel(selection.provider, modelId);
+          this.settings.speechModel = modelId || undefined;
+          if (model) {
+            this.settings.speechVoice = this.settings.speechVoice || model.defaultVoice;
+          }
+          this.notifyChange();
+          void updateVoiceOptions().then(onSelectionChange);
+        });
+      });
+
+    new Setting(parent)
+      .setName('Speech voice')
+      .addDropdown(dropdown => {
+        voiceDropdown = dropdown.selectEl;
+        void updateVoiceOptions();
+        dropdown.onChange((voice) => {
+          this.settings.speechVoice = voice || undefined;
+          this.notifyChange();
+          onSelectionChange();
+        });
+      });
+  }
+
+  private renderRealtimeVoiceSettings(parent: HTMLElement, onSelectionChange: () => void): void {
+    let modelDropdown: HTMLSelectElement | null = null;
+    let voiceDropdown: HTMLSelectElement | null = null;
+
+    const getAvailability = (): RealtimeVoiceProviderAvailability[] =>
+      buildRealtimeVoiceProviderAvailability(this.config.llmProviderSettings, this.getRealtimeAppStates());
+
+    const getSelection = (): DefaultRealtimeVoiceModelSettings => {
+      const availability = getAvailability();
+      const configuredProvider = this.settings.realtimeVoiceProvider;
+      const provider = configuredProvider
+        || availability.find(item => item.enabled && item.configured && (item.models?.length ?? 0) > 0)?.provider;
+      const providerAvailability = availability.find(item => item.provider === provider);
+      const model = this.settings.realtimeVoiceModel && providerAvailability?.models?.some(candidate => candidate.id === this.settings.realtimeVoiceModel)
+        ? this.settings.realtimeVoiceModel
+        : providerAvailability?.models?.[0]?.id;
+
+      return {
+        provider,
+        model,
+        voice: this.settings.realtimeVoiceVoice,
+        source: 'user'
+      };
+    };
+
+    const updateVoiceOptions = (): void => {
+      if (!voiceDropdown) return;
+      const selection = getSelection();
+      const model = getRealtimeVoiceModel(selection.provider, selection.model);
+      const voices = model?.voices ?? [];
+
+      voiceDropdown.empty();
+      voiceDropdown.createEl('option', { value: '', text: 'Provider default' });
+      voices.forEach(voice => {
+        voiceDropdown?.createEl('option', { value: voice.id, text: voice.name });
+      });
+
+      if (selection.voice && !voices.some(voice => voice.id === selection.voice)) {
+        voiceDropdown.createEl('option', {
+          value: selection.voice,
+          text: `${selection.voice} (unavailable)`
+        });
+      }
+
+      voiceDropdown.disabled = !selection.provider || !selection.model;
+      voiceDropdown.value = selection.voice || '';
+    };
+
+    const updateModelOptions = (): void => {
+      if (!modelDropdown) return;
+      const selection = getSelection();
+      const availability = getAvailability();
+      const providerAvailability = availability.find(item => item.provider === selection.provider);
+      const providerUsable = providerAvailability?.enabled === true && providerAvailability.configured === true;
+      const models = providerAvailability?.models ?? [];
+
+      modelDropdown.empty();
+      if (!selection.provider || models.length === 0) {
+        modelDropdown.createEl('option', {
+          value: '',
+          text: 'Select a live voice provider first'
+        });
+        modelDropdown.disabled = true;
+        updateVoiceOptions();
+        return;
+      }
+
+      models.forEach(model => {
+        modelDropdown?.createEl('option', { value: model.id, text: model.name });
+      });
+
+      if (selection.model && !models.some(model => model.id === selection.model)) {
+        modelDropdown.createEl('option', {
+          value: selection.model,
+          text: `${selection.model} (unavailable)`
+        });
+      }
+
+      const selectedModelExists = models.some(model => model.id === selection.model);
+      const nextModel = selection.model && selectedModelExists
+        ? selection.model
+        : models[0]?.id || '';
+
+      this.settings.realtimeVoiceProvider = selection.provider;
+      this.settings.realtimeVoiceModel = nextModel || undefined;
+      modelDropdown.disabled = !providerUsable;
+      modelDropdown.value = nextModel;
+      this.notifyChange();
+      updateVoiceOptions();
+    };
+
+    new Setting(parent)
+      .setName('Live voice provider')
+      .setDesc('Only true realtime voice providers appear here.')
+      .addDropdown(dropdown => {
+        const availability = getAvailability();
+        const selection = getSelection();
+        const usableProviders = availability.filter(item => item.enabled && item.configured && (item.models?.length ?? 0) > 0);
+
+        if (usableProviders.length === 0 && !selection.provider) {
+          dropdown.addOption('', 'No live voice providers available');
+          dropdown.setDisabled(true);
+          return;
+        }
+
+        usableProviders.forEach(provider => {
+          dropdown.addOption(provider.provider, this.getProviderDisplayName(provider.provider));
+        });
+
+        if (selection.provider && !usableProviders.some(provider => provider.provider === selection.provider)) {
+          dropdown.addOption(
+            selection.provider,
+            `${this.getProviderDisplayName(selection.provider)} (unavailable)`
+          );
+        }
+
+        dropdown.setValue(selection.provider || usableProviders[0]?.provider || '');
+        dropdown.onChange((provider) => {
+          const providerAvailability = getAvailability().find(item => item.provider === provider);
+          const model = providerAvailability?.models?.[0];
+          this.settings.realtimeVoiceProvider = provider || undefined;
+          this.settings.realtimeVoiceModel = model?.id;
+          this.settings.realtimeVoiceVoice = model?.defaultVoice;
+          this.notifyChange();
+          updateModelOptions();
+          onSelectionChange();
+        });
+      });
+
+    new Setting(parent)
+      .setName('Live voice model')
+      .addDropdown(dropdown => {
+        modelDropdown = dropdown.selectEl;
+        updateModelOptions();
+        dropdown.onChange((modelId) => {
+          const selection = getSelection();
+          const model = getRealtimeVoiceModel(selection.provider, modelId);
+          this.settings.realtimeVoiceModel = modelId || undefined;
+          if (model) {
+            this.settings.realtimeVoiceVoice = this.settings.realtimeVoiceVoice || model.defaultVoice;
+          }
+          this.notifyChange();
+          updateVoiceOptions();
+          onSelectionChange();
+        });
+      });
+
+    new Setting(parent)
+      .setName('Live voice')
+      .addDropdown(dropdown => {
+        voiceDropdown = dropdown.selectEl;
+        updateVoiceOptions();
+        dropdown.onChange((voice) => {
+          this.settings.realtimeVoiceVoice = voice || undefined;
+          this.notifyChange();
+          onSelectionChange();
+        });
+      });
+  }
+
+  private getSpeechAppStates(): Partial<Record<SpeechProvider, { enabled: boolean; configured: boolean }>> {
+    const elevenLabs = this.getAppsSettings()?.apps.elevenlabs;
+    return elevenLabs
+      ? { elevenlabs: { enabled: elevenLabs.enabled, configured: !!elevenLabs.credentials.apiKey?.trim() } }
+      : {};
+  }
+
+  private getRealtimeAppStates(): Partial<Record<'elevenlabs', { enabled: boolean; configured: boolean }>> {
+    const elevenLabs = this.getAppsSettings()?.apps.elevenlabs;
+    return elevenLabs
+      ? { elevenlabs: { enabled: elevenLabs.enabled, configured: !!elevenLabs.credentials.apiKey?.trim() } }
+      : {};
+  }
+
+  private getVoiceWarningMessages(): string[] {
+    const messages: string[] = [];
+    const speechDefault = this.settings.speechProvider || this.settings.speechModel || this.settings.speechVoice
+      ? {
+        provider: this.settings.speechProvider,
+        model: this.settings.speechModel,
+        voice: this.settings.speechVoice,
+        source: 'user' as const
+      }
+      : undefined;
+    const realtimeDefault = this.settings.realtimeVoiceProvider || this.settings.realtimeVoiceModel || this.settings.realtimeVoiceVoice
+      ? {
+        provider: this.settings.realtimeVoiceProvider,
+        model: this.settings.realtimeVoiceModel,
+        voice: this.settings.realtimeVoiceVoice,
+        source: 'user' as const
+      }
+      : undefined;
+    const speechSelection = resolveDefaultSpeechSelection(
+      {
+        ...this.config.llmProviderSettings,
+        defaultSpeechModel: speechDefault
+      },
+      buildSpeechProviderAvailability(this.config.llmProviderSettings, this.getSpeechAppStates())
+    );
+    const realtimeSelection = resolveDefaultRealtimeVoiceSelection(
+      {
+        ...this.config.llmProviderSettings,
+        defaultRealtimeVoiceModel: realtimeDefault
+      },
+      buildRealtimeVoiceProviderAvailability(this.config.llmProviderSettings, this.getRealtimeAppStates())
+    );
+
+    if (speechSelection.status === 'invalid' && speechSelection.reason) {
+      messages.push(speechSelection.reason);
+    }
+
+    if (realtimeSelection.status === 'invalid' && realtimeSelection.reason) {
+      messages.push(realtimeSelection.reason);
+    }
+
+    return messages;
+  }
+
+  private getAppsSettings(): AppsSettings | undefined {
+    const plugin = getNexusPlugin(this.config.app) as PluginWithAppSettings | null;
+    return plugin?.settings?.settings?.apps;
+  }
+
+  private getProviderDisplayName(providerId: string): string {
+    return ProviderUtils.getProviderDisplayName(providerId);
   }
 
   // ========== CONTEXT SECTION ==========

--- a/src/services/llm/types/RealtimeVoiceTypes.ts
+++ b/src/services/llm/types/RealtimeVoiceTypes.ts
@@ -152,14 +152,15 @@ const REALTIME_VOICE_MODELS: RealtimeVoiceModelDeclaration[] = [
   }
 ];
 
+const WIRED_REALTIME_VOICE_PROVIDERS: RealtimeVoiceProvider[] = ['openai', 'google'];
+
 export const REALTIME_VOICE_PROVIDER_PRIORITY: RealtimeVoiceProvider[] = [
   'openai',
-  'google',
-  'elevenlabs'
+  'google'
 ];
 
 export function getRealtimeVoiceProviders(): RealtimeVoiceProvider[] {
-  return Array.from(new Set(REALTIME_VOICE_MODELS.map(model => model.provider)));
+  return [...WIRED_REALTIME_VOICE_PROVIDERS];
 }
 
 export function getRealtimeVoiceModelsForProvider(provider: string): RealtimeVoiceModelDeclaration[] {
@@ -178,21 +179,10 @@ export function getRealtimeVoiceModel(
 
 export function buildRealtimeVoiceProviderAvailability(
   settings: LLMProviderSettings | null,
-  appStates: RealtimeAppCapabilityStates = {}
+  _appStates: RealtimeAppCapabilityStates = {}
 ): RealtimeVoiceProviderAvailability[] {
   return getRealtimeVoiceProviders().map(provider => {
     const models = getEnabledRealtimeModelsForProvider(settings, provider);
-    if (provider === 'elevenlabs') {
-      const appState = appStates.elevenlabs;
-      return {
-        provider,
-        enabled: appState?.enabled === true,
-        configured: appState?.configured === true,
-        models,
-        error: appState?.error
-      };
-    }
-
     const providerConfig = settings?.providers?.[provider];
     return {
       provider,

--- a/src/settings/tabs/DefaultsTab.ts
+++ b/src/settings/tabs/DefaultsTab.ts
@@ -223,6 +223,7 @@ export class DefaultsTab {
       llmProviderSettings: this.services.llmProviderSettings,
       initialSettings: this.getCurrentSettings(),
       options: { workspaces, prompts },
+      showVoiceSection: false,
       showTranscriptionSection: false,
       renderAfterImageSection: (parent) => {
         this.renderVideoSection(parent);

--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -666,7 +666,8 @@ export class ChatView extends ItemView {
       },
       () => this.conversationManager.getCurrentConversation() !== null,
       this, // Pass Component for registerDomEvent
-      () => this.liveVoiceController?.stop()
+      () => this.liveVoiceController?.stop(),
+      () => this.getEffectiveVoiceLLMSettings()
     );
 
     this.liveVoiceController = new ChatLiveVoiceController({
@@ -675,6 +676,7 @@ export class ChatView extends ItemView {
       toolStatusBar: this.toolStatusBar,
       liveVoiceButton: this.layoutElements.liveVoiceButton,
       getHasConversation: () => this.conversationManager.getCurrentConversation() !== null,
+      getLLMSettings: () => this.getEffectiveVoiceLLMSettings(),
       getConversationContext: () => new LiveVoiceContextBuilder().build(this.conversationManager.getCurrentConversation()),
       onTranscriptMessage: (role, content) => {
         void this.appendLiveVoiceTranscriptMessage(role, content);
@@ -846,6 +848,12 @@ export class ChatView extends ItemView {
       this.modelAgentManager
     );
     modal.open();
+  }
+
+  private getEffectiveVoiceLLMSettings() {
+    const plugin = getNexusPlugin<NexusPlugin>(this.app);
+    const llmSettings = plugin?.settings?.settings?.llmProviders ?? null;
+    return this.modelAgentManager.applyChatVoiceOverrides(llmSettings);
   }
 
   /**

--- a/src/ui/chat/components/ChatInput.ts
+++ b/src/ui/chat/components/ChatInput.ts
@@ -15,6 +15,7 @@ import { ChatVoiceInputController, ChatVoiceInputState } from '../controllers/Ch
 import { ManagedTimeoutTracker } from '../utils/ManagedTimeoutTracker';
 import { ChatKeyboardViewportController } from '../controllers/ChatKeyboardViewportController';
 import type { LiveVoiceComposerState } from '../types/LiveVoiceTypes';
+import type { LLMProviderSettings } from '../../../types/llm/ProviderTypes';
 
 export class ChatInput {
   private element: HTMLElement | null = null;
@@ -49,7 +50,8 @@ export class ChatInput {
     private onStopGeneration?: () => void,
     private getHasConversation?: () => boolean,
     private component?: Component,
-    private onStopLiveVoice?: () => void
+    private onStopLiveVoice?: () => void,
+    private getVoiceInputLLMSettings?: () => LLMProviderSettings | null
   ) {
     if (component) {
       this.timeouts = new ManagedTimeoutTracker(component);
@@ -211,7 +213,7 @@ export class ChatInput {
       onError: (message) => {
         new Notice(message);
       }
-    });
+    }, this.getVoiceInputLLMSettings);
 
     this.initializeVoiceVisualResizeHandling();
     this.buildVoiceBars();

--- a/src/ui/chat/components/ChatSettingsModal.ts
+++ b/src/ui/chat/components/ChatSettingsModal.ts
@@ -144,6 +144,12 @@ export class ChatSettingsModal extends Modal {
       temperature: temperature,
       imageProvider: this.modelAgentManager.getImageProvider() || llmSettings?.defaultImageModel?.provider || 'google',
       imageModel: this.modelAgentManager.getImageModel() || llmSettings?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      speechProvider: this.modelAgentManager.getSpeechProvider() || llmSettings?.defaultSpeechModel?.provider,
+      speechModel: this.modelAgentManager.getSpeechModel() || llmSettings?.defaultSpeechModel?.model,
+      speechVoice: this.modelAgentManager.getSpeechVoice() || llmSettings?.defaultSpeechModel?.voice,
+      realtimeVoiceProvider: this.modelAgentManager.getRealtimeVoiceProvider() || llmSettings?.defaultRealtimeVoiceModel?.provider,
+      realtimeVoiceModel: this.modelAgentManager.getRealtimeVoiceModel() || llmSettings?.defaultRealtimeVoiceModel?.model,
+      realtimeVoiceVoice: this.modelAgentManager.getRealtimeVoiceVoice() || llmSettings?.defaultRealtimeVoiceModel?.voice,
       transcriptionProvider: this.modelAgentManager.getTranscriptionProvider() || llmSettings?.defaultTranscriptionModel?.provider,
       transcriptionModel: this.modelAgentManager.getTranscriptionModel() || llmSettings?.defaultTranscriptionModel?.model,
       workspaceId: this.modelAgentManager.getSelectedWorkspaceId(),
@@ -208,6 +214,20 @@ export class ChatSettingsModal extends Modal {
 
       // Update image model
       this.modelAgentManager.setImageModel(settings.imageProvider, settings.imageModel);
+
+      // Update speech settings
+      this.modelAgentManager.setSpeechSettings(
+        settings.speechProvider || null,
+        settings.speechModel || null,
+        settings.speechVoice || null
+      );
+
+      // Update realtime voice settings
+      this.modelAgentManager.setRealtimeVoiceSettings(
+        settings.realtimeVoiceProvider || null,
+        settings.realtimeVoiceModel || null,
+        settings.realtimeVoiceVoice || null
+      );
 
       // Update transcription model
       this.modelAgentManager.setTranscriptionModel(

--- a/src/ui/chat/controllers/ChatLiveVoiceController.ts
+++ b/src/ui/chat/controllers/ChatLiveVoiceController.ts
@@ -22,6 +22,7 @@ export interface ChatLiveVoiceControllerOptions {
   toolStatusBar: ToolStatusBar;
   liveVoiceButton: HTMLElement;
   getHasConversation: () => boolean;
+  getLLMSettings?: () => LLMProviderSettings | null;
   getConversationContext?: () => string;
   onTranscriptMessage?: (role: 'user' | 'assistant', content: string) => void | Promise<void>;
   component: Component;
@@ -150,6 +151,11 @@ export class ChatLiveVoiceController {
   }
 
   private getLLMSettings(): LLMProviderSettings | null {
+    const resolved = this.options.getLLMSettings?.();
+    if (resolved) {
+      return resolved;
+    }
+
     const plugin = getNexusPlugin(this.options.app) as PluginWithLLMSettings | null;
     return plugin?.settings?.settings?.llmProviders ?? null;
   }

--- a/src/ui/chat/controllers/ChatVoiceInputController.ts
+++ b/src/ui/chat/controllers/ChatVoiceInputController.ts
@@ -43,7 +43,8 @@ export class ChatVoiceInputController {
 
   constructor(
     private readonly app: App | undefined,
-    private readonly callbacks: ChatVoiceInputControllerCallbacks
+    private readonly callbacks: ChatVoiceInputControllerCallbacks,
+    private readonly getResolvedLLMSettings?: () => LLMProviderSettings | null
   ) {}
 
   getState(): ChatVoiceInputState {
@@ -298,6 +299,11 @@ export class ChatVoiceInputController {
   }
 
   private getLLMSettings(): LLMProviderSettings | null {
+    const resolved = this.getResolvedLLMSettings?.();
+    if (resolved) {
+      return resolved;
+    }
+
     if (!this.app) {
       return null;
     }

--- a/src/ui/chat/services/ModelAgentConversationSettingsStore.ts
+++ b/src/ui/chat/services/ModelAgentConversationSettingsStore.ts
@@ -1,4 +1,8 @@
-import type { ThinkingSettings } from '../../../types/llm/ProviderTypes';
+import type {
+  DefaultRealtimeVoiceModelSettings,
+  DefaultSpeechModelSettings,
+  ThinkingSettings
+} from '../../../types/llm/ProviderTypes';
 import type { CompactedContext } from '../../../services/chat/ContextCompactionService';
 
 interface ConversationCompactionMetadata {
@@ -20,6 +24,12 @@ export interface ConversationSettingsMetadata {
   agentThinking?: ThinkingSettings;
   imageProvider?: 'google' | 'openrouter';
   imageModel?: string;
+  speechProvider?: DefaultSpeechModelSettings['provider'] | null;
+  speechModel?: DefaultSpeechModelSettings['model'] | null;
+  speechVoice?: DefaultSpeechModelSettings['voice'] | null;
+  realtimeVoiceProvider?: DefaultRealtimeVoiceModelSettings['provider'] | null;
+  realtimeVoiceModel?: DefaultRealtimeVoiceModelSettings['model'] | null;
+  realtimeVoiceVoice?: DefaultRealtimeVoiceModelSettings['voice'] | null;
   transcriptionProvider?: string | null;
   transcriptionModel?: string | null;
 }

--- a/src/ui/chat/services/ModelAgentDefaultsResolver.ts
+++ b/src/ui/chat/services/ModelAgentDefaultsResolver.ts
@@ -1,7 +1,11 @@
 import type { App } from 'obsidian';
 import type NexusPlugin from '../../../main';
 import { StaticModelsService } from '../../../services/StaticModelsService';
-import type { ThinkingSettings } from '../../../types/llm/ProviderTypes';
+import type {
+  DefaultRealtimeVoiceModelSettings,
+  DefaultSpeechModelSettings,
+  ThinkingSettings
+} from '../../../types/llm/ProviderTypes';
 import { getNexusPlugin } from '../../../utils/pluginLocator';
 import { ModelSelectionUtility } from '../utils/ModelSelectionUtility';
 import type { ModelOption, PromptOption } from '../types/SelectionTypes';
@@ -17,6 +21,8 @@ interface PluginWithSettings {
         agentThinking?: ThinkingSettings;
         defaultImageModel?: { provider: 'google' | 'openrouter'; model: string };
         defaultTranscriptionModel?: { provider: string; model: string };
+        defaultSpeechModel?: DefaultSpeechModelSettings;
+        defaultRealtimeVoiceModel?: DefaultRealtimeVoiceModelSettings;
       };
       defaultWorkspaceId?: string;
       defaultPromptId?: string;
@@ -37,6 +43,12 @@ export interface ModelAgentDefaultState {
   agentThinkingSettings: ThinkingSettings;
   imageProvider: 'google' | 'openrouter';
   imageModel: string;
+  speechProvider: DefaultSpeechModelSettings['provider'] | null;
+  speechModel: DefaultSpeechModelSettings['model'] | null;
+  speechVoice: DefaultSpeechModelSettings['voice'] | null;
+  realtimeVoiceProvider: DefaultRealtimeVoiceModelSettings['provider'] | null;
+  realtimeVoiceModel: DefaultRealtimeVoiceModelSettings['model'] | null;
+  realtimeVoiceVoice: DefaultRealtimeVoiceModelSettings['voice'] | null;
   transcriptionProvider: string | null;
   transcriptionModel: string | null;
   temperature: number;
@@ -100,6 +112,12 @@ export class ModelAgentDefaultsResolver {
       agentThinkingSettings,
       imageProvider: llmProviders?.defaultImageModel?.provider || 'google',
       imageModel: llmProviders?.defaultImageModel?.model || 'gemini-2.5-flash-image',
+      speechProvider: llmProviders?.defaultSpeechModel?.provider || null,
+      speechModel: llmProviders?.defaultSpeechModel?.model || null,
+      speechVoice: llmProviders?.defaultSpeechModel?.voice || null,
+      realtimeVoiceProvider: llmProviders?.defaultRealtimeVoiceModel?.provider || null,
+      realtimeVoiceModel: llmProviders?.defaultRealtimeVoiceModel?.model || null,
+      realtimeVoiceVoice: llmProviders?.defaultRealtimeVoiceModel?.voice || null,
       transcriptionProvider: llmProviders?.defaultTranscriptionModel?.provider || null,
       transcriptionModel: llmProviders?.defaultTranscriptionModel?.model || null,
       temperature: llmProviders?.defaultTemperature ?? 0.5

--- a/src/ui/chat/services/ModelAgentManager.ts
+++ b/src/ui/chat/services/ModelAgentManager.ts
@@ -30,7 +30,12 @@ import { PromptConfigurationUtility } from '../utils/PromptConfigurationUtility'
 import { WorkspaceIntegrationService } from './WorkspaceIntegrationService';
 import { StaticModelsService } from '../../../services/StaticModelsService';
 import { getWebLLMLifecycleManager } from '../../../services/llm/adapters/webllm/WebLLMLifecycleManager';
-import { ThinkingSettings } from '../../../types/llm/ProviderTypes';
+import {
+  DefaultRealtimeVoiceModelSettings,
+  DefaultSpeechModelSettings,
+  LLMProviderSettings,
+  ThinkingSettings
+} from '../../../types/llm/ProviderTypes';
 import { ContextStatus, ContextTokenTracker } from '../../../services/chat/ContextTokenTracker';
 import { CompactedContext } from '../../../services/chat/ContextCompactionService';
 import {
@@ -71,6 +76,12 @@ export class ModelAgentManager {
   private agentThinkingSettings: ThinkingSettings = { enabled: false, effort: 'medium' };
   private imageProvider: 'google' | 'openrouter' = 'google';
   private imageModel = 'gemini-2.5-flash-image';
+  private speechProvider: DefaultSpeechModelSettings['provider'] | null = null;
+  private speechModel: DefaultSpeechModelSettings['model'] | null = null;
+  private speechVoice: DefaultSpeechModelSettings['voice'] | null = null;
+  private realtimeVoiceProvider: DefaultRealtimeVoiceModelSettings['provider'] | null = null;
+  private realtimeVoiceModel: DefaultRealtimeVoiceModelSettings['model'] | null = null;
+  private realtimeVoiceVoice: DefaultRealtimeVoiceModelSettings['voice'] | null = null;
   private transcriptionProvider: string | null = null;
   private transcriptionModel: string | null = null;
   private thinkingSettings: ThinkingSettings = { enabled: false, effort: 'medium' };
@@ -254,6 +265,20 @@ export class ModelAgentManager {
       this.imageModel = settings.imageModel;
     }
 
+    // Restore speech model
+    if ('speechProvider' in settings || 'speechModel' in settings || 'speechVoice' in settings) {
+      this.speechProvider = settings.speechProvider || null;
+      this.speechModel = settings.speechModel || null;
+      this.speechVoice = settings.speechVoice || null;
+    }
+
+    // Restore realtime voice model
+    if ('realtimeVoiceProvider' in settings || 'realtimeVoiceModel' in settings || 'realtimeVoiceVoice' in settings) {
+      this.realtimeVoiceProvider = settings.realtimeVoiceProvider || null;
+      this.realtimeVoiceModel = settings.realtimeVoiceModel || null;
+      this.realtimeVoiceVoice = settings.realtimeVoiceVoice || null;
+    }
+
     // Restore transcription model
     if ('transcriptionProvider' in settings || 'transcriptionModel' in settings) {
       this.transcriptionProvider = settings.transcriptionProvider || null;
@@ -308,6 +333,12 @@ export class ModelAgentManager {
       this.agentThinkingSettings = { ...defaultState.agentThinkingSettings };
       this.imageProvider = defaultState.imageProvider;
       this.imageModel = defaultState.imageModel;
+      this.speechProvider = defaultState.speechProvider;
+      this.speechModel = defaultState.speechModel;
+      this.speechVoice = defaultState.speechVoice;
+      this.realtimeVoiceProvider = defaultState.realtimeVoiceProvider;
+      this.realtimeVoiceModel = defaultState.realtimeVoiceModel;
+      this.realtimeVoiceVoice = defaultState.realtimeVoiceVoice;
       this.transcriptionProvider = defaultState.transcriptionProvider;
       this.transcriptionModel = defaultState.transcriptionModel;
       this.temperature = defaultState.temperature;
@@ -571,6 +602,90 @@ export class ModelAgentManager {
   setImageModel(provider: 'google' | 'openrouter', model: string): void {
     this.imageProvider = provider;
     this.imageModel = model;
+  }
+
+  getSpeechProvider(): DefaultSpeechModelSettings['provider'] | null {
+    return this.speechProvider;
+  }
+
+  getSpeechModel(): DefaultSpeechModelSettings['model'] | null {
+    return this.speechModel;
+  }
+
+  getSpeechVoice(): DefaultSpeechModelSettings['voice'] | null {
+    return this.speechVoice;
+  }
+
+  setSpeechSettings(
+    provider: DefaultSpeechModelSettings['provider'] | null,
+    model: DefaultSpeechModelSettings['model'] | null,
+    voice: DefaultSpeechModelSettings['voice'] | null
+  ): void {
+    this.speechProvider = provider;
+    this.speechModel = model;
+    this.speechVoice = voice;
+  }
+
+  getRealtimeVoiceProvider(): DefaultRealtimeVoiceModelSettings['provider'] | null {
+    return this.realtimeVoiceProvider;
+  }
+
+  getRealtimeVoiceModel(): DefaultRealtimeVoiceModelSettings['model'] | null {
+    return this.realtimeVoiceModel;
+  }
+
+  getRealtimeVoiceVoice(): DefaultRealtimeVoiceModelSettings['voice'] | null {
+    return this.realtimeVoiceVoice;
+  }
+
+  setRealtimeVoiceSettings(
+    provider: DefaultRealtimeVoiceModelSettings['provider'] | null,
+    model: DefaultRealtimeVoiceModelSettings['model'] | null,
+    voice: DefaultRealtimeVoiceModelSettings['voice'] | null
+  ): void {
+    this.realtimeVoiceProvider = provider;
+    this.realtimeVoiceModel = model;
+    this.realtimeVoiceVoice = voice;
+  }
+
+  applyChatVoiceOverrides(settings: LLMProviderSettings | null): LLMProviderSettings | null {
+    if (!settings) {
+      return null;
+    }
+
+    const nextSettings: LLMProviderSettings = {
+      ...settings,
+      defaultSpeechModel: settings.defaultSpeechModel ? { ...settings.defaultSpeechModel } : undefined,
+      defaultRealtimeVoiceModel: settings.defaultRealtimeVoiceModel ? { ...settings.defaultRealtimeVoiceModel } : undefined,
+      defaultTranscriptionModel: settings.defaultTranscriptionModel ? { ...settings.defaultTranscriptionModel } : undefined,
+    };
+
+    if (this.speechProvider && this.speechModel) {
+      nextSettings.defaultSpeechModel = {
+        provider: this.speechProvider,
+        model: this.speechModel,
+        voice: this.speechVoice || undefined,
+        source: 'user'
+      };
+    }
+
+    if (this.realtimeVoiceProvider && this.realtimeVoiceModel) {
+      nextSettings.defaultRealtimeVoiceModel = {
+        provider: this.realtimeVoiceProvider,
+        model: this.realtimeVoiceModel,
+        voice: this.realtimeVoiceVoice || undefined,
+        source: 'user'
+      };
+    }
+
+    if (this.transcriptionProvider && this.transcriptionModel) {
+      nextSettings.defaultTranscriptionModel = {
+        provider: this.transcriptionProvider,
+        model: this.transcriptionModel
+      };
+    }
+
+    return nextSettings;
   }
 
   /**
@@ -844,6 +959,12 @@ export class ModelAgentManager {
       agentThinking: this.agentThinkingSettings,
       imageProvider: this.imageProvider,
       imageModel: this.imageModel,
+      speechProvider: this.speechProvider,
+      speechModel: this.speechModel,
+      speechVoice: this.speechVoice,
+      realtimeVoiceProvider: this.realtimeVoiceProvider,
+      realtimeVoiceModel: this.realtimeVoiceModel,
+      realtimeVoiceVoice: this.realtimeVoiceVoice,
       transcriptionProvider: this.transcriptionProvider,
       transcriptionModel: this.transcriptionModel
     };

--- a/src/utils/connectorContent.ts
+++ b/src/utils/connectorContent.ts
@@ -5,7 +5,7 @@
  * DO NOT EDIT MANUALLY - This file is regenerated during the build process.
  * To update, modify connector.ts and rebuild.
  *
- * Generated: 2026-06-02T21:37:50.150Z
+ * Generated: 2026-06-09T12:07:36.771Z
  */
 
 export const CONNECTOR_JS_CONTENT = `"use strict";

--- a/tests/unit/ChatLiveVoiceController.test.ts
+++ b/tests/unit/ChatLiveVoiceController.test.ts
@@ -7,12 +7,13 @@ const mockSessionStart = jest.fn();
 const mockSessionStop = jest.fn();
 const mockGetAvailability = jest.fn();
 const mockCreateSession = jest.fn();
+var mockRealtimeVoiceService: jest.Mock;
 
 jest.mock('../../src/services/realtimeVoice/RealtimeVoiceService', () => ({
-  RealtimeVoiceService: jest.fn().mockImplementation(() => ({
+  RealtimeVoiceService: (mockRealtimeVoiceService = jest.fn().mockImplementation(() => ({
     getAvailability: mockGetAvailability,
     createSession: mockCreateSession,
-  })),
+  }))),
 }));
 
 describe('ChatLiveVoiceController', () => {
@@ -22,6 +23,7 @@ describe('ChatLiveVoiceController', () => {
     mockSessionStop.mockReset();
     mockGetAvailability.mockReset();
     mockCreateSession.mockReset();
+    mockRealtimeVoiceService.mockClear();
     mockSessionStart.mockResolvedValue(undefined);
     mockGetAvailability.mockReturnValue({ available: true });
     mockCreateSession.mockReturnValue({
@@ -85,7 +87,9 @@ describe('ChatLiveVoiceController', () => {
     });
 
     return {
+      app,
       chatInput,
+      component,
       controller,
       getConversationContext,
       liveVoiceButton,
@@ -120,6 +124,40 @@ describe('ChatLiveVoiceController', () => {
     expect(mockCreateSession).toHaveBeenCalledTimes(1);
     expect(mockCreateSession.mock.calls[0]?.[0].instructions).toContain('<conversation_context>Prior chat</conversation_context>');
     expect(mockSessionStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefers resolved chat voice settings when provided', async () => {
+    const { app, chatInput, component, getConversationContext, liveVoiceButton, onTranscriptMessage, toolStatusBar } = createHarness(true);
+    const resolvedSettings = {
+      providers: {
+        openai: {
+          enabled: true,
+          apiKey: 'override-key'
+        }
+      },
+      defaultModel: { provider: 'openai', model: 'gpt-4o' },
+      defaultRealtimeVoiceModel: {
+        provider: 'openai',
+        model: 'gpt-realtime-2',
+        voice: 'marin',
+        source: 'user'
+      }
+    };
+    const controllerWithOverride = new ChatLiveVoiceController({
+      app: app as never,
+      chatInput,
+      toolStatusBar,
+      liveVoiceButton,
+      getHasConversation: () => true,
+      getLLMSettings: () => resolvedSettings as never,
+      getConversationContext,
+      onTranscriptMessage,
+      component,
+    });
+
+    await controllerWithOverride.start();
+
+    expect(mockRealtimeVoiceService).toHaveBeenLastCalledWith(resolvedSettings);
   });
 
   it('reports unavailable realtime voice settings', async () => {

--- a/tests/unit/ChatVoiceInputController.test.ts
+++ b/tests/unit/ChatVoiceInputController.test.ts
@@ -135,4 +135,36 @@ describe('ChatVoiceInputController', () => {
     expect(onError).not.toHaveBeenCalled();
     expect(mediaTrackStop).toHaveBeenCalled();
   });
+
+  it('prefers resolved chat transcription settings when provided', () => {
+    const resolvedSettings = {
+      providers: {
+        openai: {
+          enabled: true,
+          apiKey: 'override-key'
+        }
+      },
+      defaultModel: { provider: 'openai', model: 'gpt-4o' },
+      defaultTranscriptionModel: { provider: 'openai', model: 'whisper-1' }
+    } as never;
+    mockedCreateOrReuse.mockReturnValue({
+      getAvailableProviders: () => [
+        {
+          provider: 'openai',
+          available: true,
+          models: [{ id: 'whisper-1' }]
+        }
+      ]
+    } as never);
+
+    const controller = new ChatVoiceInputController({} as App, {
+      onStateChange: jest.fn(),
+      onTranscriptReady: jest.fn(),
+      onError: jest.fn()
+    }, () => resolvedSettings);
+
+    expect(controller.isAvailable()).toBe(true);
+    expect(mockedCreateOrReuse).toHaveBeenCalledWith(resolvedSettings);
+    expect(mockedGetNexusPlugin).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/ModelAgentManager.test.ts
+++ b/tests/unit/ModelAgentManager.test.ts
@@ -4,6 +4,7 @@ import { ModelSelectionUtility } from '../../src/ui/chat/utils/ModelSelectionUti
 import type { WorkspaceContext } from '../../src/database/types/workspace/WorkspaceTypes';
 import type { ModelOption, PromptOption } from '../../src/ui/chat/types/SelectionTypes';
 import type { ModelAgentDefaultState } from '../../src/ui/chat/services/ModelAgentDefaultsResolver';
+import type { LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
 
 type SelectedModel = {
   providerId: string;
@@ -176,7 +177,15 @@ describe('ModelAgentManager', () => {
             temperature: 0.8,
             agentProvider: 'anthropic',
             agentModel: 'claude-sonnet',
-            agentThinking: { enabled: true, effort: 'low' }
+            agentThinking: { enabled: true, effort: 'low' },
+            speechProvider: 'openai',
+            speechModel: 'gpt-4o-mini-tts',
+            speechVoice: 'alloy',
+            realtimeVoiceProvider: 'openai',
+            realtimeVoiceModel: 'gpt-realtime-2',
+            realtimeVoiceVoice: 'marin',
+            transcriptionProvider: 'openai',
+            transcriptionModel: 'whisper-1'
           }
         }
       })
@@ -210,6 +219,14 @@ describe('ModelAgentManager', () => {
     expect(manager.getAgentProvider()).toBe('anthropic');
     expect(manager.getAgentModel()).toBe('claude-sonnet');
     expect(manager.getAgentThinkingSettings()).toEqual({ enabled: true, effort: 'low' });
+    expect(manager.getSpeechProvider()).toBe('openai');
+    expect(manager.getSpeechModel()).toBe('gpt-4o-mini-tts');
+    expect(manager.getSpeechVoice()).toBe('alloy');
+    expect(manager.getRealtimeVoiceProvider()).toBe('openai');
+    expect(manager.getRealtimeVoiceModel()).toBe('gpt-realtime-2');
+    expect(manager.getRealtimeVoiceVoice()).toBe('marin');
+    expect(manager.getTranscriptionProvider()).toBe('openai');
+    expect(manager.getTranscriptionModel()).toBe('whisper-1');
     expect(access.workspaceContextService.restoreWorkspace).toHaveBeenCalledWith('workspace_1', 'session_abc');
   });
 
@@ -236,6 +253,9 @@ describe('ModelAgentManager', () => {
     manager.setTemperature(0.35);
     manager.setAgentModel('openai', 'gpt-5');
     manager.setAgentThinkingSettings({ enabled: false, effort: 'medium' });
+    manager.setSpeechSettings('openai', 'gpt-4o-mini-tts', 'alloy');
+    manager.setRealtimeVoiceSettings('openai', 'gpt-realtime-2', 'marin');
+    manager.setTranscriptionModel('openai', 'whisper-1');
 
     await manager.saveToConversation('conv_2');
 
@@ -251,9 +271,69 @@ describe('ModelAgentManager', () => {
         temperature: 0.35,
         agentProvider: 'openai',
         agentModel: 'gpt-5',
-        agentThinking: { enabled: false, effort: 'medium' }
+        agentThinking: { enabled: false, effort: 'medium' },
+        speechProvider: 'openai',
+        speechModel: 'gpt-4o-mini-tts',
+        speechVoice: 'alloy',
+        realtimeVoiceProvider: 'openai',
+        realtimeVoiceModel: 'gpt-realtime-2',
+        realtimeVoiceVoice: 'marin',
+        transcriptionProvider: 'openai',
+        transcriptionModel: 'whisper-1'
       })
     });
+  });
+
+  it('applies chat-scoped voice overrides over plugin defaults', () => {
+    const manager = new ModelAgentManager({}, createEvents());
+    manager.setSpeechSettings('openai', 'gpt-4o-mini-tts', 'alloy');
+    manager.setRealtimeVoiceSettings('openai', 'gpt-realtime-2', 'marin');
+    manager.setTranscriptionModel('openai', 'whisper-1');
+
+    const settings: LLMProviderSettings = {
+      providers: {
+        openai: {
+          enabled: true,
+          apiKey: 'test-key'
+        }
+      },
+      defaultModel: { provider: 'openai', model: 'gpt-4o' },
+      defaultSpeechModel: {
+        provider: 'openai',
+        model: 'tts-1',
+        voice: 'echo',
+        source: 'user'
+      },
+      defaultRealtimeVoiceModel: {
+        provider: 'openai',
+        model: 'gpt-realtime-1',
+        voice: 'cedar',
+        source: 'user'
+      },
+      defaultTranscriptionModel: {
+        provider: 'google',
+        model: 'gemini-transcribe'
+      }
+    };
+
+    expect(manager.applyChatVoiceOverrides(settings)).toEqual(expect.objectContaining({
+      defaultSpeechModel: {
+        provider: 'openai',
+        model: 'gpt-4o-mini-tts',
+        voice: 'alloy',
+        source: 'user'
+      },
+      defaultRealtimeVoiceModel: {
+        provider: 'openai',
+        model: 'gpt-realtime-2',
+        voice: 'marin',
+        source: 'user'
+      },
+      defaultTranscriptionModel: {
+        provider: 'openai',
+        model: 'whisper-1'
+      }
+    }));
   });
 
   it('binds the current session and rebuilds the prompt when setting workspace context', async () => {

--- a/tests/unit/VoiceAudioCapabilityTypes.test.ts
+++ b/tests/unit/VoiceAudioCapabilityTypes.test.ts
@@ -240,7 +240,7 @@ describe('RealtimeVoiceTypes', () => {
     }));
   });
 
-  it('unlocks app-backed ElevenLabs realtime only when the app is enabled and configured', () => {
+  it('keeps unwired ElevenLabs realtime hidden even when the app is enabled and configured', () => {
     const settings = makeSettings();
     const availability = buildRealtimeVoiceProviderAvailability(settings, {
       elevenlabs: { enabled: true, configured: true }
@@ -249,10 +249,10 @@ describe('RealtimeVoiceTypes', () => {
     const selection = resolveDefaultRealtimeVoiceSelection(settings, availability);
 
     expect(selection).toEqual(expect.objectContaining({
-      provider: 'elevenlabs',
-      model: 'eleven-agents-conversation',
-      status: 'resolved'
+      source: 'auto',
+      status: 'unavailable'
     }));
+    expect(availability.find(item => item.provider === 'elevenlabs')).toBeUndefined();
   });
 
   it('keeps invalid user-selected realtime defaults instead of falling back', () => {


### PR DESCRIPTION
## Summary
- mirror the newer voice defaults in chat settings and persist chat-scoped overrides
- apply chat voice overrides to chat microphone input and live voice runtime resolution
- hide unwired realtime providers like ElevenLabs from live voice selection and fix the chat voice warning/rendering issues

## Validation
- npm test -- --runTestsByPath tests/unit/ModelAgentManager.test.ts tests/unit/ChatLiveVoiceController.test.ts tests/unit/ChatVoiceInputController.test.ts
- npm test -- --runTestsByPath tests/unit/VoiceAudioCapabilityTypes.test.ts tests/unit/RealtimeVoiceService.test.ts tests/unit/ChatLiveVoiceController.test.ts
- npm run build