### PR TITLE
feat: opt-in secure API key storage via app.secretStorage

### DIFF
--- a/src/services/secrets/SecretStore.ts
+++ b/src/services/secrets/SecretStore.ts
@@ -1,0 +1,121 @@
+/**
+ * SecretStore.ts
+ * Location: src/services/secrets/SecretStore.ts
+ *
+ * Thin, throw-safe wrapper over Obsidian's first-party `app.secretStorage`
+ * (available since Obsidian 1.11.4). Secrets stored here are device-local and
+ * OS-encrypted; they are NOT written to the synced `data.json`.
+ *
+ * Used by: src/settings.ts to strip plaintext secrets out of persisted
+ * settings on save and hydrate them back into the in-memory settings on load.
+ *
+ * The secretStorage API is synchronous and has NO removeSecret — "clearing" a
+ * secret means setting it to the empty string. If the API is unavailable
+ * (older Obsidian) or a write throws, callers fall back to plaintext persist
+ * so a user's key is never lost.
+ */
+
+/**
+ * Structural shape of `app.secretStorage`. Declared locally so the wrapper does
+ * not depend on the SecretStorage class being present in every typings build.
+ */
+export interface SecretStorageApi {
+  setSecret(id: string, secret: string): void;
+  getSecret(id: string): string | null;
+  listSecrets(): string[];
+}
+
+/**
+ * Minimal app shape needed to reach `secretStorage`. The property is optional
+ * because it is absent on Obsidian < 1.11.4.
+ */
+export interface SecretStorageHost {
+  secretStorage?: SecretStorageApi;
+}
+
+/** Prefix for every secret id Nexus owns, to avoid collisions with other plugins. */
+const ID_PREFIX = 'nexus';
+
+/**
+ * Normalize an arbitrary identifier fragment to the secretStorage id constraint
+ * (lowercase alphanumeric with dashes). Runs of disallowed characters collapse
+ * to a single dash; leading/trailing dashes are trimmed.
+ */
+export function normalizeSecretIdFragment(fragment: string): string {
+  return fragment
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Secret id for an LLM provider API key: `nexus-llm-<providerId>-apikey`. */
+export function llmApiKeySecretId(providerId: string): string {
+  return `${ID_PREFIX}-llm-${normalizeSecretIdFragment(providerId)}-apikey`;
+}
+
+/** Secret id for an LLM provider OAuth refresh token: `nexus-llm-<providerId>-oauth-refresh`. */
+export function llmOAuthRefreshSecretId(providerId: string): string {
+  return `${ID_PREFIX}-llm-${normalizeSecretIdFragment(providerId)}-oauth-refresh`;
+}
+
+/** Secret id for an app credential: `nexus-app-<appId>-<credKey>`. */
+export function appCredentialSecretId(appId: string, credKey: string): string {
+  return `${ID_PREFIX}-app-${normalizeSecretIdFragment(appId)}-${normalizeSecretIdFragment(credKey)}`;
+}
+
+/**
+ * Throw-safe wrapper over `app.secretStorage`. Every method swallows errors and
+ * reports failure via its return value so a misbehaving backend never breaks
+ * settings persistence.
+ */
+export class SecretStore {
+  private readonly host: SecretStorageHost;
+
+  constructor(host: SecretStorageHost) {
+    this.host = host;
+  }
+
+  /** True when `app.secretStorage` exists and exposes the expected methods. */
+  isAvailable(): boolean {
+    const api = this.host.secretStorage;
+    return !!api
+      && typeof api.setSecret === 'function'
+      && typeof api.getSecret === 'function'
+      && typeof api.listSecrets === 'function';
+  }
+
+  /**
+   * Store a secret under `id`. Returns true on success, false if the store is
+   * unavailable or the write throws (e.g. invalid id).
+   */
+  set(id: string, value: string): boolean {
+    const api = this.host.secretStorage;
+    if (!this.isAvailable() || !api) {
+      return false;
+    }
+    try {
+      api.setSecret(id, value);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Read a secret, or null when missing/unavailable/throwing. */
+  get(id: string): string | null {
+    const api = this.host.secretStorage;
+    if (!this.isAvailable() || !api) {
+      return null;
+    }
+    try {
+      return api.getSecret(id);
+    } catch {
+      return null;
+    }
+  }
+
+  /** Clear a secret by setting it to the empty string (no removeSecret exists). */
+  clear(id: string): boolean {
+    return this.set(id, '');
+  }
+}

--- a/src/services/secrets/SettingsSecrets.ts
+++ b/src/services/secrets/SettingsSecrets.ts
@@ -1,0 +1,195 @@
+/**
+ * SettingsSecrets.ts
+ * Location: src/services/secrets/SettingsSecrets.ts
+ *
+ * The persistence boundary that moves plaintext secrets out of the synced
+ * `data.json` and into `app.secretStorage`. The in-memory settings shape is
+ * unchanged: every secret field stays a populated string at runtime so all
+ * existing readers (adapters, ProviderManager, UI) keep working untouched.
+ *
+ * Used by: src/settings.ts.
+ *
+ * Three operations, all keyed off the same field enumeration:
+ *   - hydrateSecrets(settings):  load → fill each secret field from secretStorage
+ *   - stripSecretsForPersist(settings): save → write each secret to secretStorage
+ *                                        and return a clone with the field blanked
+ *   - migrateLegacyPlaintext(settings): on load, move any plaintext secret still
+ *                                        in data.json into secretStorage (idempotent)
+ *
+ * When secretStorage is unavailable, hydrate/strip become no-ops and the caller
+ * persists plaintext exactly as before (no behavior change on Obsidian < 1.11.4).
+ */
+
+import type { MCPSettings } from '../../types';
+import type { LLMProviderConfig } from '../../types/llm/ProviderTypes';
+import type { AppConfig } from '../../types/apps/AppTypes';
+import {
+  SecretStore,
+  appCredentialSecretId,
+  llmApiKeySecretId,
+  llmOAuthRefreshSecretId
+} from './SecretStore';
+
+/**
+ * One secret field located within a settings object: a stable secretStorage id
+ * plus get/set accessors that read and write the in-memory value at that path.
+ */
+interface SecretFieldRef {
+  id: string;
+  read(): string | undefined;
+  write(value: string): void;
+}
+
+function providerEntries(settings: MCPSettings): Array<[string, LLMProviderConfig]> {
+  const providers = settings.llmProviders?.providers;
+  if (!providers || typeof providers !== 'object') {
+    return [];
+  }
+  return Object.entries(providers);
+}
+
+function appEntries(settings: MCPSettings): Array<[string, AppConfig]> {
+  const apps = settings.apps?.apps;
+  if (!apps || typeof apps !== 'object') {
+    return [];
+  }
+  return Object.entries(apps);
+}
+
+/**
+ * Enumerate every secret-bearing field on the settings object. Each ref's
+ * read/write operate directly on the passed-in object's nested structures, so
+ * writing through them mutates the same in-memory settings.
+ */
+function collectSecretFields(settings: MCPSettings): SecretFieldRef[] {
+  const refs: SecretFieldRef[] = [];
+
+  for (const [providerId, config] of providerEntries(settings)) {
+    refs.push({
+      id: llmApiKeySecretId(providerId),
+      read: () => config.apiKey,
+      write: (value) => { config.apiKey = value; }
+    });
+    if (config.oauth) {
+      const oauth = config.oauth;
+      refs.push({
+        id: llmOAuthRefreshSecretId(providerId),
+        read: () => oauth.refreshToken,
+        write: (value) => { oauth.refreshToken = value; }
+      });
+    }
+  }
+
+  for (const [appId, config] of appEntries(settings)) {
+    const credentials = config.credentials;
+    if (!credentials || typeof credentials !== 'object') {
+      continue;
+    }
+    for (const credKey of Object.keys(credentials)) {
+      refs.push({
+        id: appCredentialSecretId(appId, credKey),
+        read: () => credentials[credKey],
+        write: (value) => { credentials[credKey] = value; }
+      });
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Load each secret field's value from secretStorage onto the in-memory settings
+ * object. No-op when secretStorage is unavailable. Only overwrites a field when
+ * a non-null secret exists, so a freshly hydrated value never clobbers a
+ * runtime-set one that hasn't been persisted yet.
+ */
+export function hydrateSecrets(settings: MCPSettings, store: SecretStore): void {
+  if (!store.isAvailable()) {
+    return;
+  }
+  for (const field of collectSecretFields(settings)) {
+    const stored = store.get(field.id);
+    if (stored !== null && stored !== '') {
+      field.write(stored);
+    }
+  }
+}
+
+/**
+ * Produce a structurally-cloned copy of `settings` with every secret field
+ * blanked, after writing each secret value to secretStorage. The original
+ * in-memory `settings` is left untouched (runtime keeps its populated values).
+ *
+ * Returns `{ settings, persisted }`. When `persisted` is false the store was
+ * unavailable (or every write failed) and the caller should persist the
+ * original plaintext settings so no key is lost.
+ */
+export function stripSecretsForPersist(
+  settings: MCPSettings,
+  store: SecretStore
+): { settings: MCPSettings; persisted: boolean } {
+  if (!store.isAvailable()) {
+    return { settings, persisted: false };
+  }
+
+  const clone = structuredCloneSettings(settings);
+  const fields = collectSecretFields(clone);
+  let anyPersisted = false;
+  let anyFailed = false;
+
+  for (const field of fields) {
+    const value = field.read();
+    if (value === undefined) {
+      continue;
+    }
+    if (value === '') {
+      field.write('');
+      continue;
+    }
+    const ok = store.set(field.id, value);
+    if (ok) {
+      anyPersisted = true;
+      field.write('');
+    } else {
+      anyFailed = true;
+    }
+  }
+
+  if (anyFailed && !anyPersisted) {
+    return { settings, persisted: false };
+  }
+  return { settings: clone, persisted: true };
+}
+
+/**
+ * Move any plaintext secret still present on the in-memory settings into
+ * secretStorage. Idempotent: safe to call on every load. Returns true if at
+ * least one secret was migrated (signaling the caller to re-save so the
+ * plaintext is stripped from data.json). No-op when unavailable.
+ */
+export function migrateLegacyPlaintext(settings: MCPSettings, store: SecretStore): boolean {
+  if (!store.isAvailable()) {
+    return false;
+  }
+  let migrated = false;
+  for (const field of collectSecretFields(settings)) {
+    const value = field.read();
+    if (value === undefined || value === '') {
+      continue;
+    }
+    if (store.set(field.id, value)) {
+      migrated = true;
+    }
+  }
+  return migrated;
+}
+
+/**
+ * Clone the settings object deeply enough that mutating secret fields on the
+ * copy does not touch the original's nested provider/app structures. Settings
+ * are plain JSON-serializable data, so a JSON round-trip is sufficient and
+ * cross-platform.
+ */
+function structuredCloneSettings(settings: MCPSettings): MCPSettings {
+  return JSON.parse(JSON.stringify(settings)) as MCPSettings;
+}

--- a/src/services/secrets/SettingsSecrets.ts
+++ b/src/services/secrets/SettingsSecrets.ts
@@ -185,6 +185,22 @@ export function migrateLegacyPlaintext(settings: MCPSettings, store: SecretStore
 }
 
 /**
+ * Remove every secret field's value from secretStorage. Called when the user
+ * turns the secure-storage option off: the in-memory settings still hold the
+ * plaintext values (which the caller persists to data.json before clearing),
+ * so dropping the stored copies leaves no orphaned secrets behind. No-op when
+ * secretStorage is unavailable.
+ */
+export function clearStoredSecrets(settings: MCPSettings, store: SecretStore): void {
+  if (!store.isAvailable()) {
+    return;
+  }
+  for (const field of collectSecretFields(settings)) {
+    store.clear(field.id);
+  }
+}
+
+/**
  * Clone the settings object deeply enough that mutating secret fields on the
  * copy does not touch the original's nested provider/app structures. Settings
  * are plain JSON-serializable data, so a JSON round-trip is sufficient and

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,7 @@ import { MCPSettings, DEFAULT_SETTINGS, type LLMProviderConfig } from './types';
 import { pluginDataLock } from './utils/pluginDataLock';
 import { SecretStore, type SecretStorageHost } from './services/secrets/SecretStore';
 import {
+    clearStoredSecrets,
     hydrateSecrets,
     migrateLegacyPlaintext,
     stripSecretsForPersist
@@ -35,9 +36,13 @@ export class Settings {
         try {
             const loadedData: unknown = await this.plugin.loadData();
             this.applyLoadedData(loadedData);
-            hydrateSecrets(this.settings, this.secretStore);
-            if (migrateLegacyPlaintext(this.settings, this.secretStore)) {
-                await this.saveSettings();
+            // Secrets only leave data.json when the user has opted in. When the
+            // option is off, keys stay in the synced settings as before.
+            if (this.settings.secureApiKeyStorage) {
+                hydrateSecrets(this.settings, this.secretStore);
+                if (migrateLegacyPlaintext(this.settings, this.secretStore)) {
+                    await this.saveSettings();
+                }
             }
         } catch {
             // Continue with defaults - plugin should still function
@@ -101,12 +106,12 @@ export class Settings {
         await pluginDataLock.acquire(async () => {
             const loadedData: unknown = await this.plugin.loadData();
             // Move secrets into app.secretStorage and persist a clone with the
-            // secret fields blanked. When secretStorage is unavailable this
-            // returns the original settings unchanged (plaintext fallback).
-            const { settings: persistableSettings } = stripSecretsForPersist(
-                this.settings,
-                this.secretStore
-            );
+            // secret fields blanked, but only when the user has opted in. When
+            // the option is off (or secretStorage is unavailable) the original
+            // settings are persisted unchanged (plaintext fallback).
+            const { settings: persistableSettings } = this.settings.secureApiKeyStorage
+                ? stripSecretsForPersist(this.settings, this.secretStore)
+                : { settings: this.settings };
             const settingsWithoutRuntimeState = {
                 ...(persistableSettings as MCPSettings & { pluginStorage?: unknown })
             };
@@ -117,6 +122,32 @@ export class Settings {
 
             await this.plugin.saveData(mergedData);
         });
+    }
+
+    /**
+     * Whether Obsidian's secretStorage API is available (requires Obsidian
+     * 1.11.4+). Gates whether the secure-key-storage option can be enabled.
+     */
+    isSecretStorageAvailable(): boolean {
+        return this.secretStore.isAvailable();
+    }
+
+    /**
+     * Turn the secure-key-storage option on or off and migrate accordingly.
+     * Enabling persists the in-memory keys into secretStorage and strips them
+     * from data.json. Disabling persists the in-memory plaintext back into
+     * data.json (so keys sync again) and then clears the stored copies. An
+     * enable request is ignored when secretStorage is unavailable.
+     */
+    async setSecureApiKeyStorage(enabled: boolean): Promise<void> {
+        if (enabled && !this.secretStore.isAvailable()) {
+            return;
+        }
+        this.settings.secureApiKeyStorage = enabled;
+        await this.saveSettings();
+        if (!enabled) {
+            clearStoredSecrets(this.settings, this.secretStore);
+        }
     }
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,12 @@
 import { Plugin } from 'obsidian';
 import { MCPSettings, DEFAULT_SETTINGS, type LLMProviderConfig } from './types';
 import { pluginDataLock } from './utils/pluginDataLock';
+import { SecretStore, type SecretStorageHost } from './services/secrets/SecretStore';
+import {
+    hydrateSecrets,
+    migrateLegacyPlaintext,
+    stripSecretsForPersist
+} from './services/secrets/SettingsSecrets';
 
 /**
  * Settings manager
@@ -8,6 +14,7 @@ import { pluginDataLock } from './utils/pluginDataLock';
  */
 export class Settings {
     private plugin: Plugin;
+    private secretStore: SecretStore;
     settings: MCPSettings;
 
     /**
@@ -16,6 +23,7 @@ export class Settings {
      */
     constructor(plugin: Plugin) {
         this.plugin = plugin;
+        this.secretStore = new SecretStore((plugin.app ?? {}) as unknown as SecretStorageHost);
         this.settings = DEFAULT_SETTINGS;
     }
 
@@ -27,6 +35,10 @@ export class Settings {
         try {
             const loadedData: unknown = await this.plugin.loadData();
             this.applyLoadedData(loadedData);
+            hydrateSecrets(this.settings, this.secretStore);
+            if (migrateLegacyPlaintext(this.settings, this.secretStore)) {
+                await this.saveSettings();
+            }
         } catch {
             // Continue with defaults - plugin should still function
         }
@@ -88,8 +100,15 @@ export class Settings {
     async saveSettings(): Promise<void> {
         await pluginDataLock.acquire(async () => {
             const loadedData: unknown = await this.plugin.loadData();
+            // Move secrets into app.secretStorage and persist a clone with the
+            // secret fields blanked. When secretStorage is unavailable this
+            // returns the original settings unchanged (plaintext fallback).
+            const { settings: persistableSettings } = stripSecretsForPersist(
+                this.settings,
+                this.secretStore
+            );
             const settingsWithoutRuntimeState = {
-                ...(this.settings as MCPSettings & { pluginStorage?: unknown })
+                ...(persistableSettings as MCPSettings & { pluginStorage?: unknown })
             };
             delete settingsWithoutRuntimeState.pluginStorage;
             const mergedData = loadedData && typeof loadedData === 'object'

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -10,8 +10,9 @@
  * Note: Default provider/model/thinking settings moved to DefaultsTab
  */
 
-import { App, Notice } from 'obsidian';
+import { App, Notice, Setting } from 'obsidian';
 import { SettingsRouter } from '../SettingsRouter';
+import { ConfirmModal } from '../components/ConfirmModal';
 import { LLMProviderSettings, LLMProviderConfig } from '../../types/llm/ProviderTypes';
 import { LLMProviderModal, LLMProviderModalConfig } from '../../components/LLMProviderModal';
 import { LLMProviderManager } from '../../services/llm/providers/ProviderManager';
@@ -402,8 +403,69 @@ export class ProvidersTab {
     render(): void {
         this.container.empty();
 
-        // Provider groups only - defaults moved to DefaultsTab
+        // Opt-in secure key storage, then the provider groups.
+        this.renderSecuritySection();
         this.renderProviders();
+    }
+
+    /**
+     * Render the opt-in toggle that moves API keys into Obsidian's device-local
+     * secretStorage and out of the synced data.json. Disabled (with an
+     * explanatory note) when secretStorage is unavailable (Obsidian < 1.11.4).
+     */
+    private renderSecuritySection(): void {
+        const settings = this.services.settings;
+        const available = settings.isSecretStorageAvailable();
+        const enabled = settings.settings.secureApiKeyStorage === true;
+
+        new Setting(this.container)
+            .setName('Store API keys in secure storage')
+            .setDesc(available
+                ? 'Keep API keys in Obsidian’s device-local secure storage instead of the synced settings file. Keys never sync, so you’ll re-enter them once on each device.'
+                : 'Requires Obsidian 1.11.4 or later. On this version, API keys are stored in the settings file.')
+            .addToggle((toggle) => {
+                toggle
+                    .setValue(enabled)
+                    .setDisabled(!available)
+                    .onChange((value) => {
+                        void this.handleSecureStorageToggle(value);
+                    });
+            });
+    }
+
+    /**
+     * Confirm the security-toggle change, apply it, then re-render. A cancelled
+     * confirm re-renders with the unchanged value, resetting the toggle.
+     */
+    private async handleSecureStorageToggle(enable: boolean): Promise<void> {
+        const app = this.services.app;
+        const confirmed = enable
+            ? await ConfirmModal.confirm(app, {
+                variant: 'archive',
+                title: 'Move API keys to secure storage?',
+                body: 'Your API keys will be moved into Obsidian’s device-local secure storage and removed from the synced settings file. You’ll need to re-enter each key once on your other devices.',
+                ctaLabel: 'Move keys'
+            })
+            : await ConfirmModal.confirm(app, {
+                variant: 'remove',
+                title: 'Disable secure storage?',
+                body: 'Your API keys will be written back into the synced settings file and removed from secure storage. They will sync across your devices again.',
+                ctaLabel: 'Disable'
+            });
+
+        if (!confirmed) {
+            this.render();
+            return;
+        }
+
+        try {
+            await this.services.settings.setSecureApiKeyStorage(enable);
+            new Notice(enable ? 'API keys moved to secure storage' : 'Secure storage disabled');
+        } catch (error) {
+            console.error('Failed to update secure key storage:', error);
+            new Notice('Failed to update secure key storage');
+        }
+        this.render();
     }
 
     /**

--- a/src/types/plugin/PluginTypes.ts
+++ b/src/types/plugin/PluginTypes.ts
@@ -87,6 +87,10 @@ export interface MCPSettings {
   customPrompts?: CustomPromptsSettings;
   llmProviders?: LLMProviderSettings;
   apps?: AppsSettings;
+  // When true, API keys / credentials are stored in Obsidian's device-local
+  // secretStorage and stripped from the synced data.json. Off by default so
+  // keys keep syncing across devices unless the user opts in.
+  secureApiKeyStorage?: boolean;
   // Default selections for chat
   defaultWorkspaceId?: string;
   defaultPromptId?: string;

--- a/tests/unit/SecretStore.test.ts
+++ b/tests/unit/SecretStore.test.ts
@@ -1,0 +1,106 @@
+import {
+  SecretStore,
+  normalizeSecretIdFragment,
+  llmApiKeySecretId,
+  llmOAuthRefreshSecretId,
+  appCredentialSecretId,
+  type SecretStorageApi,
+  type SecretStorageHost
+} from '../../src/services/secrets/SecretStore';
+
+/** In-memory stand-in for app.secretStorage with the same synchronous contract. */
+function createMockSecretStorage(overrides: Partial<SecretStorageApi> = {}): {
+  api: SecretStorageApi;
+  map: Map<string, string>;
+} {
+  const map = new Map<string, string>();
+  const api: SecretStorageApi = {
+    setSecret(id: string, secret: string): void {
+      if (!/^[a-z0-9-]+$/.test(id)) {
+        throw new Error(`invalid id: ${id}`);
+      }
+      map.set(id, secret);
+    },
+    getSecret(id: string): string | null {
+      return map.has(id) ? (map.get(id) as string) : null;
+    },
+    listSecrets(): string[] {
+      return [...map.keys()];
+    },
+    ...overrides
+  };
+  return { api, map };
+}
+
+describe('SecretStore id derivation', () => {
+  it('normalizes fragments to lowercase-alphanumeric-dashes', () => {
+    expect(normalizeSecretIdFragment('OpenAI')).toBe('openai');
+    expect(normalizeSecretIdFragment('github-copilot')).toBe('github-copilot');
+    expect(normalizeSecretIdFragment('foo_bar.baz')).toBe('foo-bar-baz');
+    expect(normalizeSecretIdFragment('  --Weird  Key!! ')).toBe('weird-key');
+  });
+
+  it('builds stable provider and app secret ids', () => {
+    expect(llmApiKeySecretId('openai')).toBe('nexus-llm-openai-apikey');
+    expect(llmApiKeySecretId('github-copilot')).toBe('nexus-llm-github-copilot-apikey');
+    expect(llmOAuthRefreshSecretId('openrouter')).toBe('nexus-llm-openrouter-oauth-refresh');
+    expect(appCredentialSecretId('elevenlabs', 'apiKey')).toBe('nexus-app-elevenlabs-apikey');
+  });
+
+  it('produces ids that satisfy the secretStorage id constraint', () => {
+    const ids = [
+      llmApiKeySecretId('anthropic-claude-code'),
+      llmOAuthRefreshSecretId('openai-codex'),
+      appCredentialSecretId('My App', 'webhook URL')
+    ];
+    for (const id of ids) {
+      expect(id).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+});
+
+describe('SecretStore get/set/clear', () => {
+  it('reports availability based on the host API', () => {
+    const { api } = createMockSecretStorage();
+    expect(new SecretStore({ secretStorage: api }).isAvailable()).toBe(true);
+    expect(new SecretStore({}).isAvailable()).toBe(false);
+    expect(new SecretStore({ secretStorage: {} as SecretStorageApi }).isAvailable()).toBe(false);
+  });
+
+  it('round-trips set and get', () => {
+    const { api, map } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    expect(store.set('nexus-llm-openai-apikey', 'sk-123')).toBe(true);
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-123');
+    expect(store.get('nexus-llm-openai-apikey')).toBe('sk-123');
+  });
+
+  it('returns null for missing keys and on unavailable store', () => {
+    const { api } = createMockSecretStorage();
+    expect(new SecretStore({ secretStorage: api }).get('absent')).toBeNull();
+    expect(new SecretStore({}).get('nexus-llm-openai-apikey')).toBeNull();
+  });
+
+  it('clear sets the empty string (no removeSecret exists)', () => {
+    const { api, map } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    store.set('nexus-app-x-apikey', 'value');
+    expect(store.clear('nexus-app-x-apikey')).toBe(true);
+    expect(map.get('nexus-app-x-apikey')).toBe('');
+  });
+
+  it('is throw-safe: a failing setSecret reports false, not an exception', () => {
+    const { api } = createMockSecretStorage({
+      setSecret() { throw new Error('boom'); }
+    });
+    const store = new SecretStore({ secretStorage: api } as SecretStorageHost);
+    expect(() => store.set('nexus-llm-openai-apikey', 'sk')).not.toThrow();
+    expect(store.set('nexus-llm-openai-apikey', 'sk')).toBe(false);
+  });
+
+  it('is throw-safe: invalid id rejected by backend yields false', () => {
+    const { api } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    expect(store.set('NOT VALID', 'x')).toBe(false);
+  });
+});

--- a/tests/unit/SettingsSecrets.test.ts
+++ b/tests/unit/SettingsSecrets.test.ts
@@ -1,0 +1,221 @@
+import type { Plugin } from 'obsidian';
+import { Settings } from '../../src/settings';
+import type { MCPSettings } from '../../src/types';
+import { SecretStore, type SecretStorageApi } from '../../src/services/secrets/SecretStore';
+import {
+  hydrateSecrets,
+  migrateLegacyPlaintext,
+  stripSecretsForPersist
+} from '../../src/services/secrets/SettingsSecrets';
+
+function createMockSecretStorage(): { api: SecretStorageApi; map: Map<string, string> } {
+  const map = new Map<string, string>();
+  const api: SecretStorageApi = {
+    setSecret(id, secret) {
+      if (!/^[a-z0-9-]+$/.test(id)) {
+        throw new Error(`invalid id: ${id}`);
+      }
+      map.set(id, secret);
+    },
+    getSecret(id) {
+      return map.has(id) ? (map.get(id) as string) : null;
+    },
+    listSecrets() {
+      return [...map.keys()];
+    }
+  };
+  return { api, map };
+}
+
+function settingsWithSecrets(): MCPSettings {
+  return {
+    enabledVault: true,
+    llmProviders: {
+      providers: {
+        openai: { apiKey: 'sk-openai', enabled: true },
+        openrouter: {
+          apiKey: 'sk-or',
+          enabled: true,
+          oauth: { connected: true, providerId: 'openrouter', connectedAt: 1, refreshToken: 'rt-secret' }
+        }
+      },
+      defaultModel: { provider: 'openai', model: 'gpt-4o' }
+    },
+    apps: {
+      apps: {
+        elevenlabs: {
+          enabled: true,
+          credentials: { apiKey: 'el-key', webhookUrl: 'https://hook' },
+          installedAt: '2026-01-01',
+          installedVersion: '1.0.0'
+        }
+      }
+    }
+  } as unknown as MCPSettings;
+}
+
+describe('SettingsSecrets boundary (unit)', () => {
+  it('strips every secret field on persist and stores it in secretStorage', () => {
+    const { api, map } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    const settings = settingsWithSecrets();
+
+    const { settings: stripped, persisted } = stripSecretsForPersist(settings, store);
+
+    expect(persisted).toBe(true);
+    // Persisted clone has secrets blanked
+    expect(stripped.llmProviders?.providers.openai.apiKey).toBe('');
+    expect(stripped.llmProviders?.providers.openrouter.apiKey).toBe('');
+    expect(stripped.llmProviders?.providers.openrouter.oauth?.refreshToken).toBe('');
+    expect(stripped.apps?.apps.elevenlabs.credentials.apiKey).toBe('');
+    expect(stripped.apps?.apps.elevenlabs.credentials.webhookUrl).toBe('');
+    // Original in-memory settings untouched
+    expect(settings.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+    // secretStorage now holds the values under stable ids
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-openai');
+    expect(map.get('nexus-llm-openrouter-apikey')).toBe('sk-or');
+    expect(map.get('nexus-llm-openrouter-oauth-refresh')).toBe('rt-secret');
+    expect(map.get('nexus-app-elevenlabs-apikey')).toBe('el-key');
+    expect(map.get('nexus-app-elevenlabs-webhookurl')).toBe('https://hook');
+  });
+
+  it('hydrate fills blanked secret fields back from secretStorage', () => {
+    const { api } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    const original = settingsWithSecrets();
+    stripSecretsForPersist(original, store);
+
+    // Simulate a freshly loaded data.json with blanked secrets
+    const loaded = settingsWithSecrets();
+    loaded.llmProviders!.providers.openai.apiKey = '';
+    loaded.llmProviders!.providers.openrouter.apiKey = '';
+    loaded.llmProviders!.providers.openrouter.oauth!.refreshToken = '';
+    loaded.apps!.apps.elevenlabs.credentials.apiKey = '';
+    loaded.apps!.apps.elevenlabs.credentials.webhookUrl = '';
+
+    hydrateSecrets(loaded, store);
+
+    expect(loaded.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+    expect(loaded.llmProviders?.providers.openrouter.apiKey).toBe('sk-or');
+    expect(loaded.llmProviders?.providers.openrouter.oauth?.refreshToken).toBe('rt-secret');
+    expect(loaded.apps?.apps.elevenlabs.credentials.apiKey).toBe('el-key');
+    expect(loaded.apps?.apps.elevenlabs.credentials.webhookUrl).toBe('https://hook');
+  });
+
+  it('migrateLegacyPlaintext moves plaintext into the store and is idempotent', () => {
+    const { api, map } = createMockSecretStorage();
+    const store = new SecretStore({ secretStorage: api });
+    const settings = settingsWithSecrets();
+
+    expect(migrateLegacyPlaintext(settings, store)).toBe(true);
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-openai');
+
+    // After a strip pass the in-memory secrets are blanked; migration is a no-op.
+    const { settings: stripped } = stripSecretsForPersist(settings, store);
+    expect(migrateLegacyPlaintext(stripped, store)).toBe(false);
+  });
+
+  it('is a no-op when secretStorage is unavailable (plaintext fallback)', () => {
+    const store = new SecretStore({});
+    const settings = settingsWithSecrets();
+
+    const { settings: result, persisted } = stripSecretsForPersist(settings, store);
+    expect(persisted).toBe(false);
+    expect(result).toBe(settings);
+    expect(result.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+
+    expect(migrateLegacyPlaintext(settings, store)).toBe(false);
+    hydrateSecrets(settings, store); // does not throw, no mutation
+    expect(settings.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+  });
+});
+
+describe('Settings class persistence boundary', () => {
+  function makePlugin(initialData: unknown, api?: SecretStorageApi): {
+    plugin: Plugin;
+    saved: Record<string, unknown>[];
+  } {
+    const saved: Record<string, unknown>[] = [];
+    let store = initialData;
+    const plugin = {
+      app: api ? { secretStorage: api } : {},
+      loadData: jest.fn(async () => store),
+      saveData: jest.fn(async (data: Record<string, unknown>) => {
+        saved.push(data);
+        store = data;
+      })
+    } as unknown as Plugin;
+    return { plugin, saved };
+  }
+
+  it('saveSettings strips plaintext from data.json and stores it in secretStorage', async () => {
+    const { api, map } = createMockSecretStorage();
+    const { plugin, saved } = makePlugin({ enabledVault: true }, api);
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.saveSettings();
+
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('');
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-openai');
+    // Runtime settings still populated
+    expect(settings.settings.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+  });
+
+  it('loadSettings migrates legacy plaintext then re-saves blanked data.json', async () => {
+    const { api, map } = createMockSecretStorage();
+    const legacy = {
+      enabledVault: true,
+      llmProviders: {
+        providers: { openai: { apiKey: 'sk-legacy', enabled: true } },
+        defaultModel: { provider: 'openai', model: 'gpt-4o' }
+      }
+    };
+    const { plugin, saved } = makePlugin(legacy, api);
+
+    const settings = new Settings(plugin);
+    await settings.loadSettings();
+
+    // Secret moved into the store
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-legacy');
+    // Runtime value hydrated/preserved
+    expect(settings.settings.llmProviders?.providers.openai.apiKey).toBe('sk-legacy');
+    // A re-save happened, blanking the persisted secret
+    expect(saved.length).toBeGreaterThan(0);
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('');
+  });
+
+  it('loadSettings hydrates secrets from store when data.json is blanked', async () => {
+    const { api } = createMockSecretStorage();
+    api.setSecret('nexus-llm-openai-apikey', 'sk-stored');
+    const blanked = {
+      enabledVault: true,
+      llmProviders: {
+        providers: { openai: { apiKey: '', enabled: true } },
+        defaultModel: { provider: 'openai', model: 'gpt-4o' }
+      }
+    };
+    const { plugin } = makePlugin(blanked, api);
+
+    const settings = new Settings(plugin);
+    await settings.loadSettings();
+
+    expect(settings.settings.llmProviders?.providers.openai.apiKey).toBe('sk-stored');
+  });
+
+  it('without secretStorage, behavior is unchanged: plaintext persists', async () => {
+    const { plugin, saved } = makePlugin({ enabledVault: true });
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.saveSettings();
+
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('sk-openai');
+  });
+});

--- a/tests/unit/SettingsSecrets.test.ts
+++ b/tests/unit/SettingsSecrets.test.ts
@@ -154,6 +154,7 @@ describe('Settings class persistence boundary', () => {
 
     const settings = new Settings(plugin);
     settings.settings = settingsWithSecrets();
+    settings.settings.secureApiKeyStorage = true;
     await settings.saveSettings();
 
     const persisted = saved[saved.length - 1];
@@ -168,6 +169,7 @@ describe('Settings class persistence boundary', () => {
     const { api, map } = createMockSecretStorage();
     const legacy = {
       enabledVault: true,
+      secureApiKeyStorage: true,
       llmProviders: {
         providers: { openai: { apiKey: 'sk-legacy', enabled: true } },
         defaultModel: { provider: 'openai', model: 'gpt-4o' }
@@ -194,6 +196,7 @@ describe('Settings class persistence boundary', () => {
     api.setSecret('nexus-llm-openai-apikey', 'sk-stored');
     const blanked = {
       enabledVault: true,
+      secureApiKeyStorage: true,
       llmProviders: {
         providers: { openai: { apiKey: '', enabled: true } },
         defaultModel: { provider: 'openai', model: 'gpt-4o' }
@@ -217,5 +220,65 @@ describe('Settings class persistence boundary', () => {
     const persisted = saved[saved.length - 1];
     const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
     expect(providers.openai.apiKey).toBe('sk-openai');
+  });
+
+  it('with the option off, plaintext persists even when secretStorage is available', async () => {
+    const { api, map } = createMockSecretStorage();
+    const { plugin, saved } = makePlugin({ enabledVault: true }, api);
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.saveSettings();
+
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('sk-openai');
+    expect(map.size).toBe(0);
+  });
+
+  it('setSecureApiKeyStorage(true) migrates keys into the store and strips data.json', async () => {
+    const { api, map } = createMockSecretStorage();
+    const { plugin, saved } = makePlugin({ enabledVault: true }, api);
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.setSecureApiKeyStorage(true);
+
+    expect(settings.settings.secureApiKeyStorage).toBe(true);
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-openai');
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('');
+    // Runtime keeps the populated value.
+    expect(settings.settings.llmProviders?.providers.openai.apiKey).toBe('sk-openai');
+  });
+
+  it('setSecureApiKeyStorage(false) writes keys back to data.json and clears the store', async () => {
+    const { api, map } = createMockSecretStorage();
+    const { plugin, saved } = makePlugin({ enabledVault: true }, api);
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.setSecureApiKeyStorage(true);
+    expect(map.get('nexus-llm-openai-apikey')).toBe('sk-openai');
+
+    await settings.setSecureApiKeyStorage(false);
+
+    expect(settings.settings.secureApiKeyStorage).toBe(false);
+    const persisted = saved[saved.length - 1];
+    const providers = (persisted.llmProviders as MCPSettings['llmProviders'])!.providers;
+    expect(providers.openai.apiKey).toBe('sk-openai');
+    // Stored copy cleared (set to '' — there is no removeSecret API).
+    expect(map.get('nexus-llm-openai-apikey')).toBe('');
+  });
+
+  it('setSecureApiKeyStorage(true) is ignored when secretStorage is unavailable', async () => {
+    const { plugin } = makePlugin({ enabledVault: true });
+
+    const settings = new Settings(plugin);
+    settings.settings = settingsWithSecrets();
+    await settings.setSecureApiKeyStorage(true);
+
+    expect(settings.settings.secureApiKeyStorage).toBeFalsy();
   });
 });


### PR DESCRIPTION
Lets users keep API keys out of the synced `data.json` by storing them in Obsidian's first-party device-local `app.secretStorage` (stable since 1.11.4).

**Commit 1 — plumbing**
- `SecretStore` wrapper over `app.secretStorage` (throw-safe, id normalization).
- `SettingsSecrets`: strip-on-save / hydrate-on-load / migrate-legacy, all keyed off one secret-field enumeration (LLM API keys, OAuth refresh tokens, app credentials). The in-memory settings shape is unchanged, so adapters and UI need no changes.

**Commit 2 — opt-in toggle**
- "Store API keys in secure storage" toggle in the Providers tab, **off by default** (keys keep syncing unless the user opts in).
- Enabling moves keys into `secretStorage` and strips them from `data.json`; disabling writes them back and clears the store. Confirmed via `ConfirmModal` warning that keys must be re-entered once per device.
- Disabled with a note on Obsidian < 1.11.4 (feature-detected; `minAppVersion` unchanged). Falls back to current plaintext behavior when unavailable.

Note: `app.secretStorage` has no `removeSecret`, so "clear" writes an empty string. Adds 21 tests (`SecretStore.test.ts`, `SettingsSecrets.test.ts`). Independent of the other audit PRs.

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_