### PR TITLE
fix: surface swallowed JSON-parse errors in the storage layer

### DIFF
--- a/src/database/repositories/MessageRepository.ts
+++ b/src/database/repositories/MessageRepository.ts
@@ -28,6 +28,7 @@ import { MessageData, AlternativeMessage } from '../../types/storage/HybridStora
 import { MessageEvent, MessageUpdatedEvent, MessageDeletedEvent, AlternativeMessageEvent } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { DatabaseRow, QueryParams } from './base/BaseRepository';
+import { parseJsonColumn } from '../utils/jsonColumn';
 
 interface MessageRow extends DatabaseRow {
   id: string;
@@ -619,37 +620,11 @@ export class MessageRepository
    * Convert SQLite row to MessageData
    */
   private rowToMessage(row: MessageRow): MessageData {
-    let toolCalls: MessageData['toolCalls'];
-    let metadata: MessageJSONValue | undefined;
-    let alternatives: AlternativeMessage[] | undefined;
-
-    // Defensive JSON parsing — corrupt data shouldn't crash the entire message load
-    if (row.toolCallsJson) {
-      try {
-        toolCalls = this.parseJsonValue<MessageData['toolCalls']>(row.toolCallsJson);
-      } catch {
-        console.error(`[MessageRepository] Failed to parse toolCallsJson for message ${row.id}`);
-        toolCalls = undefined;
-      }
-    }
-
-    if (row.metadataJson) {
-      try {
-        metadata = this.parseJsonValue<MessageJSONValue>(row.metadataJson);
-      } catch {
-        console.error(`[MessageRepository] Failed to parse metadataJson for message ${row.id}`);
-        metadata = undefined;
-      }
-    }
-
-    if (row.alternativesJson) {
-      try {
-        alternatives = this.parseJsonValue<AlternativeMessage[]>(row.alternativesJson);
-      } catch {
-        console.error(`[MessageRepository] Failed to parse alternativesJson for message ${row.id}`);
-        alternatives = undefined;
-      }
-    }
+    // Defensive JSON parsing — a corrupt column is logged (with the message id)
+    // and skipped rather than crashing the entire message load.
+    const toolCalls = parseJsonColumn<MessageData['toolCalls']>(row.toolCallsJson, `MessageRepository.toolCalls#${row.id}`);
+    const metadata = parseJsonColumn<MessageJSONValue>(row.metadataJson, `MessageRepository.metadata#${row.id}`);
+    const alternatives = parseJsonColumn<AlternativeMessage[]>(row.alternativesJson, `MessageRepository.alternatives#${row.id}`);
 
     return {
       id: row.id,
@@ -681,13 +656,6 @@ export class MessageRepository
     return parsed;
   }
 
-  private parseJsonValue<T>(json: string): T | undefined {
-    try {
-      return JSON.parse(json) as T;
-    } catch {
-      return undefined;
-    }
-  }
 
   /**
    * Convert AlternativeMessage[] to AlternativeMessageEvent[] for JSONL storage

--- a/src/database/repositories/ProjectRepository.ts
+++ b/src/database/repositories/ProjectRepository.ts
@@ -31,6 +31,7 @@ import {
   ProjectDeletedEvent
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
+import { parseJsonColumn } from '../utils/jsonColumn';
 
 interface ProjectRow extends DatabaseRow {
   id: string;
@@ -308,14 +309,7 @@ export class ProjectRepository
 
   protected rowToEntity(row: DatabaseRow): ProjectMetadata {
     const projectRow = row as ProjectRow;
-    let metadata: Record<string, unknown> | undefined;
-    if (projectRow.metadataJson) {
-      try {
-        metadata = JSON.parse(projectRow.metadataJson) as Record<string, unknown>;
-      } catch {
-        // Skip unparseable metadata
-      }
-    }
+    const metadata = parseJsonColumn<Record<string, unknown>>(projectRow.metadataJson, `ProjectRepository.metadata#${projectRow.id}`);
 
     return {
       id: projectRow.id,

--- a/src/database/repositories/StateRepository.ts
+++ b/src/database/repositories/StateRepository.ts
@@ -32,6 +32,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { QueryParams } from './base/BaseRepository';
+import { parseJsonColumn } from '../utils/jsonColumn';
 
 interface StateRow extends DatabaseRow {
   id: string;
@@ -221,11 +222,11 @@ export class StateRepository
         return null;
       }
 
-      let content = this.parseJsonValue<unknown>(savedEvent.data.stateJson);
+      let content = parseJsonColumn<unknown>(savedEvent.data.stateJson, `StateRepository.state#${id}`);
 
       for (const event of events) {
         if (event.type === 'state_updated' && event.stateId === id && event.data.stateJson !== undefined) {
-          content = this.parseJsonValue<unknown>(event.data.stateJson);
+          content = parseJsonColumn<unknown>(event.data.stateJson, `StateRepository.state#${id}`);
         }
       }
 
@@ -418,15 +419,7 @@ export class StateRepository
       name: stateRow.name,
       description: stateRow.description ?? undefined,
       created: stateRow.created,
-      tags: stateRow.tagsJson ? this.parseJsonValue<string[]>(stateRow.tagsJson) : undefined
+      tags: parseJsonColumn<string[]>(stateRow.tagsJson, `StateRepository.tags#${stateRow.id}`)
     };
-  }
-
-  private parseJsonValue<T>(json: string): T | undefined {
-    try {
-      return JSON.parse(json) as T;
-    } catch {
-      return undefined;
-    }
   }
 }

--- a/src/database/repositories/TaskRepository.ts
+++ b/src/database/repositories/TaskRepository.ts
@@ -42,6 +42,7 @@ import {
   TaskNoteUnlinkedEvent
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
+import { parseJsonColumn } from '../utils/jsonColumn';
 
 interface TaskRow extends DatabaseRow {
   id: string;
@@ -615,23 +616,8 @@ export class TaskRepository
 
   protected rowToEntity(row: DatabaseRow): TaskMetadata {
     const taskRow = row as TaskRow;
-    let tags: string[] | undefined;
-    if (taskRow.tagsJson) {
-      try {
-        tags = this.parseJsonValue<string[]>(taskRow.tagsJson);
-      } catch {
-        // Skip unparseable tags
-      }
-    }
-
-    let metadata: Record<string, unknown> | undefined;
-    if (taskRow.metadataJson) {
-      try {
-        metadata = this.parseJsonValue<Record<string, unknown>>(taskRow.metadataJson);
-      } catch {
-        // Skip unparseable metadata
-      }
-    }
+    const tags = parseJsonColumn<string[]>(taskRow.tagsJson, `TaskRepository.tags#${taskRow.id}`);
+    const metadata = parseJsonColumn<Record<string, unknown>>(taskRow.metadataJson, `TaskRepository.metadata#${taskRow.id}`);
 
     return {
       id: taskRow.id,
@@ -652,11 +638,4 @@ export class TaskRepository
     };
   }
 
-  private parseJsonValue<T>(json: string): T | undefined {
-    try {
-      return JSON.parse(json) as T;
-    } catch {
-      return undefined;
-    }
-  }
 }

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -34,6 +34,7 @@ import {
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { QueryOptions } from '../interfaces/IStorageAdapter';
 import { QueryCache } from '../optimizations/QueryCache';
+import { parseJsonColumn } from '../utils/jsonColumn';
 
 type SqliteValue = string | number | null;
 
@@ -383,9 +384,7 @@ export class WorkspaceRepository
 
   protected rowToEntity(row: DatabaseRow): WorkspaceMetadata {
     const workspaceRow = row as WorkspaceRow;
-    const context = workspaceRow.contextJson
-      ? this.parseJsonValue<WorkspaceMetadata['context']>(workspaceRow.contextJson)
-      : undefined;
+    const context = parseJsonColumn<WorkspaceMetadata['context']>(workspaceRow.contextJson, `WorkspaceRepository.context#${workspaceRow.id}`);
 
     return {
       id: workspaceRow.id,
@@ -401,11 +400,4 @@ export class WorkspaceRepository
     };
   }
 
-  private parseJsonValue<T>(json: string): T | undefined {
-    try {
-      return JSON.parse(json) as T;
-    } catch {
-      return undefined;
-    }
-  }
 }

--- a/src/database/schema/SchemaMigrator.ts
+++ b/src/database/schema/SchemaMigrator.ts
@@ -230,6 +230,7 @@ export const MIGRATIONS: Migration[] = [
       const rows = db.exec('SELECT id, metadataJson FROM conversations WHERE metadataJson IS NOT NULL');
       if (rows.length === 0) return;
 
+      let skipped = 0;
       for (const row of rows[0].values) {
         const id = row[0] as string;
         const metadataJson = row[1] as string;
@@ -256,7 +257,7 @@ export const MIGRATIONS: Migration[] = [
             sessionId = metadata.sessionId;
           }
         } catch {
-          // Skip conversations with unparseable metadataJson
+          skipped++;
           continue;
         }
 
@@ -266,6 +267,10 @@ export const MIGRATIONS: Migration[] = [
             [workspaceId, sessionId, id]
           );
         }
+      }
+
+      if (skipped > 0) {
+        console.warn(`[SchemaMigrator] workspaceId/sessionId backfill: skipped ${skipped} conversation(s) with unparseable metadataJson`);
       }
     },
   },
@@ -371,6 +376,7 @@ export const MIGRATIONS: Migration[] = [
       const rows = db.exec('SELECT id, metadataJson FROM conversations WHERE metadataJson IS NOT NULL');
       if (rows.length === 0) return;
 
+      let skipped = 0;
       for (const row of rows[0].values) {
         const id = row[0] as string;
         const metadataJson = row[1] as string;
@@ -389,8 +395,12 @@ export const MIGRATIONS: Migration[] = [
             );
           }
         } catch {
-          // Ignore unparseable metadata rows.
+          skipped++;
         }
+      }
+
+      if (skipped > 0) {
+        console.warn(`[SchemaMigrator] workflow metadata backfill: skipped ${skipped} conversation(s) with unparseable metadataJson`);
       }
     }
   },

--- a/src/database/utils/jsonColumn.ts
+++ b/src/database/utils/jsonColumn.ts
@@ -1,0 +1,21 @@
+/**
+ * Parse a JSON value stored in a SQLite column.
+ *
+ * On parse failure this logs a warning tagged with `context` — so a corrupt
+ * column becomes observable instead of silently nulling a field — and returns
+ * undefined. Callers tolerate the missing value rather than failing the whole
+ * row read, which is the right behavior for a rebuildable cache: one bad row
+ * should not abort a query, but it should not vanish without a trace either.
+ */
+export function parseJsonColumn<T>(json: string | null | undefined, context: string): T | undefined {
+  if (json === null || json === undefined || json === '') {
+    return undefined;
+  }
+  try {
+    return JSON.parse(json) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[parseJsonColumn:${context}] Failed to parse JSON column: ${message}`);
+    return undefined;
+  }
+}

--- a/tests/unit/parseJsonColumn.test.ts
+++ b/tests/unit/parseJsonColumn.test.ts
@@ -1,0 +1,32 @@
+import { parseJsonColumn } from '../../src/database/utils/jsonColumn';
+
+describe('parseJsonColumn', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('parses valid JSON', () => {
+    expect(parseJsonColumn<{ a: number }>('{"a":1}', 'ctx')).toEqual({ a: 1 });
+    expect(parseJsonColumn<string[]>('["x","y"]', 'ctx')).toEqual(['x', 'y']);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for null/undefined/empty without warning', () => {
+    expect(parseJsonColumn(null, 'ctx')).toBeUndefined();
+    expect(parseJsonColumn(undefined, 'ctx')).toBeUndefined();
+    expect(parseJsonColumn('', 'ctx')).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined AND warns (with context) on a corrupt column', () => {
+    expect(parseJsonColumn('{not json', 'MessageRepository.metadata#42')).toBeUndefined();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('MessageRepository.metadata#42');
+  });
+});


### PR DESCRIPTION
Addresses the highest-value "swallowed error" hotspots from the plugin audit — the silent JSON-parse failures in the storage layer, where a corrupt SQLite column would silently null a field with no trace.

**Repositories**
Each repository carried its own `parseJsonValue` helper (plus an inline copy in `ProjectRepository`) that swallowed `JSON.parse` failures into `undefined` with no log — 5 silent copies. `MessageRepository`'s outer try/catch logging was even dead code (the inner `parseJsonValue` swallowed first, so the `console.error` never fired).
- New shared `parseJsonColumn(json, context)` (`src/database/utils/jsonColumn.ts`) logs a warning tagged with the repository/column/row id on parse failure, then returns undefined so callers still tolerate the bad row.
- Routed `MessageRepository`, `TaskRepository`, `StateRepository`, `WorkspaceRepository`, and `ProjectRepository` through it — removing 4 duplicate private helpers and the dead outer try/catch blocks.

**SchemaMigrator**
The two per-row metadata backfills (workspaceId/sessionId, and workflow columns) silently `continue`d past unparseable rows. Added a skip counter + a single aggregated `console.warn` per migration, so a *systematic* parse failure during a migration is observable instead of silently leaving columns empty.

**Scope note:** while implementing, the audit-flagged `ToolCallTraceService` catches turned out to already be logged (line 132) or documented best-effort (skill attribution) — so they were intentionally left alone rather than churned. The repository parse swallows were the real silent gap.

Behavior is unchanged except previously-silent parse failures are now logged. Adds `tests/unit/parseJsonColumn.test.ts`; full suite green. Independent of the other audit PRs.

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_