### PR TITLE
refactor: route Perplexity and Requesty adapters through shared helpers

### DIFF
--- a/src/services/llm/adapters/BaseAdapter.ts
+++ b/src/services/llm/adapters/BaseAdapter.ts
@@ -43,6 +43,7 @@ import {
   SSEParsedUsage,
   SSEStreamOptions
 } from '../streaming/SSEStreamProcessor';
+import { pumpSseEventQueue } from './shared/SseStreamPump';
 
 // Browser-compatible hash function (djb2 algorithm)
 // Not cryptographically secure but sufficient for cache keys
@@ -181,13 +182,13 @@ export abstract class BaseAdapter {
     const { createParser } = await import('eventsource-parser');
 
     const eventQueue: StreamChunk[] = [];
-    let isCompleted = false;
+    const pumpState = { isCompleted: false };
     let usage: SSEParsedUsage | undefined = undefined;
     let metadata: Record<string, unknown> | undefined = undefined;
     const toolCallsAccumulator: Map<number, ToolCall> = new Map();
 
     const parser = createParser((event) => {
-      if (event.type === 'reconnect-interval' || isCompleted) return;
+      if (event.type === 'reconnect-interval' || pumpState.isCompleted) return;
 
       if (event.data === '[DONE]') {
         const finalToolCalls = this.getFinalToolCallsFromAccumulator(toolCallsAccumulator, options);
@@ -199,7 +200,7 @@ export abstract class BaseAdapter {
           toolCallsReady: finalToolCalls && finalToolCalls.length > 0 ? true : undefined,
           metadata
         });
-        isCompleted = true;
+        pumpState.isCompleted = true;
         return;
       }
 
@@ -299,7 +300,7 @@ export abstract class BaseAdapter {
             toolCallsReady: finalToolCalls && finalToolCalls.length > 0 ? true : undefined,
             metadata
           });
-          isCompleted = true;
+          pumpState.isCompleted = true;
         }
       } catch (parseError) {
         if (options.onParseError) {
@@ -309,50 +310,14 @@ export abstract class BaseAdapter {
     });
 
     // Read from the Node.js stream and feed to the SSE parser
-    try {
-      for await (const chunk of nodeStream as AsyncIterable<Buffer>) {
-        if (isCompleted) break;
-
-        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-        parser.feed(text);
-
-        // Yield queued events
-        while (eventQueue.length > 0) {
-          const event = eventQueue.shift();
-          if (!event) {
-            break;
-          }
-          yield event;
-          if (event.complete) {
-            isCompleted = true;
-            break;
-          }
-        }
-      }
-
-      // Yield remaining events after stream ends
-      while (eventQueue.length > 0) {
-        const event = eventQueue.shift();
-        if (event) {
-          yield event;
-        }
-      }
-
-      // If stream ended without a completion event, yield one
-      if (!isCompleted) {
-        yield {
-          content: '',
-          complete: true,
-          usage: this.formatStreamUsage(usage)
-        };
-      }
-    } catch (error) {
-      // If stream was destroyed (abort), yield completion
-      if (!isCompleted) {
-        yield { content: '', complete: true };
-      }
-      throw error;
-    }
+    yield* pumpSseEventQueue(nodeStream, (text) => parser.feed(text), eventQueue, pumpState, {
+      buildFinalChunk: () => ({
+        content: '',
+        complete: true,
+        usage: this.formatStreamUsage(usage)
+      }),
+      buildErrorChunk: () => ({ content: '', complete: true })
+    });
   }
 
   /**

--- a/src/services/llm/adapters/anthropic/AnthropicAdapter.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicAdapter.ts
@@ -16,6 +16,7 @@ import {
 } from '../types';
 import { ANTHROPIC_MODELS, ANTHROPIC_DEFAULT_MODEL } from './AnthropicModels';
 import { ThinkingEffortMapper } from '../../utils/ThinkingEffortMapper';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 interface AnthropicMessage {
   role: string;
@@ -266,26 +267,9 @@ export class AnthropicAdapter extends BaseAdapter {
   listModels(): Promise<ModelInfo[]> {
     try {
       return Promise.resolve(ANTHROPIC_MODELS.map(model => ({
+        ...staticModelToModelInfo(model),
         // For 1M context models, append :1m to make ID unique
-        id: model.contextWindow >= 1000000 ? `${model.apiName}:1m` : model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: model.capabilities.supportsThinking,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
+        id: model.contextWindow >= 1000000 ? `${model.apiName}:1m` : model.apiName
       })));
     } catch (error) {
       this.handleError(error, 'listing models');
@@ -508,24 +492,7 @@ export class AnthropicAdapter extends BaseAdapter {
     return undefined;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = ANTHROPIC_MODELS.find(m => m.apiName === this.normalizeModelId(modelId));
-    if (!model) return undefined;
-
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
+    return Promise.resolve(getStaticModelPricing(ANTHROPIC_MODELS, this.normalizeModelId(modelId)));
   }
 }

--- a/src/services/llm/adapters/deepseek/DeepSeekAdapter.ts
+++ b/src/services/llm/adapters/deepseek/DeepSeekAdapter.ts
@@ -37,6 +37,13 @@ import {
   isDeepSeekThinkingModel,
   resolveDeepSeekApiModel
 } from './DeepSeekModels';
+import {
+  buildBearerJsonHeaders,
+  mapOpenAiCompatFinishReason,
+  buildMessagesWithConversationHistory,
+  convertFunctionTools
+} from '../shared/OpenAICompatHelpers';
+import { getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 interface DeepSeekChatCompletionUsage {
   prompt_tokens?: number;
@@ -114,10 +121,7 @@ export class DeepSeekAdapter extends BaseAdapter {
         url: `${this.baseUrl}/chat/completions`,
         operation: 'streaming generation',
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json'
-        },
+        headers: buildBearerJsonHeaders(this.apiKey),
         body: JSON.stringify(requestBody),
         timeoutMs: 120_000
       });
@@ -212,14 +216,7 @@ export class DeepSeekAdapter extends BaseAdapter {
   }
 
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const model = DEEPSEEK_MODELS.find(m => m.apiName === modelId);
-    if (!model) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: model.inputCostPerMillion,
-      rateOutputPerMillion: model.outputCostPerMillion,
-      currency: 'USD'
-    });
+    return Promise.resolve(getStaticModelPricing(DEEPSEEK_MODELS, modelId));
   }
 
   private async generateWithChatCompletions(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
@@ -229,10 +226,7 @@ export class DeepSeekAdapter extends BaseAdapter {
       url: `${this.baseUrl}/chat/completions`,
       operation: 'generation',
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json'
-      },
+      headers: buildBearerJsonHeaders(this.apiKey),
       body: JSON.stringify(requestBody),
       timeoutMs: 60_000
     });
@@ -322,30 +316,11 @@ export class DeepSeekAdapter extends BaseAdapter {
   }
 
   private convertTools(tools: Tool[]): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> {
-    return tools.map(tool => {
-      if (tool.type === 'function' && tool.function) {
-        return {
-          type: 'function' as const,
-          function: {
-            name: tool.function.name,
-            description: tool.function.description,
-            parameters: tool.function.parameters
-          }
-        };
-      }
-      throw new Error(`Unsupported tool type: ${tool.type}`);
-    });
+    return convertFunctionTools(tools);
   }
 
   private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
-    if (!reason) return 'stop';
-    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
-      stop: 'stop',
-      length: 'length',
-      tool_calls: 'tool_calls',
-      content_filter: 'content_filter'
-    };
-    return reasonMap[reason] || 'stop';
+    return mapOpenAiCompatFinishReason(reason);
   }
 
   protected extractUsage(response: DeepSeekChatCompletionResponse): TokenUsage | undefined {
@@ -360,16 +335,6 @@ export class DeepSeekAdapter extends BaseAdapter {
   }
 
   private buildMessagesForRequest(prompt: string, options?: GenerateOptions): DeepSeekChatCompletionMessageParam[] {
-    if (options?.conversationHistory && options.conversationHistory.length > 0) {
-      const messages = options.conversationHistory;
-      if (options.systemPrompt) {
-        const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
-        if (!hasSystem) {
-          return [{ role: 'system', content: options.systemPrompt }, ...messages];
-        }
-      }
-      return messages;
-    }
-    return this.buildMessages(prompt, options?.systemPrompt);
+    return buildMessagesWithConversationHistory(prompt, options);
   }
 }

--- a/src/services/llm/adapters/google/GoogleAdapter.ts
+++ b/src/services/llm/adapters/google/GoogleAdapter.ts
@@ -21,6 +21,7 @@ import { ReasoningPreserver } from '../shared/ReasoningPreserver';
 import { SchemaValidator } from '../../utils/SchemaValidator';
 import { ThinkingEffortMapper } from '../../utils/ThinkingEffortMapper';
 import { ProviderHttpError } from '../shared/ProviderHttpClient';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 type JsonObject = Record<string, unknown>;
 
@@ -441,27 +442,7 @@ export class GoogleAdapter extends BaseAdapter {
 
   listModels(): Promise<ModelInfo[]> {
     try {
-      return Promise.resolve(GOOGLE_MODELS.map(model => ({
-        id: model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: model.capabilities.supportsThinking,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
-      })));
+      return Promise.resolve(GOOGLE_MODELS.map(model => staticModelToModelInfo(model)));
     } catch (error) {
       this.handleError(error, 'listing models');
       return Promise.resolve([]);
@@ -803,25 +784,8 @@ export class GoogleAdapter extends BaseAdapter {
     return undefined;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = GOOGLE_MODELS.find(m => m.apiName === modelId);
-    if (!model) return undefined;
-    
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
+    return Promise.resolve(getStaticModelPricing(GOOGLE_MODELS, modelId));
   }
 }
 

--- a/src/services/llm/adapters/groq/GroqAdapter.ts
+++ b/src/services/llm/adapters/groq/GroqAdapter.ts
@@ -17,6 +17,12 @@ import {
 } from '../types';
 import type { SSEToolCall } from '../../streaming/SSEStreamProcessor';
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL } from './GroqModels';
+import {
+  buildBearerJsonHeaders,
+  mapOpenAiCompatFinishReason,
+  convertFunctionTools
+} from '../shared/OpenAICompatHelpers';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 /**
  * Extended Groq chunk type with x_groq metadata
@@ -103,10 +109,7 @@ export class GroqAdapter extends BaseAdapter {
         url: `${this.baseUrl}/chat/completions`,
         operation: 'streaming generation',
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json'
-        },
+        headers: buildBearerJsonHeaders(this.apiKey),
         body: JSON.stringify({
           model: options?.model || this.currentModel,
           messages: this.buildMessages(prompt, options?.systemPrompt),
@@ -176,25 +179,8 @@ export class GroqAdapter extends BaseAdapter {
   listModels(): Promise<ModelInfo[]> {
     try {
       return Promise.resolve(GROQ_MODELS.map(model => ({
-        id: model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: false,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
+        ...staticModelToModelInfo(model),
+        supportsThinking: false
       })));
     } catch (error) {
       this.handleError(error, 'listing models');
@@ -261,10 +247,7 @@ export class GroqAdapter extends BaseAdapter {
       url: `${this.baseUrl}/chat/completions`,
       operation: 'generation',
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json'
-      },
+      headers: buildBearerJsonHeaders(this.apiKey),
       body: JSON.stringify(chatParams),
       timeoutMs: 60_000
     });
@@ -297,36 +280,11 @@ export class GroqAdapter extends BaseAdapter {
 
   // Private methods
   private convertTools(tools: Tool[]): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> {
-    return tools.map(tool => {
-      if (tool.type === 'function' && tool.function) {
-        return {
-          type: 'function' as const,
-          function: {
-            name: tool.function.name,
-            description: tool.function.description,
-            parameters: tool.function.parameters
-          }
-        };
-      }
-      // Fallback for malformed tools - should not happen with proper Tool type
-      throw new Error(`Unsupported tool type: ${tool.type}`);
-    });
-  }
-
-  private extractToolCalls(message: GroqChatCompletionMessage | null | undefined): unknown[] {
-    return message?.tool_calls || [];
+    return convertFunctionTools(tools);
   }
 
   private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
-    if (!reason) return 'stop';
-    
-    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
-      'stop': 'stop',
-      'length': 'length',
-      'tool_calls': 'tool_calls',
-      'content_filter': 'content_filter'
-    };
-    return reasonMap[reason] || 'stop';
+    return mapOpenAiCompatFinishReason(reason);
   }
 
   protected extractUsage(response: GroqChatCompletionChunk): TokenUsage | undefined {
@@ -346,42 +304,7 @@ export class GroqAdapter extends BaseAdapter {
     return undefined;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = GROQ_MODELS.find(m => m.apiName === modelId);
-    if (!model) return undefined;
-    
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
-  }
-
-  /**
-   * Build messages array, using conversationHistory for tool continuations
-   * and prepending system prompt if it was stripped by the context builder.
-   */
-  private buildMessagesForRequest(prompt: string, options?: GenerateOptions): Array<Record<string, unknown>> {
-    if (options?.conversationHistory && options.conversationHistory.length > 0) {
-      const messages = options.conversationHistory;
-      if (options.systemPrompt) {
-        const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
-        if (!hasSystem) {
-          return [{ role: 'system', content: options.systemPrompt }, ...messages];
-        }
-      }
-      return messages;
-    }
-    return this.buildMessages(prompt, options?.systemPrompt);
+    return Promise.resolve(getStaticModelPricing(GROQ_MODELS, modelId));
   }
 }

--- a/src/services/llm/adapters/mistral/MistralAdapter.ts
+++ b/src/services/llm/adapters/mistral/MistralAdapter.ts
@@ -14,6 +14,11 @@ import {
   TokenUsage,
 } from '../types';
 import { MISTRAL_MODELS, MISTRAL_DEFAULT_MODEL } from './MistralModels';
+import {
+  buildBearerJsonHeaders,
+  buildMessagesWithConversationHistory
+} from '../shared/OpenAICompatHelpers';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 interface MistralToolDefinition {
   type?: string;
@@ -117,13 +122,10 @@ export class MistralAdapter extends BaseAdapter {
         url: `${this.baseUrl}/v1/chat/completions`,
         operation: 'streaming generation',
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${this.apiKey}`,
-          'Content-Type': 'application/json'
-        },
+        headers: buildBearerJsonHeaders(this.apiKey),
         body: JSON.stringify({
           model: options?.model || this.currentModel,
-          messages: this.buildMessagesForRequest(prompt, options),
+          messages: buildMessagesWithConversationHistory(prompt, options),
           temperature: options?.temperature,
           max_tokens: options?.maxTokens,
           top_p: options?.topP,
@@ -155,25 +157,8 @@ export class MistralAdapter extends BaseAdapter {
   listModels(): Promise<ModelInfo[]> {
     try {
       return Promise.resolve(MISTRAL_MODELS.map(model => ({
-        id: model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: false,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
+        ...staticModelToModelInfo(model),
+        supportsThinking: false
       })));
     } catch (error) {
       this.handleError(error, 'listing models');
@@ -228,10 +213,7 @@ export class MistralAdapter extends BaseAdapter {
       url: `${this.baseUrl}/v1/chat/completions`,
       operation: 'generation',
       method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
-        'Content-Type': 'application/json'
-      },
+      headers: buildBearerJsonHeaders(this.apiKey),
       body: JSON.stringify(requestBody),
       timeoutMs: 60_000
     });
@@ -287,10 +269,6 @@ export class MistralAdapter extends BaseAdapter {
     });
   }
 
-  private extractToolCalls(message: MistralMessage | undefined): Array<Record<string, unknown>> {
-    return message?.toolCalls || [];
-  }
-
   private extractMessageContent(content: MistralMessage['content']): string {
     if (typeof content === 'string') {
       return content;
@@ -302,19 +280,6 @@ export class MistralAdapter extends BaseAdapter {
         .join('');
     }
     return '';
-  }
-
-  private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
-    if (!reason) return 'stop';
-    
-    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
-      'stop': 'stop',
-      'length': 'length',
-      'tool_calls': 'tool_calls',
-      'model_length': 'length',
-      'content_filter': 'content_filter'
-    };
-    return reasonMap[reason] || 'stop';
   }
 
   protected extractUsage(response: MistralChatResponse): TokenUsage | undefined {
@@ -329,42 +294,7 @@ export class MistralAdapter extends BaseAdapter {
     return undefined;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = MISTRAL_MODELS.find(m => m.apiName === modelId);
-    if (!model) return undefined;
-    
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
-  }
-
-  /**
-   * Build messages array, using conversationHistory for tool continuations
-   * and prepending system prompt if it was stripped by the context builder.
-   */
-  private buildMessagesForRequest(prompt: string, options?: GenerateOptions): Array<Record<string, unknown>> {
-    if (options?.conversationHistory && options.conversationHistory.length > 0) {
-      const messages = options.conversationHistory;
-      if (options.systemPrompt) {
-        const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
-        if (!hasSystem) {
-          return [{ role: 'system', content: options.systemPrompt }, ...messages];
-        }
-      }
-      return messages;
-    }
-    return this.buildMessages(prompt, options?.systemPrompt);
+    return Promise.resolve(getStaticModelPricing(MISTRAL_MODELS, modelId));
   }
 }

--- a/src/services/llm/adapters/openai/OpenAIAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAIAdapter.ts
@@ -24,6 +24,8 @@ import { DeepResearchHandler } from './DeepResearchHandler';
 import { WebSearchUtils } from '../../utils/WebSearchUtils';
 import { OPENAI_MODELS } from './OpenAIModels';
 import { ProviderHttpError } from '../shared/ProviderHttpClient';
+import { buildBearerJsonHeaders } from '../shared/OpenAICompatHelpers';
+import { getRegistryModelPricing } from '../shared/StaticModelHelpers';
 
 interface OpenAIResponsesTool {
   type: string;
@@ -656,10 +658,7 @@ export class OpenAIAdapter extends BaseAdapter {
   }
 
   private buildOpenAIHeaders(): Record<string, string> {
-    return {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${this.apiKey}`
-    };
+    return buildBearerJsonHeaders(this.apiKey);
   }
 
   /**
@@ -798,21 +797,7 @@ export class OpenAIAdapter extends BaseAdapter {
    * Get model pricing
    */
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    try {
-      const models = ModelRegistry.getProviderModels('openai');
-      const model = models.find(m => m.apiName === modelId);
-      if (!model) {
-        return Promise.resolve(null);
-      }
-
-      return Promise.resolve({
-        rateInputPerMillion: model.inputCostPerMillion,
-        rateOutputPerMillion: model.outputCostPerMillion,
-        currency: 'USD'
-      });
-    } catch {
-      return Promise.resolve(null);
-    }
+    return Promise.resolve(getRegistryModelPricing('openai', modelId));
   }
 }
 

--- a/src/services/llm/adapters/openai/OpenAIAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAIAdapter.ts
@@ -25,6 +25,7 @@ import { WebSearchUtils } from '../../utils/WebSearchUtils';
 import { OPENAI_MODELS } from './OpenAIModels';
 import { ProviderHttpError } from '../shared/ProviderHttpClient';
 import { buildBearerJsonHeaders } from '../shared/OpenAICompatHelpers';
+import { pumpSseEventQueue } from '../shared/SseStreamPump';
 import { getRegistryModelPricing } from '../shared/StaticModelHelpers';
 
 interface OpenAIResponsesTool {
@@ -409,14 +410,14 @@ export class OpenAIAdapter extends BaseAdapter {
     let currentReasoningId: string | null = null;
     let currentReasoningEncryptedContent: string | null = null;
     let isInReasoningPart = false;
-    let isCompleted = false;
+    const pumpState = { isCompleted: false };
 
     const eventQueue: StreamChunk[] = [];
 
     const parser = createParser((sseEvent) => {
-      if (sseEvent.type === 'reconnect-interval' || isCompleted) return;
+      if (sseEvent.type === 'reconnect-interval' || pumpState.isCompleted) return;
       if (sseEvent.data === '[DONE]') {
-        isCompleted = true;
+        pumpState.isCompleted = true;
         return;
       }
 
@@ -548,39 +549,16 @@ export class OpenAIAdapter extends BaseAdapter {
             toolCallsReady: toolCallsArray.length > 0,
             metadata
           });
-          isCompleted = true;
+          pumpState.isCompleted = true;
           break;
         }
       }
     });
 
     try {
-      for await (const chunk of nodeStream as AsyncIterable<Buffer>) {
-        if (isCompleted) break;
-        const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-        parser.feed(text);
-
-        while (eventQueue.length > 0) {
-          const evt = eventQueue.shift();
-          if (!evt) {
-            break;
-          }
-          yield evt;
-          if (evt.complete) { isCompleted = true; break; }
-        }
-      }
-
-      while (eventQueue.length > 0) {
-        const evt = eventQueue.shift();
-        if (!evt) {
-          continue;
-        }
-        yield evt;
-      }
-
-      if (!isCompleted) {
-        yield { content: '', complete: true, usage };
-      }
+      yield* pumpSseEventQueue(nodeStream, (text) => parser.feed(text), eventQueue, pumpState, {
+        buildFinalChunk: () => ({ content: '', complete: true, usage })
+      });
     } catch (error) {
       console.error('[OpenAIAdapter] Error processing Responses API stream:', error);
       throw error;

--- a/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
@@ -24,6 +24,7 @@ import { WebSearchUtils } from '../../utils/WebSearchUtils';
 import { BRAND_NAME } from '../../../../constants/branding';
 import { MCPToolExecution } from '../shared/ToolExecutionUtils';
 import { SSEToolCall } from '../../streaming/SSEStreamProcessor';
+import { getRegistryModelPricing } from '../shared/StaticModelHelpers';
 
 type JsonObject = Record<string, unknown>;
 
@@ -827,21 +828,7 @@ export class OpenRouterAdapter extends BaseAdapter {
    * Get model pricing
    */
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    try {
-      const models = ModelRegistry.getProviderModels('openrouter');
-      const model = models.find(m => m.apiName === modelId);
-      if (!model) {
-        return Promise.resolve(null);
-      }
-
-      return Promise.resolve({
-        rateInputPerMillion: model.inputCostPerMillion,
-        rateOutputPerMillion: model.outputCostPerMillion,
-        currency: 'USD'
-      });
-    } catch {
-      return Promise.resolve(null);
-    }
+    return Promise.resolve(getRegistryModelPricing('openrouter', modelId));
   }
 
   private convertTools(tools: Tool[]): OpenRouterTool[] {

--- a/src/services/llm/adapters/perplexity/PerplexityAdapter.ts
+++ b/src/services/llm/adapters/perplexity/PerplexityAdapter.ts
@@ -17,6 +17,8 @@ import {
 } from '../types';
 import { PERPLEXITY_MODELS, PERPLEXITY_DEFAULT_MODEL } from './PerplexityModels';
 import { WebSearchUtils } from '../../utils/WebSearchUtils';
+import { mapOpenAiCompatFinishReason } from '../shared/OpenAICompatHelpers';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 export interface PerplexityOptions extends GenerateOptions {
   webSearch?: boolean;
@@ -140,26 +142,10 @@ export class PerplexityAdapter extends BaseAdapter {
 
   listModels(): Promise<ModelInfo[]> {
     try {
+      // Perplexity exposes no thinking models, so supportsThinking stays false.
       return Promise.resolve(PERPLEXITY_MODELS.map(model => ({
-        id: model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: false,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
+        ...staticModelToModelInfo(model),
+        supportsThinking: false
       })));
     } catch (error) {
       this.handleError(error, 'listing models');
@@ -219,7 +205,7 @@ export class PerplexityAdapter extends BaseAdapter {
     const usage = this.extractUsage(data);
     const rawFinishReason = choice.finish_reason || 'stop';
 
-    const finishReason = this.mapFinishReason(rawFinishReason);
+    const finishReason = mapOpenAiCompatFinishReason(rawFinishReason);
     const metadata = this.extractResponseMetadata(data);
 
     return this.buildLLMResponse(
@@ -297,18 +283,6 @@ export class PerplexityAdapter extends BaseAdapter {
     return Array.from(urls);
   }
 
-  private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
-    if (!reason) return 'stop';
-    
-    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
-      'stop': 'stop',
-      'length': 'length',
-      'tool_calls': 'tool_calls',
-      'content_filter': 'content_filter'
-    };
-    return reasonMap[reason] || 'stop';
-  }
-
   protected extractUsage(response: PerplexityChatResponse): TokenUsage | undefined {
     const usage = response?.usage;
     if (usage) {
@@ -347,24 +321,7 @@ export class PerplexityAdapter extends BaseAdapter {
     return requestBody;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = PERPLEXITY_MODELS.find(m => m.apiName === modelId);
-    if (!model) return undefined;
-    
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
+    return Promise.resolve(getStaticModelPricing(PERPLEXITY_MODELS, modelId));
   }
 }

--- a/src/services/llm/adapters/requesty/RequestyAdapter.ts
+++ b/src/services/llm/adapters/requesty/RequestyAdapter.ts
@@ -14,6 +14,8 @@ import {
   ModelPricing
 } from '../types';
 import { REQUESTY_MODELS, REQUESTY_DEFAULT_MODEL } from './RequestyModels';
+import { mapOpenAiCompatFinishReason, buildMessagesWithConversationHistory } from '../shared/OpenAICompatHelpers';
+import { staticModelToModelInfo, getStaticModelPricing } from '../shared/StaticModelHelpers';
 
 /**
  * Requesty API response structure (OpenAI-compatible)
@@ -114,7 +116,7 @@ export class RequestyAdapter extends BaseAdapter {
         },
         body: JSON.stringify({
           model: options?.model || this.currentModel,
-          messages: this.buildMessagesForRequest(prompt, options),
+          messages: buildMessagesWithConversationHistory(prompt, options),
           temperature: options?.temperature,
           max_tokens: options?.maxTokens,
           response_format: options?.jsonMode ? { type: 'json_object' } : undefined,
@@ -157,26 +159,10 @@ export class RequestyAdapter extends BaseAdapter {
 
   listModels(): Promise<ModelInfo[]> {
     try {
+      // Thinking is surfaced per-upstream-model at the router, not advertised here.
       return Promise.resolve(REQUESTY_MODELS.map(model => ({
-        id: model.apiName,
-        name: model.name,
-        contextWindow: model.contextWindow,
-        maxOutputTokens: model.maxTokens,
-        supportsJSON: model.capabilities.supportsJSON,
-        supportsImages: model.capabilities.supportsImages,
-        supportsFunctions: model.capabilities.supportsFunctions,
-        supportsStreaming: model.capabilities.supportsStreaming,
-        supportsThinking: false,
-        costPer1kTokens: {
-          input: model.inputCostPerMillion / 1000,
-          output: model.outputCostPerMillion / 1000
-        },
-        pricing: {
-          inputPerMillion: model.inputCostPerMillion,
-          outputPerMillion: model.outputCostPerMillion,
-          currency: 'USD',
-          lastUpdated: new Date().toISOString()
-        }
+        ...staticModelToModelInfo(model),
+        supportsThinking: false
       })));
     } catch (error) {
       this.handleError(error, 'listing models');
@@ -253,7 +239,7 @@ export class RequestyAdapter extends BaseAdapter {
     
     let text = choice.message?.content || '';
     const usage = this.extractUsage(data);
-    const finishReason = this.mapFinishReason(choice.finish_reason || null);
+    const finishReason = mapOpenAiCompatFinishReason(choice.finish_reason || null);
 
     // If tools were provided and we got tool calls, return placeholder text
     if (options?.tools && choice.message?.toolCalls && choice.message.toolCalls.length > 0) {
@@ -274,18 +260,6 @@ export class RequestyAdapter extends BaseAdapter {
     return message?.toolCalls || [];
   }
 
-  private mapFinishReason(reason: string | null): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
-    if (!reason) return 'stop';
-    
-    const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
-      'stop': 'stop',
-      'length': 'length',
-      'tool_calls': 'tool_calls',
-      'content_filter': 'content_filter'
-    };
-    return reasonMap[reason] || 'stop';
-  }
-
   protected extractUsage(response: RequestyChatCompletionResponse): { promptTokens: number; completionTokens: number; totalTokens: number } | undefined {
     const usage = response.usage;
     if (usage) {
@@ -298,42 +272,7 @@ export class RequestyAdapter extends BaseAdapter {
     return undefined;
   }
 
-  private getCostPer1kTokens(modelId: string): { input: number; output: number } | undefined {
-    const model = REQUESTY_MODELS.find(m => m.apiName === modelId);
-    if (!model) return undefined;
-    
-    return {
-      input: model.inputCostPerMillion / 1000,
-      output: model.outputCostPerMillion / 1000
-    };
-  }
-
   getModelPricing(modelId: string): Promise<ModelPricing | null> {
-    const costs = this.getCostPer1kTokens(modelId);
-    if (!costs) return Promise.resolve(null);
-
-    return Promise.resolve({
-      rateInputPerMillion: costs.input * 1000,
-      rateOutputPerMillion: costs.output * 1000,
-      currency: 'USD'
-    });
-  }
-
-  /**
-   * Build messages array, using conversationHistory for tool continuations
-   * and prepending system prompt if it was stripped by the context builder.
-   */
-  private buildMessagesForRequest(prompt: string, options?: GenerateOptions): Array<Record<string, unknown>> {
-    if (options?.conversationHistory && options.conversationHistory.length > 0) {
-      const messages = options.conversationHistory;
-      if (options.systemPrompt) {
-        const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
-        if (!hasSystem) {
-          return [{ role: 'system', content: options.systemPrompt }, ...messages];
-        }
-      }
-      return messages;
-    }
-    return this.buildMessages(prompt, options?.systemPrompt);
+    return Promise.resolve(getStaticModelPricing(REQUESTY_MODELS, modelId));
   }
 }

--- a/src/services/llm/adapters/shared/OpenAICompatHelpers.ts
+++ b/src/services/llm/adapters/shared/OpenAICompatHelpers.ts
@@ -1,0 +1,87 @@
+/**
+ * OpenAI-Compatible Chat Helpers
+ * Location: src/services/llm/adapters/shared/OpenAICompatHelpers.ts
+ *
+ * Shared request-building helpers for adapters that speak the OpenAI
+ * chat-completions wire shape (Groq, Mistral, DeepSeek, OpenRouter, OpenAI).
+ * Extracted from per-adapter copies; behavior-preserving.
+ */
+import { GenerateOptions, Tool } from '../types';
+
+/**
+ * Standard Bearer-token JSON headers used by OpenAI-compatible providers.
+ */
+export function buildBearerJsonHeaders(apiKey: string): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${apiKey}`
+  };
+}
+
+/**
+ * Map an OpenAI-compatible finish_reason onto the unified finish reason.
+ * Unknown or missing reasons fall back to 'stop'.
+ */
+export function mapOpenAiCompatFinishReason(
+  reason: string | null
+): 'stop' | 'length' | 'tool_calls' | 'content_filter' {
+  if (!reason) return 'stop';
+
+  const reasonMap: Record<string, 'stop' | 'length' | 'tool_calls' | 'content_filter'> = {
+    'stop': 'stop',
+    'length': 'length',
+    'tool_calls': 'tool_calls',
+    'content_filter': 'content_filter'
+  };
+  return reasonMap[reason] || 'stop';
+}
+
+/**
+ * Build a chat messages array, using conversationHistory for tool
+ * continuations and prepending the system prompt if it was stripped by the
+ * context builder. Falls back to [system?, user] built from the prompt.
+ */
+export function buildMessagesWithConversationHistory(
+  prompt: string,
+  options?: Pick<GenerateOptions, 'systemPrompt' | 'conversationHistory'>
+): Array<Record<string, unknown>> {
+  if (options?.conversationHistory && options.conversationHistory.length > 0) {
+    const messages = options.conversationHistory;
+    if (options.systemPrompt) {
+      const hasSystem = (messages as Array<{ role: string }>).some(m => m.role === 'system');
+      if (!hasSystem) {
+        return [{ role: 'system', content: options.systemPrompt }, ...messages];
+      }
+    }
+    return messages;
+  }
+
+  const messages: Array<Record<string, unknown>> = [];
+  if (options?.systemPrompt) {
+    messages.push({ role: 'system', content: options.systemPrompt });
+  }
+  messages.push({ role: 'user', content: prompt });
+  return messages;
+}
+
+/**
+ * Convert unified Tool definitions to the OpenAI chat-completions tool shape.
+ * Throws on non-function tools (matches prior Groq/DeepSeek behavior).
+ */
+export function convertFunctionTools(
+  tools: Tool[]
+): Array<{ type: 'function'; function: { name: string; description: string; parameters: Record<string, unknown> } }> {
+  return tools.map(tool => {
+    if (tool.type === 'function' && tool.function) {
+      return {
+        type: 'function' as const,
+        function: {
+          name: tool.function.name,
+          description: tool.function.description,
+          parameters: tool.function.parameters
+        }
+      };
+    }
+    throw new Error(`Unsupported tool type: ${tool.type}`);
+  });
+}

--- a/src/services/llm/adapters/shared/SseStreamPump.ts
+++ b/src/services/llm/adapters/shared/SseStreamPump.ts
@@ -1,0 +1,75 @@
+/**
+ * SSE Stream Pump
+ * Location: src/services/llm/adapters/shared/SseStreamPump.ts
+ *
+ * Shared read-feed-drain loop for SSE streaming: reads raw chunks from a
+ * Node.js readable stream (or the buffered mobile fallback), feeds them to an
+ * eventsource parser whose callback fills `eventQueue`, and yields queued
+ * StreamChunks until a completion chunk is seen. Extracted from the
+ * duplicated loops in BaseAdapter.processNodeStream and
+ * OpenAIAdapter.processResponsesNodeStream; behavior-preserving.
+ */
+import { StreamChunk } from '../types';
+
+export interface SseStreamPumpState {
+  isCompleted: boolean;
+}
+
+export interface SseStreamPumpOptions {
+  /** Chunk to yield when the stream ends without a completion event. */
+  buildFinalChunk: () => StreamChunk;
+  /**
+   * Chunk to yield (before rethrowing) when the stream errors prior to
+   * completion. Omit to rethrow without yielding.
+   */
+  buildErrorChunk?: () => StreamChunk;
+}
+
+export async function* pumpSseEventQueue(
+  nodeStream: NodeJS.ReadableStream,
+  feed: (text: string) => void,
+  eventQueue: StreamChunk[],
+  state: SseStreamPumpState,
+  options: SseStreamPumpOptions
+): AsyncGenerator<StreamChunk, void, unknown> {
+  try {
+    for await (const chunk of nodeStream as AsyncIterable<Buffer>) {
+      if (state.isCompleted) break;
+
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+      feed(text);
+
+      // Yield queued events
+      while (eventQueue.length > 0) {
+        const event = eventQueue.shift();
+        if (!event) {
+          break;
+        }
+        yield event;
+        if (event.complete) {
+          state.isCompleted = true;
+          break;
+        }
+      }
+    }
+
+    // Yield remaining events after stream ends
+    while (eventQueue.length > 0) {
+      const event = eventQueue.shift();
+      if (event) {
+        yield event;
+      }
+    }
+
+    // If stream ended without a completion event, yield one
+    if (!state.isCompleted) {
+      yield options.buildFinalChunk();
+    }
+  } catch (error) {
+    // If stream was destroyed (abort), optionally yield completion
+    if (!state.isCompleted && options.buildErrorChunk) {
+      yield options.buildErrorChunk();
+    }
+    throw error;
+  }
+}

--- a/src/services/llm/adapters/shared/StaticModelHelpers.ts
+++ b/src/services/llm/adapters/shared/StaticModelHelpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Static Model Helpers
+ * Location: src/services/llm/adapters/shared/StaticModelHelpers.ts
+ *
+ * Shared listModels/getModelPricing helpers for adapters whose model catalogs
+ * are static ModelSpec arrays (Groq, Mistral, Anthropic, Google) or live in
+ * the central ModelRegistry (OpenAI, OpenRouter). Extracted from per-adapter
+ * copies; behavior-preserving.
+ */
+import { ModelSpec } from '../modelTypes';
+import { ModelInfo, ModelPricing } from '../types';
+import { ModelRegistry } from '../ModelRegistry';
+
+export type StaticModelInfo = ModelInfo & {
+  costPer1kTokens: { input: number; output: number };
+};
+
+/**
+ * Map a static ModelSpec onto the ModelInfo shape returned by listModels.
+ * Capability flags (including supportsThinking) come from the spec; callers
+ * that need to override fields (e.g. Groq forcing supportsThinking: false,
+ * Anthropic suffixing :1m ids) spread over the result.
+ */
+export function staticModelToModelInfo(model: ModelSpec): StaticModelInfo {
+  return {
+    id: model.apiName,
+    name: model.name,
+    contextWindow: model.contextWindow,
+    maxOutputTokens: model.maxTokens,
+    supportsJSON: model.capabilities.supportsJSON,
+    supportsImages: model.capabilities.supportsImages,
+    supportsFunctions: model.capabilities.supportsFunctions,
+    supportsStreaming: model.capabilities.supportsStreaming,
+    supportsThinking: model.capabilities.supportsThinking,
+    costPer1kTokens: {
+      input: model.inputCostPerMillion / 1000,
+      output: model.outputCostPerMillion / 1000
+    },
+    pricing: {
+      inputPerMillion: model.inputCostPerMillion,
+      outputPerMillion: model.outputCostPerMillion,
+      currency: 'USD',
+      lastUpdated: new Date().toISOString()
+    }
+  };
+}
+
+/**
+ * Look up pricing for a model in a static ModelSpec array.
+ */
+export function getStaticModelPricing(models: ModelSpec[], modelId: string): ModelPricing | null {
+  const model = models.find(m => m.apiName === modelId);
+  if (!model) return null;
+
+  return {
+    rateInputPerMillion: model.inputCostPerMillion,
+    rateOutputPerMillion: model.outputCostPerMillion,
+    currency: 'USD'
+  };
+}
+
+/**
+ * Look up pricing for a model in the central ModelRegistry.
+ */
+export function getRegistryModelPricing(provider: string, modelId: string): ModelPricing | null {
+  try {
+    const models = ModelRegistry.getProviderModels(provider);
+    const model = models.find(m => m.apiName === modelId);
+    if (!model) {
+      return null;
+    }
+
+    return {
+      rateInputPerMillion: model.inputCostPerMillion,
+      rateOutputPerMillion: model.outputCostPerMillion,
+      currency: 'USD'
+    };
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/AnthropicAdapter.test.ts
+++ b/tests/unit/AnthropicAdapter.test.ts
@@ -1,0 +1,224 @@
+/**
+ * AnthropicAdapter characterization tests.
+ *
+ * Pin current behavior of the Messages API adapter (non-streaming generate,
+ * SSE event streaming including thinking and tool_use blocks, withRetry-wrapped
+ * error mapping, API-key handling) ahead of shared-code extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { AnthropicAdapter } from '../../src/services/llm/adapters/anthropic/AnthropicAdapter';
+import { ANTHROPIC_DEFAULT_MODEL } from '../../src/services/llm/adapters/anthropic/AnthropicModels';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import { ProviderHttpError } from '../../src/services/llm/adapters/shared/ProviderHttpClient';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('AnthropicAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses text and thinking blocks, maps end_turn, and derives totalTokens', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          model: 'claude-test-model',
+          content: [
+            { type: 'thinking', thinking: 'pondering' },
+            { type: 'text', text: 'Hello' },
+            { type: 'text', text: ' world' }
+          ],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 5 }
+        });
+      });
+
+      const adapter = new AnthropicAdapter('ak-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Hello world');
+      expect(result.model).toBe('claude-test-model');
+      expect(result.provider).toBe('anthropic');
+      expect(result.finishReason).toBe('stop');
+      // totalTokens is derived as input + output (Anthropic sends no total)
+      expect(result.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+      expect(result.metadata?.thinking).toBe('pondering');
+
+      expect(requests[0].url).toBe('https://api.anthropic.com/v1/messages');
+      expect(requests[0].headers?.['x-api-key']).toBe('ak-test');
+      expect(requests[0].headers?.['anthropic-version']).toBe('2023-06-01');
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.system).toBe('Be brief');
+      expect(body.messages).toEqual([{ role: 'user', content: 'hi' }]);
+      expect(body.max_tokens).toBe(4096);
+    });
+
+    it('extracts tool_use blocks into toolCalls with stringified input', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        content: [
+          { type: 'text', text: 'Using a tool' },
+          { type: 'tool_use', id: 'toolu_1', name: 'search', input: { q: 'x' } }
+        ],
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 4, output_tokens: 2 }
+      }));
+
+      const adapter = new AnthropicAdapter('ak-test');
+      const result = await adapter.generateUncached('hi');
+
+      expect(result.finishReason).toBe('tool_calls');
+      expect(result.toolCalls).toEqual([
+        { id: 'toolu_1', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+    });
+
+    it('falls back to the current model when the response omits model', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        content: [{ type: 'text', text: 'ok' }],
+        stop_reason: 'end_turn'
+      }));
+
+      const adapter = new AnthropicAdapter('ak-test');
+      const result = await adapter.generateUncached('hi');
+      expect(result.model).toBe(ANTHROPIC_DEFAULT_MODEL);
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields text deltas, thinking deltas, accumulated tool calls, and final usage', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 1 } } },
+        { type: 'content_block_start', index: 0, content_block: { type: 'thinking' } },
+        { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'hmm' } },
+        { type: 'content_block_stop', index: 0 },
+        { type: 'content_block_delta', index: 1, delta: { type: 'text_delta', text: 'Hello' } },
+        { type: 'content_block_start', index: 2, content_block: { type: 'tool_use', id: 'toolu_1', name: 'search' } },
+        { type: 'content_block_delta', index: 2, delta: { type: 'input_json_delta', partial_json: '{"q":"x"}' } },
+        { type: 'message_delta', usage: { input_tokens: 10, output_tokens: 5 } },
+        { type: 'message_stop' }
+      )));
+
+      const adapter = new AnthropicAdapter('ak-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toBe('Hello');
+
+      const reasoningChunks = chunks.filter(chunk => chunk.reasoning !== undefined);
+      expect(reasoningChunks[0]).toMatchObject({ reasoning: 'hmm', reasoningComplete: false });
+      expect(reasoningChunks[1]).toMatchObject({ reasoning: '', reasoningComplete: true });
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      // Anthropic streaming usage has no total_tokens; totalTokens stays 0
+      expect(final.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 0 });
+      expect(final.toolCallsReady).toBe(true);
+      // Current behavior: the synthetic id from input_json_delta overwrites
+      // the real tool_use id supplied by content_block_start
+      expect(final.toolCalls).toEqual([
+        { id: 'anthropic-tool-2', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+    });
+
+    it('rethrows streaming HTTP errors as raw ProviderHttpError (not LLMProviderError)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'invalid x-api-key' } }));
+
+      const adapter = new AnthropicAdapter('ak-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi')));
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect((error as ProviderHttpError).response.status).toBe(401);
+    });
+  });
+
+  describe('error mapping (non-streaming, withRetry-wrapped)', () => {
+    it('maps HTTP 401 to AUTHENTICATION_ERROR without retrying', async () => {
+      let calls = 0;
+      __setRequestUrlMock(async () => {
+        calls++;
+        return jsonResponse(401, { error: { message: 'invalid x-api-key' } });
+      });
+
+      const adapter = new AnthropicAdapter('ak-bad');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('AUTHENTICATION_ERROR');
+      expect(error.provider).toBe('anthropic');
+      expect(error.message).toBe('generation failed: invalid x-api-key');
+      expect(calls).toBe(1);
+    });
+
+    it.each([
+      [429, 'RATE_LIMIT_ERROR', 'rate limited'],
+      [500, 'SERVER_ERROR', 'overloaded']
+    ])('retries HTTP %i three times before failing with %s', async (status, code, providerMessage) => {
+      jest.useFakeTimers();
+      let calls = 0;
+      __setRequestUrlMock(async () => {
+        calls++;
+        return jsonResponse(status, { error: { message: providerMessage } });
+      });
+
+      const adapter = new AnthropicAdapter('ak-test');
+      const settled = adapter.generateUncached('hi').then(
+        () => null,
+        (error: unknown) => error
+      );
+      await jest.runAllTimersAsync();
+      const error = await settled as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+      expect(calls).toBe(4);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new AnthropicAdapter('ak-test-4321').getApiKey()).toBe('***4321');
+      expect(new AnthropicAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (static listModels)', async () => {
+      await expect(new AnthropicAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new AnthropicAdapter('ak-test').isAvailable()).resolves.toBe(true);
+    });
+
+    it('suffixes :1m onto ids of 1M-context models in listModels', async () => {
+      const adapter = new AnthropicAdapter('ak-test');
+      const models = await adapter.listModels();
+
+      expect(models.length).toBeGreaterThan(0);
+      for (const model of models) {
+        if (model.contextWindow >= 1000000) {
+          expect(model.id.endsWith(':1m')).toBe(true);
+        } else {
+          expect(model.id.endsWith(':1m')).toBe(false);
+        }
+      }
+    });
+  });
+});

--- a/tests/unit/DeepSeekAdapter.test.ts
+++ b/tests/unit/DeepSeekAdapter.test.ts
@@ -1,0 +1,204 @@
+/**
+ * DeepSeekAdapter characterization tests.
+ *
+ * Pin current behavior (non-streaming generate with reasoning_content and
+ * cache-hit usage, thinking-mode request shaping, SSE streaming with
+ * reasoning deltas, error mapping, API-key handling) ahead of shared-code
+ * extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { DeepSeekAdapter } from '../../src/services/llm/adapters/deepseek/DeepSeekAdapter';
+import { DEEPSEEK_DEFAULT_MODEL } from '../../src/services/llm/adapters/deepseek/DeepSeekModels';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import { ProviderHttpError } from '../../src/services/llm/adapters/shared/ProviderHttpClient';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('DeepSeekAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses content, reasoning_content metadata, and cache-hit usage', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{
+            message: { content: 'Answer', reasoning_content: 'step by step' },
+            finish_reason: 'stop'
+          }],
+          usage: {
+            prompt_tokens: 9,
+            completion_tokens: 4,
+            total_tokens: 13,
+            prompt_cache_hit_tokens: 6
+          }
+        });
+      });
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Answer');
+      expect(result.model).toBe(DEEPSEEK_DEFAULT_MODEL);
+      expect(result.provider).toBe('deepseek');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage).toEqual({
+        promptTokens: 9,
+        completionTokens: 4,
+        totalTokens: 13,
+        cachedTokens: 6
+      });
+      expect(result.metadata?.reasoning).toBe('step by step');
+      expect(result.metadata?.apiModel).toBe(DEEPSEEK_DEFAULT_MODEL);
+
+      expect(requests[0].url).toBe('https://api.deepseek.com/chat/completions');
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer dk-test');
+    });
+
+    it('strips the -thinking suffix on the wire while keeping the user-facing model id', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }]
+        });
+      });
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      const result = await adapter.generateUncached('hi', { model: 'deepseek-v4-flash-thinking' });
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.model).toBe('deepseek-v4-flash');
+      expect(body.thinking).toEqual({ type: 'enabled', reasoning_effort: 'high' });
+      expect(result.model).toBe('deepseek-v4-flash-thinking');
+      expect(result.metadata?.apiModel).toBe('deepseek-v4-flash');
+    });
+
+    it('never forwards frequency/presence penalties and drops undefined keys', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }]
+        });
+      });
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      await adapter.generateUncached('hi', { frequencyPenalty: 0.5, presencePenalty: 0.5 });
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body).not.toHaveProperty('frequency_penalty');
+      expect(body).not.toHaveProperty('presence_penalty');
+      expect(body).not.toHaveProperty('temperature');
+      expect(body).not.toHaveProperty('stop');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields reasoning_content deltas as reasoning and content deltas as text', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { choices: [{ delta: { reasoning_content: 'thinking...' } }] },
+        { choices: [{ delta: { content: 'Ans' } }] },
+        { choices: [{ delta: { content: 'wer' } }] },
+        {
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 }
+        },
+        '[DONE]'
+      )));
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      const reasoningChunk = chunks.find(chunk => chunk.reasoning !== undefined);
+      expect(reasoningChunk).toMatchObject({ reasoning: 'thinking...', reasoningComplete: false });
+      expect(concatContent(chunks)).toBe('Answer');
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toEqual({ promptTokens: 5, completionTokens: 2, totalTokens: 7 });
+    });
+
+    it('prepends the system prompt to conversationHistory when missing', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse({ choices: [{ delta: {}, finish_reason: 'stop' }] }, '[DONE]'));
+      });
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      await collect(adapter.generateStreamAsync('ignored', {
+        systemPrompt: 'SYS',
+        conversationHistory: [{ role: 'user', content: 'earlier turn' }]
+      }));
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'SYS' },
+        { role: 'user', content: 'earlier turn' }
+      ]);
+    });
+
+    it('rethrows streaming HTTP errors as raw ProviderHttpError (not LLMProviderError)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'Authentication Fails' } }));
+
+      const adapter = new DeepSeekAdapter('dk-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi')));
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect((error as ProviderHttpError).response.status).toBe(401);
+    });
+  });
+
+  describe('error mapping (non-streaming)', () => {
+    it.each([
+      [401, 'AUTHENTICATION_ERROR', 'Authentication Fails'],
+      [429, 'RATE_LIMIT_ERROR', 'Rate limit reached'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('maps HTTP %i to %s', async (status, code, providerMessage) => {
+      __setRequestUrlMock(async () => jsonResponse(status, { error: { message: providerMessage } }));
+
+      const adapter = new DeepSeekAdapter('dk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.provider).toBe('deepseek');
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new DeepSeekAdapter('dk-test-1357').getApiKey()).toBe('***1357');
+      expect(new DeepSeekAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (static listModels)', async () => {
+      await expect(new DeepSeekAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new DeepSeekAdapter('dk-test').isAvailable()).resolves.toBe(true);
+    });
+  });
+});

--- a/tests/unit/GoogleAdapter.test.ts
+++ b/tests/unit/GoogleAdapter.test.ts
@@ -1,0 +1,209 @@
+/**
+ * GoogleAdapter characterization tests.
+ *
+ * Pin current behavior of the Gemini generateContent adapter (non-streaming
+ * generate, SSE streaming including thought parts and functionCall parts,
+ * finish-reason mapping including blocked-response surfacing, withRetry-wrapped
+ * error mapping, API-key handling) ahead of shared-code extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { GoogleAdapter } from '../../src/services/llm/adapters/google/GoogleAdapter';
+import { GOOGLE_DEFAULT_MODEL } from '../../src/services/llm/adapters/google/GoogleModels';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import { ProviderHttpError } from '../../src/services/llm/adapters/shared/ProviderHttpClient';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('GoogleAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses candidate parts, usageMetadata, and maps STOP', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          candidates: [{
+            content: { parts: [{ text: 'Hi' }, { text: ' there' }] },
+            finishReason: 'STOP'
+          }],
+          usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 2, totalTokenCount: 7 }
+        });
+      });
+
+      const adapter = new GoogleAdapter('gk-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Hi there');
+      expect(result.model).toBe(GOOGLE_DEFAULT_MODEL);
+      expect(result.provider).toBe('google');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage).toEqual({ promptTokens: 5, completionTokens: 2, totalTokens: 7 });
+
+      expect(requests[0].url).toBe(
+        `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(GOOGLE_DEFAULT_MODEL)}:generateContent`
+      );
+      expect(requests[0].headers?.['x-goog-api-key']).toBe('gk-test');
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.contents).toEqual([{ role: 'user', parts: [{ text: 'hi' }] }]);
+      expect(body.systemInstruction).toEqual({ parts: [{ text: 'Be brief' }] });
+    });
+
+    it('maps MAX_TOKENS to length and SAFETY to content_filter', async () => {
+      const adapter = new GoogleAdapter('gk-test');
+
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        candidates: [{ content: { parts: [{ text: 'x' }] }, finishReason: 'MAX_TOKENS' }]
+      }));
+      expect((await adapter.generateUncached('hi')).finishReason).toBe('length');
+
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        candidates: [{ content: { parts: [] }, finishReason: 'SAFETY' }]
+      }));
+      expect((await adapter.generateUncached('hi')).finishReason).toBe('content_filter');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields content, thought parts as reasoning, function calls, and final usage', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse(
+          { candidates: [{ content: { parts: [{ thought: 'pondering' }] } }] },
+          { candidates: [{ content: { parts: [{ text: 'Hello' }] } }] },
+          { candidates: [{ content: { parts: [{ functionCall: { name: 'search', args: { q: 'x' } } }] } }] },
+          {
+            candidates: [{ content: { parts: [{ text: '!' }] }, finishReason: 'STOP' }],
+            usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 3, totalTokenCount: 8 }
+          }
+        ));
+      });
+
+      const adapter = new GoogleAdapter('gk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(requests[0].url).toContain(':streamGenerateContent?alt=sse');
+      expect(concatContent(chunks)).toBe('Hello!');
+
+      const reasoningChunk = chunks.find(chunk => chunk.reasoning !== undefined);
+      expect(reasoningChunk).toMatchObject({ reasoning: 'pondering', reasoningComplete: false });
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toEqual({ promptTokens: 5, completionTokens: 3, totalTokens: 8 });
+      expect(final.toolCallsReady).toBe(true);
+      expect(final.toolCalls).toEqual([
+        { id: 'search_0', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+    });
+
+    it('surfaces MALFORMED_FUNCTION_CALL as user-facing error content and completes the stream', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { candidates: [{ finishReason: 'MALFORMED_FUNCTION_CALL' }] }
+      )));
+
+      const adapter = new GoogleAdapter('gk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toContain('[Error: MALFORMED_FUNCTION_CALL');
+      expect(chunks[chunks.length - 1].complete).toBe(true);
+    });
+
+    it('rethrows streaming HTTP errors as raw ProviderHttpError (not LLMProviderError)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'API key not valid' } }));
+
+      const adapter = new GoogleAdapter('gk-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi')));
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect((error as ProviderHttpError).response.status).toBe(401);
+    });
+  });
+
+  describe('error mapping (non-streaming, withRetry-wrapped)', () => {
+    it('maps HTTP 401 to AUTHENTICATION_ERROR without retrying', async () => {
+      let calls = 0;
+      __setRequestUrlMock(async () => {
+        calls++;
+        return jsonResponse(401, { error: { message: 'API key not valid' } });
+      });
+
+      const adapter = new GoogleAdapter('gk-bad');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('AUTHENTICATION_ERROR');
+      expect(error.provider).toBe('google');
+      expect(error.message).toBe('generation failed: API key not valid');
+      expect(calls).toBe(1);
+    });
+
+    it.each([
+      [429, 'RATE_LIMIT_ERROR', 'Resource has been exhausted'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('retries HTTP %i three times before failing with %s', async (status, code, providerMessage) => {
+      jest.useFakeTimers();
+      let calls = 0;
+      __setRequestUrlMock(async () => {
+        calls++;
+        return jsonResponse(status, { error: { message: providerMessage } });
+      });
+
+      const adapter = new GoogleAdapter('gk-test');
+      const settled = adapter.generateUncached('hi').then(
+        () => null,
+        (error: unknown) => error
+      );
+      await jest.runAllTimersAsync();
+      const error = await settled as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+      expect(calls).toBe(4);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new GoogleAdapter('gk-test-7777').getApiKey()).toBe('***7777');
+      expect(new GoogleAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (static listModels)', async () => {
+      await expect(new GoogleAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new GoogleAdapter('gk-test').isAvailable()).resolves.toBe(true);
+    });
+
+    it('lists static models with capability-driven supportsThinking', async () => {
+      const adapter = new GoogleAdapter('gk-test');
+      const models = await adapter.listModels();
+
+      expect(models.length).toBeGreaterThan(0);
+      expect(models[0].pricing.currency).toBe('USD');
+    });
+  });
+});

--- a/tests/unit/GroqAdapter.test.ts
+++ b/tests/unit/GroqAdapter.test.ts
@@ -1,0 +1,219 @@
+/**
+ * GroqAdapter characterization tests.
+ *
+ * Pin current behavior of the OpenAI-compatible chat completions adapter
+ * (non-streaming generate, SSE streaming with tool-call accumulation, error
+ * mapping, API-key handling) ahead of shared-code extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { GroqAdapter } from '../../src/services/llm/adapters/groq/GroqAdapter';
+import { GROQ_DEFAULT_MODEL } from '../../src/services/llm/adapters/groq/GroqModels';
+import { LLMProviderError, TokenUsage } from '../../src/services/llm/adapters/types';
+import { ProviderHttpError } from '../../src/services/llm/adapters/shared/ProviderHttpClient';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('GroqAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses chat completion text, usage (with Groq timing metrics), and finish reason', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{ message: { content: 'Hi there' }, finish_reason: 'stop' }],
+          usage: {
+            prompt_tokens: 7,
+            completion_tokens: 3,
+            total_tokens: 10,
+            queue_time: 0.01,
+            prompt_time: 0.02,
+            completion_time: 0.03
+          }
+        });
+      });
+
+      const adapter = new GroqAdapter('gsk-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Hi there');
+      expect(result.model).toBe(GROQ_DEFAULT_MODEL);
+      expect(result.provider).toBe('groq');
+      expect(result.finishReason).toBe('stop');
+      const usage = result.usage as TokenUsage & { queueTime?: number; promptTime?: number; completionTime?: number };
+      expect(usage.promptTokens).toBe(7);
+      expect(usage.completionTokens).toBe(3);
+      expect(usage.totalTokens).toBe(10);
+      expect(usage.queueTime).toBe(0.01);
+      expect(usage.promptTime).toBe(0.02);
+      expect(usage.completionTime).toBe(0.03);
+
+      expect(requests[0].url).toBe('https://api.groq.com/openai/v1/chat/completions');
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer gsk-test');
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'Be brief' },
+        { role: 'user', content: 'hi' }
+      ]);
+    });
+
+    it('maps length finish reason and unknown reasons to length/stop respectively', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        choices: [{ message: { content: 'truncated' }, finish_reason: 'length' }]
+      }));
+      const adapter = new GroqAdapter('gsk-test');
+      expect((await adapter.generateUncached('hi')).finishReason).toBe('length');
+
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        choices: [{ message: { content: 'x' }, finish_reason: 'some_future_reason' }]
+      }));
+      expect((await adapter.generateUncached('hi')).finishReason).toBe('stop');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields content deltas and final usage from x_groq metadata', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { choices: [{ delta: { content: 'Hello' } }] },
+        { choices: [{ delta: { content: ' world' } }] },
+        {
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          x_groq: { usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 } }
+        },
+        '[DONE]'
+      )));
+
+      const adapter = new GroqAdapter('gsk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toBe('Hello world');
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toEqual({ promptTokens: 7, completionTokens: 2, totalTokens: 9 });
+    });
+
+    it('accumulates incremental tool-call deltas into the final chunk', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        {
+          choices: [{
+            delta: {
+              tool_calls: [{ index: 0, id: 'call_1', type: 'function', function: { name: 'search', arguments: '' } }]
+            }
+          }]
+        },
+        { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":' } }] } }] },
+        { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '"x"}' } }] } }] },
+        { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+        '[DONE]'
+      )));
+
+      const adapter = new GroqAdapter('gsk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      // Initial yield when the tool call first appears
+      const initial = chunks.find(chunk => !chunk.complete && chunk.toolCalls);
+      expect(initial?.toolCalls?.[0].function.name).toBe('search');
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.toolCallsReady).toBe(true);
+      expect(final.toolCalls).toEqual([
+        { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+    });
+
+    it('ignores conversationHistory and rebuilds messages from the prompt (current behavior)', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse({ choices: [{ delta: {}, finish_reason: 'stop' }] }, '[DONE]'));
+      });
+
+      const adapter = new GroqAdapter('gsk-test');
+      await collect(adapter.generateStreamAsync('current prompt', {
+        systemPrompt: 'SYS',
+        conversationHistory: [
+          { role: 'user', content: 'earlier turn' },
+          { role: 'assistant', content: 'earlier answer' }
+        ]
+      }));
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'SYS' },
+        { role: 'user', content: 'current prompt' }
+      ]);
+    });
+
+    it('rethrows streaming HTTP errors as raw ProviderHttpError (not LLMProviderError)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'Invalid API key' } }));
+
+      const adapter = new GroqAdapter('gsk-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi')));
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect((error as ProviderHttpError).response.status).toBe(401);
+    });
+  });
+
+  describe('error mapping (non-streaming)', () => {
+    it.each([
+      [401, 'AUTHENTICATION_ERROR', 'Invalid API key'],
+      [429, 'RATE_LIMIT_ERROR', 'Rate limit exceeded'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('maps HTTP %i to %s', async (status, code, providerMessage) => {
+      __setRequestUrlMock(async () => jsonResponse(status, { error: { message: providerMessage } }));
+
+      const adapter = new GroqAdapter('gsk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.provider).toBe('groq');
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new GroqAdapter('gsk-test-5678').getApiKey()).toBe('***5678');
+      expect(new GroqAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (static listModels)', async () => {
+      await expect(new GroqAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new GroqAdapter('gsk-test').isAvailable()).resolves.toBe(true);
+    });
+
+    it('lists static models with supportsThinking forced to false', async () => {
+      const adapter = new GroqAdapter('gsk-test');
+      const models = await adapter.listModels();
+
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.every(model => model.supportsThinking === false)).toBe(true);
+      expect(models[0].pricing.currency).toBe('USD');
+    });
+  });
+});

--- a/tests/unit/MistralAdapter.test.ts
+++ b/tests/unit/MistralAdapter.test.ts
@@ -1,0 +1,200 @@
+/**
+ * MistralAdapter characterization tests.
+ *
+ * Pin current behavior (non-streaming generate including content-part arrays,
+ * SSE streaming, finish-reason passthrough, error mapping, API-key handling)
+ * ahead of shared-code extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { MistralAdapter } from '../../src/services/llm/adapters/mistral/MistralAdapter';
+import { MISTRAL_DEFAULT_MODEL } from '../../src/services/llm/adapters/mistral/MistralModels';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import { ProviderHttpError } from '../../src/services/llm/adapters/shared/ProviderHttpClient';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('MistralAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses chat completion text, usage, and request shape', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{ message: { content: 'Bonjour' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 }
+        });
+      });
+
+      const adapter = new MistralAdapter('mk-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Bonjour');
+      expect(result.model).toBe(MISTRAL_DEFAULT_MODEL);
+      expect(result.provider).toBe('mistral');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage).toEqual({ promptTokens: 3, completionTokens: 2, totalTokens: 5 });
+
+      expect(requests[0].url).toBe('https://api.mistral.ai/v1/chat/completions');
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer mk-test');
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'Be brief' },
+        { role: 'user', content: 'hi' }
+      ]);
+    });
+
+    it('joins text parts when message content is a content-part array', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        choices: [{
+          message: {
+            content: [
+              { type: 'text', text: 'A' },
+              { type: 'image_url' },
+              { type: 'text', text: 'B' }
+            ]
+          },
+          finish_reason: 'stop'
+        }]
+      }));
+
+      const adapter = new MistralAdapter('mk-test');
+      const result = await adapter.generateUncached('hi');
+      expect(result.text).toBe('AB');
+    });
+
+    it('passes provider finish reasons through unmapped (current behavior)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, {
+        choices: [{ message: { content: 'x' }, finish_reason: 'model_length' }]
+      }));
+
+      const adapter = new MistralAdapter('mk-test');
+      const result = await adapter.generateUncached('hi');
+      // Mistral's private mapFinishReason is dead code; raw value flows through
+      expect(result.finishReason).toBe('model_length');
+    });
+
+    it('throws when choices are missing', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, { choices: [] }));
+
+      const adapter = new MistralAdapter('mk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.message).toBe('generation failed: No response from Mistral');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields content deltas and final usage', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { choices: [{ delta: { content: 'Bon' } }] },
+        { choices: [{ delta: { content: 'jour' } }] },
+        {
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 }
+        },
+        '[DONE]'
+      )));
+
+      const adapter = new MistralAdapter('mk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toBe('Bonjour');
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toEqual({ promptTokens: 4, completionTokens: 2, totalTokens: 6 });
+    });
+
+    it('prepends the system prompt to conversationHistory when missing', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse({ choices: [{ delta: {}, finish_reason: 'stop' }] }, '[DONE]'));
+      });
+
+      const adapter = new MistralAdapter('mk-test');
+      await collect(adapter.generateStreamAsync('ignored', {
+        systemPrompt: 'SYS',
+        conversationHistory: [{ role: 'user', content: 'earlier turn' }]
+      }));
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'SYS' },
+        { role: 'user', content: 'earlier turn' }
+      ]);
+    });
+
+    it('rethrows streaming HTTP errors as raw ProviderHttpError (not LLMProviderError)', async () => {
+      __setRequestUrlMock(async () => jsonResponse(429, { message: 'Requests rate limit exceeded' }));
+
+      const adapter = new MistralAdapter('mk-test');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi')));
+
+      expect(error).toBeInstanceOf(ProviderHttpError);
+      expect((error as ProviderHttpError).response.status).toBe(429);
+    });
+  });
+
+  describe('error mapping (non-streaming)', () => {
+    it.each([
+      [401, 'AUTHENTICATION_ERROR', 'Unauthorized'],
+      [429, 'RATE_LIMIT_ERROR', 'Requests rate limit exceeded'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('maps HTTP %i to %s', async (status, code, providerMessage) => {
+      __setRequestUrlMock(async () => jsonResponse(status, { error: { message: providerMessage } }));
+
+      const adapter = new MistralAdapter('mk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.provider).toBe('mistral');
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new MistralAdapter('mk-test-9999').getApiKey()).toBe('***9999');
+      expect(new MistralAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (static listModels)', async () => {
+      await expect(new MistralAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new MistralAdapter('mk-test').isAvailable()).resolves.toBe(true);
+    });
+
+    it('lists static models with supportsThinking forced to false', async () => {
+      const adapter = new MistralAdapter('mk-test');
+      const models = await adapter.listModels();
+
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.every(model => model.supportsThinking === false)).toBe(true);
+    });
+  });
+});

--- a/tests/unit/OpenAIAdapter.test.ts
+++ b/tests/unit/OpenAIAdapter.test.ts
@@ -1,0 +1,235 @@
+/**
+ * OpenAIAdapter characterization tests.
+ *
+ * Pin current behavior of the Responses API adapter (non-streaming generate,
+ * SSE streaming, error mapping, API-key handling) ahead of shared-code
+ * extraction. Mocks at the requestUrl seam; no live network calls.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { OpenAIAdapter } from '../../src/services/llm/adapters/openai/OpenAIAdapter';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('OpenAIAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses Responses API output into text, usage, and responseId metadata', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          id: 'resp_123',
+          output: [
+            {
+              type: 'message',
+              content: [
+                { type: 'output_text', text: 'Hello' },
+                { type: 'output_text', text: ' world' }
+              ]
+            }
+          ],
+          usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 }
+        });
+      });
+
+      const adapter = new OpenAIAdapter('sk-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Hello world');
+      expect(result.model).toBe('gpt-5.5');
+      expect(result.provider).toBe('openai');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+      expect(result.metadata?.responseId).toBe('resp_123');
+
+      expect(requests[0].url).toBe('https://api.openai.com/v1/responses');
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer sk-test');
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.input).toBe('hi');
+      expect(body.instructions).toBe('Be brief');
+      expect(body.stream).toBe(false);
+    });
+
+    it('throws when the Responses API returns no output items', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, { id: 'resp_1', output: [] }));
+
+      const adapter = new OpenAIAdapter('sk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.message).toBe('generation failed: No output from OpenAI Responses API');
+    });
+
+    it('rejects tools on the non-streaming path', async () => {
+      const adapter = new OpenAIAdapter('sk-test');
+      const error = await captureError(adapter.generateUncached('hi', {
+        tools: [{ type: 'function', function: { name: 't', description: 'd', parameters: {} } }]
+      })) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.message).toBe('generation failed: Tool execution requires streaming. Use generateStreamAsync() instead.');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields text deltas and a final chunk with usage, tool calls, and responseId', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { type: 'response.created', response: { id: 'resp_abc' } },
+        { type: 'response.output_text.delta', delta: 'Hello' },
+        { type: 'response.output_text.delta', delta: ' world' },
+        {
+          type: 'response.output_item.done',
+          output_index: 0,
+          item: { type: 'function_call', call_id: 'call_1', name: 'search', arguments: '{"q":"x"}' }
+        },
+        {
+          type: 'response.completed',
+          response: { id: 'resp_abc', usage: { input_tokens: 12, output_tokens: 4, total_tokens: 16 } }
+        }
+      )));
+
+      const adapter = new OpenAIAdapter('sk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toBe('Hello world');
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toEqual({ promptTokens: 12, completionTokens: 4, totalTokens: 16 });
+      expect(final.toolCalls).toEqual([
+        { id: 'call_1', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+      expect(final.toolCallsReady).toBe(true);
+      expect(final.metadata).toEqual({ responseId: 'resp_abc' });
+    });
+
+    it('yields reasoning summary deltas with reasoningId and encrypted content', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { type: 'response.output_item.added', item: { type: 'reasoning', id: 'rs_1' } },
+        { type: 'response.reasoning_summary_text.delta', delta: 'thinking...', item_id: 'rs_1' },
+        { type: 'response.output_item.done', item: { type: 'reasoning', id: 'rs_1', encrypted_content: 'enc123' } },
+        { type: 'response.completed', response: { id: 'resp_r' } }
+      )));
+
+      const adapter = new OpenAIAdapter('sk-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      const reasoningChunks = chunks.filter(chunk => chunk.reasoning !== undefined);
+      expect(reasoningChunks[0]).toMatchObject({ reasoning: '', reasoningComplete: false, reasoningId: 'rs_1' });
+      expect(reasoningChunks[1]).toMatchObject({ reasoning: 'thinking...', reasoningComplete: false, reasoningId: 'rs_1' });
+      expect(reasoningChunks[2]).toMatchObject({
+        reasoning: '',
+        reasoningComplete: true,
+        reasoningId: 'rs_1',
+        reasoningEncryptedContent: 'enc123'
+      });
+    });
+
+    it('converts Chat Completions tools to flat Responses API tools in the request body', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse({ type: 'response.completed', response: { id: 'resp_1' } }));
+      });
+
+      const adapter = new OpenAIAdapter('sk-test');
+      await collect(adapter.generateStreamAsync('hi', {
+        tools: [{
+          type: 'function',
+          function: { name: 'search', description: 'Search', parameters: { type: 'object', properties: {} } }
+        }]
+      }));
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.stream).toBe(true);
+      expect(body.tools).toEqual([{
+        type: 'function',
+        name: 'search',
+        description: 'Search',
+        parameters: { type: 'object', properties: {} },
+        strict: null
+      }]);
+    });
+
+    it('maps a streaming 401 to LLMProviderError AUTHENTICATION_ERROR', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'Invalid API key' } }));
+
+      const adapter = new OpenAIAdapter('sk-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi'))) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('AUTHENTICATION_ERROR');
+      expect(error.provider).toBe('openai');
+    });
+  });
+
+  describe('error mapping (non-streaming)', () => {
+    it.each([
+      [401, 'AUTHENTICATION_ERROR', 'Invalid API key'],
+      [429, 'RATE_LIMIT_ERROR', 'Rate limit exceeded'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('maps HTTP %i to %s', async (status, code, providerMessage) => {
+      __setRequestUrlMock(async () => jsonResponse(status, { error: { message: providerMessage } }));
+
+      const adapter = new OpenAIAdapter('sk-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.provider).toBe('openai');
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new OpenAIAdapter('sk-test-1234').getApiKey()).toBe('***1234');
+      expect(new OpenAIAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (registry-backed listModels)', async () => {
+      await expect(new OpenAIAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new OpenAIAdapter('sk-test').isAvailable()).resolves.toBe(true);
+    });
+
+    it('still sends requests with an empty Bearer token (no client-side key guard)', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          id: 'resp_1',
+          output: [{ type: 'message', content: [{ type: 'output_text', text: 'ok' }] }]
+        });
+      });
+
+      const adapter = new OpenAIAdapter('');
+      await adapter.generateUncached('hi');
+
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer ');
+    });
+  });
+});

--- a/tests/unit/OpenRouterAdapter.test.ts
+++ b/tests/unit/OpenRouterAdapter.test.ts
@@ -1,0 +1,204 @@
+/**
+ * OpenRouterAdapter characterization tests.
+ *
+ * Pin current behavior (non-streaming generate with OpenRouter headers and
+ * usage tracking flag, SSE streaming with tool-call accumulation and
+ * reasoning_details, error mapping, API-key handling) ahead of shared-code
+ * extraction.
+ */
+import { __setRequestUrlMock } from '../mocks/obsidian';
+
+jest.mock('../../src/utils/platform', () => ({
+  ...jest.requireActual('../../src/utils/platform'),
+  hasNodeRuntime: () => false,
+}));
+
+import { OpenRouterAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterAdapter';
+import { LLMProviderError } from '../../src/services/llm/adapters/types';
+import { BRAND_NAME } from '../../src/constants/branding';
+import {
+  jsonResponse,
+  sseResponse,
+  sse,
+  collect,
+  concatContent,
+  captureError,
+  CapturedRequest
+} from './helpers/llmAdapterTestHarness';
+
+describe('OpenRouterAdapter', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('non-streaming generate', () => {
+    it('parses chat completion text and usage, sending OpenRouter attribution headers', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return jsonResponse(200, {
+          choices: [{ message: { content: 'Routed' }, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 6, completion_tokens: 2, total_tokens: 8 }
+        });
+      });
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
+
+      expect(result.text).toBe('Routed');
+      expect(result.model).toBe('openai/gpt-5.5');
+      expect(result.provider).toBe('openrouter');
+      expect(result.finishReason).toBe('stop');
+      expect(result.usage).toEqual({ promptTokens: 6, completionTokens: 2, totalTokens: 8 });
+
+      expect(requests[0].url).toBe('https://openrouter.ai/api/v1/chat/completions');
+      expect(requests[0].headers?.['Authorization']).toBe('Bearer or-test');
+      expect(requests[0].headers?.['HTTP-Referer']).toBe('https://synapticlabs.ai');
+      expect(requests[0].headers?.['X-Title']).toBe(BRAND_NAME);
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.usage).toEqual({ include: true });
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'Be brief' },
+        { role: 'user', content: 'hi' }
+      ]);
+    });
+
+    it('throws UNKNOWN_ERROR when the response has no choices', async () => {
+      __setRequestUrlMock(async () => jsonResponse(200, { choices: [] }));
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('UNKNOWN_ERROR');
+      expect(error.message).toBe('generation failed: OpenRouter generation returned an empty response');
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('yields content deltas and completes without usage (fetched async via generation id)', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { id: 'gen-1', choices: [{ delta: { content: 'Hel' } }] },
+        { choices: [{ delta: { content: 'lo' } }] },
+        { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        '[DONE]'
+      )));
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      expect(concatContent(chunks)).toBe('Hello');
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.usage).toBeUndefined();
+    });
+
+    it('accumulates incremental tool-call deltas into the final chunk', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        {
+          choices: [{
+            delta: {
+              tool_calls: [{ index: 0, id: 'call_or_1', type: 'function', function: { name: 'search', arguments: '' } }]
+            }
+          }]
+        },
+        { choices: [{ delta: { tool_calls: [{ index: 0, function: { arguments: '{"q":"x"}' } }] } }] },
+        { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+        '[DONE]'
+      )));
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      const final = chunks[chunks.length - 1];
+      expect(final.complete).toBe(true);
+      expect(final.toolCallsReady).toBe(true);
+      expect(final.toolCalls).toEqual([
+        { id: 'call_or_1', type: 'function', function: { name: 'search', arguments: '{"q":"x"}' } }
+      ]);
+    });
+
+    it('yields reasoning.text entries from reasoning_details as reasoning chunks', async () => {
+      __setRequestUrlMock(async () => sseResponse(sse(
+        { choices: [{ delta: { reasoning_details: [{ type: 'reasoning.text', text: 'Let me think' }] } }] },
+        { choices: [{ delta: { content: 'Answer' } }] },
+        { choices: [{ delta: {}, finish_reason: 'stop' }] },
+        '[DONE]'
+      )));
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const chunks = await collect(adapter.generateStreamAsync('hi'));
+
+      const reasoningChunk = chunks.find(chunk => chunk.reasoning !== undefined);
+      expect(reasoningChunk).toMatchObject({ reasoning: 'Let me think', reasoningComplete: false });
+      expect(concatContent(chunks)).toBe('Answer');
+    });
+
+    it('prepends the system prompt to conversationHistory when missing', async () => {
+      const requests: CapturedRequest[] = [];
+      __setRequestUrlMock(async (request) => {
+        requests.push(request);
+        return sseResponse(sse({ choices: [{ delta: {}, finish_reason: 'stop' }] }, '[DONE]'));
+      });
+
+      const adapter = new OpenRouterAdapter('or-test');
+      await collect(adapter.generateStreamAsync('ignored', {
+        systemPrompt: 'SYS',
+        conversationHistory: [{ role: 'user', content: 'earlier turn' }]
+      }));
+
+      const body = JSON.parse(requests[0].body ?? '{}');
+      expect(body.messages).toEqual([
+        { role: 'system', content: 'SYS' },
+        { role: 'user', content: 'earlier turn' }
+      ]);
+    });
+
+    it('maps streaming HTTP errors through handleError to LLMProviderError', async () => {
+      __setRequestUrlMock(async () => jsonResponse(401, { error: { message: 'No auth credentials found' } }));
+
+      const adapter = new OpenRouterAdapter('or-bad');
+      const error = await captureError(collect(adapter.generateStreamAsync('hi'))) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe('AUTHENTICATION_ERROR');
+      expect(error.message).toBe('streaming generation failed: No auth credentials found');
+    });
+  });
+
+  describe('error mapping (non-streaming)', () => {
+    it.each([
+      [401, 'AUTHENTICATION_ERROR', 'No auth credentials found'],
+      [429, 'RATE_LIMIT_ERROR', 'Rate limit exceeded'],
+      [500, 'SERVER_ERROR', 'Internal error']
+    ])('maps HTTP %i to %s', async (status, code, providerMessage) => {
+      __setRequestUrlMock(async () => jsonResponse(status, { error: { message: providerMessage } }));
+
+      const adapter = new OpenRouterAdapter('or-test');
+      const error = await captureError(adapter.generateUncached('hi')) as LLMProviderError;
+
+      expect(error).toBeInstanceOf(LLMProviderError);
+      expect(error.code).toBe(code);
+      expect(error.provider).toBe('openrouter');
+      expect(error.message).toBe(`generation failed: ${providerMessage}`);
+    });
+  });
+
+  describe('config / API key handling', () => {
+    it('masks the API key and reports NOT_SET when missing', () => {
+      expect(new OpenRouterAdapter('or-test-2468').getApiKey()).toBe('***2468');
+      expect(new OpenRouterAdapter('').getApiKey()).toBe('NOT_SET');
+    });
+
+    it('isAvailable is false without an API key and true with one (registry-backed listModels)', async () => {
+      await expect(new OpenRouterAdapter('').isAvailable()).resolves.toBe(false);
+      await expect(new OpenRouterAdapter('or-test').isAvailable()).resolves.toBe(true);
+    });
+  });
+});

--- a/tests/unit/helpers/llmAdapterTestHarness.ts
+++ b/tests/unit/helpers/llmAdapterTestHarness.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared helpers for LLM chat adapter characterization tests.
+ *
+ * These tests mock at the requestUrl seam (via the obsidian mock's
+ * __setRequestUrlMock) and force ProviderHttpClient.requestStream onto its
+ * buffered requestUrl fallback by mocking hasNodeRuntime to false in each
+ * test file. No live network calls are made.
+ */
+import type { StreamChunk } from '../../../src/services/llm/adapters/types';
+
+export interface MockHttpResponse {
+  status: number;
+  headers: Record<string, string>;
+  text: string;
+  json: unknown;
+  arrayBuffer: ArrayBuffer;
+}
+
+export interface CapturedRequest {
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+export function jsonResponse(status: number, json: unknown): MockHttpResponse {
+  return {
+    status,
+    headers: {},
+    text: JSON.stringify(json),
+    json,
+    arrayBuffer: new ArrayBuffer(0)
+  };
+}
+
+export function sseResponse(text: string): MockHttpResponse {
+  return {
+    status: 200,
+    headers: {},
+    text,
+    json: null,
+    arrayBuffer: new ArrayBuffer(0)
+  };
+}
+
+/** Build SSE wire text from a sequence of JSON events (or raw strings like '[DONE]'). */
+export function sse(...events: unknown[]): string {
+  return events
+    .map(event => `data: ${typeof event === 'string' ? event : JSON.stringify(event)}\n\n`)
+    .join('');
+}
+
+export async function collect(
+  stream: AsyncGenerator<StreamChunk, void, unknown>
+): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+export function concatContent(chunks: StreamChunk[]): string {
+  return chunks.map(chunk => chunk.content).join('');
+}
+
+export async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  return promise.then(
+    () => {
+      throw new Error('Expected promise to reject');
+    },
+    (error: unknown) => error
+  );
+}


### PR DESCRIPTION
Follow-up to #253, migrating the two remaining OpenAI-compatible HTTP adapters (Perplexity, Requesty) onto the shared helpers — finishing the adapter dedup for the cloud HTTP adapters.

**Stacked on #253** (the shared helpers live there) — base is `audit/adapter-dedup`, not `main`. Retarget to `main` once #253 merges.

Swaps (all behavior-preserving, verified byte-identical against the helpers):
- `mapFinishReason` → `mapOpenAiCompatFinishReason`
- `listModels` mapping → `staticModelToModelInfo`, with an explicit `supportsThinking: false` override preserving each adapter's hardcoded value
- `getCostPer1kTokens` + `getModelPricing` → `getStaticModelPricing`
- Requesty `buildMessagesForRequest` → `buildMessagesWithConversationHistory` (`BaseAdapter.buildMessages` is exactly the helper's `[system?, user]` fallback)

Net −104 lines. Full suite green; tsc + lint clean.

**Intentionally left out:** the local providers `ollama` (native non-OpenAI API) and `lmstudio` (its own `ToolCallContentParser` for tool-call-in-content handling) — they diverge from the OpenAI-compatible shape and shouldn't be forced onto these helpers.

A separate PR will refresh the (stale) Requesty *model catalog* aligned to OpenRouter — that's data in `RequestyModels.ts`, independent of this logic change.

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_