### PR TITLE
feat: refresh Requesty model catalog and add Claude Fable 5

### DIFF
--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -1,6 +1,6 @@
 /**
  * Anthropic Model Specifications
- * Updated May 2026 with Claude Opus 4.8
+ * Updated June 2026 with Claude Fable 5
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -15,6 +15,24 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     maxTokens: 64000,
     inputCostPerMillion: 1.00,
     outputCostPerMillion: 5.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // Claude Fable 5
+  {
+    provider: 'anthropic',
+    name: 'Claude Fable 5',
+    apiName: 'claude-fable-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -139,6 +139,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'Claude Fable 5',
+    apiName: 'anthropic/claude-fable-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Claude Sonnet 4.6',
     apiName: 'anthropic/claude-sonnet-4.6',
     contextWindow: 200000,

--- a/src/services/llm/adapters/requesty/RequestyModels.ts
+++ b/src/services/llm/adapters/requesty/RequestyModels.ts
@@ -1,7 +1,14 @@
 /**
  * Requesty Model Specifications
  * Requesty provides access to multiple providers through a unified API
- * Updated June 17, 2025
+ * Updated June 10, 2026 — aligned with OpenRouterModels.ts metadata.
+ *
+ * Slug conventions (verified against requesty.ai/models pages):
+ * - OpenAI and Google slugs match OpenRouter exactly (openai/gpt-5.5,
+ *   google/gemini-3.5-flash).
+ * - Anthropic slugs use Anthropic's upstream dashed IDs
+ *   (anthropic/claude-opus-4-8), NOT OpenRouter's dotted renames
+ *   (anthropic/claude-opus-4.8).
  */
 
 import { ModelSpec } from '../modelTypes';
@@ -12,113 +19,65 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   // OpenAI models via Requesty
   {
     provider: 'requesty',
-    name: 'GPT-5.2',
-    apiName: 'openai/gpt-5.2',
-    contextWindow: 200000,
-    maxTokens: 65536,
+    name: 'GPT-5.5',
+    apiName: 'openai/gpt-5.5',
+    contextWindow: 1050000,
+    maxTokens: 128000,
     inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'requesty',
+    name: 'GPT-5.4',
+    apiName: 'openai/gpt-5.4',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 2.50,
     outputCostPerMillion: 15.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
       supportsFunctions: true,
       supportsStreaming: true,
-      supportsThinking: false
-    }
-  },
-  {
-    provider: 'requesty',
-    name: 'GPT-5.2 Pro',
-    apiName: 'openai/gpt-5.2-pro',
-    contextWindow: 200000,
-    maxTokens: 65536,
-    inputCostPerMillion: 15.00,
-    outputCostPerMillion: 60.00,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: true,
-      supportsStreaming: false, // Pro model does not support streaming
       supportsThinking: true
     }
   },
   {
     provider: 'requesty',
-    name: 'GPT-5.2 Mini',
-    apiName: 'openai/gpt-5.2-mini',
-    contextWindow: 200000,
-    maxTokens: 65536,
-    inputCostPerMillion: 0.25,
-    outputCostPerMillion: 1.00,
+    name: 'GPT-5.4 Mini',
+    apiName: 'openai/gpt-5.4-mini',
+    contextWindow: 400000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0.75,
+    outputCostPerMillion: 4.50,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
       supportsFunctions: true,
       supportsStreaming: true,
-      supportsThinking: false
+      supportsThinking: true
     }
   },
   {
     provider: 'requesty',
-    name: 'GPT-5 Nano',
-    apiName: 'openai/gpt-5-nano',
-    contextWindow: 200000,
-    maxTokens: 65536,
-    inputCostPerMillion: 0.05,
-    outputCostPerMillion: 0.20,
+    name: 'GPT-5.4 Nano',
+    apiName: 'openai/gpt-5.4-nano',
+    contextWindow: 400000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0.20,
+    outputCostPerMillion: 1.25,
     capabilities: {
       supportsJSON: true,
-      supportsImages: false,
+      supportsImages: true,
       supportsFunctions: true,
       supportsStreaming: true,
-      supportsThinking: false
-    }
-  },
-  {
-    provider: 'requesty',
-    name: 'o3',
-    apiName: 'openai/o3',
-    contextWindow: 200000,
-    maxTokens: 100000,
-    inputCostPerMillion: 2.00,
-    outputCostPerMillion: 8.00,
-    capabilities: {
-      supportsJSON: false,
-      supportsImages: false,
-      supportsFunctions: false,
-      supportsStreaming: false,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'requesty',
-    name: 'o3 Pro',
-    apiName: 'openai/o3-pro',
-    contextWindow: 200000,
-    maxTokens: 100000,
-    inputCostPerMillion: 20.00,
-    outputCostPerMillion: 80.00,
-    capabilities: {
-      supportsJSON: false,
-      supportsImages: false,
-      supportsFunctions: false,
-      supportsStreaming: false,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'requesty',
-    name: 'o4 Mini',
-    apiName: 'openai/o4-mini',
-    contextWindow: 200000,
-    maxTokens: 100000,
-    inputCostPerMillion: 1.10,
-    outputCostPerMillion: 4.40,
-    capabilities: {
-      supportsJSON: false,
-      supportsImages: false,
-      supportsFunctions: false,
-      supportsStreaming: false,
       supportsThinking: true
     }
   },
@@ -126,12 +85,12 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   // Google models via Requesty
   {
     provider: 'requesty',
-    name: 'Gemini 3.0 Flash Preview',
-    apiName: 'google/gemini-3-flash-preview',
+    name: 'Gemini 3.5 Flash',
+    apiName: 'google/gemini-3.5-flash',
     contextWindow: 1048576,
     maxTokens: 65536,
-    inputCostPerMillion: 0.50,
-    outputCostPerMillion: 3.00,
+    inputCostPerMillion: 1.50,
+    outputCostPerMillion: 9.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
@@ -142,10 +101,26 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   },
   {
     provider: 'requesty',
-    name: 'Gemini 2.5 Pro Experimental',
+    name: 'Gemini 3.1 Pro Preview',
+    apiName: 'google/gemini-3.1-pro-preview',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 2.00,
+    outputCostPerMillion: 12.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'requesty',
+    name: 'Gemini 2.5 Pro',
     apiName: 'google/gemini-2.5-pro',
     contextWindow: 1048576,
-    maxTokens: 65535,
+    maxTokens: 66000,
     inputCostPerMillion: 1.25,
     outputCostPerMillion: 10.00,
     capabilities: {
@@ -169,11 +144,59 @@ export const REQUESTY_MODELS: ModelSpec[] = [
       supportsImages: true,
       supportsFunctions: true,
       supportsStreaming: true,
-      supportsThinking: false
+      supportsThinking: true
     }
   },
 
-  // Anthropic models via Requesty
+  // Anthropic models via Requesty (dashed upstream slugs)
+  {
+    provider: 'requesty',
+    name: 'Claude Fable 5',
+    apiName: 'anthropic/claude-fable-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'requesty',
+    name: 'Claude Opus 4.8',
+    apiName: 'anthropic/claude-opus-4-8',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'requesty',
+    name: 'Claude Sonnet 4.6',
+    apiName: 'anthropic/claude-sonnet-4-6',
+    contextWindow: 1000000,
+    maxTokens: 64000,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
   {
     provider: 'requesty',
     name: 'Claude 4.5 Haiku',
@@ -188,22 +211,6 @@ export const REQUESTY_MODELS: ModelSpec[] = [
       supportsFunctions: true,
       supportsStreaming: true,
       supportsThinking: true
-    }
-  },
-  {
-    provider: 'requesty',
-    name: 'Claude 4 Sonnet',
-    apiName: 'anthropic/claude-sonnet-4-20250514',
-    contextWindow: 200000,
-    maxTokens: 64000,
-    inputCostPerMillion: 3.00,
-    outputCostPerMillion: 15.00,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: true,
-      supportsStreaming: true,
-      supportsThinking: false
     }
   },
 
@@ -226,4 +233,4 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   }
 ];
 
-export const REQUESTY_DEFAULT_MODEL = 'anthropic/claude-sonnet-4-20250514';
+export const REQUESTY_DEFAULT_MODEL = 'anthropic/claude-sonnet-4-6';


### PR DESCRIPTION
Refreshes the Requesty model catalog (last touched June 2025) and adds **Claude Fable 5** across the three registries it belongs in.

## Requesty catalog refresh (`RequestyModels.ts`)
Out: `gpt-5.2` family, `o3`/`o3-pro`/`o4-mini`, `gemini-3-flash-preview`, and the dead dated `anthropic/claude-sonnet-4-20250514`.
In (metadata aligned 1:1 with `OpenRouterModels.ts`): GPT-5.5, GPT-5.4/-mini/-nano, Gemini 3.5 Flash / 3.1 Pro Preview / 2.5 Pro / 2.5 Flash, Claude Fable 5 / Opus 4.8 / Sonnet 4.6 / Haiku 4.5, Mistral Large (kept).

**Slug-convention finding (the reason this wasn't a blind mirror):** Requesty's model pages confirm OpenAI and Google slugs match OpenRouter exactly (`openai/gpt-5.5`, `google/gemini-3.5-flash`), but Anthropic models use upstream **dashed** IDs (`anthropic/claude-opus-4-8`, `anthropic/claude-sonnet-4-6`) — OpenRouter's dotted renames (`claude-opus-4.8`) would 404 on Requesty. Verified via requesty.ai/models pages for claude-opus-4-8, claude-sonnet-4-6, claude-fable-5, gpt-5.5, and the gemini set.

Default: `REQUESTY_DEFAULT_MODEL` moves from the dead dated sonnet-4 ID → `anthropic/claude-sonnet-4-6`.

## Claude Fable 5 (released June 9, 2026)
Added to `AnthropicModels.ts` (`claude-fable-5`), `OpenRouterModels.ts` (`anthropic/claude-fable-5`), and `RequestyModels.ts`. Specs corroborated across Anthropic docs, OpenRouter, and Requesty model pages: 1M context (default, like Opus 4.8 — single entry, no `:1m` variant), 128K max output, $10/$50 per 1M tokens, reasoning + vision + tools. Anthropic/OpenRouter defaults unchanged.

## Verification
- ModelRegistry static tests pass; full suite 3385 passed / 0 failed; tsc, lint, production build clean.
- ⚠️ **Live smoke tests and the eval harness were NOT run** — no provider API keys in this sandbox and its egress blocks the provider hosts. Before promoting Fable 5 or relying on the new Requesty IDs in production, run locally:
  ```bash
  RUN_MODEL_SMOKE=1 MODEL_SMOKE_MAX_TOKENS=4096 MODEL_SMOKE_PROVIDER=requesty MODEL_SMOKE_MODEL=anthropic/claude-sonnet-4-6 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
  RUN_MODEL_SMOKE=1 MODEL_SMOKE_MAX_TOKENS=4096 MODEL_SMOKE_PROVIDER=anthropic MODEL_SMOKE_MODEL=claude-fable-5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
  ```
  (4096-token budget because these are thinking models — the 16-token default starves them.)

Sources: [Requesty models](https://www.requesty.ai/models), [requesty claude-opus-4-8](https://www.requesty.ai/models/anthropic/claude-opus-4-8), [requesty claude-fable-5](https://www.requesty.ai/models/anthropic/claude-fable-5), [requesty gpt-5.5](https://www.requesty.ai/models/openai/gpt-5.5), [OpenRouter claude-fable-5](https://openrouter.ai/anthropic/claude-fable-5), [Anthropic docs — Introducing Claude Fable 5](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5).

Independent of the other audit PRs (data-only; no adapter logic).

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_