### PR TITLE
refactor: extract HybridStorageAssembly factory (storage split Phase 1)

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -16,6 +16,7 @@
  * - D: Depends on repository abstractions
  *
  * Related Files:
+ * - src/database/adapters/HybridStorageAssembly.ts - Construction wiring
  * - src/database/repositories/* - Entity repositories
  * - src/database/services/* - Business services
  * - src/database/interfaces/IStorageAdapter.ts - Interface definition
@@ -42,7 +43,6 @@ import {
   ExportData,
   SyncResult
 } from '../../types/storage/HybridStorageTypes';
-import { RepositoryDependencies } from '../repositories/base/BaseRepository';
 import { LegacyMigrator } from '../migration/LegacyMigrator';
 import { WorkspaceEvent, ConversationEvent, TaskEvent } from '../interfaces/StorageEvents';
 import { WorkspaceEventApplier } from '../sync/WorkspaceEventApplier';
@@ -68,14 +68,13 @@ import {
   VaultRootRelocationService,
   type VaultRootRelocationResult
 } from '../migration/VaultRootRelocationService';
-import { resolvePluginStorageRoot, resolveActivePluginFolderName } from '../storage/PluginStoragePathResolver';
 import { resolveVaultRoot } from '../storage/VaultRootResolver';
 import { VaultEventStore } from '../storage/vaultRoot/VaultEventStore';
 import { DEFAULT_STORAGE_SETTINGS } from '../../types/plugin/PluginTypes';
 import { CacheBackendMigration, type CacheBackendStateAccessor } from '../migration/CacheBackendMigration';
-import { createCacheBlobStore, computeIdbKey } from '../storage/CacheBlobStoreFactory';
 import type { CacheBlobStore } from '../storage/CacheBlobStore';
 import { isDesktop } from '../../utils/platform';
+import { assembleHybridStorage } from './HybridStorageAssembly';
 
 // Import all repositories
 import { WorkspaceRepository } from '../repositories/WorkspaceRepository';
@@ -88,10 +87,6 @@ import { ProjectRepository } from '../repositories/ProjectRepository';
 import { TaskRepository } from '../repositories/TaskRepository';
 // Import services
 import { ExportService } from '../services/ExportService';
-
-type ExportServiceStateRepo = {
-  getStates(workspaceId: string, sessionId: string | undefined, options?: { pageSize?: number }): Promise<{ items: StateData[] }>;
-};
 
 /**
  * Configuration options for HybridStorageAdapter
@@ -197,71 +192,31 @@ export class HybridStorageAdapter implements IStorageAdapter {
     this.plugin = options.plugin;
     this.basePath = options.basePath ?? '.nexus';
     this.startupRebuildIdleTimeoutMs = options.startupRebuildIdleTimeoutMs ?? DEFAULT_STARTUP_REBUILD_IDLE_TIMEOUT_MS;
-    const storageRoots = resolvePluginStorageRoot(this.app, this.plugin);
-    this.storageCoordinator = new PluginScopedStorageCoordinator(this.app, this.plugin, this.basePath);
 
-    // Initialize infrastructure
-    this.jsonlWriter = new JSONLWriter({
+    // Construction wiring lives in HybridStorageAssembly (split plan Phase 1);
+    // the adapter receives the assembled collaborators as a typed bundle.
+    const assembly = assembleHybridStorage({
       app: this.app,
-      basePath: this.basePath
+      plugin: this.plugin,
+      basePath: this.basePath,
+      cacheTTL: options.cacheTTL,
+      cacheMaxSize: options.cacheMaxSize
     });
-
-    // Build the cache-blob store ONCE here so the migration runner and the
-    // SQLiteCacheManager share the same instance. The store is selected by
-    // platform: IndexedDB on desktop (cloud-sync-immune), vault.adapter on
-    // mobile (iOS WKWebView IDB durability is insufficient for 150+ MB blobs).
-    const pluginFolderName = resolveActivePluginFolderName(this.plugin);
-    this.cacheBlobStore = createCacheBlobStore({
-      app: this.app,
-      vaultRelativePath: `${storageRoots.dataRoot}/cache.db`,
-      idbKey: computeIdbKey(this.app, pluginFolderName)
-    });
-
-    this.sqliteCache = new SQLiteCacheManager({
-      app: this.app,
-      dbPath: `${storageRoots.dataRoot}/cache.db`,
-      wasmPath: `${storageRoots.pluginDir}/sqlite3.wasm`,
-      blobStore: this.cacheBlobStore,
-      plugin: this.plugin
-    });
-
-    this.syncCoordinator = new SyncCoordinator(
-      this.jsonlWriter,
-      this.sqliteCache
-    );
-
-    this.queryCache = new QueryCache({
-      defaultTTL: options.cacheTTL ?? 60000,
-      maxSize: options.cacheMaxSize ?? 500
-    });
-
-    // Create repository dependencies
-    const deps: RepositoryDependencies = {
-      jsonlWriter: this.jsonlWriter,
-      sqliteCache: this.sqliteCache,
-      queryCache: this.queryCache
-    };
-
-    // Initialize all repositories
-    this.workspaceRepo = new WorkspaceRepository(deps);
-    this.sessionRepo = new SessionRepository(deps);
-    this.stateRepo = new StateRepository(deps);
-    this.traceRepo = new TraceRepository(deps);
-    this.conversationRepo = new ConversationRepository(deps);
-    this.messageRepo = new MessageRepository(deps);
-    this.projectRepo = new ProjectRepository(deps);
-    this.taskRepo = new TaskRepository(deps);
-
-    // Initialize services
-    this.exportService = new ExportService({
-      app: this.app,
-      conversationRepo: this.conversationRepo,
-      messageRepo: this.messageRepo,
-      workspaceRepo: this.workspaceRepo,
-      sessionRepo: this.sessionRepo,
-      stateRepo: this.stateRepo as unknown as ExportServiceStateRepo,
-      traceRepo: this.traceRepo
-    });
+    this.storageCoordinator = assembly.storageCoordinator;
+    this.jsonlWriter = assembly.jsonlWriter;
+    this.cacheBlobStore = assembly.cacheBlobStore;
+    this.sqliteCache = assembly.sqliteCache;
+    this.syncCoordinator = assembly.syncCoordinator;
+    this.queryCache = assembly.queryCache;
+    this.workspaceRepo = assembly.workspaceRepo;
+    this.sessionRepo = assembly.sessionRepo;
+    this.stateRepo = assembly.stateRepo;
+    this.traceRepo = assembly.traceRepo;
+    this.conversationRepo = assembly.conversationRepo;
+    this.messageRepo = assembly.messageRepo;
+    this.projectRepo = assembly.projectRepo;
+    this.taskRepo = assembly.taskRepo;
+    this.exportService = assembly.exportService;
   }
 
   // ============================================================================

--- a/src/database/adapters/HybridStorageAssembly.ts
+++ b/src/database/adapters/HybridStorageAssembly.ts
@@ -1,0 +1,178 @@
+/**
+ * Location: src/database/adapters/HybridStorageAssembly.ts
+ *
+ * Construction wiring for HybridStorageAdapter (Phase 1 of
+ * docs/plans/hybrid-storage-adapter-split-plan.md).
+ *
+ * Builds the storage backends (JSONLWriter, CacheBlobStore,
+ * SQLiteCacheManager, SyncCoordinator, QueryCache,
+ * PluginScopedStorageCoordinator), the eight entity repositories, and the
+ * ExportService in the exact order the adapter constructor previously did.
+ * Pure assembly only: anything that closes over adapter state (lifecycle
+ * controllers, event subscriptions, the reconcile pipeline) stays in the
+ * adapter constructor.
+ *
+ * Related Files:
+ * - src/database/adapters/HybridStorageAdapter.ts - Sole consumer
+ * - src/database/repositories/* - Entity repositories
+ * - src/database/services/ExportService.ts - Export business service
+ */
+
+import { App, Plugin } from 'obsidian';
+import { JSONLWriter } from '../storage/JSONLWriter';
+import { SQLiteCacheManager } from '../storage/SQLiteCacheManager';
+import { SyncCoordinator } from '../sync/SyncCoordinator';
+import { QueryCache } from '../optimizations/QueryCache';
+import { PluginScopedStorageCoordinator } from '../migration/PluginScopedStorageCoordinator';
+import { resolvePluginStorageRoot, resolveActivePluginFolderName } from '../storage/PluginStoragePathResolver';
+import { createCacheBlobStore, computeIdbKey } from '../storage/CacheBlobStoreFactory';
+import type { CacheBlobStore } from '../storage/CacheBlobStore';
+import { RepositoryDependencies } from '../repositories/base/BaseRepository';
+import { StateData } from '../../types/storage/HybridStorageTypes';
+
+// Import all repositories
+import { WorkspaceRepository } from '../repositories/WorkspaceRepository';
+import { SessionRepository } from '../repositories/SessionRepository';
+import { StateRepository } from '../repositories/StateRepository';
+import { TraceRepository } from '../repositories/TraceRepository';
+import { ConversationRepository } from '../repositories/ConversationRepository';
+import { MessageRepository } from '../repositories/MessageRepository';
+import { ProjectRepository } from '../repositories/ProjectRepository';
+import { TaskRepository } from '../repositories/TaskRepository';
+// Import services
+import { ExportService } from '../services/ExportService';
+
+type ExportServiceStateRepo = {
+  getStates(workspaceId: string, sessionId: string | undefined, options?: { pageSize?: number }): Promise<{ items: StateData[] }>;
+};
+
+/**
+ * Inputs the construction wiring consumes. Mirrors the subset of
+ * HybridStorageAdapterOptions the old constructor body read, with
+ * `basePath` already defaulted by the adapter.
+ */
+export interface HybridStorageAssemblyOptions {
+  /** Obsidian app instance */
+  app: App;
+  /** Active plugin instance for plugin-scoped storage resolution */
+  plugin: Plugin;
+  /** Base path for storage (already defaulted by the adapter) */
+  basePath: string;
+  /** Query cache TTL in ms (default: 60000) */
+  cacheTTL?: number;
+  /** Query cache max size (default: 500) */
+  cacheMaxSize?: number;
+}
+
+/**
+ * The assembled collaborators handed back to the adapter constructor.
+ */
+export interface HybridStorageAssembly {
+  storageCoordinator: PluginScopedStorageCoordinator;
+  jsonlWriter: JSONLWriter;
+  cacheBlobStore: CacheBlobStore;
+  sqliteCache: SQLiteCacheManager;
+  syncCoordinator: SyncCoordinator;
+  queryCache: QueryCache;
+  workspaceRepo: WorkspaceRepository;
+  sessionRepo: SessionRepository;
+  stateRepo: StateRepository;
+  traceRepo: TraceRepository;
+  conversationRepo: ConversationRepository;
+  messageRepo: MessageRepository;
+  projectRepo: ProjectRepository;
+  taskRepo: TaskRepository;
+  exportService: ExportService;
+}
+
+/**
+ * Assemble the adapter's collaborators. Construction order matches the
+ * pre-split constructor exactly; no I/O happens here (initialization is
+ * deferred to `HybridStorageAdapter.initialize()`).
+ */
+export function assembleHybridStorage(options: HybridStorageAssemblyOptions): HybridStorageAssembly {
+  const { app, plugin, basePath } = options;
+  const storageRoots = resolvePluginStorageRoot(app, plugin);
+  const storageCoordinator = new PluginScopedStorageCoordinator(app, plugin, basePath);
+
+  // Initialize infrastructure
+  const jsonlWriter = new JSONLWriter({
+    app,
+    basePath
+  });
+
+  // Build the cache-blob store ONCE here so the migration runner and the
+  // SQLiteCacheManager share the same instance. The store is selected by
+  // platform: IndexedDB on desktop (cloud-sync-immune), vault.adapter on
+  // mobile (iOS WKWebView IDB durability is insufficient for 150+ MB blobs).
+  const pluginFolderName = resolveActivePluginFolderName(plugin);
+  const cacheBlobStore = createCacheBlobStore({
+    app,
+    vaultRelativePath: `${storageRoots.dataRoot}/cache.db`,
+    idbKey: computeIdbKey(app, pluginFolderName)
+  });
+
+  const sqliteCache = new SQLiteCacheManager({
+    app,
+    dbPath: `${storageRoots.dataRoot}/cache.db`,
+    wasmPath: `${storageRoots.pluginDir}/sqlite3.wasm`,
+    blobStore: cacheBlobStore,
+    plugin
+  });
+
+  const syncCoordinator = new SyncCoordinator(
+    jsonlWriter,
+    sqliteCache
+  );
+
+  const queryCache = new QueryCache({
+    defaultTTL: options.cacheTTL ?? 60000,
+    maxSize: options.cacheMaxSize ?? 500
+  });
+
+  // Create repository dependencies
+  const deps: RepositoryDependencies = {
+    jsonlWriter,
+    sqliteCache,
+    queryCache
+  };
+
+  // Initialize all repositories
+  const workspaceRepo = new WorkspaceRepository(deps);
+  const sessionRepo = new SessionRepository(deps);
+  const stateRepo = new StateRepository(deps);
+  const traceRepo = new TraceRepository(deps);
+  const conversationRepo = new ConversationRepository(deps);
+  const messageRepo = new MessageRepository(deps);
+  const projectRepo = new ProjectRepository(deps);
+  const taskRepo = new TaskRepository(deps);
+
+  // Initialize services
+  const exportService = new ExportService({
+    app,
+    conversationRepo,
+    messageRepo,
+    workspaceRepo,
+    sessionRepo,
+    stateRepo: stateRepo as unknown as ExportServiceStateRepo,
+    traceRepo
+  });
+
+  return {
+    storageCoordinator,
+    jsonlWriter,
+    cacheBlobStore,
+    sqliteCache,
+    syncCoordinator,
+    queryCache,
+    workspaceRepo,
+    sessionRepo,
+    stateRepo,
+    traceRepo,
+    conversationRepo,
+    messageRepo,
+    projectRepo,
+    taskRepo,
+    exportService
+  };
+}

--- a/tests/unit/HybridStorageAdapter.phase0.test.ts
+++ b/tests/unit/HybridStorageAdapter.phase0.test.ts
@@ -1,0 +1,860 @@
+/**
+ * Phase 0 characterization tests for the HybridStorageAdapter split
+ * (docs/plans/hybrid-storage-adapter-split-plan.md).
+ *
+ * These tests pin the CURRENT behavior of surfaces that Phases 1–2 will move:
+ *   - rebuildCache idempotency/coalescing (`rebuildInFlight`)
+ *   - onExternalSync/offExternalSync event flow
+ *   - relocateVaultRoot happy + failure paths
+ *   - close() teardown ordering
+ *   - per-entity delegation smoke (public surface → repository args)
+ *
+ * They intentionally characterize, not improve: where current behavior is
+ * imperfect it is pinned as-is and flagged with
+ * `// pins current behavior; see report`.
+ */
+
+jest.mock('@dao-xyz/sqlite3-vec/wasm', () => jest.fn(), { virtual: true });
+
+jest.mock('../../src/database/migration/VaultRootRelocationService', () => {
+  const relocateVaultRoot = jest.fn();
+  const VaultRootRelocationService = jest.fn().mockImplementation(() => ({
+    relocateVaultRoot
+  }));
+  return { VaultRootRelocationService, __relocateVaultRootMock: relocateVaultRoot };
+});
+
+import { Events, EventRef, App, Plugin } from 'obsidian';
+import {
+  HybridStorageAdapter,
+  ExternalSyncEvent
+} from '../../src/database/adapters/HybridStorageAdapter';
+import { InitLifecycleController } from '../../src/database/adapters/lifecycle/InitLifecycleController';
+import { ReconcilePipeline } from '../../src/database/sync/ReconcilePipeline';
+import type { ModifiedStream } from '../../src/database/sync/JsonlVaultWatcher';
+import type {
+  SessionMetadata,
+  WorkspaceMetadata,
+  ConversationMetadata,
+  MemoryTraceData,
+  SyncResult
+} from '../../src/types/storage/HybridStorageTypes';
+import { DEFAULT_STORAGE_SETTINGS } from '../../src/types/plugin/PluginTypes';
+
+const relocationModule = jest.requireMock('../../src/database/migration/VaultRootRelocationService') as {
+  VaultRootRelocationService: jest.Mock;
+  __relocateVaultRootMock: jest.Mock;
+};
+
+/** InitLifecycleController that has already completed a successful no-op init. */
+async function createReadyLifecycle(): Promise<InitLifecycleController> {
+  const lifecycle = new InitLifecycleController();
+  await lifecycle.run(async () => undefined, { blocking: true });
+  return lifecycle;
+}
+
+const successfulSyncResult: SyncResult = {
+  success: true,
+  eventsApplied: 0,
+  eventsSkipped: 0,
+  errors: [],
+  duration: 0,
+  filesProcessed: [],
+  lastSyncTimestamp: 1
+};
+
+describe('HybridStorageAdapter (Phase 0 characterization)', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // 1. rebuildCache — idempotency / coalescing
+  // ==========================================================================
+
+  describe('rebuildCache', () => {
+    type RebuildHarness = HybridStorageAdapter & {
+      initLifecycle: InitLifecycleController;
+      sqliteCache: {
+        stopAutoSave: jest.Mock;
+        close: jest.Mock;
+        initialize: jest.Mock;
+      };
+      cacheBlobStore: { remove: jest.Mock };
+      syncCoordinator: { fullRebuild: jest.Mock };
+    };
+
+    async function makeHarness(initialized = true): Promise<RebuildHarness> {
+      const adapter = Object.create(HybridStorageAdapter.prototype) as RebuildHarness;
+      adapter.initLifecycle = initialized
+        ? await createReadyLifecycle()
+        : new InitLifecycleController();
+      adapter.sqliteCache = {
+        stopAutoSave: jest.fn(),
+        close: jest.fn().mockResolvedValue(undefined),
+        initialize: jest.fn().mockResolvedValue(undefined)
+      };
+      adapter.cacheBlobStore = { remove: jest.fn().mockResolvedValue(undefined) };
+      adapter.syncCoordinator = {
+        fullRebuild: jest.fn().mockResolvedValue(successfulSyncResult)
+      };
+      return adapter;
+    }
+
+    it('coalesces concurrent invocations into a single rebuild', async () => {
+      const adapter = await makeHarness();
+      let resolveRebuild!: (result: SyncResult) => void;
+      adapter.syncCoordinator.fullRebuild.mockReturnValue(
+        new Promise<SyncResult>((resolve) => {
+          resolveRebuild = resolve;
+        })
+      );
+
+      const first = adapter.rebuildCache();
+      const second = adapter.rebuildCache();
+
+      resolveRebuild(successfulSyncResult);
+      await Promise.all([first, second]);
+
+      expect(adapter.sqliteCache.stopAutoSave).toHaveBeenCalledTimes(1);
+      expect(adapter.sqliteCache.close).toHaveBeenCalledTimes(1);
+      expect(adapter.cacheBlobStore.remove).toHaveBeenCalledTimes(1);
+      expect(adapter.sqliteCache.initialize).toHaveBeenCalledTimes(1);
+      expect(adapter.syncCoordinator.fullRebuild).toHaveBeenCalledTimes(1);
+
+      // After settling, the in-flight slot is cleared: a third call re-runs.
+      await adapter.rebuildCache();
+      expect(adapter.syncCoordinator.fullRebuild).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports progress phases through onProgress and forwards it to fullRebuild', async () => {
+      const adapter = await makeHarness();
+      adapter.syncCoordinator.fullRebuild.mockImplementation(
+        ({ onProgress }: { onProgress?: (label: string, done: number, total: number) => void }) => {
+          onProgress?.('Processing workspaces', 1, 2);
+          return Promise.resolve(successfulSyncResult);
+        }
+      );
+
+      const labels: string[] = [];
+      await adapter.rebuildCache({ onProgress: (label) => labels.push(label) });
+
+      expect(labels).toEqual([
+        'Stopping auto-save',
+        'Closing cache',
+        'Removing cache blob',
+        'Reopening cache',
+        'Rebuilding from JSONL',
+        'Processing workspaces',
+        'Complete'
+      ]);
+    });
+
+    it('rejects when the adapter is not initialized', async () => {
+      const adapter = await makeHarness(false);
+
+      await expect(adapter.rebuildCache()).rejects.toThrow(
+        'Storage adapter is not initialized; cannot rebuild cache'
+      );
+      expect(adapter.sqliteCache.stopAutoSave).not.toHaveBeenCalled();
+      expect(adapter.sqliteCache.close).not.toHaveBeenCalled();
+    });
+
+    it('propagates a failed rebuild to all concurrent callers and clears the in-flight slot', async () => {
+      const adapter = await makeHarness();
+      let resolveRebuild!: (result: SyncResult) => void;
+      adapter.syncCoordinator.fullRebuild.mockReturnValueOnce(
+        new Promise<SyncResult>((resolve) => {
+          resolveRebuild = resolve;
+        })
+      );
+
+      const first = adapter.rebuildCache();
+      const second = adapter.rebuildCache();
+      const firstRejection = expect(first).rejects.toThrow('Cache rebuild failed: disk vanished');
+      const secondRejection = expect(second).rejects.toThrow('Cache rebuild failed: disk vanished');
+
+      resolveRebuild({ ...successfulSyncResult, success: false, errors: ['disk vanished'] });
+      await firstRejection;
+      await secondRejection;
+
+      // The failure cleared rebuildInFlight, so a retry runs a fresh rebuild.
+      adapter.syncCoordinator.fullRebuild.mockResolvedValue(successfulSyncResult);
+      await adapter.rebuildCache();
+      expect(adapter.syncCoordinator.fullRebuild).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ==========================================================================
+  // 2. External sync event flow — onExternalSync / offExternalSync
+  // ==========================================================================
+
+  describe('external sync events', () => {
+    type ExternalSyncHarness = HybridStorageAdapter & {
+      externalEvents: Events;
+      syncCoordinator: { reconcileStream: jest.Mock };
+      reconcilePipeline: unknown;
+      queryCache: { clear: jest.Mock };
+      reconcileMissingWorkspaces: jest.Mock;
+      reconcileMissingConversations: jest.Mock;
+      reconcileMissingTasks: jest.Mock;
+    };
+
+    function makeHarness(): ExternalSyncHarness {
+      const adapter = Object.create(HybridStorageAdapter.prototype) as ExternalSyncHarness;
+      adapter.externalEvents = new Events();
+      adapter.reconcilePipeline = {};
+      adapter.syncCoordinator = {
+        reconcileStream: jest.fn().mockResolvedValue(undefined)
+      };
+      adapter.queryCache = { clear: jest.fn() };
+      // Instance properties shadow the private prototype methods so the
+      // post-sync reconcilers are observable without a full repo stack.
+      adapter.reconcileMissingWorkspaces = jest.fn().mockResolvedValue(0);
+      adapter.reconcileMissingConversations = jest.fn().mockResolvedValue(0);
+      adapter.reconcileMissingTasks = jest.fn().mockResolvedValue(0);
+      return adapter;
+    }
+
+    function fireChange(adapter: ExternalSyncHarness, modified: ModifiedStream[]): Promise<void> {
+      return (adapter as unknown as {
+        handleExternalJsonlChange(modified: ModifiedStream[]): Promise<void>;
+      }).handleExternalJsonlChange(modified);
+    }
+
+    const modifiedStreams: ModifiedStream[] = [
+      {
+        category: 'conversations',
+        streamId: 'conv_abc',
+        businessId: 'abc',
+        samplePath: 'conversations/conv_abc/shard-000001.jsonl'
+      },
+      {
+        category: 'workspaces',
+        streamId: 'ws_xyz',
+        businessId: 'xyz',
+        samplePath: 'workspaces/ws_xyz/shard-000001.jsonl'
+      }
+    ];
+
+    it('reconciles each modified stream and delivers external-sync to a subscriber', async () => {
+      const adapter = makeHarness();
+      const received: ExternalSyncEvent[] = [];
+      adapter.onExternalSync((event) => received.push(event));
+
+      await fireChange(adapter, modifiedStreams);
+
+      expect(adapter.syncCoordinator.reconcileStream).toHaveBeenCalledTimes(2);
+      expect(adapter.syncCoordinator.reconcileStream).toHaveBeenNthCalledWith(1, 'conversations', 'conv_abc');
+      expect(adapter.syncCoordinator.reconcileStream).toHaveBeenNthCalledWith(2, 'workspaces', 'ws_xyz');
+      expect(adapter.reconcileMissingWorkspaces).toHaveBeenCalledTimes(1);
+      expect(adapter.reconcileMissingConversations).toHaveBeenCalledTimes(1);
+      expect(adapter.reconcileMissingTasks).toHaveBeenCalledTimes(1);
+      expect(adapter.queryCache.clear).toHaveBeenCalledTimes(1);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].modified).toBe(modifiedStreams);
+      expect(received[0].result.success).toBe(true);
+      expect(received[0].result.filesProcessed).toEqual([
+        'conversations/conv_abc/shard-000001.jsonl',
+        'workspaces/ws_xyz/shard-000001.jsonl'
+      ]);
+    });
+
+    it('offExternalSync removes only the unsubscribed listener', async () => {
+      const adapter = makeHarness();
+      const firstListener = jest.fn();
+      const secondListener = jest.fn();
+      const firstRef: EventRef = adapter.onExternalSync(firstListener);
+      adapter.onExternalSync(secondListener);
+
+      await fireChange(adapter, modifiedStreams);
+      expect(firstListener).toHaveBeenCalledTimes(1);
+      expect(secondListener).toHaveBeenCalledTimes(1);
+
+      adapter.offExternalSync(firstRef);
+
+      await fireChange(adapter, modifiedStreams);
+      expect(firstListener).toHaveBeenCalledTimes(1);
+      expect(secondListener).toHaveBeenCalledTimes(2);
+    });
+
+    it('multiple subscribers each receive the same event payload', async () => {
+      const adapter = makeHarness();
+      const payloads: ExternalSyncEvent[] = [];
+      adapter.onExternalSync((event) => payloads.push(event));
+      adapter.onExternalSync((event) => payloads.push(event));
+      adapter.onExternalSync((event) => payloads.push(event));
+
+      await fireChange(adapter, [modifiedStreams[0]]);
+
+      expect(payloads).toHaveLength(3);
+      expect(payloads[1]).toBe(payloads[0]);
+      expect(payloads[2]).toBe(payloads[0]);
+    });
+
+    it('does nothing for an empty modified list', async () => {
+      const adapter = makeHarness();
+      const listener = jest.fn();
+      adapter.onExternalSync(listener);
+
+      await fireChange(adapter, []);
+
+      expect(adapter.syncCoordinator.reconcileStream).not.toHaveBeenCalled();
+      expect(adapter.queryCache.clear).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // 3. relocateVaultRoot
+  // ==========================================================================
+
+  describe('relocateVaultRoot', () => {
+    type RelocateHarness = HybridStorageAdapter & {
+      app: unknown;
+      basePath: string;
+      vaultEventStore: unknown;
+      jsonlWriter: {
+        setBasePath: jest.Mock;
+        setVaultEventStore: jest.Mock;
+        setVaultEventStoreReadEnabled: jest.Mock;
+        getDeviceId: jest.Mock;
+      };
+      jsonlVaultWatcher?: { setDataPath: jest.Mock };
+      syncCoordinator: {
+        getAppliers: jest.Mock;
+        setReconcilePipeline: jest.Mock;
+      };
+      sqliteCache: { getSyncStateStore: jest.Mock };
+      queryCache: { clear: jest.Mock };
+      reconcilePipeline: unknown;
+    };
+
+    const baseRelocationResult = {
+      success: true,
+      verified: true,
+      relation: 'identical' as const,
+      durationMs: 5,
+      sourceRootPath: 'Nexus',
+      destinationRootPath: 'Archive/Nexus',
+      sourceStreamCount: 2,
+      destinationStreamCountBefore: 0,
+      destinationStreamCountAfter: 2,
+      copiedEventCount: 10,
+      skippedEventCount: 0,
+      fileResults: [],
+      conflicts: [],
+      errors: []
+    };
+
+    function makeHarness(): RelocateHarness {
+      const adapter = Object.create(HybridStorageAdapter.prototype) as RelocateHarness;
+      adapter.app = { vault: { configDir: '.obsidian', adapter: {} } };
+      adapter.basePath = 'Nexus/data';
+      adapter.vaultEventStore = { marker: 'source-store' };
+      adapter.jsonlWriter = {
+        setBasePath: jest.fn(),
+        setVaultEventStore: jest.fn(),
+        setVaultEventStoreReadEnabled: jest.fn(),
+        getDeviceId: jest.fn().mockReturnValue('device-1')
+      };
+      adapter.jsonlVaultWatcher = { setDataPath: jest.fn() };
+      adapter.syncCoordinator = {
+        getAppliers: jest.fn().mockReturnValue({
+          workspace: {},
+          conversation: {},
+          task: {}
+        }),
+        setReconcilePipeline: jest.fn()
+      };
+      adapter.sqliteCache = { getSyncStateStore: jest.fn().mockReturnValue({}) };
+      adapter.queryCache = { clear: jest.fn() };
+      adapter.reconcilePipeline = null;
+      return adapter;
+    }
+
+    it('returns switched:false with an error when the vault event store is not initialized', async () => {
+      const adapter = makeHarness();
+      adapter.vaultEventStore = null;
+
+      const result = await adapter.relocateVaultRoot('Archive/Nexus');
+
+      expect(result.switched).toBe(false);
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(['Vault event store is not initialized.']);
+      expect(result.destinationRootPath).toBe('Archive/Nexus');
+      expect(relocationModule.VaultRootRelocationService).not.toHaveBeenCalled();
+      expect(adapter.jsonlWriter.setBasePath).not.toHaveBeenCalled();
+    });
+
+    it('returns switched:false and leaves wiring untouched when relocation fails verification', async () => {
+      const adapter = makeHarness();
+      relocationModule.__relocateVaultRootMock.mockResolvedValue({
+        ...baseRelocationResult,
+        success: false,
+        errors: ['copy mismatch'],
+        destinationStore: { marker: 'dest-store' }
+      });
+
+      const result = await adapter.relocateVaultRoot('Archive/Nexus');
+
+      expect(result.switched).toBe(false);
+      expect(result.errors).toEqual(['copy mismatch']);
+      expect(adapter.basePath).toBe('Nexus/data');
+      expect(adapter.vaultEventStore).toEqual({ marker: 'source-store' });
+      expect(adapter.jsonlWriter.setBasePath).not.toHaveBeenCalled();
+      expect(adapter.jsonlWriter.setVaultEventStore).not.toHaveBeenCalled();
+      expect(adapter.queryCache.clear).not.toHaveBeenCalled();
+      expect(adapter.syncCoordinator.setReconcilePipeline).not.toHaveBeenCalled();
+    });
+
+    it('returns switched:false when the result is verified but carries no destination store', async () => {
+      const adapter = makeHarness();
+      relocationModule.__relocateVaultRootMock.mockResolvedValue({
+        ...baseRelocationResult
+        // no destinationStore
+      });
+
+      const result = await adapter.relocateVaultRoot('Archive/Nexus');
+
+      expect(result.switched).toBe(false);
+      expect(adapter.jsonlWriter.setBasePath).not.toHaveBeenCalled();
+    });
+
+    it('hot-swaps the event store, paths, watcher, and reconcile pipeline on success', async () => {
+      const adapter = makeHarness();
+      const destinationStore = { marker: 'dest-store' };
+      relocationModule.__relocateVaultRootMock.mockResolvedValue({
+        ...baseRelocationResult,
+        destinationStore
+      });
+
+      const result = await adapter.relocateVaultRoot('Archive/Nexus');
+
+      expect(result.switched).toBe(true);
+      expect(result.success).toBe(true);
+
+      // Service was constructed against the current store with the default shard size.
+      expect(relocationModule.VaultRootRelocationService).toHaveBeenCalledTimes(1);
+      const ctorOptions = relocationModule.VaultRootRelocationService.mock.calls[0][0] as {
+        sourceStore: unknown;
+        targetRootPath: string;
+        maxShardBytes: number;
+      };
+      expect(ctorOptions.sourceStore).toEqual({ marker: 'source-store' });
+      expect(ctorOptions.targetRootPath).toBe('Archive/Nexus');
+      expect(ctorOptions.maxShardBytes).toBe(DEFAULT_STORAGE_SETTINGS.maxShardBytes);
+
+      // Hot-swap: all reads/writes now point at the destination.
+      expect(adapter.vaultEventStore).toBe(destinationStore);
+      expect(adapter.basePath).toBe('Archive/Nexus/data');
+      expect(adapter.jsonlWriter.setBasePath).toHaveBeenCalledWith('Archive/Nexus/data');
+      expect(adapter.jsonlWriter.setVaultEventStore).toHaveBeenCalledWith(destinationStore);
+      expect(adapter.jsonlWriter.setVaultEventStoreReadEnabled).toHaveBeenCalledWith(true);
+      expect(adapter.jsonlVaultWatcher?.setDataPath).toHaveBeenCalledWith('Archive/Nexus/data');
+      expect(adapter.syncCoordinator.setReconcilePipeline).toHaveBeenCalledWith(expect.any(ReconcilePipeline));
+      expect(adapter.reconcilePipeline).toBeInstanceOf(ReconcilePipeline);
+      expect(adapter.queryCache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors an explicit maxShardBytes override', async () => {
+      const adapter = makeHarness();
+      relocationModule.__relocateVaultRootMock.mockResolvedValue({
+        ...baseRelocationResult,
+        destinationStore: { marker: 'dest-store' }
+      });
+
+      await adapter.relocateVaultRoot('Archive/Nexus', { maxShardBytes: 1024 });
+
+      const ctorOptions = relocationModule.VaultRootRelocationService.mock.calls[0][0] as {
+        maxShardBytes: number;
+      };
+      expect(ctorOptions.maxShardBytes).toBe(1024);
+    });
+  });
+
+  // ==========================================================================
+  // 4. close() teardown
+  // ==========================================================================
+
+  describe('close', () => {
+    type CloseHarness = HybridStorageAdapter & {
+      initLifecycle: InitLifecycleController;
+      syncInterval?: number;
+      jsonlVaultWatcher?: { stop: jest.Mock };
+      jsonlWriter: { setBeforeWriteHook: jest.Mock };
+      queryCache: { clear: jest.Mock };
+      sqliteCache: { close: jest.Mock };
+    };
+
+    async function makeHarness(initialized = true): Promise<CloseHarness> {
+      const adapter = Object.create(HybridStorageAdapter.prototype) as CloseHarness;
+      adapter.initLifecycle = initialized
+        ? await createReadyLifecycle()
+        : new InitLifecycleController();
+      adapter.jsonlVaultWatcher = { stop: jest.fn() };
+      adapter.jsonlWriter = { setBeforeWriteHook: jest.fn() };
+      adapter.queryCache = { clear: jest.fn() };
+      adapter.sqliteCache = { close: jest.fn().mockResolvedValue(undefined) };
+      return adapter;
+    }
+
+    it('is a no-op before initialization has run', async () => {
+      const adapter = await makeHarness(false);
+
+      await expect(adapter.close()).resolves.toBeUndefined();
+
+      expect(adapter.jsonlVaultWatcher?.stop).not.toHaveBeenCalled();
+      expect(adapter.queryCache.clear).not.toHaveBeenCalled();
+      expect(adapter.sqliteCache.close).not.toHaveBeenCalled();
+    });
+
+    it('stops the watcher, clears the query cache, then closes the SQLite cache', async () => {
+      const adapter = await makeHarness();
+      const watcher = adapter.jsonlVaultWatcher as { stop: jest.Mock };
+      adapter.syncInterval = window.setInterval(() => undefined, 60_000) as unknown as number;
+
+      await adapter.close();
+
+      // Watcher teardown: hook removed, watcher stopped and dereferenced.
+      expect(adapter.jsonlWriter.setBeforeWriteHook).toHaveBeenCalledWith(undefined);
+      expect(watcher.stop).toHaveBeenCalledTimes(1);
+      expect(adapter.jsonlVaultWatcher).toBeUndefined();
+      expect(adapter.syncInterval).toBeUndefined();
+      expect(adapter.queryCache.clear).toHaveBeenCalledTimes(1);
+      expect(adapter.sqliteCache.close).toHaveBeenCalledTimes(1);
+
+      // Ordering: watcher stop → query cache clear → sqlite close.
+      const stopOrder = watcher.stop.mock.invocationCallOrder[0];
+      const clearOrder = adapter.queryCache.clear.mock.invocationCallOrder[0];
+      const closeOrder = adapter.sqliteCache.close.mock.invocationCallOrder[0];
+      expect(stopOrder).toBeLessThan(clearOrder);
+      expect(clearOrder).toBeLessThan(closeOrder);
+    });
+
+    it('runs teardown again on double-close without throwing', async () => {
+      // pins current behavior; see report — close() is NOT idempotent-guarded:
+      // a second call re-clears the query cache and re-closes the SQLite
+      // cache (the watcher branch is a no-op because the handle was cleared).
+      const adapter = await makeHarness();
+      const watcher = adapter.jsonlVaultWatcher as { stop: jest.Mock };
+
+      await adapter.close();
+      await expect(adapter.close()).resolves.toBeUndefined();
+
+      expect(watcher.stop).toHaveBeenCalledTimes(1);
+      expect(adapter.queryCache.clear).toHaveBeenCalledTimes(2);
+      expect(adapter.sqliteCache.close).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows when closing the SQLite cache fails', async () => {
+      const adapter = await makeHarness();
+      adapter.sqliteCache.close.mockRejectedValue(new Error('wasm teardown failed'));
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await expect(adapter.close()).rejects.toThrow('wasm teardown failed');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // 5. Per-entity delegation smoke — public surface → repository args
+  // ==========================================================================
+
+  describe('entity delegation', () => {
+    type MockRepo = Record<string, jest.Mock>;
+    type DelegationHarness = HybridStorageAdapter & {
+      initLifecycle: InitLifecycleController;
+      sqliteCache: unknown;
+      workspaceRepo: MockRepo;
+      sessionRepo: MockRepo;
+      stateRepo: MockRepo;
+      traceRepo: MockRepo;
+      conversationRepo: MockRepo;
+      messageRepo: MockRepo;
+      projectRepo: MockRepo;
+      taskRepo: MockRepo;
+      exportService: MockRepo;
+    };
+
+    /**
+     * The entity delegates are class fields (arrow functions) assigned during
+     * construction, so a prototype-only harness cannot reach them. The full
+     * constructor is side-effect-light (it only wires collaborators), so we
+     * construct for real against a minimal App/Plugin and then swap the
+     * private repositories for mocks.
+     */
+    function makeRealAdapter(): HybridStorageAdapter {
+      const app = {
+        vault: { configDir: '.obsidian', adapter: {} },
+        loadLocalStorage: jest.fn().mockReturnValue('phase0-device-id'),
+        saveLocalStorage: jest.fn()
+      } as unknown as App;
+      const plugin = {
+        manifest: { id: 'claudesidian-mcp', dir: '.obsidian/plugins/claudesidian-mcp' }
+      } as unknown as Plugin;
+      return new HybridStorageAdapter({ app, plugin });
+    }
+
+    async function makeHarness(): Promise<DelegationHarness> {
+      const adapter = makeRealAdapter() as DelegationHarness;
+      adapter.initLifecycle = await createReadyLifecycle();
+      adapter.sqliteCache = { marker: 'sqlite-cache' };
+      adapter.workspaceRepo = {
+        getById: jest.fn().mockResolvedValue(null),
+        getWorkspaces: jest.fn().mockResolvedValue({ items: [] }),
+        create: jest.fn().mockResolvedValue('ws-id'),
+        update: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+        search: jest.fn().mockResolvedValue([])
+      };
+      adapter.sessionRepo = {
+        getById: jest.fn().mockResolvedValue(null),
+        getByWorkspaceId: jest.fn().mockResolvedValue({ items: [] }),
+        create: jest.fn().mockResolvedValue('session-id'),
+        update: jest.fn().mockResolvedValue(undefined),
+        moveToWorkspace: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined)
+      };
+      adapter.stateRepo = {
+        getStateData: jest.fn().mockResolvedValue(null),
+        getStates: jest.fn().mockResolvedValue({ items: [] }),
+        saveState: jest.fn().mockResolvedValue('state-id'),
+        updateState: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+        countStates: jest.fn().mockResolvedValue(3)
+      };
+      adapter.traceRepo = {
+        getTraces: jest.fn().mockResolvedValue({ items: [] }),
+        addTrace: jest.fn().mockResolvedValue('trace-id'),
+        searchTraces: jest.fn().mockResolvedValue({ items: [] })
+      };
+      adapter.conversationRepo = {
+        getById: jest.fn().mockResolvedValue(null),
+        getConversations: jest.fn().mockResolvedValue({ items: [] }),
+        create: jest.fn().mockResolvedValue('conv-id'),
+        update: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(undefined),
+        search: jest.fn().mockResolvedValue([])
+      };
+      adapter.messageRepo = {
+        getMessages: jest.fn().mockResolvedValue({ items: [] }),
+        addMessage: jest.fn().mockResolvedValue('msg-id'),
+        update: jest.fn().mockResolvedValue(undefined),
+        deleteMessage: jest.fn().mockResolvedValue(undefined)
+      };
+      adapter.projectRepo = {};
+      adapter.taskRepo = {};
+      adapter.exportService = {
+        exportForFineTuning: jest.fn().mockResolvedValue('jsonl-export'),
+        exportAllData: jest.fn().mockResolvedValue({ marker: 'export' })
+      };
+      return adapter;
+    }
+
+    it('workspace methods delegate to WorkspaceRepository with the same args', async () => {
+      const adapter = await makeHarness();
+      const workspace = { name: 'My Workspace' } as Omit<WorkspaceMetadata, 'id'>;
+
+      await adapter.getWorkspace('ws-1');
+      await adapter.createWorkspace(workspace);
+      await adapter.updateWorkspace('ws-1', { name: 'Renamed' });
+      await adapter.deleteWorkspace('ws-1');
+      await adapter.searchWorkspaces('query');
+
+      expect(adapter.workspaceRepo.getById).toHaveBeenCalledWith('ws-1');
+      expect(adapter.workspaceRepo.create).toHaveBeenCalledWith(workspace);
+      expect(adapter.workspaceRepo.update).toHaveBeenCalledWith('ws-1', { name: 'Renamed' });
+      expect(adapter.workspaceRepo.delete).toHaveBeenCalledWith('ws-1');
+      expect(adapter.workspaceRepo.search).toHaveBeenCalledWith('query');
+    });
+
+    it('session create merges workspaceId; update forwards only whitelisted fields', async () => {
+      const adapter = await makeHarness();
+
+      await adapter.createSession('ws-1', { name: 'Session A' } as Omit<SessionMetadata, 'id' | 'workspaceId'>);
+      expect(adapter.sessionRepo.create).toHaveBeenCalledWith({ name: 'Session A', workspaceId: 'ws-1' });
+
+      // pins current behavior; see report — updateSession overrides any
+      // workspaceId present in `updates` with the positional arg, and drops
+      // every field other than name/description/endTime/isActive.
+      await adapter.updateSession('ws-1', 'session-1', {
+        name: 'Renamed',
+        description: 'desc',
+        endTime: 123,
+        isActive: false,
+        workspaceId: 'SHOULD-BE-IGNORED',
+        startTime: 999
+      } as Partial<SessionMetadata>);
+      expect(adapter.sessionRepo.update).toHaveBeenCalledWith('session-1', {
+        name: 'Renamed',
+        description: 'desc',
+        endTime: 123,
+        isActive: false,
+        workspaceId: 'ws-1'
+      });
+
+      await adapter.moveSessionToWorkspace('session-1', 'ws-2');
+      expect(adapter.sessionRepo.moveToWorkspace).toHaveBeenCalledWith('session-1', 'ws-2');
+
+      await adapter.deleteSession('session-1');
+      expect(adapter.sessionRepo.delete).toHaveBeenCalledWith('session-1');
+    });
+
+    it('state methods delegate to StateRepository with the same args', async () => {
+      const adapter = await makeHarness();
+      const stateContent = { name: 'Checkpoint', content: { foo: 'bar' } };
+
+      await adapter.getState('state-1');
+      await adapter.getStates('ws-1', 'session-1', { page: 0, pageSize: 10 });
+      await adapter.saveState('ws-1', 'session-1', stateContent as never);
+      await adapter.updateState('state-1', { name: 'Renamed', tags: ['a'] });
+      await adapter.deleteState('state-1');
+      await expect(adapter.countStates('ws-1', 'session-1')).resolves.toBe(3);
+
+      expect(adapter.stateRepo.getStateData).toHaveBeenCalledWith('state-1');
+      expect(adapter.stateRepo.getStates).toHaveBeenCalledWith('ws-1', 'session-1', { page: 0, pageSize: 10 });
+      expect(adapter.stateRepo.saveState).toHaveBeenCalledWith('ws-1', 'session-1', stateContent);
+      expect(adapter.stateRepo.updateState).toHaveBeenCalledWith('state-1', { name: 'Renamed', tags: ['a'] });
+      expect(adapter.stateRepo.delete).toHaveBeenCalledWith('state-1');
+      expect(adapter.stateRepo.countStates).toHaveBeenCalledWith('ws-1', 'session-1');
+    });
+
+    it('trace methods delegate; searchTraces unwraps the paginated result', async () => {
+      const adapter = await makeHarness();
+      const trace = { content: 'tool ran' } as Omit<MemoryTraceData, 'id' | 'workspaceId' | 'sessionId'>;
+      const foundTrace = { id: 'trace-9' } as MemoryTraceData;
+      adapter.traceRepo.searchTraces.mockResolvedValue({ items: [foundTrace] });
+
+      await adapter.getTraces('ws-1', 'session-1', { page: 1, pageSize: 5 });
+      await adapter.addTrace('ws-1', 'session-1', trace);
+      const results = await adapter.searchTraces('ws-1', 'needle', 'session-1');
+
+      expect(adapter.traceRepo.getTraces).toHaveBeenCalledWith('ws-1', 'session-1', { page: 1, pageSize: 5 });
+      expect(adapter.traceRepo.addTrace).toHaveBeenCalledWith('ws-1', 'session-1', trace);
+      expect(adapter.traceRepo.searchTraces).toHaveBeenCalledWith('ws-1', 'needle', 'session-1');
+      expect(results).toEqual([foundTrace]);
+    });
+
+    it('conversation methods delegate; delete cascades into child branches first', async () => {
+      const adapter = await makeHarness();
+      const branch = {
+        id: 'branch-1',
+        metadata: { parentConversationId: 'conv-1' }
+      } as unknown as ConversationMetadata;
+      const unrelated = {
+        id: 'other-1',
+        metadata: { parentConversationId: 'conv-OTHER' }
+      } as unknown as ConversationMetadata;
+      adapter.conversationRepo.getConversations.mockResolvedValue({ items: [branch, unrelated] });
+
+      await adapter.getConversation('conv-1');
+      await adapter.createConversation({ title: 'Chat' } as Omit<ConversationMetadata, 'id' | 'messageCount'>);
+      await adapter.updateConversation('conv-1', { title: 'Renamed' } as Partial<ConversationMetadata>);
+      await adapter.searchConversations('needle');
+      await adapter.deleteConversation('conv-1');
+
+      expect(adapter.conversationRepo.getById).toHaveBeenCalledWith('conv-1');
+      expect(adapter.conversationRepo.create).toHaveBeenCalledWith({ title: 'Chat' });
+      expect(adapter.conversationRepo.update).toHaveBeenCalledWith('conv-1', { title: 'Renamed' });
+      expect(adapter.conversationRepo.search).toHaveBeenCalledWith('needle');
+
+      // Cascade: branch lookup uses the fixed page shape, child deleted before parent.
+      expect(adapter.conversationRepo.getConversations).toHaveBeenCalledWith({
+        pageSize: 100,
+        includeBranches: true
+      });
+      expect(adapter.conversationRepo.delete.mock.calls.map((call) => call[0])).toEqual([
+        'branch-1',
+        'conv-1'
+      ]);
+    });
+
+    it('message methods delegate; updateMessage discards the conversationId arg', async () => {
+      const adapter = await makeHarness();
+      const message = { role: 'user', content: 'hi' };
+      adapter.conversationRepo.getConversations.mockResolvedValue({ items: [] });
+
+      await adapter.getMessages('conv-1', { page: 0, pageSize: 50 });
+      await adapter.addMessage('conv-1', message as never);
+      // pins current behavior; see report — the conversationId positional arg
+      // is unused by updateMessage; only messageId + updates reach the repo.
+      await adapter.updateMessage('conv-IGNORED', 'msg-1', { content: 'edited' } as never);
+      await adapter.deleteMessage('conv-1', 'msg-1');
+
+      expect(adapter.messageRepo.getMessages).toHaveBeenCalledWith('conv-1', { page: 0, pageSize: 50 });
+      expect(adapter.messageRepo.addMessage).toHaveBeenCalledWith('conv-1', message);
+      expect(adapter.messageRepo.update).toHaveBeenCalledWith('msg-1', { content: 'edited' });
+      expect(adapter.messageRepo.deleteMessage).toHaveBeenCalledWith('conv-1', 'msg-1');
+    });
+
+    it('deleteMessage cascades into branch conversations anchored on the message', async () => {
+      const adapter = await makeHarness();
+      const messageBranch = {
+        id: 'branch-2',
+        metadata: { parentMessageId: 'msg-1' }
+      } as unknown as ConversationMetadata;
+      adapter.conversationRepo.getConversations.mockResolvedValue({ items: [messageBranch] });
+
+      await adapter.deleteMessage('conv-1', 'msg-1');
+
+      expect(adapter.conversationRepo.delete).toHaveBeenCalledWith('branch-2');
+      expect(adapter.messageRepo.deleteMessage).toHaveBeenCalledWith('conv-1', 'msg-1');
+    });
+
+    it('project/task/message accessors expose the underlying repositories; cache accessors expose SQLite', async () => {
+      const adapter = await makeHarness();
+
+      expect(adapter.projects).toBe(adapter.projectRepo);
+      expect(adapter.tasks).toBe(adapter.taskRepo);
+      expect(adapter.messages).toBe(adapter.messageRepo);
+      expect(adapter.cache).toBe(adapter.sqliteCache);
+      expect(adapter.getSqliteCache()).toBe(adapter.sqliteCache);
+    });
+
+    it('export methods delegate to ExportService; importData is unimplemented', async () => {
+      const adapter = await makeHarness();
+      const filter = { workspaceId: 'ws-1' } as never;
+
+      await expect(adapter.exportConversationsForFineTuning(filter)).resolves.toBe('jsonl-export');
+      await expect(adapter.exportAllData()).resolves.toEqual({ marker: 'export' });
+      expect(adapter.exportService.exportForFineTuning).toHaveBeenCalledWith(filter);
+      expect(adapter.exportService.exportAllData).toHaveBeenCalledTimes(1);
+
+      // pins current behavior; see report — importData throws unconditionally.
+      await expect(adapter.importData({} as never)).rejects.toThrow('importData not yet implemented');
+    });
+
+    it('delegates reject when initialize() was never called', async () => {
+      const adapter = await makeHarness();
+      adapter.initLifecycle = new InitLifecycleController();
+
+      await expect(adapter.getWorkspace('ws-1')).rejects.toThrow(
+        'HybridStorageAdapter not initialized. Call initialize() first.'
+      );
+      expect(adapter.workspaceRepo.getById).not.toHaveBeenCalled();
+    });
+
+    it('delegates surface the init error when initialization failed', async () => {
+      const adapter = await makeHarness();
+      const failed = new InitLifecycleController();
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await failed.run(async () => {
+          throw new Error('boot exploded');
+        }, { blocking: false });
+        await failed.waitForReady();
+      } finally {
+        errSpy.mockRestore();
+      }
+      adapter.initLifecycle = failed;
+
+      await expect(adapter.getWorkspace('ws-1')).rejects.toThrow('boot exploded');
+      expect(adapter.workspaceRepo.getById).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Phase 1 of the HybridStorageAdapter split plan (#260). **Stacked on #261** (Phase 0 characterization tests) — merge that first, then this.

Pure code motion: the constructor's assembly wiring (storage roots → `PluginScopedStorageCoordinator` → `JSONLWriter` → shared `CacheBlobStore` → `SQLiteCacheManager` → `SyncCoordinator` → `QueryCache` → the 8 repositories → `ExportService`, in exactly the original order with cross-references preserved) moves into a new typed factory `src/database/adapters/HybridStorageAssembly.ts` (`assembleHybridStorage(options)`). The adapter constructor destructures the returned bundle into its existing private fields.

Not moved (deliberately): `hydration`/`initLifecycle`/`externalEvents`/`rebuildInFlight` field initializers (adapter lifecycle state, not assembly) and everything constructed during `initialize()`/`applyStoragePlan` (`reconcilePipeline`, `vaultEventStore`, `reconciliationCoordinator`) — that's Phase 2.

No public-surface or `HybridStorageAdapterOptions` change. Adapter: 1292 → 1247 lines; ~120 LOC moved (within the plan's estimate).

**Verification:** the 46 pinning tests (#261's 28 + the existing 18) pass with **zero edits** to either test file; full suite 3558 / 0 failed; tsc, eslint, production build clean.

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_