### PR TITLE
refactor: extract StorageMaintenanceService (storage split Phase 2)

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -17,12 +17,13 @@
  *
  * Related Files:
  * - src/database/adapters/HybridStorageAssembly.ts - Construction wiring
+ * - src/database/adapters/lifecycle/StorageMaintenanceService.ts - Maintenance/sync surface
  * - src/database/repositories/* - Entity repositories
  * - src/database/services/* - Business services
  * - src/database/interfaces/IStorageAdapter.ts - Interface definition
  */
 
-import { App, Events, EventRef, Plugin } from 'obsidian';
+import { App, EventRef, Plugin } from 'obsidian';
 import { IStorageAdapter, QueryOptions, ImportOptions } from '../interfaces/IStorageAdapter';
 import { JSONLWriter } from '../storage/JSONLWriter';
 import { SQLiteCacheManager } from '../storage/SQLiteCacheManager';
@@ -44,11 +45,6 @@ import {
   SyncResult
 } from '../../types/storage/HybridStorageTypes';
 import { LegacyMigrator } from '../migration/LegacyMigrator';
-import { WorkspaceEvent, ConversationEvent, TaskEvent } from '../interfaces/StorageEvents';
-import { WorkspaceEventApplier } from '../sync/WorkspaceEventApplier';
-import { ConversationEventApplier } from '../sync/ConversationEventApplier';
-import { TaskEventApplier } from '../sync/TaskEventApplier';
-import { resolveWorkspaceId } from '../sync/resolveWorkspaceId';
 import {
   PluginScopedStorageCoordinator,
   PluginScopedStoragePlan
@@ -59,18 +55,11 @@ import {
   shouldBlockStartupHydrationForVerifiedCutover
 } from './lifecycle/StartupHydrationController';
 import { InitLifecycleController } from './lifecycle/InitLifecycleController';
-import {
-  ReconciliationCoordinator,
-  type ReconcileCategory
-} from './lifecycle/ReconciliationCoordinator';
+import { ReconciliationCoordinator } from './lifecycle/ReconciliationCoordinator';
+import { StorageMaintenanceService } from './lifecycle/StorageMaintenanceService';
 import { VaultRootMigrationService } from '../migration/VaultRootMigrationService';
-import {
-  VaultRootRelocationService,
-  type VaultRootRelocationResult
-} from '../migration/VaultRootRelocationService';
-import { resolveVaultRoot } from '../storage/VaultRootResolver';
+import { type VaultRootRelocationResult } from '../migration/VaultRootRelocationService';
 import { VaultEventStore } from '../storage/vaultRoot/VaultEventStore';
-import { DEFAULT_STORAGE_SETTINGS } from '../../types/plugin/PluginTypes';
 import { CacheBackendMigration, type CacheBackendStateAccessor } from '../migration/CacheBackendMigration';
 import type { CacheBlobStore } from '../storage/CacheBlobStore';
 import { isDesktop } from '../../utils/platform';
@@ -145,23 +134,19 @@ export class HybridStorageAdapter implements IStorageAdapter {
    * `external-sync` event. See JsonlVaultWatcher for design notes.
    */
   private jsonlVaultWatcher?: JsonlVaultWatcher;
-  /**
-   * Typed event bus for adapter consumers. Currently emits one event:
-   *   `external-sync` — payload: { result: SyncResult, modified: ModifiedStream[] }
-   * fired after a watcher-triggered sync completes.
-   */
-  private readonly externalEvents = new Events();
   private readonly hydration = new StartupHydrationController();
   private readonly initLifecycle = new InitLifecycleController();
   private readonly startupRebuildIdleTimeoutMs: number;
 
   /**
-   * Coalesces concurrent `rebuildCache` invocations. When a rebuild is in
-   * flight, subsequent calls return the same promise so a double-click on
-   * "Nexus: Rebuild cache" cannot start two simultaneous rebuilds (which
-   * would race over close/remove/initialize/save on `sqliteCache`).
+   * Lazily-constructed maintenance/sync surface (rebuildCache, sync,
+   * relocateVaultRoot, vault watcher, external-sync events, missing-entity
+   * reconcilers). Created on first use via the `maintenance` getter so the
+   * service always closes over the adapter's CURRENT collaborators —
+   * mutable state (basePath, vaultEventStore, reconcilePipeline, watcher
+   * handle) stays adapter-owned and is reached through accessor callbacks.
    */
-  private rebuildInFlight: Promise<void> | null = null;
+  private maintenanceService?: StorageMaintenanceService;
 
   // Infrastructure (owned by adapter)
   private jsonlWriter: JSONLWriter;
@@ -217,6 +202,35 @@ export class HybridStorageAdapter implements IStorageAdapter {
     this.projectRepo = assembly.projectRepo;
     this.taskRepo = assembly.taskRepo;
     this.exportService = assembly.exportService;
+  }
+
+  private get maintenance(): StorageMaintenanceService {
+    if (!this.maintenanceService) {
+      this.maintenanceService = new StorageMaintenanceService({
+        getApp: () => this.app,
+        getJsonlWriter: () => this.jsonlWriter,
+        getSqliteCache: () => this.sqliteCache,
+        getSyncCoordinator: () => this.syncCoordinator,
+        getQueryCache: () => this.queryCache,
+        getCacheBlobStore: () => this.cacheBlobStore,
+        getInitLifecycle: () => this.initLifecycle,
+        getReconciliationCoordinator: () => this.reconciliationCoordinator,
+        getWorkspaceRepo: () => this.workspaceRepo,
+        getConversationRepo: () => this.conversationRepo,
+        getBasePath: () => this.basePath,
+        setBasePath: (path) => { this.basePath = path; },
+        getVaultEventStore: () => this.vaultEventStore,
+        setVaultEventStore: (store) => { this.vaultEventStore = store; },
+        getReconcilePipeline: () => this.reconcilePipeline,
+        getJsonlVaultWatcher: () => this.jsonlVaultWatcher,
+        setJsonlVaultWatcher: (watcher) => { this.jsonlVaultWatcher = watcher; },
+        wireReconcilePipeline: () => this.wireReconcilePipeline(),
+        reconcileMissingWorkspaces: () => this.reconcileMissingWorkspaces(),
+        reconcileMissingConversations: () => this.reconcileMissingConversations(),
+        reconcileMissingTasks: () => this.reconcileMissingTasks()
+      });
+    }
+    return this.maintenanceService;
   }
 
   // ============================================================================
@@ -494,76 +508,19 @@ export class HybridStorageAdapter implements IStorageAdapter {
     });
   }
 
-  /**
-   * Reconcile JSONL workspace files that are missing from SQLite.
-   * Handles the case where incremental sync skips same-device events.
-   */
+  /** Reconcile JSONL workspace files missing from SQLite. See StorageMaintenanceService. */
   private reconcileMissingWorkspaces(): Promise<number> {
-    const applier = new WorkspaceEventApplier(this.sqliteCache);
-    const category: ReconcileCategory<WorkspaceEvent> = {
-      label: 'workspace',
-      subdir: 'workspaces',
-      filenameRegex: /workspaces\/ws_(.+)\.jsonl$/,
-      existsInCache: async (id) => (await this.workspaceRepo.getById(id)) !== null,
-      shouldSkipEvents: (events) => {
-        // Skip deletes — no need to create then immediately delete.
-        if (events.some(e => e.type === 'workspace_deleted')) return true;
-        // Skip files with no workspace_created event (corrupt/incomplete).
-        return !events.some(e => e.type === 'workspace_created');
-      },
-      applyEvent: (e) => applier.apply(e)
-    };
-    return this.reconciliationCoordinator.reconcile(category);
+    return this.maintenance.reconcileMissingWorkspaces();
   }
 
-  /**
-   * Reconcile JSONL conversation files that are missing from SQLite.
-   * Handles the case where incremental sync skips remote files whose
-   * event timestamps predate the local sync watermark.
-   */
+  /** Reconcile JSONL conversation files missing from SQLite. See StorageMaintenanceService. */
   private reconcileMissingConversations(): Promise<number> {
-    const applier = new ConversationEventApplier(this.sqliteCache);
-    const category: ReconcileCategory<ConversationEvent> = {
-      label: 'conversation',
-      subdir: 'conversations',
-      filenameRegex: /conversations\/conv_(.+)\.jsonl$/,
-      existsInCache: async (id) => (await this.conversationRepo.getById(id)) !== null,
-      shouldSkipEvents: (events) => {
-        if (events.some(e => e.type === 'conversation_deleted')) return true;
-        return !events.some(e => e.type === 'metadata');
-      },
-      applyEvent: (e) => applier.apply(e)
-    };
-    return this.reconciliationCoordinator.reconcile(category);
+    return this.maintenance.reconcileMissingConversations();
   }
 
-  /**
-   * Reconcile JSONL task files that are missing from SQLite.
-   *
-   * Note: tasks resolve the workspace id (name → UUID) and probe `projects`
-   * directly rather than going through a repository's getById — they are
-   * keyed by workspaceId, not entity id, so the standard "exists?" probe
-   * is a SQL count instead.
-   */
+  /** Reconcile JSONL task files missing from SQLite. See StorageMaintenanceService. */
   private reconcileMissingTasks(): Promise<number> {
-    const applier = new TaskEventApplier(this.sqliteCache);
-    const category: ReconcileCategory<TaskEvent> = {
-      label: 'tasks',
-      subdir: 'tasks',
-      filenameRegex: /tasks\/tasks_(.+)\.jsonl$/,
-      existsInCache: async (fileWorkspaceId) => {
-        const resolved = await resolveWorkspaceId(fileWorkspaceId, this.sqliteCache);
-        const effectiveId = resolved.id ?? fileWorkspaceId;
-        const projects = await this.sqliteCache.query<{ id: string }>(
-          'SELECT id FROM projects WHERE workspaceId = ? LIMIT 1',
-          [effectiveId]
-        );
-        return projects.length > 0;
-      },
-      shouldSkipEvents: () => false,
-      applyEvent: (e) => applier.apply(e)
-    };
-    return this.reconciliationCoordinator.reconcile(category);
+    return this.maintenance.reconcileMissingTasks();
   }
 
   /**
@@ -690,56 +647,10 @@ export class HybridStorageAdapter implements IStorageAdapter {
    * Wipe the cache backend and rebuild SQLite from the JSONL source of truth.
    * Used by the "Nexus: Rebuild cache" command to recover from a corrupted or
    * out-of-sync cache without touching the (synced) JSONL event store.
+   * Concurrent invocations coalesce onto one in-flight rebuild.
    */
   async rebuildCache(options: { onProgress?: (label: string, done: number, total: number) => void } = {}): Promise<void> {
-    // Coalesce concurrent invocations. A second click on "Nexus: Rebuild
-    // cache" while one is in flight returns the same promise — both callers
-    // settle on the same outcome, errors propagate to both.
-    if (this.rebuildInFlight) {
-      return this.rebuildInFlight;
-    }
-
-    this.rebuildInFlight = (async () => {
-      try {
-        if (!this.initLifecycle.isInitialized()) {
-          throw new Error('Storage adapter is not initialized; cannot rebuild cache');
-        }
-
-        options.onProgress?.('Stopping auto-save', 0, 1);
-        this.sqliteCache.stopAutoSave();
-
-        options.onProgress?.('Closing cache', 0, 1);
-        await this.sqliteCache.close();
-
-        options.onProgress?.('Removing cache blob', 0, 1);
-        await this.cacheBlobStore.remove();
-
-        options.onProgress?.('Reopening cache', 0, 1);
-        await this.sqliteCache.initialize();
-
-        if (!this.syncCoordinator) {
-          throw new Error('Sync coordinator unavailable; cannot rebuild from JSONL');
-        }
-
-        options.onProgress?.('Rebuilding from JSONL', 0, 1);
-        const result = await this.syncCoordinator.fullRebuild({
-          onProgress: options.onProgress
-        });
-
-        if (!result.success) {
-          const summary = result.errors.length > 0 ? result.errors.join('; ') : 'Unknown error';
-          throw new Error(`Cache rebuild failed: ${summary}`);
-        }
-
-        options.onProgress?.('Complete', 1, 1);
-      } finally {
-        // Clear on both success and failure so a follow-up rebuild can
-        // re-run; the original error (if any) still rejects this promise.
-        this.rebuildInFlight = null;
-      }
-    })();
-
-    return this.rebuildInFlight;
+    return this.maintenance.rebuildCache(options);
   }
 
   // ============================================================================
@@ -757,137 +668,40 @@ export class HybridStorageAdapter implements IStorageAdapter {
    * the plugin's `registerEvent(ref)` for auto-cleanup on unload).
    */
   onExternalSync(callback: (event: ExternalSyncEvent) => void): EventRef {
-    // Obsidian's Events.on takes a variadic `unknown[]` handler; we narrow
-    // here by wrapping so callers get a typed API.
-    return this.externalEvents.on('external-sync', (...data: unknown[]) => {
-      callback(data[0] as ExternalSyncEvent);
-    });
+    return this.maintenance.onExternalSync(callback);
   }
 
   /** Remove a subscription previously added via `onExternalSync`. */
   offExternalSync(ref: EventRef): void {
-    this.externalEvents.offref(ref);
+    this.maintenance.offExternalSync(ref);
   }
 
   /**
-   * Start the JSONL vault watcher. Idempotent. Wires the before-write hook
-   * on `JSONLWriter` so self-writes don't echo back as sync triggers.
+   * Start the JSONL vault watcher. Idempotent. The watcher handle stays
+   * adapter-owned (`jsonlVaultWatcher`); the service operates through
+   * accessor callbacks.
    */
   private startJsonlVaultWatcher(): void {
-    if (this.jsonlVaultWatcher) {
-      return;
-    }
-
-    const watcher = new JsonlVaultWatcher({
-      app: this.app,
-      dataPath: this.basePath,
-      onChange: async (modified) => {
-        await this.handleExternalJsonlChange(modified);
-      }
-    });
-
-    this.jsonlVaultWatcher = watcher;
-    this.jsonlWriter.setBeforeWriteHook((logicalPath) => {
-      watcher.suppressLogicalPath(logicalPath);
-    });
-
-    watcher.start();
+    this.maintenance.startJsonlVaultWatcher();
   }
 
   /**
    * Stop the watcher and tear down its hook. Safe if never started.
    */
   private stopJsonlVaultWatcher(): void {
-    if (!this.jsonlVaultWatcher) {
-      return;
-    }
-    this.jsonlWriter.setBeforeWriteHook(undefined);
-    this.jsonlVaultWatcher.stop();
-    this.jsonlVaultWatcher = undefined;
+    this.maintenance.stopJsonlVaultWatcher();
   }
 
   /**
    * Reconcile after the watcher detects a modified stream set and emit
-   * `external-sync` so open UI can refresh only the affected content.
-   * Called by JsonlVaultWatcher's onChange callback.
-   *
-   * Phase 1 sync-safe reconcile: when the ReconcilePipeline is wired, scope
-   * reconcile to the precise streams that fired the modify event instead of
-   * sweeping the whole cache. Falls back to a full `sync()` if the pipeline
-   * isn't yet wired (e.g. legacy plugin-scoped storage layout) so behavior
-   * stays compatible.
+   * `external-sync`. See StorageMaintenanceService.
    */
-  private async handleExternalJsonlChange(modified: ModifiedStream[]): Promise<void> {
-    if (modified.length === 0) {
-      return;
-    }
-    try {
-      let result: SyncResult;
-      if (this.reconcilePipeline) {
-        for (const m of modified) {
-          await this.syncCoordinator.reconcileStream(m.category, m.streamId);
-        }
-        await this.runMissingEntityReconcilers();
-        this.queryCache.clear();
-        result = {
-          success: true,
-          eventsApplied: 0,
-          eventsSkipped: 0,
-          errors: [],
-          duration: 0,
-          filesProcessed: modified.map((m) => m.samplePath),
-          lastSyncTimestamp: Date.now()
-        };
-      } else {
-        result = await this.sync();
-      }
-      this.externalEvents.trigger('external-sync', { result, modified } satisfies ExternalSyncEvent);
-    } catch (error) {
-      console.error('[HybridStorageAdapter] External JSONL change sync failed:', error);
-    }
-  }
-
-  /**
-   * Run the post-sync entity-existence reconcilers (workspaces, conversations,
-   * tasks). Mirrors the existing `sync()` post-step so scoped reconcile via
-   * `ReconcilePipeline` stays semantically equivalent to the full sweep for
-   * cache-fill purposes. Errors are logged but do not propagate.
-   */
-  private async runMissingEntityReconcilers(): Promise<void> {
-    try {
-      await Promise.all([
-        this.reconcileMissingWorkspaces(),
-        this.reconcileMissingConversations(),
-        this.reconcileMissingTasks()
-      ]);
-    } catch (reconcileError) {
-      console.error('[HybridStorageAdapter] Post-sync reconciliation failed:', reconcileError);
-    }
+  private handleExternalJsonlChange(modified: ModifiedStream[]): Promise<void> {
+    return this.maintenance.handleExternalJsonlChange(modified);
   }
 
   async sync(): Promise<SyncResult> {
-    try {
-      const result = await this.syncCoordinator.sync();
-
-      try {
-        await Promise.all([
-          this.reconcileMissingWorkspaces(),
-          this.reconcileMissingConversations(),
-          this.reconcileMissingTasks()
-        ]);
-      } catch (reconcileError) {
-        console.error('[HybridStorageAdapter] Post-sync reconciliation failed:', reconcileError);
-      }
-
-      // Invalidate all query cache on sync
-      this.queryCache.clear();
-
-      return result;
-
-    } catch (error) {
-      console.error('[HybridStorageAdapter] Sync failed:', error);
-      throw error;
-    }
+    return this.maintenance.sync();
   }
 
   /**
@@ -902,56 +716,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
     targetRootPath: string,
     options?: { maxShardBytes?: number }
   ): Promise<VaultRootRelocationResult & { switched: boolean }> {
-    if (!this.vaultEventStore) {
-      return {
-        success: false,
-        verified: false,
-        relation: 'conflict',
-        durationMs: 0,
-        sourceRootPath: '',
-        destinationRootPath: targetRootPath,
-        sourceStreamCount: 0,
-        destinationStreamCountBefore: 0,
-        destinationStreamCountAfter: 0,
-        copiedEventCount: 0,
-        skippedEventCount: 0,
-        fileResults: [],
-        conflicts: [],
-        errors: ['Vault event store is not initialized.'],
-        switched: false
-      };
-    }
-
-    const maxShardBytes = options?.maxShardBytes ?? DEFAULT_STORAGE_SETTINGS.maxShardBytes;
-
-    const relocationService = new VaultRootRelocationService({
-      app: this.app,
-      sourceStore: this.vaultEventStore,
-      targetRootPath,
-      maxShardBytes
-    });
-
-    const result = await relocationService.relocateVaultRoot();
-
-    if (!result.success || !result.verified || !result.destinationStore) {
-      return { ...result, switched: false };
-    }
-
-    const resolution = resolveVaultRoot(
-      { storage: { rootPath: targetRootPath, maxShardBytes } },
-      { configDir: this.app.vault.configDir }
-    );
-
-    this.vaultEventStore = result.destinationStore;
-    this.basePath = resolution.dataPath;
-    this.jsonlWriter.setBasePath(resolution.dataPath);
-    this.jsonlWriter.setVaultEventStore(this.vaultEventStore);
-    this.jsonlWriter.setVaultEventStoreReadEnabled(true);
-    this.jsonlVaultWatcher?.setDataPath(resolution.dataPath);
-    this.wireReconcilePipeline();
-    this.queryCache.clear();
-
-    return { ...result, switched: true };
+    return this.maintenance.relocateVaultRoot(targetRootPath, options);
   }
 
   // ============================================================================

--- a/src/database/adapters/lifecycle/StorageMaintenanceService.ts
+++ b/src/database/adapters/lifecycle/StorageMaintenanceService.ts
@@ -1,0 +1,434 @@
+import { App, Events, EventRef } from 'obsidian';
+import { JSONLWriter } from '../../storage/JSONLWriter';
+import { SQLiteCacheManager } from '../../storage/SQLiteCacheManager';
+import { SyncCoordinator } from '../../sync/SyncCoordinator';
+import { JsonlVaultWatcher, ModifiedStream } from '../../sync/JsonlVaultWatcher';
+import { ReconcilePipeline } from '../../sync/ReconcilePipeline';
+import { QueryCache } from '../../optimizations/QueryCache';
+import { SyncResult } from '../../../types/storage/HybridStorageTypes';
+import { WorkspaceEvent, ConversationEvent, TaskEvent } from '../../interfaces/StorageEvents';
+import { WorkspaceEventApplier } from '../../sync/WorkspaceEventApplier';
+import { ConversationEventApplier } from '../../sync/ConversationEventApplier';
+import { TaskEventApplier } from '../../sync/TaskEventApplier';
+import { resolveWorkspaceId } from '../../sync/resolveWorkspaceId';
+import {
+  VaultRootRelocationService,
+  type VaultRootRelocationResult
+} from '../../migration/VaultRootRelocationService';
+import { resolveVaultRoot } from '../../storage/VaultRootResolver';
+import { VaultEventStore } from '../../storage/vaultRoot/VaultEventStore';
+import { DEFAULT_STORAGE_SETTINGS } from '../../../types/plugin/PluginTypes';
+import type { CacheBlobStore } from '../../storage/CacheBlobStore';
+import { InitLifecycleController } from './InitLifecycleController';
+import {
+  ReconciliationCoordinator,
+  type ReconcileCategory
+} from './ReconciliationCoordinator';
+import type { WorkspaceRepository } from '../../repositories/WorkspaceRepository';
+import type { ConversationRepository } from '../../repositories/ConversationRepository';
+import type { ExternalSyncEvent } from '../HybridStorageAdapter';
+
+/**
+ * Dependencies the maintenance service reaches through the adapter.
+ *
+ * Everything is an accessor callback evaluated at call time rather than a
+ * captured reference: the adapter reassigns `basePath`, `vaultEventStore`,
+ * `reconcilePipeline`, `reconciliationCoordinator`, and the vault-watcher
+ * handle at runtime (`applyStoragePlan`, `relocateVaultRoot`,
+ * re-initialization), and that mutable state stays adapter-owned so the
+ * adapter remains the single source of truth. The `reconcileMissing*`
+ * callbacks dispatch back through the adapter instance so the post-sync
+ * reconcilers always run the adapter's current implementation.
+ */
+export interface StorageMaintenanceDeps {
+  getApp(): App;
+  getJsonlWriter(): JSONLWriter;
+  getSqliteCache(): SQLiteCacheManager;
+  getSyncCoordinator(): SyncCoordinator;
+  getQueryCache(): QueryCache;
+  getCacheBlobStore(): CacheBlobStore;
+  getInitLifecycle(): InitLifecycleController;
+  getReconciliationCoordinator(): ReconciliationCoordinator;
+  getWorkspaceRepo(): WorkspaceRepository;
+  getConversationRepo(): ConversationRepository;
+  getBasePath(): string;
+  setBasePath(path: string): void;
+  getVaultEventStore(): VaultEventStore | null;
+  setVaultEventStore(store: VaultEventStore): void;
+  getReconcilePipeline(): ReconcilePipeline | null;
+  getJsonlVaultWatcher(): JsonlVaultWatcher | undefined;
+  setJsonlVaultWatcher(watcher: JsonlVaultWatcher | undefined): void;
+  wireReconcilePipeline(): void;
+  reconcileMissingWorkspaces(): Promise<number>;
+  reconcileMissingConversations(): Promise<number>;
+  reconcileMissingTasks(): Promise<number>;
+}
+
+/**
+ * Maintenance & sync surface for HybridStorageAdapter (Phase 2 of
+ * docs/plans/hybrid-storage-adapter-split-plan.md).
+ *
+ * Owns the post-initialization operations: cache rebuild with in-flight
+ * coalescing, manual `sync()`, vault-root relocation, the JSONL vault
+ * watcher pair, the `external-sync` event emitter, and the three
+ * missing-entity reconcilers. The adapter keeps thin public wrappers with
+ * identical signatures; this class holds the bodies plus the state that
+ * moves with them (`rebuildInFlight`, the `externalEvents` emitter).
+ */
+export class StorageMaintenanceService {
+  /**
+   * Coalesces concurrent `rebuildCache` invocations. When a rebuild is in
+   * flight, subsequent calls return the same promise so a double-click on
+   * "Nexus: Rebuild cache" cannot start two simultaneous rebuilds (which
+   * would race over close/remove/initialize/save on `sqliteCache`).
+   */
+  private rebuildInFlight: Promise<void> | null = null;
+
+  /**
+   * Typed event bus for adapter consumers. Currently emits one event:
+   *   `external-sync` — payload: { result: SyncResult, modified: ModifiedStream[] }
+   * fired after a watcher-triggered sync completes.
+   */
+  private readonly externalEvents = new Events();
+
+  constructor(private readonly deps: StorageMaintenanceDeps) {}
+
+  /**
+   * Wipe the cache backend and rebuild SQLite from the JSONL source of truth.
+   * Used by the "Nexus: Rebuild cache" command to recover from a corrupted or
+   * out-of-sync cache without touching the (synced) JSONL event store.
+   */
+  async rebuildCache(options: { onProgress?: (label: string, done: number, total: number) => void } = {}): Promise<void> {
+    // Coalesce concurrent invocations. A second click on "Nexus: Rebuild
+    // cache" while one is in flight returns the same promise — both callers
+    // settle on the same outcome, errors propagate to both.
+    if (this.rebuildInFlight) {
+      return this.rebuildInFlight;
+    }
+
+    this.rebuildInFlight = (async () => {
+      try {
+        if (!this.deps.getInitLifecycle().isInitialized()) {
+          throw new Error('Storage adapter is not initialized; cannot rebuild cache');
+        }
+
+        options.onProgress?.('Stopping auto-save', 0, 1);
+        this.deps.getSqliteCache().stopAutoSave();
+
+        options.onProgress?.('Closing cache', 0, 1);
+        await this.deps.getSqliteCache().close();
+
+        options.onProgress?.('Removing cache blob', 0, 1);
+        await this.deps.getCacheBlobStore().remove();
+
+        options.onProgress?.('Reopening cache', 0, 1);
+        await this.deps.getSqliteCache().initialize();
+
+        const syncCoordinator = this.deps.getSyncCoordinator();
+        if (!syncCoordinator) {
+          throw new Error('Sync coordinator unavailable; cannot rebuild from JSONL');
+        }
+
+        options.onProgress?.('Rebuilding from JSONL', 0, 1);
+        const result = await syncCoordinator.fullRebuild({
+          onProgress: options.onProgress
+        });
+
+        if (!result.success) {
+          const summary = result.errors.length > 0 ? result.errors.join('; ') : 'Unknown error';
+          throw new Error(`Cache rebuild failed: ${summary}`);
+        }
+
+        options.onProgress?.('Complete', 1, 1);
+      } finally {
+        // Clear on both success and failure so a follow-up rebuild can
+        // re-run; the original error (if any) still rejects this promise.
+        this.rebuildInFlight = null;
+      }
+    })();
+
+    return this.rebuildInFlight;
+  }
+
+  /**
+   * Subscribe to external-sync events. Fired after the JSONL vault watcher
+   * detects a change (e.g. a Sync-pushed JSONL from another device) and
+   * the resulting reconciliation has been applied to SQLite. Subscribers
+   * use the `modified` stream list to decide whether their currently-viewed
+   * content needs to re-query.
+   *
+   * Returns an Obsidian EventRef. Pass it to `offExternalSync()` (or use
+   * the plugin's `registerEvent(ref)` for auto-cleanup on unload).
+   */
+  onExternalSync(callback: (event: ExternalSyncEvent) => void): EventRef {
+    // Obsidian's Events.on takes a variadic `unknown[]` handler; we narrow
+    // here by wrapping so callers get a typed API.
+    return this.externalEvents.on('external-sync', (...data: unknown[]) => {
+      callback(data[0] as ExternalSyncEvent);
+    });
+  }
+
+  /** Remove a subscription previously added via `onExternalSync`. */
+  offExternalSync(ref: EventRef): void {
+    this.externalEvents.offref(ref);
+  }
+
+  /**
+   * Start the JSONL vault watcher. Idempotent. Wires the before-write hook
+   * on `JSONLWriter` so self-writes don't echo back as sync triggers.
+   */
+  startJsonlVaultWatcher(): void {
+    if (this.deps.getJsonlVaultWatcher()) {
+      return;
+    }
+
+    const watcher = new JsonlVaultWatcher({
+      app: this.deps.getApp(),
+      dataPath: this.deps.getBasePath(),
+      onChange: async (modified) => {
+        await this.handleExternalJsonlChange(modified);
+      }
+    });
+
+    this.deps.setJsonlVaultWatcher(watcher);
+    this.deps.getJsonlWriter().setBeforeWriteHook((logicalPath) => {
+      watcher.suppressLogicalPath(logicalPath);
+    });
+
+    watcher.start();
+  }
+
+  /**
+   * Stop the watcher and tear down its hook. Safe if never started.
+   */
+  stopJsonlVaultWatcher(): void {
+    const watcher = this.deps.getJsonlVaultWatcher();
+    if (!watcher) {
+      return;
+    }
+    this.deps.getJsonlWriter().setBeforeWriteHook(undefined);
+    watcher.stop();
+    this.deps.setJsonlVaultWatcher(undefined);
+  }
+
+  /**
+   * Reconcile after the watcher detects a modified stream set and emit
+   * `external-sync` so open UI can refresh only the affected content.
+   * Called by JsonlVaultWatcher's onChange callback.
+   *
+   * Phase 1 sync-safe reconcile: when the ReconcilePipeline is wired, scope
+   * reconcile to the precise streams that fired the modify event instead of
+   * sweeping the whole cache. Falls back to a full `sync()` if the pipeline
+   * isn't yet wired (e.g. legacy plugin-scoped storage layout) so behavior
+   * stays compatible.
+   */
+  async handleExternalJsonlChange(modified: ModifiedStream[]): Promise<void> {
+    if (modified.length === 0) {
+      return;
+    }
+    try {
+      let result: SyncResult;
+      if (this.deps.getReconcilePipeline()) {
+        for (const m of modified) {
+          await this.deps.getSyncCoordinator().reconcileStream(m.category, m.streamId);
+        }
+        await this.runMissingEntityReconcilers();
+        this.deps.getQueryCache().clear();
+        result = {
+          success: true,
+          eventsApplied: 0,
+          eventsSkipped: 0,
+          errors: [],
+          duration: 0,
+          filesProcessed: modified.map((m) => m.samplePath),
+          lastSyncTimestamp: Date.now()
+        };
+      } else {
+        result = await this.sync();
+      }
+      this.externalEvents.trigger('external-sync', { result, modified } satisfies ExternalSyncEvent);
+    } catch (error) {
+      console.error('[HybridStorageAdapter] External JSONL change sync failed:', error);
+    }
+  }
+
+  /**
+   * Run the post-sync entity-existence reconcilers (workspaces, conversations,
+   * tasks). Mirrors the existing `sync()` post-step so scoped reconcile via
+   * `ReconcilePipeline` stays semantically equivalent to the full sweep for
+   * cache-fill purposes. Errors are logged but do not propagate.
+   */
+  private async runMissingEntityReconcilers(): Promise<void> {
+    try {
+      await Promise.all([
+        this.deps.reconcileMissingWorkspaces(),
+        this.deps.reconcileMissingConversations(),
+        this.deps.reconcileMissingTasks()
+      ]);
+    } catch (reconcileError) {
+      console.error('[HybridStorageAdapter] Post-sync reconciliation failed:', reconcileError);
+    }
+  }
+
+  async sync(): Promise<SyncResult> {
+    try {
+      const result = await this.deps.getSyncCoordinator().sync();
+
+      try {
+        await Promise.all([
+          this.deps.reconcileMissingWorkspaces(),
+          this.deps.reconcileMissingConversations(),
+          this.deps.reconcileMissingTasks()
+        ]);
+      } catch (reconcileError) {
+        console.error('[HybridStorageAdapter] Post-sync reconciliation failed:', reconcileError);
+      }
+
+      // Invalidate all query cache on sync
+      this.deps.getQueryCache().clear();
+
+      return result;
+
+    } catch (error) {
+      console.error('[HybridStorageAdapter] Sync failed:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Relocate the vault-root event store to a new path.
+   *
+   * Copies all events from the current store to the destination, verifies
+   * integrity, then hot-swaps internal state so all subsequent reads and
+   * writes use the new location. Returns `switched: true` only when the
+   * swap completed successfully.
+   */
+  async relocateVaultRoot(
+    targetRootPath: string,
+    options?: { maxShardBytes?: number }
+  ): Promise<VaultRootRelocationResult & { switched: boolean }> {
+    const sourceStore = this.deps.getVaultEventStore();
+    if (!sourceStore) {
+      return {
+        success: false,
+        verified: false,
+        relation: 'conflict',
+        durationMs: 0,
+        sourceRootPath: '',
+        destinationRootPath: targetRootPath,
+        sourceStreamCount: 0,
+        destinationStreamCountBefore: 0,
+        destinationStreamCountAfter: 0,
+        copiedEventCount: 0,
+        skippedEventCount: 0,
+        fileResults: [],
+        conflicts: [],
+        errors: ['Vault event store is not initialized.'],
+        switched: false
+      };
+    }
+
+    const maxShardBytes = options?.maxShardBytes ?? DEFAULT_STORAGE_SETTINGS.maxShardBytes;
+
+    const relocationService = new VaultRootRelocationService({
+      app: this.deps.getApp(),
+      sourceStore,
+      targetRootPath,
+      maxShardBytes
+    });
+
+    const result = await relocationService.relocateVaultRoot();
+
+    if (!result.success || !result.verified || !result.destinationStore) {
+      return { ...result, switched: false };
+    }
+
+    const resolution = resolveVaultRoot(
+      { storage: { rootPath: targetRootPath, maxShardBytes } },
+      { configDir: this.deps.getApp().vault.configDir }
+    );
+
+    this.deps.setVaultEventStore(result.destinationStore);
+    this.deps.setBasePath(resolution.dataPath);
+    this.deps.getJsonlWriter().setBasePath(resolution.dataPath);
+    this.deps.getJsonlWriter().setVaultEventStore(result.destinationStore);
+    this.deps.getJsonlWriter().setVaultEventStoreReadEnabled(true);
+    this.deps.getJsonlVaultWatcher()?.setDataPath(resolution.dataPath);
+    this.deps.wireReconcilePipeline();
+    this.deps.getQueryCache().clear();
+
+    return { ...result, switched: true };
+  }
+
+  /**
+   * Reconcile JSONL workspace files that are missing from SQLite.
+   * Handles the case where incremental sync skips same-device events.
+   */
+  reconcileMissingWorkspaces(): Promise<number> {
+    const applier = new WorkspaceEventApplier(this.deps.getSqliteCache());
+    const category: ReconcileCategory<WorkspaceEvent> = {
+      label: 'workspace',
+      subdir: 'workspaces',
+      filenameRegex: /workspaces\/ws_(.+)\.jsonl$/,
+      existsInCache: async (id) => (await this.deps.getWorkspaceRepo().getById(id)) !== null,
+      shouldSkipEvents: (events) => {
+        // Skip deletes — no need to create then immediately delete.
+        if (events.some(e => e.type === 'workspace_deleted')) return true;
+        // Skip files with no workspace_created event (corrupt/incomplete).
+        return !events.some(e => e.type === 'workspace_created');
+      },
+      applyEvent: (e) => applier.apply(e)
+    };
+    return this.deps.getReconciliationCoordinator().reconcile(category);
+  }
+
+  /**
+   * Reconcile JSONL conversation files that are missing from SQLite.
+   * Handles the case where incremental sync skips remote files whose
+   * event timestamps predate the local sync watermark.
+   */
+  reconcileMissingConversations(): Promise<number> {
+    const applier = new ConversationEventApplier(this.deps.getSqliteCache());
+    const category: ReconcileCategory<ConversationEvent> = {
+      label: 'conversation',
+      subdir: 'conversations',
+      filenameRegex: /conversations\/conv_(.+)\.jsonl$/,
+      existsInCache: async (id) => (await this.deps.getConversationRepo().getById(id)) !== null,
+      shouldSkipEvents: (events) => {
+        if (events.some(e => e.type === 'conversation_deleted')) return true;
+        return !events.some(e => e.type === 'metadata');
+      },
+      applyEvent: (e) => applier.apply(e)
+    };
+    return this.deps.getReconciliationCoordinator().reconcile(category);
+  }
+
+  /**
+   * Reconcile JSONL task files that are missing from SQLite.
+   *
+   * Note: tasks resolve the workspace id (name → UUID) and probe `projects`
+   * directly rather than going through a repository's getById — they are
+   * keyed by workspaceId, not entity id, so the standard "exists?" probe
+   * is a SQL count instead.
+   */
+  reconcileMissingTasks(): Promise<number> {
+    const applier = new TaskEventApplier(this.deps.getSqliteCache());
+    const category: ReconcileCategory<TaskEvent> = {
+      label: 'tasks',
+      subdir: 'tasks',
+      filenameRegex: /tasks\/tasks_(.+)\.jsonl$/,
+      existsInCache: async (fileWorkspaceId) => {
+        const resolved = await resolveWorkspaceId(fileWorkspaceId, this.deps.getSqliteCache());
+        const effectiveId = resolved.id ?? fileWorkspaceId;
+        const projects = await this.deps.getSqliteCache().query<{ id: string }>(
+          'SELECT id FROM projects WHERE workspaceId = ? LIMIT 1',
+          [effectiveId]
+        );
+        return projects.length > 0;
+      },
+      shouldSkipEvents: () => false,
+      applyEvent: (e) => applier.apply(e)
+    };
+    return this.deps.getReconciliationCoordinator().reconcile(category);
+  }
+}


### PR DESCRIPTION
Phase 2 (final) of the HybridStorageAdapter split plan (#260). **Stacked on #262** (Phase 1), which stacks on #261 (Phase 0). Merge order: #261 → #262 → this.

Moves the maintenance/sync surface into a new `src/database/adapters/lifecycle/StorageMaintenanceService.ts` (434 lines), continuing the existing `lifecycle/` controller pattern. Moved bodies (adapter keeps signature-identical public wrappers, so none of the 21 consumers change): `rebuildCache`, `sync()`, `relocateVaultRoot`, `onExternalSync`/`offExternalSync`, the JSONL vault watcher pair, `handleExternalJsonlChange`, and the three `reconcileMissing*` reconcilers.

**One deliberate deviation from the plan**, forced by the pinning tests: the plan said the service should own the watcher handle, but the Phase 0 / existing tests assert `adapter.jsonlVaultWatcher`, `adapter.basePath`, `adapter.reconcilePipeline` etc. **by name** on the adapter (several build it via `Object.create(prototype)`, so the ctor never runs). The design therefore uses (a) lazy service construction via a cached getter, and (b) call-time accessor thunks into adapter-owned state rather than captured references — which also makes `relocateVaultRoot`'s runtime hot-swap and harness-injected mocks always visible to the service. State that genuinely moved: `rebuildInFlight` coalescing and the `externalEvents` emitter (no test names them).

**Verification:** all 46 pinning tests pass with zero edits (git confirms only the adapter modified + the new file), plus the 12 untouched cache-backend rebuild integration tests; pinned latent behaviors (close non-idempotence, teardown order, failure-clears-slot, progress-label sequence) all hold. Full suite **3558 / 0 failed**; tsc, eslint, production build clean.

**Net result of the split** (Phases 1+2): `HybridStorageAdapter.ts` **1292 → 1012 lines**; what remains is contract (entity delegates), init/readiness orchestration, and accessors — per the plan, Phase 3 is "stop here."

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_