### PR TITLE
fix: session startTime updates and updateMessage conversation scoping

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -774,9 +774,11 @@ export class HybridStorageAdapter implements IStorageAdapter {
 
   updateSession = async (workspaceId: string, sessionId: string, updates: Partial<SessionMetadata>): Promise<void> => {
     await this.ensureInitialized();
-    // Extract fields that are valid for UpdateSessionData (includes required workspaceId)
-    const { name, description, endTime, isActive } = updates;
-    return this.sessionRepo.update(sessionId, { name, description, endTime, isActive, workspaceId });
+    // Extract fields that are valid for UpdateSessionData. The positional
+    // workspaceId always wins (it routes the JSONL write); moving a session
+    // goes through moveSessionToWorkspace instead.
+    const { name, description, startTime, endTime, isActive } = updates;
+    return this.sessionRepo.update(sessionId, { name, description, startTime, endTime, isActive, workspaceId });
   };
 
   moveSessionToWorkspace = async (sessionId: string, workspaceId: string): Promise<void> => {
@@ -942,12 +944,12 @@ export class HybridStorageAdapter implements IStorageAdapter {
   };
 
   updateMessage = async (
-    _conversationId: string,
+    conversationId: string,
     messageId: string,
     updates: Partial<MessageData>
   ): Promise<void> => {
     await this.ensureInitialized();
-    return this.messageRepo.update(messageId, updates);
+    return this.messageRepo.update(messageId, updates, conversationId);
   };
 
   deleteMessage = async (conversationId: string, messageId: string): Promise<void> => {

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -156,6 +156,7 @@ export interface SessionUpdatedEvent extends BaseStorageEvent {
   data: Partial<{
     name: string;
     description: string;
+    startTime: number;
     endTime: number;
     isActive: boolean;
     workspaceId: string;

--- a/src/database/repositories/MessageRepository.ts
+++ b/src/database/repositories/MessageRepository.ts
@@ -439,12 +439,17 @@ export class MessageRepository
    * O(N) redundant JSONL events when callers pass the full message array
    * through ConversationService.updateConversation().
    */
-  async update(messageId: string, data: UpdateMessageData): Promise<void> {
+  async update(messageId: string, data: UpdateMessageData, expectedConversationId?: string): Promise<void> {
     try {
       // Load full current message — used for both change detection and conversationId
       const current = await this.getById(messageId);
       if (!current) {
         throw new Error(`Message ${messageId} not found`);
+      }
+      if (expectedConversationId !== undefined && current.conversationId !== expectedConversationId) {
+        throw new Error(
+          `Message ${messageId} belongs to conversation ${current.conversationId}, not ${expectedConversationId}`
+        );
       }
 
       // Skip entirely if nothing actually changed (prevents JSONL write amplification)

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -151,6 +151,7 @@ export class SessionRepository
             data: {
               name: data.name,
               description: data.description,
+              startTime: data.startTime,
               endTime: data.endTime,
               isActive: data.isActive
             }
@@ -168,6 +169,10 @@ export class SessionRepository
         if (data.description !== undefined) {
           setClauses.push('description = ?');
           params.push(data.description);
+        }
+        if (data.startTime !== undefined) {
+          setClauses.push('startTime = ?');
+          params.push(data.startTime);
         }
         if (data.endTime !== undefined) {
           setClauses.push('endTime = ?');

--- a/src/database/repositories/interfaces/ISessionRepository.ts
+++ b/src/database/repositories/interfaces/ISessionRepository.ts
@@ -32,6 +32,7 @@ export interface CreateSessionData {
 export interface UpdateSessionData {
   name?: string;
   description?: string;
+  startTime?: number;
   endTime?: number;
   isActive?: boolean;
   workspaceId?: string;

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -159,6 +159,7 @@ export class WorkspaceEventApplier {
 
     if (event.data.name !== undefined) { updates.push('name = ?'); values.push(event.data.name); }
     if (event.data.description !== undefined) { updates.push('description = ?'); values.push(event.data.description); }
+    if (event.data.startTime !== undefined) { updates.push('startTime = ?'); values.push(event.data.startTime); }
     if (event.data.endTime !== undefined) { updates.push('endTime = ?'); values.push(event.data.endTime); }
     if (event.data.isActive !== undefined) { updates.push('isActive = ?'); values.push(event.data.isActive ? 1 : 0); }
     if (event.data.workspaceId !== undefined) { updates.push('workspaceId = ?'); values.push(event.data.workspaceId); }

--- a/tests/unit/HybridStorageAdapter.phase0.test.ts
+++ b/tests/unit/HybridStorageAdapter.phase0.test.ts
@@ -673,15 +673,15 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
       expect(adapter.workspaceRepo.search).toHaveBeenCalledWith('query');
     });
 
-    it('session create merges workspaceId; update forwards only whitelisted fields', async () => {
+    it('session create merges workspaceId; update forwards updatable fields incl. startTime', async () => {
       const adapter = await makeHarness();
 
       await adapter.createSession('ws-1', { name: 'Session A' } as Omit<SessionMetadata, 'id' | 'workspaceId'>);
       expect(adapter.sessionRepo.create).toHaveBeenCalledWith({ name: 'Session A', workspaceId: 'ws-1' });
 
-      // pins current behavior; see report — updateSession overrides any
-      // workspaceId present in `updates` with the positional arg, and drops
-      // every field other than name/description/endTime/isActive.
+      // The positional workspaceId always wins over one in `updates` (it routes
+      // the JSONL write; moving a session goes through moveSessionToWorkspace).
+      // All other updatable SessionMetadata fields pass through, incl. startTime.
       await adapter.updateSession('ws-1', 'session-1', {
         name: 'Renamed',
         description: 'desc',
@@ -693,6 +693,7 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
       expect(adapter.sessionRepo.update).toHaveBeenCalledWith('session-1', {
         name: 'Renamed',
         description: 'desc',
+        startTime: 999,
         endTime: 123,
         isActive: false,
         workspaceId: 'ws-1'
@@ -774,21 +775,19 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
       ]);
     });
 
-    it('message methods delegate; updateMessage discards the conversationId arg', async () => {
+    it('message methods delegate; updateMessage forwards conversationId for validation', async () => {
       const adapter = await makeHarness();
       const message = { role: 'user', content: 'hi' };
       adapter.conversationRepo.getConversations.mockResolvedValue({ items: [] });
 
       await adapter.getMessages('conv-1', { page: 0, pageSize: 50 });
       await adapter.addMessage('conv-1', message as never);
-      // pins current behavior; see report — the conversationId positional arg
-      // is unused by updateMessage; only messageId + updates reach the repo.
-      await adapter.updateMessage('conv-IGNORED', 'msg-1', { content: 'edited' } as never);
+      await adapter.updateMessage('conv-1', 'msg-1', { content: 'edited' } as never);
       await adapter.deleteMessage('conv-1', 'msg-1');
 
       expect(adapter.messageRepo.getMessages).toHaveBeenCalledWith('conv-1', { page: 0, pageSize: 50 });
       expect(adapter.messageRepo.addMessage).toHaveBeenCalledWith('conv-1', message);
-      expect(adapter.messageRepo.update).toHaveBeenCalledWith('msg-1', { content: 'edited' });
+      expect(adapter.messageRepo.update).toHaveBeenCalledWith('msg-1', { content: 'edited' }, 'conv-1');
       expect(adapter.messageRepo.deleteMessage).toHaveBeenCalledWith('conv-1', 'msg-1');
     });
 

--- a/tests/unit/StorageUpdateDelegateFixes.test.ts
+++ b/tests/unit/StorageUpdateDelegateFixes.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for two storage update bugs surfaced by the Phase 0
+ * characterization pass (see docs/plans/hybrid-storage-adapter-split-plan.md):
+ *  1. updateSession silently dropped startTime end-to-end (adapter delegate,
+ *     UpdateSessionData, SessionUpdatedEvent, SQL, and rebuild fold all
+ *     omitted it).
+ *  2. MessageRepository.update ignored the conversationId the adapter was
+ *     given, so an update aimed at conversation X silently applied to a
+ *     message in conversation Y.
+ */
+
+import { SessionRepository } from '../../src/database/repositories/SessionRepository';
+import { MessageRepository } from '../../src/database/repositories/MessageRepository';
+import type { SessionUpdatedEvent } from '../../src/database/interfaces/StorageEvents';
+
+type AnyRecord = Record<string, unknown>;
+
+function makeSessionRepo(): {
+  repo: SessionRepository;
+  writeEvent: jest.Mock;
+  run: jest.Mock;
+} {
+  const repo = Object.create(SessionRepository.prototype) as SessionRepository & AnyRecord;
+  const writeEvent = jest.fn().mockResolvedValue(undefined);
+  const run = jest.fn().mockResolvedValue(undefined);
+  Object.assign(repo, {
+    jsonlPath: (id: string) => `workspaces/ws_${id}.jsonl`,
+    writeEvent,
+    transaction: (fn: () => Promise<void>) => fn(),
+    sqliteCache: { run },
+    queryCache: { invalidateByType: jest.fn() },
+    invalidateCache: jest.fn(),
+    log: jest.fn(),
+    logError: jest.fn()
+  });
+  return { repo, writeEvent, run };
+}
+
+describe('SessionRepository.update startTime passthrough', () => {
+  it('writes startTime into the JSONL event and the SQL update', async () => {
+    const { repo, writeEvent, run } = makeSessionRepo();
+
+    await repo.update('session-1', {
+      name: 'Renamed',
+      startTime: 999,
+      workspaceId: 'ws-1'
+    });
+
+    const event = writeEvent.mock.calls[0][1] as SessionUpdatedEvent;
+    expect(event.type).toBe('session_updated');
+    expect(event.data.startTime).toBe(999);
+
+    const [sql, params] = run.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('startTime = ?');
+    expect(params).toContain(999);
+  });
+
+  it('omits startTime from SQL when not provided', async () => {
+    const { repo, run } = makeSessionRepo();
+
+    await repo.update('session-1', { name: 'Renamed', workspaceId: 'ws-1' });
+
+    const [sql] = run.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toContain('startTime');
+  });
+});
+
+describe('MessageRepository.update conversationId validation', () => {
+  function makeMessageRepo(currentConversationId: string): MessageRepository {
+    const repo = Object.create(MessageRepository.prototype) as MessageRepository & AnyRecord;
+    Object.assign(repo, {
+      getById: jest.fn().mockResolvedValue({
+        id: 'msg-1',
+        conversationId: currentConversationId,
+        role: 'user',
+        content: 'hi',
+        timestamp: 1,
+        state: 'complete',
+        sequenceNumber: 0,
+        activeAlternativeIndex: 0
+      }),
+      logError: jest.fn()
+    });
+    return repo;
+  }
+
+  it('throws when the message belongs to a different conversation', async () => {
+    const repo = makeMessageRepo('conv-REAL');
+
+    await expect(
+      repo.update('msg-1', { content: 'edited' }, 'conv-WRONG')
+    ).rejects.toThrow('belongs to conversation conv-REAL, not conv-WRONG');
+  });
+
+  it('proceeds when the conversationId matches (no-op update returns cleanly)', async () => {
+    const repo = makeMessageRepo('conv-1');
+
+    // content identical to current -> hasChanges is false -> returns before
+    // any JSONL/SQL infrastructure is touched.
+    await expect(repo.update('msg-1', { content: 'hi' }, 'conv-1')).resolves.toBeUndefined();
+  });
+
+  it('skips validation when no expected conversationId is provided', async () => {
+    const repo = makeMessageRepo('conv-REAL');
+
+    await expect(repo.update('msg-1', { content: 'hi' })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes the two real bugs surfaced (and deliberately pinned, not fixed) by the Phase 0 characterization pass (#261).

**1. `updateSession` silently dropped `startTime`** — the omission ran end-to-end: `UpdateSessionData`, `SessionUpdatedEvent.data`, the `SessionRepository` SQL update, and the `WorkspaceEventApplier` rebuild fold all lacked the field, so the adapter delegate's destructure dropped it. Added `startTime` through the whole chain (the `sessions` table already has the column + index). Unchanged on purpose: the positional `workspaceId` still wins over one passed in `updates` — it routes the JSONL write, and moving a session remains `moveSessionToWorkspace`'s job (documented in the delegate).

**2. `updateMessage` ignored its `conversationId` arg** — an update aimed at conversation X silently applied to a message in conversation Y. `MessageRepository.update` now takes an optional `expectedConversationId`, validated at the point it already loads the message (zero extra I/O); the adapter passes it through. A mismatch now throws `Message msg-1 belongs to conversation conv-REAL, not conv-WRONG`. Direct repo callers without the arg keep prior behavior. Audited all `updateMessage` call sites (`ConversationService`, `BranchManager`/`BranchService`) — every caller passes the message's true conversation/branch id, so the only behavior change is the erroneous-mismatch case.

The two Phase 0 pinning tests are updated to assert the fixed behavior (the only intended test edits), plus 5 new repo-level tests in `StorageUpdateDelegateFixes.test.ts` covering the event/SQL passthrough and the validation (mismatch throws / match proceeds / absent arg skips).

Full suite **3568 passed / 0 failed**; tsc and eslint clean.

https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM

---
_Generated by [Claude Code](https://claude.ai/code/session_014TW5huXgBRXkdeRiFEgQoM)_