### PR TITLE
feat(toolManager): nudge agent to batch known multi-file reads

### DIFF
--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -15,7 +15,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   ) {
     this.slug = 'useTools';
     this.name = 'Use Tools';
-    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
+    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. When you already know several files you want to read, batch them as comma-separated "content read" commands in ONE call with strategy "parallel" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
     this.version = '1.0.0';
   }
 
@@ -54,12 +54,12 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
         },
         tool: {
           type: 'string',
-          description: 'CLI-style tool command string. Supports one or more commands separated by commas. Example: "storage move --path notes/a.md --new-path archive/a.md, content read --path archive/a.md".'
+          description: 'CLI-style tool command string. Supports one or more commands separated by commas. Example: "storage move --path notes/a.md --new-path archive/a.md, content read --path archive/a.md". Reading multiple known files? Batch them here as one comma-separated list (e.g. "content read --path a.md, content read --path b.md, content read --path c.md") instead of separate calls.'
         },
         strategy: {
           type: 'string',
           enum: ['serial', 'parallel'],
-          description: 'Execution strategy for multiple CLI commands. Defaults to serial.'
+          description: 'Execution strategy for multiple CLI commands. Defaults to serial. Use "parallel" for independent read-only commands (e.g. batched content reads) to avoid wasted round-trips.'
         }
       },
       required: ['workspaceId', 'sessionId', 'memory', 'goal', 'tool']


### PR DESCRIPTION
## What

Adds agent-facing guidance to `useTools` encouraging it to batch multiple known file reads into **one** call (comma-separated `content read` commands with `strategy: parallel`) instead of issuing a separate `useTools` call per file. **Description strings only — no logic change.**

## Why (evidence)

Measured next-tool/next-file predictability and read-batching waste across three real vaults (Rose N Thorn, Synaptic Labs, Professor Synapse; ~2,000 read calls, ~150 days each):

- **~30–35% of read *turns* are consecutive single `content read` invocations** that could have shared one `useTools` call. Consistent across all three vaults, not declining over time.
- `useTools` **already** supports comma-batched commands + a `parallel` strategy — the capability existed, but no agent-facing text told the model to use it for reads. This PR closes that gap.

## What was evaluated and deliberately *not* built

The same traces were used to test the larger "agent steering / next-step prediction" idea (`docs/plans/agent-steering-nudge-plan.md`). The evidence shelved it:

- **Next-tool prediction**: weak after removing intra-batch self-loops (~0.71–0.77, workload-dependent).
- **Next-file prediction**: fails — file paths are high-cardinality and every cross-session pair is cold-start.
- **Read-after-write verification waste**: already driven to ~0 by the newer response architecture (not a standing problem).
- **Load-time content prefetch**: coverage ceiling ~16% even shipping 20 note bodies; ~78% of reads are notes never read in a prior session of that workspace. Not worth the context cost.

So this one-line-per-field prompt nudge is the only intervention the data supports — zero new infrastructure, no predictor, no cache.

## Test

- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)