### PR TITLE
feat(task-board): delete-task icon + fix empty board on cold start

### DIFF
--- a/src/ui/tasks/TaskBoardView.ts
+++ b/src/ui/tasks/TaskBoardView.ts
@@ -101,6 +101,7 @@ export class TaskBoardView extends ItemView {
       groupTasksByParent: (columnTasks) => this.groupTasksByParent(columnTasks),
       onTaskStatusDrop: (taskId, newStatus) => this.handleTaskStatusDrop(taskId, newStatus),
       onEditTask: (task) => this.openEditModal(task),
+      onDeleteTask: (task) => void this.editCoordinator.deleteTask(task),
       onFlushPendingEvent: () => this.syncCoordinator.flushPendingEvent()
     });
   }

--- a/src/ui/tasks/services/TaskBoardDataController.ts
+++ b/src/ui/tasks/services/TaskBoardDataController.ts
@@ -2,6 +2,7 @@ import type NexusPlugin from '../../../main';
 import type { WorkspaceService } from '../../../services/WorkspaceService';
 import type { AgentRegistrationService } from '../../../services/agent/AgentRegistrationService';
 import type { AgentManager } from '../../../services/AgentManager';
+import type { HybridStorageAdapter } from '../../../database/adapters/HybridStorageAdapter';
 import type { WorkspaceMetadata } from '../../../types/storage/StorageTypes';
 import type { TaskService } from '../../../agents/taskManager/services/TaskService';
 import type { ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
@@ -25,6 +26,7 @@ export class TaskBoardDataController {
   private workspaceService: WorkspaceService | null = null;
   private agentRegistrationService: AgentRegistrationService | null = null;
   private taskService: TaskService | null = null;
+  private storageAdapter: HybridStorageAdapter | null = null;
 
   constructor(private plugin: NexusPlugin) {}
 
@@ -61,6 +63,25 @@ export class TaskBoardDataController {
     }
 
     this.taskService = taskAgent.getTaskService();
+
+    if (!this.storageAdapter) {
+      this.storageAdapter = await this.plugin.getService<HybridStorageAdapter>('hybridStorageAdapter');
+    }
+  }
+
+  /**
+   * Block until the local SQLite cache is hydrated from JSONL so the first
+   * board load reads real data instead of an empty cache. During a cold start
+   * or cache rebuild the adapter reports query-ready only once hydration has
+   * finished; without this gate `getWorkspaces()` returns [] and the board
+   * renders "No tasks" with no later refresh. Resolves (and proceeds) on the
+   * adapter's own idle timeout rather than hanging forever.
+   */
+  private async waitForQueryReady(): Promise<void> {
+    const adapter = this.storageAdapter;
+    if (adapter && typeof adapter.waitForQueryReady === 'function') {
+      await adapter.waitForQueryReady();
+    }
   }
 
   async loadBoardData(filterState: TaskBoardViewState): Promise<TaskBoardDataSnapshot> {
@@ -69,6 +90,8 @@ export class TaskBoardDataController {
     if (!workspaceService || !taskService) {
       throw new Error('Task board services are not initialized');
     }
+
+    await this.waitForQueryReady();
 
     const nextFilterState = TaskBoardFilterController.normalizeState(filterState);
     const workspaces = (await workspaceService.getWorkspaces({

--- a/src/ui/tasks/services/TaskBoardEditCoordinator.ts
+++ b/src/ui/tasks/services/TaskBoardEditCoordinator.ts
@@ -1,4 +1,5 @@
 import { Notice, type App } from 'obsidian';
+import { ConfirmModal } from '../../../settings/components/ConfirmModal';
 import type { LinkType } from '../../../database/repositories/interfaces/ITaskRepository';
 import type { ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
 import type { TaskService } from '../../../agents/taskManager/services/TaskService';
@@ -44,6 +45,33 @@ export class TaskBoardEditCoordinator {
         this.deps.onEditModalClose();
       }
     }).open();
+  }
+
+  async deleteTask(task: TaskBoardTask): Promise<void> {
+    const confirmed = await ConfirmModal.confirm(this.deps.app, {
+      variant: 'delete',
+      title: 'Delete task?',
+      body: `Delete task "${task.title}"? This also removes its dependency links and cannot be undone.`
+    });
+    if (!confirmed) {
+      return;
+    }
+
+    const taskService = this.deps.getTaskService();
+    if (!taskService) {
+      new Notice('Task service is not available');
+      return;
+    }
+
+    try {
+      await taskService.deleteTask(task.id);
+      await this.deps.reloadBoard();
+      this.deps.renderBoard();
+      new Notice('Task deleted');
+    } catch (error) {
+      console.error('[TaskBoardEditCoordinator] Failed to delete task:', error);
+      new Notice('Failed to delete task');
+    }
   }
 
   async saveTaskChanges(originalTask: TaskBoardTask, updatedTask: TaskBoardEditableTask): Promise<void> {

--- a/src/ui/tasks/services/TaskBoardRenderer.ts
+++ b/src/ui/tasks/services/TaskBoardRenderer.ts
@@ -11,6 +11,7 @@ interface TaskBoardRendererDependencies {
   groupTasksByParent: (columnTasks: TaskBoardTask[]) => SwimlaneGroup[];
   onTaskStatusDrop: (taskId: string, newStatus: TaskStatus) => Promise<void>;
   onEditTask: (task: TaskBoardTask) => void;
+  onDeleteTask: (task: TaskBoardTask) => void;
   onFlushPendingEvent: () => Promise<void>;
 }
 
@@ -153,7 +154,9 @@ export class TaskBoardRenderer {
       text: task.title
     });
 
-    const editButton = row.createEl('button', {
+    const actions = row.createDiv('nexus-task-board-card-actions');
+
+    const editButton = actions.createEl('button', {
       cls: 'clickable-icon nexus-task-board-icon-button',
       attr: {
         'aria-label': `Edit ${task.title}`,
@@ -164,6 +167,19 @@ export class TaskBoardRenderer {
     this.safeRegisterDomEvent(editButton, 'click', (event: MouseEvent) => {
       event.stopPropagation();
       this.deps.onEditTask(task);
+    });
+
+    const deleteButton = actions.createEl('button', {
+      cls: 'clickable-icon nexus-task-board-icon-button nexus-icon-danger',
+      attr: {
+        'aria-label': `Delete ${task.title}`,
+        type: 'button'
+      }
+    });
+    setIcon(deleteButton, 'trash');
+    this.safeRegisterDomEvent(deleteButton, 'click', (event: MouseEvent) => {
+      event.stopPropagation();
+      this.deps.onDeleteTask(task);
     });
 
     card.createDiv({

--- a/styles.css
+++ b/styles.css
@@ -7624,6 +7624,12 @@ body.is-mobile .nexus-branch-task {
     line-height: 1.35;
 }
 
+.nexus-task-board-card-actions {
+    display: flex;
+    flex-shrink: 0;
+    gap: var(--space-xs);
+}
+
 .nexus-task-board-card-meta {
     margin-top: var(--space-xs);
 }


### PR DESCRIPTION
## Summary

Two focused Task Board fixes.

**1. Delete-task icon on board cards.** Each card now shows a confirm-gated delete (trash) icon next to the edit icon, mirroring the workspace-row idiom. Previously the standalone Task Board had no way to delete a task (the edit modal had none either) even though `TaskService.deleteTask` already existed. Delete routes through `TaskBoardEditCoordinator.deleteTask` → `ConfirmModal` → `TaskService.deleteTask` → board reload/re-render.

**2. Empty board on cold start.** `loadBoardData` read `workspaceService.getWorkspaces()` before the local SQLite cache was hydrated from JSONL (only `TaskService` had the query-ready waiter), so on a cold/rebuilding cache it got `[]`, rendered "No tasks", and never refreshed. `TaskBoardDataController` now awaits the storage adapter's `waitForQueryReady()` before loading, keeping the spinner up until hydration completes.

## Changes
- `TaskBoardRenderer.ts` — delete button grouped with edit in `nexus-task-board-card-actions`; new `onDeleteTask` dep
- `TaskBoardEditCoordinator.ts` — `deleteTask()` with confirm gate
- `TaskBoardView.ts` — wired `onDeleteTask`
- `TaskBoardDataController.ts` — `waitForQueryReady()` gate before load
- `styles.css` — `.nexus-task-board-card-actions` flex group

## Testing
- `npm run build` clean (eslint + tsc + esbuild)
- Full Jest suite: 3625 passed / 0 failed / 22 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)