### PR TITLE
Clarify useTools CLI guidance

### DIFF
--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -15,7 +15,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   ) {
     this.slug = 'useTools';
     this.name = 'Use Tools';
-    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. When you already know several files you want to read, batch them as comma-separated "content read" commands in ONE call with strategy "parallel" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
+    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. Multiple commands are separated only by a top-level comma outside quotes, so commas inside quoted values are preserved. For multiline text such as note bodies or Markdown, wrap the value in quotes and use escaped newlines like \"# Title\\n\\nBody\"; the parser decodes them before execution. When you already know several files you want to read, batch them as comma-separated "content read" commands in ONE call with strategy "parallel" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.';
     this.version = '1.0.0';
   }
 
@@ -54,7 +54,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
         },
         tool: {
           type: 'string',
-          description: 'CLI-style tool command string. Supports one or more commands separated by commas. Example: "storage move --path notes/a.md --new-path archive/a.md, content read --path archive/a.md". Reading multiple known files? Batch them here as one comma-separated list (e.g. "content read --path a.md, content read --path b.md, content read --path c.md") instead of separate calls.'
+          description: 'CLI-style tool command string. Supports one or more commands separated by commas. Only top-level commas split commands; commas inside quoted values stay literal. For multiline content, quote the value and use escaped newlines such as "content write --path note.md --content \"# Title\\n\\nBody\"". Example: "storage move --path notes/a.md --new-path archive/a.md, content read --path archive/a.md". Reading multiple known files? Batch them here as one comma-separated list (e.g. "content read --path a.md, content read --path b.md, content read --path c.md") instead of separate calls.'
         },
         strategy: {
           type: 'string',

--- a/src/ui/chat/services/SystemPromptBuilder.ts
+++ b/src/ui/chat/services/SystemPromptBuilder.ts
@@ -252,6 +252,12 @@ Exact useTools payload shape:
   "constraints": "optional rules or limits",
   "tool": "storage move --path notes/a.md --new-path archive/a.md, content read --path archive/a.md"
 }
+
+CLI string rules:
+- Separate commands with a top-level comma outside quotes: `cmd1, cmd2`
+- Commas inside quoted values stay literal and do not split commands
+- For multiline content, quote the value and use `\\n` escapes; they are decoded before execution
+- Example: `content write --path note.md --content "# Title\\n\\nAlpha, beta, gamma"`
 `;
 
     // Inject the live agent→tools catalog so the LLM knows what's available.


### PR DESCRIPTION
## Summary
- clarify that only top-level commas split CLI commands
- document quoted multiline content with \n escapes
- add the same guidance to the chat system prompt

## Validation
- get_errors on touched files