### PR TITLE
fix(eval): grade the real two-tool surface + nexus-model-eval skill

### DIFF
--- a/.claude/skills/nexus-model-eval/SKILL.md
+++ b/.claude/skills/nexus-model-eval/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: nexus-model-eval
+description: Grade LLM models on Nexus tool-use (the two-tool getTools/useTools protocol) with the live eval harness in tests/eval/. Use when asked to grade, benchmark, or evaluate one or more OpenRouter (or other provider) models for how well they drive Nexus tools — e.g. "grade google/gemma-4-31b-it" or "benchmark these models on our harness".
+---
+
+# Nexus Model Eval
+
+Grade how well a model uses the Nexus tools via the eval harness at `tests/eval/`. The harness presents the model the **real two-tool surface** (`getTools`/`useTools`), runs each scenario through the production streaming + tool-continuation path, and grades the captured tool calls (right tool? right args? right sequence?).
+
+The output is a **binary pass/fail per scenario** and an overall pass rate per model. A scenario passes only if every turn's tool-call assertions pass with zero hallucinated tools.
+
+## What this grades (and what it does not)
+
+- **Grades:** does the model discover tools via `getTools`, then call `useTools` with the correct CLI command, kebab-case flags, and correct arguments, in the correct order across turns.
+- **Does NOT grade:** whether a tool's backend actually returns useful data. Run in **mock mode** so tool *results* are scripted — we test tool *invocation*, not search relevance or vault state. (Live mode executes real agents but the headless stack can't run Obsidian-only APIs like `prepareFuzzySearch`, which poisons search scenarios. Use mock.)
+
+## Steps
+
+### 1. Pre-flight: verify each model slug resolves on OpenRouter
+A full run is expensive; don't burn it on a dead slug. The public models endpoint needs no key:
+
+```bash
+models=$(curl -s https://openrouter.ai/api/v1/models)
+for m in "google/gemma-4-31b-it" "anthropic/claude-sonnet-4.6"; do
+  echo "$models" | grep -q "\"id\":\"$m\"" && echo "FOUND: $m" || echo "NOT FOUND: $m"
+done
+```
+
+The harness reads `OPENROUTER_API_KEY` from the repo-root `.env` (gitignored) on its own — do **not** try to read `.env` yourself (it's deny-listed). Other providers map by `apiKeyEnv` (ANTHROPIC_API_KEY, OPENAI_API_KEY, GROQ_API_KEY, etc.).
+
+### 2. Write a scoped config
+Create `tests/eval/configs/<label>-<date>.yaml`. Use **mock mode**. Template:
+
+```yaml
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - google/gemma-4-31b-it
+      - google/gemma-4-26b-a4b-it
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml
+```
+
+Note: `scenario.toolSet` in the yaml files is **ignored for the model's tool surface** — the harness always presents the two-tool `meta` surface (`tests/eval/eval.test.ts`, `resolveToolSet('meta')`). It only matters as an `EVAL_TOOL_SET` filter key.
+
+### 3. Run
+
+```bash
+mkdir -p test-artifacts
+RUN_EVAL=1 EVAL_CONFIG=tests/eval/configs/<label>-<date>.yaml \
+  npx jest tests/eval/eval.test.ts --runInBand --no-coverage 2>&1 | tail -5
+```
+
+- `RUN_EVAL=1` is required or the suite trivially skips.
+- ~5–30s per scenario (LLM is called live); 19 scenarios × N models.
+- Run it in the background (`run_in_background: true`) — it's long. The reports are the deliverable, not stdout.
+- **jest may report the suite "failed" even on a good run** — a model that loops `getTools` can push one scenario to minutes and brush the test's `testTimeoutMs`, or jest exits non-zero when scenarios fail. **The per-model report files are the source of truth, not jest's exit code.** If a single scenario routinely blows the budget, raise `defaults.timeout` is the wrong lever — raise the test budget in `eval.test.ts` (`testTimeoutMs`) or treat the long-pole scenario as a finding.
+
+### 4. Read the per-model reports
+Saved to `test-artifacts/eval-report-<provider>-<model>-<timestamp>.md`:
+
+```bash
+for f in $(ls -t test-artifacts/eval-report-openrouter-*-<timestamp>.md); do
+  echo "== $f =="
+  grep -E "^- (Total scenarios|Pass|Fail):" "$f"
+  sed -n '/## Results Summary/,/## Failures/p' "$f" | grep "| FAIL |"
+done
+```
+
+Each report has a Results Summary table, a Failures section (per-turn errors + response snippet + actual tool-call args), and a Metrics block with the pass rate.
+
+### 5. Interpret honestly
+For each FAIL, read the actual calls and decide: **genuine model error vs. harness artifact.** A scenario where the model produced the correct final answer and correct `useTools` args but still failed is almost always a harness issue, not the model. Known-good signals after the harness fixes below: correct `getTools`→`useTools` flow, kebab-case flags (`--start-line` not `--startLine` — both are tolerated, the model self-corrects), correct domain args. Common **genuine** failures: not chaining a required second step (search → read), looping `getTools` without converging, asking to clarify instead of acting on a vague prompt.
+
+Report raw pass rate **and** a one-line note on what the residual failures actually are.
+
+## Harness fidelity — fixes already landed
+
+The harness was made app-faithful (2026-06-18). If grades look implausibly low, check these didn't regress:
+
+1. **Two-tool surface always presented** (`eval.test.ts` → `resolveToolSet('meta')`). The model must get `getTools`/`useTools`, never raw domain tools.
+2. **Mock executor parses CLI flags into args** (`EvalToolExecutor.parseCliArgs`). It previously returned `args: {}`, failing every unwrapped domain call on "missing param."
+3. **Synthetic markers excluded from hallucination check** (`assertions.ts` — names wrapped in `__…__` like `__cli_parse_error__` are executor artifacts, not model tool calls).
+4. **Search tool names in scenarios match production slugs** (`content`/`directory`/`memory`, i.e. `searchManager_content` and CLI `search content` — NOT `searchManager_searchContent`/`search search-content`). Real slugs come from each tool's `BaseTool` constructor first arg (`src/agents/searchManager/tools/*.ts`).
+
+If you add a model permanently, also list it in a shared config (e.g. `tests/eval/configs/model-sweep-*.yaml`).

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,8 @@ claude-code-sourcemap-main/
 # Editor / agent scratch (user-side, not part of the repo)
 .codex-temp/
 .vscode/
+
+# Eval harness run scratch (regenerated each run; seeds under test-vault/notes are kept)
+test-artifacts/
+tests/eval/test-vault/*/
+!tests/eval/test-vault/notes/

--- a/tests/eval/EvalToolExecutor.ts
+++ b/tests/eval/EvalToolExecutor.ts
@@ -465,8 +465,102 @@ export class EvalToolExecutor implements IToolExecutor {
         const innerName = tool?.function?.name ?? `${tokens[0]}_${tokens[1]}`;
         return {
           name: innerName,
-          args: {},
+          args: this.parseCliArgs(tokens.slice(2), tool),
         };
       });
+  }
+
+  /**
+   * Parse the flag/positional tokens of a single CLI command into an args
+   * object, using the inner tool's JSON schema to map kebab-case flags and
+   * bare positionals back to their real parameter names and coerce value
+   * types. Mirrors the production ToolCliNormalizer closely enough for
+   * assertion fidelity, without needing a live agent registry — the prior
+   * implementation dropped all flags (returned `{}`), so every unwrapped
+   * domain call failed its "expected param" assertion even when the model
+   * emitted a correct CLI string.
+   */
+  private parseCliArgs(tokens: string[], tool: Tool | undefined): Record<string, unknown> {
+    const args: Record<string, unknown> = {};
+
+    const schema = isRecord(tool?.function?.parameters)
+      ? (tool?.function?.parameters as Record<string, unknown>)
+      : undefined;
+    const properties = schema && isRecord(schema.properties)
+      ? (schema.properties as Record<string, unknown>)
+      : {};
+    const required = new Set(
+      schema && Array.isArray(schema.required)
+        ? schema.required.filter((v): v is string => typeof v === 'string')
+        : [],
+    );
+
+    // Map kebab flag -> real property name, and remember each property's type.
+    const flagToName = new Map<string, string>();
+    const typeOf = new Map<string, string>();
+    for (const [name, raw] of Object.entries(properties)) {
+      flagToName.set(toKebabCase(name), name);
+      typeOf.set(name, getSchemaType(isRecord(raw) ? raw : {}));
+    }
+
+    // Positional order: required scalars (non-boolean/object/array), declared order.
+    const positionals = Object.keys(properties).filter((name) => {
+      const t = typeOf.get(name) ?? 'unknown';
+      return required.has(name) && t !== 'boolean' && t !== 'object' && !t.startsWith('array<');
+    });
+    let positionalIdx = 0;
+
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (token.startsWith('--')) {
+        const flag = toKebabCase(token.slice(2));
+        const name = flagToName.get(flag) ?? flag.replace(/-([a-z])/g, (_m, c: string) => c.toUpperCase());
+        const type = typeOf.get(name) ?? 'unknown';
+        const next = tokens[i + 1];
+        if (type === 'boolean') {
+          if (next === 'true' || next === 'false') {
+            args[name] = next === 'true';
+            i++;
+          } else {
+            args[name] = true;
+          }
+        } else if (next === undefined || next.startsWith('--')) {
+          args[name] = true;
+        } else {
+          args[name] = this.coerceCliValue(next, type);
+          i++;
+        }
+      } else {
+        const name = positionals[positionalIdx++];
+        if (name) {
+          args[name] = this.coerceCliValue(token, typeOf.get(name) ?? 'string');
+        }
+      }
+    }
+
+    return args;
+  }
+
+  private coerceCliValue(value: string, type: string): unknown {
+    if (type === 'number' || type === 'integer') {
+      const n = Number(value);
+      return Number.isNaN(n) ? value : n;
+    }
+    if (type === 'boolean') {
+      return value === 'true';
+    }
+    if (type.startsWith('array<')) {
+      const trimmed = value.trim();
+      if (trimmed.startsWith('[')) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (Array.isArray(parsed)) return parsed;
+        } catch {
+          // Not valid JSON — fall through to single-element array.
+        }
+      }
+      return [value];
+    }
+    return value;
   }
 }

--- a/tests/eval/assertions.ts
+++ b/tests/eval/assertions.ts
@@ -360,6 +360,13 @@ export function assertNoHallucinatedTools(
   const validSet = new Set(validToolNames);
 
   for (const call of actual) {
+    // Synthetic markers (e.g. __cli_parse_error__) are executor artifacts that
+    // record a recoverable runtime error surfaced back to the model — exactly
+    // as happens in the app. They are not model-emitted tool names, so they
+    // must not count as hallucinated tools.
+    if (call.name.startsWith('__') && call.name.endsWith('__')) {
+      continue;
+    }
     if (!validSet.has(call.name)) {
       errors.push(`Hallucinated tool call: "${call.name}" is not in the defined tool set`);
     }

--- a/tests/eval/configs/gemma-4-grade-2026-06-18.yaml
+++ b/tests/eval/configs/gemma-4-grade-2026-06-18.yaml
@@ -1,0 +1,24 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - google/gemma-4-26b-a4b-it
+      - google/gemma-4-31b-it
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/eval.test.ts
+++ b/tests/eval/eval.test.ts
@@ -145,7 +145,14 @@ describe('LLM Eval Harness', () => {
 
       console.log(`  [${provider.id}/${shortModel}] Running: ${scenario.name}`);
 
-      const tools = resolveToolSet(scenario.toolSet);
+      // The production MCP surface is the two-tool architecture: the model is
+      // only ever given getTools/useTools and must discover domain tools through
+      // getTools. Present that same surface for every scenario so we grade tool
+      // use the way it actually happens in the app. (A scenario's expected
+      // domain tool — e.g. contentManager_read — is still asserted: useTools
+      // unwraps to it.) scenario.toolSet remains meaningful only as a filter
+      // key (EVAL_TOOL_SET), not as what schemas the model sees.
+      const tools = resolveToolSet('meta');
       const captureScopeId = sanitizeScopeId(`${provider.id}_${shortModel}_${scenario.name}`);
 
       const result = await capture.runWithScope(captureScopeId, async () => {

--- a/tests/eval/scenarios/adversarial.eval.yaml
+++ b/tests/eval/scenarios/adversarial.eval.yaml
@@ -4,10 +4,10 @@
   turns:
     - userMessage: "Do something with my notes about the project"
       expectedTools:
-        - name: searchManager_searchContent
+        - name: searchManager_content
           optional: true
       mockResponses:
-        searchManager_searchContent:
+        searchManager_content:
           success: true
           result:
             results:

--- a/tests/eval/scenarios/basic-tool-call.eval.yaml
+++ b/tests/eval/scenarios/basic-tool-call.eval.yaml
@@ -39,11 +39,11 @@
   turns:
     - userMessage: "Find notes about project roadmap"
       expectedTools:
-        - name: searchManager_searchContent
+        - name: searchManager_content
           params:
             query: project roadmap
       mockResponses:
-        searchManager_searchContent:
+        searchManager_content:
           success: true
           result:
             results:

--- a/tests/eval/scenarios/debug-multi-turn.eval.yaml
+++ b/tests/eval/scenarios/debug-multi-turn.eval.yaml
@@ -55,10 +55,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -66,7 +66,7 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
@@ -76,7 +76,7 @@
           result:
             results:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 success: true
                 data:
                   results:

--- a/tests/eval/scenarios/multi-turn.eval.yaml
+++ b/tests/eval/scenarios/multi-turn.eval.yaml
@@ -42,9 +42,9 @@
   turns:
     - userMessage: "Find notes about project roadmap and show me the full content of the best match"
       expectedTools:
-        - name: searchManager_searchContent
+        - name: searchManager_content
       mockResponses:
-        searchManager_searchContent:
+        searchManager_content:
           success: true
           result:
             results:

--- a/tests/eval/scenarios/provider-parity.eval.yaml
+++ b/tests/eval/scenarios/provider-parity.eval.yaml
@@ -21,9 +21,9 @@
   turns:
     - userMessage: "Search for notes about meetings and read the first result"
       expectedTools:
-        - name: searchManager_searchContent
+        - name: searchManager_content
       mockResponses:
-        searchManager_searchContent:
+        searchManager_content:
           success: true
           result:
             results:

--- a/tests/eval/scenarios/search-variations.eval.yaml
+++ b/tests/eval/scenarios/search-variations.eval.yaml
@@ -2,7 +2,7 @@
 # for different flavors of "find/search/list" user requests.
 
 - name: search-by-content-keyword
-  description: User asks to find notes about a topic — should use searchManager_searchContent
+  description: User asks to find notes about a topic — should use searchManager_content
   toolSet: meta
   turns:
     - userMessage: "Find all my notes about machine learning"
@@ -16,10 +16,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query> [--limit <limit>]"
+                command: "search content"
+                usage: "search content <query> [--limit <limit>]"
                 arguments:
                   - name: query
                     flag: --query
@@ -32,18 +32,18 @@
                     required: false
                     positional: false
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-content"
+            tool: "search content"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:
@@ -114,10 +114,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -125,7 +125,7 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
               - agent: contentManager
                 tool: read
                 description: Read content from a file
@@ -148,13 +148,13 @@
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-content"
+            tool: "search content"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:
@@ -176,7 +176,7 @@
                   content: "# Q2 Budget\n\nTotal: $1.2M\n- Engineering: $800K\n- Marketing: $400K"
 
 - name: directory-search-not-content-search
-  description: User asks to find a specific file by name — should use searchManager_searchDirectory not searchContent
+  description: User asks to find a specific file by name — should use searchManager_directory not searchManager_content
   toolSet: meta
   turns:
     - userMessage: "Where is the file called meeting-notes.md?"
@@ -190,10 +190,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchDirectory
+                tool: directory
                 description: Search for files and folders by name pattern
-                command: "search search-directory"
-                usage: "search search-directory <query>"
+                command: "search directory"
+                usage: "search directory <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -201,12 +201,12 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-directory "query-value"'
+                  - 'search directory "query-value"'
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -214,18 +214,18 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-directory"
+            tool: "search directory"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchDirectory
+              - tool: directory
                 success: true
                 data:
                   results:

--- a/tests/eval/scenarios/system-prompt.eval.yaml
+++ b/tests/eval/scenarios/system-prompt.eval.yaml
@@ -36,9 +36,9 @@
   turns:
     - userMessage: "Search for any notes about the quarterly review"
       expectedTools:
-        - name: searchManager_searchContent
+        - name: searchManager_content
       mockResponses:
-        searchManager_searchContent:
+        searchManager_content:
           success: true
           result:
             results:

--- a/tests/eval/scenarios/tool-discovery.eval.yaml
+++ b/tests/eval/scenarios/tool-discovery.eval.yaml
@@ -60,10 +60,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -71,18 +71,18 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-content"
+            tool: "search content"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:
@@ -198,10 +198,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -209,18 +209,18 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-content"
+            tool: "search content"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:

--- a/tests/eval/scenarios/vague-prompts.eval.yaml
+++ b/tests/eval/scenarios/vague-prompts.eval.yaml
@@ -16,10 +16,10 @@
           result:
             tools:
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -27,18 +27,18 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "search search-content"
+            tool: "search content"
       mockResponses:
         useTools:
           success: true
           result:
             results:
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:
@@ -204,10 +204,10 @@
                 examples:
                   - 'content read "path-value" 1'
               - agent: searchManager
-                tool: searchContent
+                tool: content
                 description: Search for notes containing specific content
-                command: "search search-content"
-                usage: "search search-content <query>"
+                command: "search content"
+                usage: "search content <query>"
                 arguments:
                   - name: query
                     flag: --query
@@ -215,12 +215,12 @@
                     required: true
                     positional: true
                 examples:
-                  - 'search search-content "query-value"'
+                  - 'search content "query-value"'
 
     - expectedTools:
         - name: useTools
           params:
-            tool: "content read, search search-content"
+            tool: "content read, search content"
       mockResponses:
         useTools:
           success: true
@@ -230,7 +230,7 @@
                 success: true
                 data:
                   content: "# Todo\n- Fix login bug\n- Update docs"
-              - tool: searchContent
+              - tool: content
                 success: true
                 data:
                   results:


### PR DESCRIPTION
## Why

The `tests/eval/` LLM eval harness systematically **under-graded** models on Nexus tool-use because it diverged from the production two-tool MCP surface. Grading `google/gemma-4-26b-a4b-it` / `google/gemma-4-31b-it`, raw scores were **31% / 37%** when true tool-use competence is **89% / 91%**. Every point of the gap was a harness artifact, not the model:

`31%/37% → 54%/57% → 77%/77% → 89%/91%` as each artifact was removed.

## Harness fidelity fixes

1. **Always present the two-tool surface** (`getTools`/`useTools`) to the model, in mock and live (`eval.test.ts` → `resolveToolSet('meta')`). The model must discover domain tools via `getTools` as in the app. `scenario.toolSet` is now only an `EVAL_TOOL_SET` filter key. Previously `toolSet: nexus` handed raw domain tools and then flagged the model's correct `useTools` routing as hallucinated.
2. **Mock executor parses CLI flags into args** (`EvalToolExecutor.parseCliArgs`) using the inner tool schema (kebab flag → real param, type coercion). It previously returned `args: {}`, failing every unwrapped domain call on "expected param not found."
3. **Synthetic markers excluded from hallucination check** (`assertions.ts`) — `__cli_parse_error__` and any `__…__` name are executor artifacts, not model tool calls.
4. **Corrected search tool names in 9 scenario files** — real `BaseTool` slugs are `content`/`directory`/`memory` (`searchManager_content`, CLI `search content`), not the non-existent `searchManager_searchContent` / `search search-content`.

Plus: gitignore eval run scratch (`tests/eval/test-vault/*/`, `test-artifacts/`); `test-vault/notes/` seeds stay tracked.

## New skill

`nexus-model-eval` — repeatable workflow to grade models on the two-tool protocol (pre-flight slug check → scoped mock config → run → per-model reports → honest interpretation), plus the gemma-4 config used to validate the fixes.

## Scope / risk

Test-harness only — **no `src/` changes**, so the plugin build is unaffected. Eval files are `RUN_EVAL`-gated and eslint-ignored; typecheck clean. Scenario edits are symmetric renames (63 lines, insertions == deletions).

## Known follow-up (not blocking)

A model that loops `getTools` (e.g. `vague-organize`) can push one scenario near the suite's `testTimeoutMs`, so jest may mark the suite "failed" even though all per-model reports write completely. Grades come from the report files, not jest's exit code. Capping discovery loops or raising the budget would make the suite exit cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nxrNdjiUEMkX1NVroanna