### PR TITLE
feat(eval+toolManager): context contract, failure-analysis prompt iteration & harness hardening

### DIFF
--- a/docs/plans/gettools-loop-breaker-plan.md
+++ b/docs/plans/gettools-loop-breaker-plan.md
@@ -1,0 +1,67 @@
+# Plan: getTools Loop-Breaker + Tool-Result "What's Next" Decoration
+
+**Status:** Proposed (scoped, not yet implemented)
+**Date:** 2026-06-19
+**Origin:** Eval failure-pattern analysis — two recurring model failures share one root cause.
+
+## Problem
+
+Two distinct model failures observed across the eval sweep turn out to be the same disease:
+
+1. **getTools loop.** A model forms a plan (e.g. "search for 2024 notes, then move them"), calls `getTools` for a tool, gets back something it reads as "not what I asked for / incomplete," and **re-issues getTools forever**. Observed live: gemma-4-31b made 24 calls / 1307s on `vague-organize-request`, its own `memory` annotations cycling through *"getTools returned storage tools instead of search"*, *"only a subset."* At temperature 0 this is a deterministic fixed point — the same context yields the same getTools call every round until the global iteration cap or timeout.
+
+2. **search→read satisfice.** A model runs `search content`, gets `{path, score}` (a *location*, no contents), and **answers anyway — fabricating the file body from the path**. `search-then-read-chain` failed 0/5 across all cloud models AND gemma local; a soft system-prompt nudge ("after search you're encouraged to read") did **not** move it.
+
+**Common root cause:** the model cannot tell *when it has what it needs*. It either **satisfices** (search result → fabricated answer) or **thrashes** (getTools → infinite loop). Both are "uncertainty about task state," and both are best fixed where the model can't ignore it: **in the tool result itself.**
+
+### What already exists (and why it's insufficient)
+- `ToolContinuationService.TOOL_ITERATION_LIMIT = 15` (src/services/llm/core/ToolContinuationService.ts:42) is a *global* backstop that yields `TOOL_LIMIT_REACHED` after 15 total iterations. It fires too late (15 wasted rounds), is not specific to discovery loops, and tells the model to *ask the user* rather than *correct course*.
+- The system-prompt 3-bucket reframe (exploration→inspection→exploitation) helped discovery/protocol patterns but did NOT fix either failure above — prompt-level guidance loses to in-the-moment satisficing.
+
+## Approach — two surgical, low-risk interventions
+
+Both are **steers, never blocks**: they add guidance to a tool result; they never reject a call or change what executes. Legitimate multi-step work is unaffected.
+
+### Intervention A — getTools loop-breaker (orchestrator)
+
+In `ToolContinuationService`, track getTools calls *within one user exchange*:
+- Keep a small ring of recent `getTools` selectors (the `tool` arg string, normalized).
+- **Trigger** when either: (a) ≥ N consecutive getTools calls with no intervening `useTools` (proposed N=3), OR (b) the *same* normalized selector requested ≥ 2 times.
+- **On trigger**, append a steering note to that getTools result (not a new round, not an error):
+  > `You have already discovered these tools this turn: [<accumulated tool list>]. getTools returns SCHEMAS, not data or results — it does not execute anything. To act, call useTools with a command, e.g. {"tool": "storage move --path X --destination Y"}. If a tool you want is not listed, it is not available for this task — adjust your plan with the tools you have.`
+- Reset the tracker on each new user message (per-exchange, not per-session).
+
+This converts a silent infinite loop into a single, actionable correction the model sees on its *next* token — and at temp 0 the changed context breaks the fixed point.
+
+### Intervention B — tool-result "what's next" decoration (toolManager)
+
+Decorate the *results* of the discovery/exploration tools so the model knows the result is intermediate:
+- **getTools result** (src/agents/toolManager/tools/getTools.ts): prefix/annotate with `Discovered N tools. These are schemas — call useTools to run one.`
+- **searchManager.content / searchManager.directory / storageManager.list results**: annotate with `These are locations/matches, not file contents. To read or act on a result, call useTools again (e.g. content read --path <path>).`
+
+This is production-realistic (a real search API returning hits *should* signal they're hits, not contents) and doubles as the recovery steer for the satisfice pattern — addressing failure #2 that the system prompt couldn't.
+
+## Files
+- `src/services/llm/core/ToolContinuationService.ts` — getTools tracker + steer injection (Intervention A). Per-exchange state reset where a new user message starts.
+- `src/agents/toolManager/tools/getTools.ts` — getTools result decoration (Intervention B).
+- `src/agents/searchManager/tools/*.ts` (content, directory) + `src/agents/storageManager/tools/list.ts` — result decoration (Intervention B). Keep the machine-readable payload intact; add a sibling `hint`/`guidance` field or a leading note line — do NOT mutate `data` shape (downstream parsers depend on it).
+- Tests: unit coverage for the tracker (consecutive-getTools trigger, same-selector trigger, reset-on-new-exchange, no false-positive on legitimate getTools→useTools→getTools).
+
+## Eval harness support (to measure the fix)
+- Add a deterministic knob mirroring `forceContextSteering`: e.g. **`forceGetToolsLoop`** or simply rely on the now-fixed `vague-organize` plus a new scenario where the model's likely plan needs a tool the scenario *intentionally* omits — assert the model receives the steer and converges within `maxRecoveryRounds` rather than looping.
+- Add a `search-then-read` recovery assertion: with Intervention B's decoration present in the mock search result, assert the model proceeds to `content read` instead of answering from the snippet.
+- The JSON report's per-result `turns[].toolCalls` already makes "count consecutive getTools" trivial to assert offline.
+
+## Risks / guardrails
+- **False positives on legitimate discovery.** A model may legitimately call getTools twice for different agents before acting. Mitigate: trigger on *consecutive* getTools (no useTools between) or *repeated identical selector*, not on total getTools count. N=3 leaves room for normal multi-agent discovery.
+- **Don't break the payload contract.** Result decoration must be additive (sibling field or note line); the no-ajv rule means downstream code reads `data`/`results` positionally — mutating shape would silently break callers.
+- **Per-exchange reset.** The tracker must reset on each new user message, or a long conversation would accumulate false triggers.
+- **Steer, never block.** Neither intervention rejects a call; both only add guidance. Worst case of a bad heuristic is a slightly noisy result, not a failed operation.
+- **Keep the global `TOOL_ITERATION_LIMIT`** as the final backstop; the loop-breaker is an earlier, gentler, course-correcting layer.
+
+## Sequencing
+1. Intervention A (loop-breaker) — highest value, contained to one file; lands the behavior change.
+2. Intervention B (decoration) — addresses the satisfice pattern the system prompt couldn't; touches several tool files but each change is tiny + additive.
+3. Eval scenarios + harness knob to lock in regression coverage.
+
+Each is independently shippable and independently testable.

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -544,8 +544,139 @@ export function parseCliForDisplay(toolString: string): CliDisplaySegment[] {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Context-contract steering
+//
+// The two-tool surface declares memory + goal as required (see UseToolTool's
+// schema), but schema `required` is documentation only — nothing enforces it at
+// runtime. These pure helpers turn a poorly-filled context block into
+// predictable, model-facing steering so a model can self-correct. Shared by
+// production (UseToolTool execution) and the eval harness (recovery grading) so
+// both agree on what "filled correctly" means.
+// ---------------------------------------------------------------------------
+
+export type ContextContractField = 'memory' | 'goal' | 'workspaceId' | 'sessionId';
+
+export interface ContextContractViolation {
+  field: ContextContractField;
+  message: string;
+}
+
+// Placeholder detection. Models don't only send the empty string — they send
+// dismissive fillers ("N/A", "N/A (First turn)", "None yet", "TBD"). We
+// normalize (drop parentheticals + punctuation) then match against compact
+// tokens, known phrases, and a short leading-dismissive heuristic. Real
+// summaries (sentences) pass; one-word/dismissive fillers are caught.
+const COMPACT_PLACEHOLDERS = new Set([
+  'string', 'todo', 'tbd', 'tba', 'na', 'none', 'nil', 'null', 'undefined',
+  'xxx', 'idk', 'placeholder', 'example', 'memory', 'goal', 'empty', 'nothing',
+  'noidea', 'unknown',
+]);
+const PHRASE_PLACEHOLDERS = new Set([
+  'your memory here', 'your goal here', 'no memory', 'no memory yet', 'none yet',
+  'nothing yet', 'not applicable', 'no context', 'no prior context', 'first turn',
+  'no summary', 'to be determined', 'to be added', 'no goal', 'no goal yet',
+]);
+const LEADING_DISMISSIVE = new Set(['na', 'none', 'tbd', 'todo', 'nil', 'nothing', 'empty']);
+
+function normalizeForPlaceholder(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')   // drop parentheticals, e.g. "(first turn)"
+    .replace(/[^a-z0-9]+/g, ' ')   // punctuation/symbols -> space
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function isPlaceholderText(value: string): boolean {
+  const n = normalizeForPlaceholder(value);
+  if (n.length === 0) return true;
+  if (PHRASE_PLACEHOLDERS.has(n)) return true;
+  if (COMPACT_PLACEHOLDERS.has(n.replace(/ /g, ''))) return true;
+  const tokens = n.split(' ');
+  if (tokens.length <= 3 && LEADING_DISMISSIVE.has(tokens[0])) return true;
+  return false;
+}
+
+// memory/goal are required: empty OR placeholder/dismissive is a violation.
+function isMeaningfulContextValue(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.trim().length === 0) return false;
+  return !isPlaceholderText(value);
+}
+
+// workspaceId/sessionId carry valid silent defaults, so absence/empty is fine
+// ("default" / auto-session). Only a present, non-empty placeholder is junk.
+function isPlaceholderJunk(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  if (value.trim().length === 0) return false;
+  return isPlaceholderText(value);
+}
+
+/**
+ * Collect predictable steering for a useTools context block.
+ * - memory + goal: hard-required (empty or placeholder → steer).
+ * - workspaceId + sessionId: default silently; steer only if present-but-junk.
+ * Pure — no agent registry needed, so the eval harness can call it directly.
+ */
+export function collectContextContractViolations(
+  params: Pick<UseToolParams, 'memory' | 'goal' | 'workspaceId' | 'sessionId'>
+): ContextContractViolation[] {
+  const violations: ContextContractViolation[] = [];
+
+  if (!isMeaningfulContextValue(params.memory)) {
+    violations.push({
+      field: 'memory',
+      message: 'The "memory" field is empty. Fill it with a brief summary of the conversation so far — what you are doing and what you have learned — then re-issue the call.',
+    });
+  }
+  if (!isMeaningfulContextValue(params.goal)) {
+    violations.push({
+      field: 'goal',
+      message: 'The "goal" field is empty. State the current objective in one sentence, then re-issue the call.',
+    });
+  }
+  if (isPlaceholderJunk(params.workspaceId)) {
+    violations.push({
+      field: 'workspaceId',
+      message: 'The "workspaceId" looks like a placeholder. Use "default" for the global workspace, or a real workspace ID — or omit it to default to "default".',
+    });
+  }
+  if (isPlaceholderJunk(params.sessionId)) {
+    violations.push({
+      field: 'sessionId',
+      message: 'The "sessionId" looks like a placeholder. Reuse one stable, human-readable session name for the whole conversation.',
+    });
+  }
+
+  return violations;
+}
+
+/** Build one recoverable, model-facing steering message from violations. */
+export function formatContextContractError(violations: ContextContractViolation[]): string {
+  if (violations.length === 0) return '';
+  if (violations.length === 1) {
+    return `Context incomplete — ${violations[0].message}`;
+  }
+  const lines = violations.map((v) => `- ${v.message}`).join('\n');
+  return `Context incomplete. Fix the following, then re-issue the call:\n${lines}`;
+}
+
 export class ToolCliNormalizer {
   constructor(private agentRegistry: Map<string, IAgent>) {}
+
+  /**
+   * Enforce the required context contract for an EXECUTION (useTools) call.
+   * Throws a recoverable steering error if memory/goal are missing or any
+   * provided ID field is an obvious placeholder. Discovery (getTools) is exempt
+   * — it is often the first call, before there is any conversation to summarize.
+   */
+  validateExecutionContext(params: UseToolParams): void {
+    const violations = collectContextContractViolations(params);
+    if (violations.length > 0) {
+      throw new Error(formatContextContractError(violations));
+    }
+  }
 
   normalizeContext(params: GetToolsParams | UseToolParams): ToolContext {
     if (hasOwn(params, 'context')) {

--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -20,6 +20,11 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   }
 
   async execute(params: UseToolParams): Promise<UseToolResult> {
+    // Enforce the required context contract (memory + goal) before executing.
+    // Throws a recoverable steering error the model can self-correct from —
+    // matching how malformed CLI flags already steer in normalizeExecutionCalls.
+    this.cliNormalizer.validateExecutionContext(params);
+
     const normalizedParams: NormalizedUseToolParams = {
       context: this.cliNormalizer.normalizeContext(params),
       calls: this.cliNormalizer.normalizeExecutionCalls(params),

--- a/src/ui/chat/services/SystemPromptBuilder.ts
+++ b/src/ui/chat/services/SystemPromptBuilder.ts
@@ -300,15 +300,18 @@ For multi-step or ongoing work, suggest using TaskManager to track it. Ask befor
 
 Before major structured action, check whether a useful custom prompt already exists. If the pattern seems reusable or recurring, suggest creating a custom prompt or workflow. Ask before creating either. If a workflow is created, consider attaching the right prompt or agent.
 
-Follow a two-phase approach — EXPLORE first, then ACT:
+Most requests need MORE THAN ONE tool call, moving through up to three stages — expect to use several in a single task:
 
-EXPLORE phase (gather context before making changes):
+1. EXPLORATION — find where things are (you don't yet know the file):
 - "find/search notes about X" → searchManager.content (full-text search across vault)
 - "where is file X" / "find file named X" → searchManager.searchDirectory (search by filename/path)
 - "what's in this folder" / "list files" → storageManager.list (directory listing)
-- "show me / read file X" → contentManager.read (read a specific known file)
 
-ACT phase (modify only after you have context):
+2. INSPECTION — read what's inside what you found:
+- "show me / read file X" → contentManager.read (read a specific file by path)
+- After an exploration step returns matches, you are encouraged to read the relevant file(s) before answering — search and list results are locations, not contents.
+
+3. EXPLOITATION — change things (only after you have the context you need):
 - "write/create/save" → contentManager.write (create or overwrite a file)
 - "add to / append / insert into" → contentManager.insert (add content to existing file)
 - "replace/change X to Y in file" → contentManager.replace (find-and-replace in a file)

--- a/tests/eval/ConfigLoader.ts
+++ b/tests/eval/ConfigLoader.ts
@@ -10,6 +10,9 @@ import * as path from 'path';
 import { parse as parseYaml } from 'yaml';
 import type { EvalConfig, ProviderConfig } from './types';
 
+// Local providers run against a keyless localhost OpenAI-compatible endpoint.
+const KEYLESS_LOCAL_PROVIDERS = new Set(['ollama', 'lmstudio']);
+
 const PROVIDER_API_KEY_ENV: Record<string, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   google: 'GOOGLE_API_KEY',
@@ -284,6 +287,13 @@ export function getEnabledProviders(
 
   for (const [id, providerConfig] of Object.entries(config.providers)) {
     if (!providerConfig.enabled) continue;
+
+    // Local providers (Ollama, LM Studio) run keyless against a localhost
+    // OpenAI-compatible endpoint — they have no API key to resolve.
+    if (KEYLESS_LOCAL_PROVIDERS.has(id)) {
+      result.push({ id, apiKey: '', models: providerConfig.models });
+      continue;
+    }
 
     const apiKey = resolveApiKey(providerConfig.apiKeyEnv);
     if (!apiKey) {

--- a/tests/eval/ConfigLoader.ts
+++ b/tests/eval/ConfigLoader.ts
@@ -105,6 +105,7 @@ function applyEnvOverrides(config: EvalConfig): EvalConfig {
 function applyDefaultEnvOverrides(defaults: EvalConfig['defaults']): EvalConfig['defaults'] {
   return {
     ...defaults,
+    temperature: getNumberEnv('EVAL_TEMP') ?? defaults.temperature,
     maxRetries: getNumberEnv('EVAL_MAX_RETRIES') ?? defaults.maxRetries,
     retryDelayMs: getNumberEnv('EVAL_RETRY_DELAY_MS') ?? defaults.retryDelayMs,
     retryBackoffMultiplier: getNumberEnv('EVAL_RETRY_BACKOFF_MULTIPLIER')

--- a/tests/eval/EvalRunner.ts
+++ b/tests/eval/EvalRunner.ts
@@ -514,6 +514,20 @@ async function createToolExecutor(
   if (isMetaToolSet(tools)) {
     mockExecutor.setDomainTools(NEXUS_TOOLS);
   }
+  // Must be set before registerTurnResponses so registrations route to the
+  // per-round FIFO queue rather than the last-write-wins map.
+  if (scenario.sequentialMockResponses === true) {
+    mockExecutor.setSequentialResponses(true);
+  }
+  // Enforce the production context contract (recovery testing) when the scenario
+  // opts in, or globally via EVAL_ENFORCE_CONTEXT=1 (handy for probing whether a
+  // model that omits memory/goal can self-correct on the existing scenarios).
+  if (scenario.enforceContextContract === true || process.env.EVAL_ENFORCE_CONTEXT === '1') {
+    mockExecutor.setEnforceContextContract(true);
+  }
+  if (typeof scenario.forceContextSteering === 'number' && scenario.forceContextSteering > 0) {
+    mockExecutor.setForceContextSteering(scenario.forceContextSteering);
+  }
   return { executor: mockExecutor };
 }
 
@@ -674,6 +688,33 @@ async function executeScenario(
     const hallucinationAssertion = assertNoHallucinatedTools(capturedCalls, validToolNames);
 
     const errors = [...roundAssertion.errors, ...hallucinationAssertion.errors];
+
+    // Context-contract recovery grading. If enforcement steered the model
+    // (incomplete memory/goal), report whether it recovered within the allowed
+    // rounds. Non-recovery already fails the round assertion (no valid call was
+    // ever executed); this just gives a clearer, dedicated reason.
+    if (config.mode === 'mock' && toolExecutor instanceof EvalToolExecutor) {
+      const ctx = toolExecutor.getContextContractStats();
+      if (ctx.enforced && ctx.steeringErrors > 0) {
+        const maxRecovery = scenario.maxRecoveryRounds ?? 3;
+        if (!ctx.recovered) {
+          errors.push(
+            `Context-contract: received ${ctx.steeringErrors} steering error(s) for an incomplete context block (empty memory/goal) and never re-issued a valid useTools call — no recovery.`
+          );
+        } else if (ctx.steeringErrors > maxRecovery) {
+          errors.push(
+            `Context-contract: recovered, but only after ${ctx.steeringErrors} steering errors (max ${maxRecovery}).`
+          );
+        }
+        trace?.write('context_recovery', {
+          turnIndex,
+          steeringErrors: ctx.steeringErrors,
+          recovered: ctx.recovered,
+          maxRecovery,
+        });
+      }
+    }
+
     trace?.write('assertion_result', {
       turnIndex,
       passed: errors.length === 0,
@@ -783,6 +824,19 @@ async function createAdapter(provider: ProviderEntry): Promise<BaseAdapter> {
     case 'requesty': {
       const { RequestyAdapter } = await import('../../src/services/llm/adapters/requesty/RequestyAdapter');
       return new RequestyAdapter(provider.apiKey);
+    }
+    case 'ollama': {
+      // Ollama's OpenAI-compatible endpoint (/v1/chat/completions). The Nexus
+      // OllamaAdapter is text-only (supportsFunctions: false), so reuse the
+      // LMStudioAdapter — keyless, posts to `${serverUrl}/v1/chat/completions`,
+      // and parses tool calls (native + [TOOL_CALLS]/XML fallbacks). Override
+      // the host with OLLAMA_BASE_URL.
+      const { LMStudioAdapter } = await import('../../src/services/llm/adapters/lmstudio/LMStudioAdapter');
+      return new LMStudioAdapter(process.env.OLLAMA_BASE_URL || 'http://localhost:11434');
+    }
+    case 'lmstudio': {
+      const { LMStudioAdapter } = await import('../../src/services/llm/adapters/lmstudio/LMStudioAdapter');
+      return new LMStudioAdapter(process.env.LMSTUDIO_BASE_URL || 'http://localhost:1234');
     }
     case 'openrouter':
     default: {

--- a/tests/eval/EvalToolExecutor.ts
+++ b/tests/eval/EvalToolExecutor.ts
@@ -14,6 +14,9 @@
 import type { IToolExecutor, ToolResult, ToolExecutionContext } from '../../src/services/llm/adapters/shared/ToolExecutionUtils';
 import type { ToolCall, Tool } from '../../src/services/llm/adapters/types';
 import type { CapturedToolCall, MockToolResponse } from './types';
+// Reuse the SAME context-contract steering production enforces (UseToolTool),
+// so harness recovery grading matches real app behavior — single source.
+import { collectContextContractViolations, formatContextContractError } from '../../src/agents/toolManager/services/ToolCliNormalizer';
 
 type ResponseHandler = (args: Record<string, unknown>) => ToolResult;
 
@@ -139,6 +142,29 @@ export class EvalToolExecutor implements IToolExecutor {
   private responseHandlers: Map<string, ResponseHandler> = new Map();
   private capturedCalls: CapturedToolCall[] = [];
 
+  // Sequential (per-round) response mode. Off by default (name-keyed,
+  // last-write-wins — unchanged for existing scenarios). When on, responses for
+  // a tool are QUEUED in registration order and consumed FIFO across rounds, so
+  // the same tool can return error-then-success (recovery patterns like
+  // read→error→read→success). Queues are cleared per exchange in resetCalls.
+  private sequentialResponses = false;
+  private responseQueues: Map<string, ResponseHandler[]> = new Map();
+  private queueConsumed: Map<string, number> = new Map();
+
+  // Context-contract enforcement (recovery testing). When enabled, a useTools
+  // call whose context block fails the shared validator gets a recoverable
+  // steering error INSTEAD of executing — letting us observe whether the model
+  // self-corrects across rounds. Stats are per-exchange (reset in resetCalls).
+  private enforceContextContract = false;
+  private contextSteeringErrors = 0;
+  private contextRecovered = false;
+  private sawValidExecution = false;
+  // Deterministic recovery test: reject the first N useTools calls with a real
+  // steering error regardless of input, so recovery is exercised even when the
+  // model fills the context block acceptably. Reset per exchange.
+  private forceSteeringTotal = 0;
+  private forceSteeringRemaining = 0;
+
   /**
    * Domain tool definitions — set when running in two-tool (meta) mode.
    * Used by the getTools handler to return realistic tool schemas.
@@ -154,10 +180,71 @@ export class EvalToolExecutor implements IToolExecutor {
   }
 
   /**
+   * Enable/disable context-contract enforcement on useTools execution.
+   * When on, a useTools call with empty memory/goal (or junk IDs) is rejected
+   * with the shared production steering message so the model can recover.
+   */
+  setEnforceContextContract(enabled: boolean): void {
+    this.enforceContextContract = enabled;
+  }
+
+  /**
+   * Force the first N useTools calls to fail with a real context steering error
+   * (deterministic recovery test). The model must re-issue to proceed.
+   */
+  setForceContextSteering(rounds: number): void {
+    this.forceSteeringTotal = Math.max(0, rounds);
+    this.forceSteeringRemaining = this.forceSteeringTotal;
+  }
+
+  /**
+   * Per-exchange context-contract stats: how many steering errors were issued
+   * and whether a valid execution call eventually landed (recovery).
+   */
+  getContextContractStats(): { enforced: boolean; steeringErrors: number; recovered: boolean } {
+    return {
+      enforced: this.enforceContextContract || this.forceSteeringTotal > 0,
+      steeringErrors: this.contextSteeringErrors,
+      // First-try-valid is not "recovery"; recovery = valid call AFTER ≥1 steer.
+      recovered: this.contextSteeringErrors > 0 && this.contextRecovered,
+    };
+  }
+
+  /**
+   * Enable per-round (FIFO) response consumption so a tool can return different
+   * results across rounds (e.g. error then success). Off = last-write-wins.
+   */
+  setSequentialResponses(enabled: boolean): void {
+    this.sequentialResponses = enabled;
+  }
+
+  /**
+   * Resolve the handler for a tool. In sequential mode, consume the FIFO queue
+   * (clamping to the last entry once exhausted); otherwise the name-keyed map.
+   */
+  private resolveHandler(toolName: string): ResponseHandler | undefined {
+    if (this.sequentialResponses && this.responseQueues.has(toolName)) {
+      const queue = this.responseQueues.get(toolName) ?? [];
+      if (queue.length === 0) return undefined;
+      const consumed = this.queueConsumed.get(toolName) ?? 0;
+      const index = Math.min(consumed, queue.length - 1);
+      this.queueConsumed.set(toolName, consumed + 1);
+      return queue[index];
+    }
+    return this.responseHandlers.get(toolName);
+  }
+
+  /**
    * Register a dynamic handler for a tool name.
    * The handler receives parsed args and returns a ToolResult.
    */
   registerHandler(toolName: string, handler: ResponseHandler): void {
+    if (this.sequentialResponses) {
+      const queue = this.responseQueues.get(toolName) ?? [];
+      queue.push(handler);
+      this.responseQueues.set(toolName, queue);
+      return;
+    }
     this.responseHandlers.set(toolName, handler);
   }
 
@@ -165,13 +252,15 @@ export class EvalToolExecutor implements IToolExecutor {
    * Register a static mock response for a tool name.
    */
   registerStaticResponse(toolName: string, response: MockToolResponse): void {
-    this.responseHandlers.set(toolName, (_args: Record<string, unknown>) => ({
+    const handler: ResponseHandler = (_args: Record<string, unknown>) => ({
       id: '', // Will be filled at execution time
       name: toolName,
       success: response.success,
       result: response.result,
       error: response.error,
-    }));
+    });
+    // registerHandler routes to the FIFO queue in sequential mode, else the map.
+    this.registerHandler(toolName, handler);
   }
 
   /**
@@ -226,7 +315,7 @@ export class EvalToolExecutor implements IToolExecutor {
         // Direct domain tool call
         this.capturedCalls.push({ name: toolName, args, id: tc.id });
 
-        const handler = this.responseHandlers.get(toolName);
+        const handler = this.resolveHandler(toolName);
         if (handler) {
           const result = handler(args);
           result.id = tc.id;
@@ -266,7 +355,7 @@ export class EvalToolExecutor implements IToolExecutor {
     args: Record<string, unknown>
   ): ToolResult {
     // Check for scenario-specific mock response first
-    const handler = this.responseHandlers.get(toolName);
+    const handler = this.resolveHandler(toolName);
     if (handler) {
       const result = handler(args);
       result.id = id;
@@ -320,8 +409,40 @@ export class EvalToolExecutor implements IToolExecutor {
     toolName: string,
     args: Record<string, unknown>
   ): ToolResult {
+    // Recovery enforcement runs BEFORE any scripted response, exactly like
+    // production (UseToolTool validates before executing).
+    //
+    // 1. Forced steering: reject the first N calls with a real steering error
+    //    regardless of input — deterministic recovery test.
+    // 2. Contract enforcement: reject calls whose context block fails the shared
+    //    validator (empty memory/goal) — production-faithful.
+    // A call that survives both, after a prior steer, counts as recovery.
+    if (this.forceSteeringRemaining > 0) {
+      this.forceSteeringRemaining -= 1;
+      this.contextSteeringErrors += 1;
+      // Reuse the real production memory-steering message (goal filled → only
+      // the memory violation is reported).
+      const forced = collectContextContractViolations({ goal: 'forced-steering' });
+      return { id, name: toolName, success: false, error: formatContextContractError(forced) };
+    }
+    if (this.enforceContextContract) {
+      const violations = collectContextContractViolations(args);
+      if (violations.length > 0) {
+        this.contextSteeringErrors += 1;
+        return { id, name: toolName, success: false, error: formatContextContractError(violations) };
+      }
+    }
+    if (this.enforceContextContract || this.forceSteeringTotal > 0) {
+      // A call that reached here passed all gates. If we steered earlier, this
+      // is the recovery.
+      if (this.contextSteeringErrors > 0) {
+        this.contextRecovered = true;
+      }
+      this.sawValidExecution = true;
+    }
+
     // Check for scenario-specific mock response first
-    const handler = this.responseHandlers.get(toolName);
+    const handler = this.resolveHandler(toolName);
     if (handler) {
       const result = handler(args);
       result.id = id;
@@ -344,7 +465,7 @@ export class EvalToolExecutor implements IToolExecutor {
         id: `${id}_inner_${innerName}`,
       });
 
-      const innerHandler = this.responseHandlers.get(innerName);
+      const innerHandler = this.resolveHandler(innerName);
       if (innerHandler) {
         const innerResult = innerHandler(innerArgs);
         innerResults.push({
@@ -382,14 +503,27 @@ export class EvalToolExecutor implements IToolExecutor {
    */
   reset(): void {
     this.responseHandlers.clear();
+    this.responseQueues.clear();
+    this.queueConsumed.clear();
     this.capturedCalls = [];
   }
 
   /**
-   * Clear only captured calls (keep handlers).
+   * Clear only captured calls (keep handlers). Also resets per-exchange
+   * context-contract stats so recovery is measured within one exchange.
    */
   resetCalls(): void {
     this.capturedCalls = [];
+    this.contextSteeringErrors = 0;
+    this.contextRecovered = false;
+    this.sawValidExecution = false;
+    this.forceSteeringRemaining = this.forceSteeringTotal;
+    // Sequential queues are re-registered per exchange by EvalRunner; clear so
+    // they don't accumulate, and reset FIFO consumption to the start.
+    if (this.sequentialResponses) {
+      this.responseQueues.clear();
+    }
+    this.queueConsumed.clear();
   }
 
   private buildCliSchema(tool: Tool): Record<string, unknown> {

--- a/tests/eval/EvalToolExecutorRecovery.test.ts
+++ b/tests/eval/EvalToolExecutorRecovery.test.ts
@@ -1,0 +1,151 @@
+/**
+ * tests/eval/EvalToolExecutorRecovery.test.ts — fast, model-free coverage of
+ * the mock executor's context-contract enforcement + recovery tracking.
+ *
+ * Simulates the orchestrator calling executeToolCalls round-by-round and
+ * asserts the steering/recovery stats, so the recovery feature is covered
+ * without running a live model.
+ */
+import { EvalToolExecutor } from './EvalToolExecutor';
+import { NEXUS_TOOLS } from './fixtures/tools';
+import type { ToolCall } from '../../src/services/llm/adapters/types';
+
+function useToolsCall(id: string, args: Record<string, unknown>): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: { name: 'useTools', arguments: JSON.stringify(args) },
+  } as ToolCall;
+}
+
+function domainCall(id: string, name: string, args: Record<string, unknown>): ToolCall {
+  return {
+    id,
+    type: 'function',
+    function: { name, arguments: JSON.stringify(args) },
+  } as ToolCall;
+}
+
+describe('EvalToolExecutor — context-contract recovery', () => {
+  it('forceContextSteering rejects the first useTools call, then records recovery on a valid retry', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setDomainTools(NEXUS_TOOLS);
+    ex.setForceContextSteering(1);
+    ex.resetCalls();
+
+    // Round 1 — forced steering regardless of (here, valid) input.
+    const r1 = await ex.executeToolCalls([
+      useToolsCall('c1', { memory: 'a summary', goal: 'read it', tool: 'content read --path notes/a.md' }),
+    ]);
+    expect(r1[0].success).toBe(false);
+    expect(r1[0].error).toMatch(/Context incomplete/);
+    expect(ex.getContextContractStats()).toMatchObject({ steeringErrors: 1, recovered: false });
+
+    // Round 2 — model re-issues; forced budget spent, valid context executes.
+    const r2 = await ex.executeToolCalls([
+      useToolsCall('c2', { memory: 'a summary', goal: 'read it', tool: 'content read --path notes/a.md' }),
+    ]);
+    expect(r2[0].success).toBe(true);
+    expect(ex.getContextContractStats()).toMatchObject({ enforced: true, steeringErrors: 1, recovered: true });
+  });
+
+  it('enforceContextContract steers empty memory and does not mark recovery without a valid retry', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setDomainTools(NEXUS_TOOLS);
+    ex.setEnforceContextContract(true);
+    ex.resetCalls();
+
+    const r = await ex.executeToolCalls([
+      useToolsCall('c1', { memory: '', goal: 'g', tool: 'content read --path a.md' }),
+    ]);
+    expect(r[0].success).toBe(false);
+    expect(r[0].error).toMatch(/memory/i);
+    expect(ex.getContextContractStats()).toMatchObject({ steeringErrors: 1, recovered: false });
+  });
+
+  it('enforceContextContract also catches dismissive memory ("N/A (First turn)")', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setDomainTools(NEXUS_TOOLS);
+    ex.setEnforceContextContract(true);
+    ex.resetCalls();
+
+    const r = await ex.executeToolCalls([
+      useToolsCall('c1', { memory: 'N/A (First turn)', goal: 'read it', tool: 'content read --path a.md' }),
+    ]);
+    expect(r[0].success).toBe(false);
+    expect(ex.getContextContractStats().steeringErrors).toBe(1);
+  });
+
+  it('does not enforce when neither mode is enabled (empty context tolerated)', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setDomainTools(NEXUS_TOOLS);
+    ex.resetCalls();
+
+    const r = await ex.executeToolCalls([
+      useToolsCall('c1', { memory: '', goal: '', tool: 'content read --path a.md' }),
+    ]);
+    expect(r[0].success).toBe(true);
+    expect(ex.getContextContractStats()).toMatchObject({ enforced: false, steeringErrors: 0 });
+  });
+
+  it('resetCalls restores the forced-steering budget for the next exchange', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setDomainTools(NEXUS_TOOLS);
+    ex.setForceContextSteering(1);
+
+    ex.resetCalls();
+    const a = await ex.executeToolCalls([useToolsCall('a', { memory: 'm', goal: 'g', tool: 'content read --path a.md' })]);
+    expect(a[0].success).toBe(false); // steered
+
+    ex.resetCalls(); // new exchange — budget refilled
+    const b = await ex.executeToolCalls([useToolsCall('b', { memory: 'm', goal: 'g', tool: 'content read --path a.md' })]);
+    expect(b[0].success).toBe(false); // steered again
+    expect(ex.getContextContractStats().steeringErrors).toBe(1);
+  });
+});
+
+describe('EvalToolExecutor — sequential (per-round) responses', () => {
+  it('consumes FIFO: same tool returns error then success across rounds', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setSequentialResponses(true);
+    ex.resetCalls(); // mirror EvalRunner: reset, then register the rounds
+    ex.registerStaticResponse('contentManager_read', { success: false, error: 'Permission denied' });
+    ex.registerStaticResponse('contentManager_read', { success: true, result: { content: 'ok' } });
+
+    const r1 = await ex.executeToolCalls([domainCall('d1', 'contentManager_read', { path: 'a.md' })]);
+    expect(r1[0].success).toBe(false);
+    expect(r1[0].error).toBe('Permission denied');
+
+    const r2 = await ex.executeToolCalls([domainCall('d2', 'contentManager_read', { path: 'a.md' })]);
+    expect(r2[0].success).toBe(true);
+
+    // Once exhausted, the last response is reused (clamped).
+    const r3 = await ex.executeToolCalls([domainCall('d3', 'contentManager_read', { path: 'a.md' })]);
+    expect(r3[0].success).toBe(true);
+  });
+
+  it('default (non-sequential) mode is unchanged: last registration wins for all calls', async () => {
+    const ex = new EvalToolExecutor();
+    ex.resetCalls();
+    ex.registerStaticResponse('contentManager_read', { success: false, error: 'first' });
+    ex.registerStaticResponse('contentManager_read', { success: true, result: { content: 'ok' } });
+
+    const r1 = await ex.executeToolCalls([domainCall('d1', 'contentManager_read', { path: 'a.md' })]);
+    const r2 = await ex.executeToolCalls([domainCall('d2', 'contentManager_read', { path: 'a.md' })]);
+    expect(r1[0].success).toBe(true); // last-write-wins
+    expect(r2[0].success).toBe(true);
+  });
+
+  it('resetCalls clears the queue so the next exchange re-registers from scratch', async () => {
+    const ex = new EvalToolExecutor();
+    ex.setSequentialResponses(true);
+    ex.resetCalls();
+    ex.registerStaticResponse('contentManager_read', { success: false, error: 'e1' });
+    await ex.executeToolCalls([domainCall('d1', 'contentManager_read', { path: 'a.md' })]);
+
+    ex.resetCalls(); // new exchange — queue cleared
+    ex.registerStaticResponse('contentManager_read', { success: true, result: { content: 'fresh' } });
+    const r = await ex.executeToolCalls([domainCall('d2', 'contentManager_read', { path: 'a.md' })]);
+    expect(r[0].success).toBe(true);
+  });
+});

--- a/tests/eval/ReportGenerator.ts
+++ b/tests/eval/ReportGenerator.ts
@@ -9,6 +9,36 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type { EvalRunResult, EvalConfig } from './types';
 
+/** Machine-readable shape of an eval run, emitted alongside the markdown report. */
+export interface EvalReportJson {
+  config: string;
+  mode: string;
+  providers: string[];
+  startTime: number;
+  endTime: number;
+  durationMs: number;
+  metrics: { totalScenarios: number; pass: number; fail: number; passRate: number; retriesUsed: number };
+  byModel: Array<{ model: string; pass: number; fail: number; total: number; passRate: number }>;
+  results: Array<{
+    scenario: string;
+    model: string;
+    fullModel: string;
+    passed: boolean;
+    excludedFromBoard: boolean;
+    error: string | null;
+    retryCount: number;
+    durationMs: number;
+    tracePath: string | null;
+    turns: Array<{
+      turnIndex: number;
+      passed: boolean;
+      errors: string[];
+      textContent: string;
+      toolCalls: Array<{ name: string; args: unknown }>;
+    }>;
+  }>;
+}
+
 /**
  * Generate a markdown report string from eval results.
  */
@@ -106,19 +136,97 @@ export function generateReport(runResult: EvalRunResult, config: EvalConfig): st
 }
 
 /**
+ * Generate a machine-readable JSON report from eval results.
+ *
+ * Mirrors the markdown report but keeps the full, untruncated structure so
+ * downstream analysis (failure-pattern bucketing, leaderboards, exact-payload
+ * extraction) can run with `jq`/Python instead of regex-scraping markdown.
+ * Tool-call args are kept as parsed objects, not stringified+truncated.
+ */
+export function generateReportJson(runResult: EvalRunResult, config: EvalConfig): EvalReportJson {
+  const providerNames = Object.keys(config.providers).filter((p) => config.providers[p].enabled);
+  const totalScenarios = runResult.results.length;
+  const passCount = runResult.results.filter((r) => r.passed).length;
+
+  // Per-model rollup so a leaderboard is one field away. Scenarios flagged
+  // excludeFromBoard (known fixture bugs) are run + reported but do not count
+  // toward pass rate.
+  const byModelMap = new Map<string, { model: string; pass: number; fail: number; total: number }>();
+  for (const r of runResult.results) {
+    if (r.excludedFromBoard) continue;
+    const key = shortModel(r.model);
+    const agg = byModelMap.get(key) ?? { model: key, pass: 0, fail: 0, total: 0 };
+    agg.total += 1;
+    if (r.passed) agg.pass += 1;
+    else agg.fail += 1;
+    byModelMap.set(key, agg);
+  }
+  const byModel = [...byModelMap.values()]
+    .map((m) => ({ ...m, passRate: m.total > 0 ? Math.round((m.pass / m.total) * 100) : 0 }))
+    .sort((a, b) => b.passRate - a.passRate);
+
+  return {
+    config: runResult.config,
+    mode: runResult.mode,
+    providers: providerNames,
+    startTime: runResult.startTime,
+    endTime: runResult.endTime,
+    durationMs: runResult.endTime - runResult.startTime,
+    metrics: {
+      totalScenarios,
+      pass: passCount,
+      fail: totalScenarios - passCount,
+      passRate: totalScenarios > 0 ? Math.round((passCount / totalScenarios) * 100) : 0,
+      retriesUsed: runResult.results.reduce((sum, r) => sum + r.retryCount, 0),
+    },
+    byModel,
+    results: runResult.results.map((r) => ({
+      scenario: r.scenario,
+      model: shortModel(r.model),
+      fullModel: r.model,
+      passed: r.passed,
+      excludedFromBoard: r.excludedFromBoard ?? false,
+      error: r.error ?? null,
+      retryCount: r.retryCount,
+      durationMs: r.totalDurationMs,
+      tracePath: r.tracePath ?? null,
+      turns: r.turns.map((t) => ({
+        turnIndex: t.turnIndex,
+        passed: t.passed,
+        errors: t.errors,
+        textContent: t.textContent,
+        toolCalls: t.actualToolCalls.map((c) => ({ name: c.name, args: c.args })),
+      })),
+    })),
+  };
+}
+
+/**
  * Save report to a timestamped file.
  */
 export function saveReport(report: string, artifactsDir: string, prefix = 'eval-report'): string {
+  const filePath = resolveReportPath(artifactsDir, prefix, 'md');
+  fs.writeFileSync(filePath, report, 'utf-8');
+  return filePath;
+}
+
+/**
+ * Save the machine-readable JSON report alongside the markdown one.
+ */
+export function saveReportJson(report: EvalReportJson, artifactsDir: string, prefix = 'eval-report'): string {
+  const filePath = resolveReportPath(artifactsDir, prefix, 'json');
+  fs.writeFileSync(filePath, JSON.stringify(report, null, 2), 'utf-8');
+  return filePath;
+}
+
+function resolveReportPath(artifactsDir: string, prefix: string, ext: string): string {
   const dir = path.resolve(process.cwd(), artifactsDir);
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
-
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
   const safePrefix = prefix.replace(/[^a-zA-Z0-9_-]/g, '-');
-  const filePath = path.join(dir, `${safePrefix}-${timestamp}.md`);
-  fs.writeFileSync(filePath, report, 'utf-8');
-  return filePath;
+  return path.join(dir, `${safePrefix}-${timestamp}.${ext}`);
 }
 
 function shortModel(model: string): string {

--- a/tests/eval/configs/cloud-appfaithful-2026-06-19.yaml
+++ b/tests/eval/configs/cloud-appfaithful-2026-06-19.yaml
@@ -1,0 +1,27 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - google/gemma-4-31b-it
+      - google/gemma-4-26b-a4b-it
+      - qwen/qwen3.6-27b
+      - qwen/qwen3.5-9b
+      - poolside/laguna-xs.2
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/configs/laguna-xs2-grade-2026-06-19.yaml
+++ b/tests/eval/configs/laguna-xs2-grade-2026-06-19.yaml
@@ -1,0 +1,23 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - poolside/laguna-xs.2
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/configs/ollama-gemma4-e4b-2026-06-19.yaml
+++ b/tests/eval/configs/ollama-gemma4-e4b-2026-06-19.yaml
@@ -1,0 +1,23 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  ollama:
+    apiKeyEnv: OLLAMA_LOCAL
+    models:
+      - gemma4:e4b
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/configs/ollama-qwen3.5-4b-2026-06-19.yaml
+++ b/tests/eval/configs/ollama-qwen3.5-4b-2026-06-19.yaml
@@ -1,0 +1,23 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  ollama:
+    apiKeyEnv: OLLAMA_LOCAL
+    models:
+      - qwen3.5:4b
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/configs/qwen3.5-9b-grade-2026-06-19.yaml
+++ b/tests/eval/configs/qwen3.5-9b-grade-2026-06-19.yaml
@@ -1,0 +1,23 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - qwen/qwen3.5-9b
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/configs/qwen3.6-27b-grade-2026-06-19.yaml
+++ b/tests/eval/configs/qwen3.6-27b-grade-2026-06-19.yaml
@@ -1,0 +1,23 @@
+mode: mock
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - qwen/qwen3.6-27b
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/eval/eval.test.ts
+++ b/tests/eval/eval.test.ts
@@ -22,7 +22,7 @@ import { loadConfig, getEnabledProviders } from './ConfigLoader';
 import { loadScenarios } from './ScenarioLoader';
 import { RequestCapture } from './RequestCapture';
 import { calculateMaxRetryDelayMs, runScenario } from './EvalRunner';
-import { generateReport, saveReport } from './ReportGenerator';
+import { generateReport, saveReport, generateReportJson, saveReportJson } from './ReportGenerator';
 import { META_TOOLS, NEXUS_TOOLS, SIMPLE_TOOLS } from './fixtures/tools';
 import { DEFAULT_SYSTEM_PROMPT, MINIMAL_SYSTEM_PROMPT, initializeSystemPrompts } from './fixtures/system-prompt';
 import type { EvalConfig, EvalScenario, ScenarioResult, ToolSetType } from './types';
@@ -275,6 +275,13 @@ describe('LLM Eval Harness', () => {
 
       const jobStartMs = Date.now();
       const finish = (result: ScenarioResult): ScenarioResult => {
+        if (scenario.excludeFromBoard) result.excludedFromBoard = true;
+        // Accumulate incrementally so a mid-run TEST TIMEOUT still yields a
+        // report. mapWithConcurrency only resolves once every job finishes, so
+        // pushing after it (the old behavior) lost ALL results when the test
+        // timed out partway — afterAll then saw an empty allResults and saved
+        // nothing. The per-scenario progress log was the only survivor.
+        allResults.push(result);
         completed += 1;
         const status = result.passed ? 'PASS' : 'FAIL';
         const turnsPassed = result.turns.filter((t) => t.passed).length;
@@ -353,7 +360,8 @@ describe('LLM Eval Harness', () => {
       }
     });
 
-    allResults.push(...results);
+    // NOTE: allResults is now populated incrementally in finish() (above) so a
+    // timeout still produces a report. Do not re-push here or results double.
 
     const resultsByModel = new Map<string, ScenarioResult[]>();
     for (const result of results) {
@@ -376,14 +384,17 @@ describe('LLM Eval Harness', () => {
       };
 
       const modelReport = generateReport(modelRunResult, config);
-      const modelReportPath = saveReport(
-        modelReport,
+      const modelReportPrefix = buildModelReportPrefix(providerId, shortModel);
+      const modelReportPath = saveReport(modelReport, config.capture.artifactsDir, modelReportPrefix);
+      const modelJsonPath = saveReportJson(
+        generateReportJson(modelRunResult, config),
         config.capture.artifactsDir,
-        buildModelReportPrefix(providerId, shortModel),
+        modelReportPrefix,
       );
 
       const passed = modelResults.filter((r) => r.passed).length;
       console.log(`  [${providerId}/${shortModel}] Report saved: ${modelReportPath}`);
+      console.log(`  [${providerId}/${shortModel}] JSON saved: ${modelJsonPath}`);
       console.log(`\n  [${providerId}/${shortModel}] Summary: ${passed}/${modelResults.length} scenarios passed`);
     }
 
@@ -403,7 +414,9 @@ describe('LLM Eval Harness', () => {
 
       const report = generateReport(runResult, config);
       const reportPath = saveReport(report, config.capture.artifactsDir);
+      const jsonPath = saveReportJson(generateReportJson(runResult, config), config.capture.artifactsDir);
       console.log(`\n[Eval] Report saved: ${reportPath}`);
+      console.log(`[Eval] JSON saved: ${jsonPath}`);
       console.log(report);
     }
   });

--- a/tests/eval/eval.test.ts
+++ b/tests/eval/eval.test.ts
@@ -16,6 +16,8 @@
  *   RUN_EVAL=1 EVAL_MODE=live EVAL_TOOL_SET=meta EVAL_TARGETS='openrouter=deepseek/deepseek-v4-pro,openrouter=deepseek/deepseek-v4-flash' npx jest tests/eval/eval.test.ts --runInBand --no-coverage --verbose
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import { loadConfig, getEnabledProviders } from './ConfigLoader';
 import { loadScenarios } from './ScenarioLoader';
 import { RequestCapture } from './RequestCapture';
@@ -75,6 +77,103 @@ function buildModelReportPrefix(providerId: string, model: string): string {
   return `eval-report-${providerId}-${model.replace(/[^a-zA-Z0-9_-]/g, '-')}`;
 }
 
+// ---------------------------------------------------------------------------
+// Concurrency control
+//
+// Cloud providers tolerate full fan-out, but local single-slot servers
+// (Ollama, LM Studio) serialize inference: firing every scenario at once just
+// makes them queue and blow past the per-request timeout (manifesting as a wave
+// of 500s and a discarded run). Default to serial for local providers; override
+// with EVAL_CONCURRENCY=N for any provider.
+// ---------------------------------------------------------------------------
+
+const LOCAL_PROVIDERS = new Set(['ollama', 'lmstudio']);
+
+function resolveConcurrency(providers: Array<{ id: string }>): number {
+  const override = Number(process.env.EVAL_CONCURRENCY);
+  if (Number.isFinite(override) && override >= 1) return Math.floor(override);
+  if (providers.some((p) => LOCAL_PROVIDERS.has(p.id))) return 1;
+  return Infinity;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (!Number.isFinite(limit) || limit >= items.length) {
+    return Promise.all(items.map((item, index) => fn(item, index)));
+  }
+
+  const results: R[] = new Array(items.length);
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const index = cursor++;
+      results[index] = await fn(items[index], index);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.max(1, limit) }, () => worker()));
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Streaming progress log
+//
+// jest buffers stdout in non-TTY runs, so per-scenario console.log only surfaces
+// when the whole run ends. This appends one line per completed case to a log
+// file that can be `tail -f`'d live while a (often slow, local) run is in flight.
+// ---------------------------------------------------------------------------
+
+function createProgressLog(
+  artifactsDir: string,
+  startedAtMs: number,
+  totalJobs: number,
+  concurrency: number
+): { path: string; record: (line: string) => void } {
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  const stamp = new Date(startedAtMs).toISOString().replace(/[:.]/g, '-');
+  const logPath = path.join(artifactsDir, `eval-progress-${stamp}.log`);
+  const lanes = Number.isFinite(concurrency) ? String(concurrency) : 'all';
+  fs.writeFileSync(
+    logPath,
+    `# Eval progress — ${totalJobs} jobs, concurrency=${lanes} — started ${new Date(startedAtMs).toISOString()}\n`
+  );
+  return {
+    path: logPath,
+    record: (line: string) => {
+      try {
+        fs.appendFileSync(logPath, `${line}\n`);
+      } catch {
+        /* progress logging is best-effort — never fail a run over it */
+      }
+    },
+  };
+}
+
+// Cheap synchronous upper-bound count of scenario files for the glob's base dir.
+// Used only to size the jest test timeout — an overestimate is harmless.
+function countScenarioFiles(globPattern: string): number {
+  const base = (globPattern.split('**')[0] || 'tests/eval/scenarios/').replace(/\/+$/, '');
+  const root = path.isAbsolute(base) ? base : path.resolve(process.cwd(), base);
+  let count = 0;
+  const walk = (dir: string): void => {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith('.eval.yaml')) count += 1;
+    }
+  };
+  walk(root);
+  return count;
+}
+
 function shouldRunScenario(scenario: EvalScenario, providerId: string, model: string): boolean {
   if (config.scenarioNames && !config.scenarioNames.includes(scenario.name)) {
     return false;
@@ -112,9 +211,26 @@ describe('LLM Eval Harness', () => {
 
   const allResults: ScenarioResult[] = [];
   const startTime = Date.now();
-  const testTimeoutMs = (
-    config.defaults.timeout * (config.defaults.maxRetries + 1) * 2
-  ) + calculateMaxRetryDelayMs(config.defaults.maxRetries, config) + 10_000;
+  // jest's per-test timeout must cover the WHOLE matrix. A parallel run finishes
+  // in roughly one case's worst-case budget; a serial run (local single-slot
+  // providers) needs the sum across every serialized lane. Scale by lane count
+  // so serial local grades don't trip the timeout mid-run. Override with
+  // EVAL_TEST_TIMEOUT_MS.
+  const perCaseBudgetMs =
+    config.defaults.timeout * (config.defaults.maxRetries + 1) +
+    calculateMaxRetryDelayMs(config.defaults.maxRetries, config);
+  const dispatchConcurrency = resolveConcurrency(enabledProviders);
+  const estimatedJobs = Math.max(
+    1,
+    countScenarioFiles(config.scenarios) *
+      enabledProviders.reduce((sum, p) => sum + p.models.length, 0)
+  );
+  const serialLanes = Number.isFinite(dispatchConcurrency)
+    ? Math.ceil(estimatedJobs / Math.max(1, dispatchConcurrency))
+    : 1;
+  const testTimeoutMs =
+    Number(process.env.EVAL_TEST_TIMEOUT_MS) ||
+    perCaseBudgetMs * (serialLanes + 1) + 10_000;
 
   it('runs the configured provider/model/scenario matrix in parallel', async () => {
     const scenarios = await loadScenarios(config.scenarios);
@@ -134,7 +250,19 @@ describe('LLM Eval Harness', () => {
       console.warn('[Eval] No runnable provider/model/scenario jobs after filters');
     }
 
-    const results = await Promise.all(jobs.map(async ({ provider, model, scenario }) => {
+    const concurrency = resolveConcurrency(enabledProviders);
+    const progress = createProgressLog(
+      config.capture.artifactsDir,
+      startTime,
+      jobs.length,
+      concurrency
+    );
+    let completed = 0;
+    console.log(
+      `  [Eval] ${jobs.length} jobs, concurrency=${Number.isFinite(concurrency) ? concurrency : 'all'} → live progress: ${progress.path}`
+    );
+
+    const results = await mapWithConcurrency(jobs, concurrency, async ({ provider, model, scenario }) => {
       const shortModel = model.split('/').pop() || model;
       const resolvedScenario = {
         ...scenario,
@@ -144,6 +272,22 @@ describe('LLM Eval Harness', () => {
       };
 
       console.log(`  [${provider.id}/${shortModel}] Running: ${scenario.name}`);
+
+      const jobStartMs = Date.now();
+      const finish = (result: ScenarioResult): ScenarioResult => {
+        completed += 1;
+        const status = result.passed ? 'PASS' : 'FAIL';
+        const turnsPassed = result.turns.filter((t) => t.passed).length;
+        const detail = result.error
+          ? `ERROR: ${result.error}`
+          : `${turnsPassed}/${result.turns.length} turns`;
+        progress.record(
+          `[${new Date().toISOString()}] ${completed}/${jobs.length} ${status} ${provider.id}/${shortModel} :: ${scenario.name} (${detail}, ${(result.totalDurationMs / 1000).toFixed(1)}s)`
+        );
+        return result;
+      };
+
+      try {
 
       // The production MCP surface is the two-tool architecture: the model is
       // only ever given getTools/useTools and must discover domain tools through
@@ -187,8 +331,27 @@ describe('LLM Eval Harness', () => {
         }
       }
 
-      return result;
-    }));
+      return finish(result);
+      } catch (err) {
+        // A thrown job (e.g. an HTTP/timeout error from the adapter) used to
+        // reject the whole Promise.all and discard the entire report. Record it
+        // as a failed scenario instead so siblings still complete and a partial
+        // report is generated.
+        const message = err instanceof Error ? err.message : String(err);
+        console.log(`  [${provider.id}/${shortModel}] ERROR: ${scenario.name} — ${message}`);
+        return finish({
+          scenario: scenario.name,
+          description: scenario.description ?? '',
+          provider: provider.id,
+          model,
+          passed: false,
+          turns: [],
+          totalDurationMs: Date.now() - jobStartMs,
+          retryCount: 0,
+          error: message,
+        });
+      }
+    });
 
     allResults.push(...results);
 

--- a/tests/eval/scenarios/context-recovery.eval.yaml
+++ b/tests/eval/scenarios/context-recovery.eval.yaml
@@ -1,0 +1,63 @@
+# Context-contract recovery scenarios.
+#
+# forceContextSteering deterministically rejects the first N useTools calls with
+# a REAL production context steering error (the same message UseToolTool returns
+# for empty memory), regardless of what the model sent. The model must then
+# re-issue a valid call. This tests recovery reliably — it does not depend on the
+# model first making a mistake (which is non-deterministic across models/turns).
+#
+# allowReorder is set because the extra steered round would otherwise misalign
+# strict round-by-round ordering.
+
+- name: recover-context-on-write
+  description: First useTools is steered with a context error; model must recover and complete the write
+  forceContextSteering: 1
+  maxRecoveryRounds: 3
+  allowReorder: true
+  turns:
+    - userMessage: "Create a note at ideas/feature-requests.md with a '# Feature Requests' heading followed by an empty bullet list."
+      expectedTools:
+        - name: contentManager_write
+      mockResponses:
+        contentManager_write:
+          success: true
+          result: "Note created at ideas/feature-requests.md"
+
+- name: recover-context-on-read
+  description: First useTools is steered with a context error; model must recover and complete the read
+  forceContextSteering: 1
+  maxRecoveryRounds: 3
+  allowReorder: true
+  turns:
+    - userMessage: "Read the note at notes/today.md and tell me what it says."
+      expectedTools:
+        - name: contentManager_read
+      mockResponses:
+        contentManager_read:
+          success: true
+          result:
+            content: "# Today\n\n- Ship the recovery feature."
+
+# Tool-result recovery (sequentialMockResponses): the SAME tool returns an error
+# on round 0 then success on round 1, so we test whether the model retries after
+# a genuine tool failure rather than giving up. Requires the per-round FIFO queue.
+- name: recover-from-tool-error
+  description: First read fails with a transient error; model should retry and succeed
+  sequentialMockResponses: true
+  maxRecoveryRounds: 3
+  allowReorder: true
+  turns:
+    - userMessage: "Read notes/today.md and tell me what it says."
+      expectedTools:
+        - name: contentManager_read
+      mockResponses:
+        contentManager_read:
+          success: false
+          error: "Transient read error (lock contention). Retry the same read."
+    - expectedTools:
+        - name: contentManager_read
+      mockResponses:
+        contentManager_read:
+          success: true
+          result:
+            content: "# Today\n\n- Ship the recovery feature."

--- a/tests/eval/scenarios/vague-prompts.eval.yaml
+++ b/tests/eval/scenarios/vague-prompts.eval.yaml
@@ -90,16 +90,23 @@
               - tool: write
                 success: true
 
+# Either discovery path is valid here: the model may LIST the folder or SEARCH
+# for 2024 notes before moving them. The getTools mock therefore exposes BOTH
+# storage AND search tools — otherwise a model that plans to search first asks
+# getTools for `search`, the selector-insensitive scripted mock hands back only
+# storage tools, the model reads that as "discovery is broken," and loops
+# getTools forever (gemma-31b: 24 calls / 1307s). See project memory: getTools
+# loops. Result mocks are DOMAIN-tool-keyed (storageManager_list /
+# searchManager_content / storageManager_move) so the executor dispatches per
+# inner command in any order/round. Required action graded = the two moves.
 - name: vague-organize-request
-  description: User asks to "clean up" which implies move/archive
+  description: User asks to "clean up" which implies move/archive; list-then-move or search-then-move both acceptable
   toolSet: meta
   allowReorder: true
   turns:
     - userMessage: "Can you clean up the old meeting notes? Move anything from 2024 to the archive folder."
       expectedTools:
         - name: getTools
-          params:
-            tool: "storage"
       mockResponses:
         getTools:
           success: true
@@ -136,44 +143,59 @@
                     positional: true
                 examples:
                   - 'storage move "path-value" "destination-value"'
-
-    - expectedTools:
-        - name: useTools
-          params:
-            tool: "storage list"
-      mockResponses:
-        useTools:
+              - agent: searchManager
+                tool: content
+                description: Search for notes containing specific content
+                command: "search content"
+                usage: "search content <query>"
+                arguments:
+                  - name: query
+                    flag: --query
+                    type: string
+                    required: true
+                    positional: true
+                examples:
+                  - 'search content "query-value"'
+        # Domain-tool-keyed: both discovery paths surface the same 2024 files.
+        storageManager_list:
+          success: true
+          result:
+            items:
+              - name: "2024-q1-meeting.md"
+                type: file
+              - name: "2024-q2-meeting.md"
+                type: file
+              - name: "2025-q1-meeting.md"
+                type: file
+        searchManager_content:
           success: true
           result:
             results:
-              - tool: list
-                success: true
-                data:
-                  items:
-                    - name: "2024-q1-meeting.md"
-                      type: file
-                    - name: "2024-q2-meeting.md"
-                      type: file
-                    - name: "2025-q1-meeting.md"
-                      type: file
+              - path: "notes/2024-q1-meeting.md"
+                score: 0.92
+              - path: "notes/2024-q2-meeting.md"
+                score: 0.90
+        storageManager_move:
+          success: true
 
     - expectedTools:
         - name: useTools
           params:
             tool: "storage move, storage move"
-      mockResponses:
-        useTools:
-          success: true
-          result:
-            results:
-              - tool: move
-                success: true
-              - tool: move
-                success: true
 
+# NOTE: excludeFromBoard until re-verified on a strong model. This scenario was
+# previously a fixture trap: its single useTools turn returned the todo content
+# for EVERY read, so when a model followed the search hit and read
+# engineering/api-redesign.md it got the todo back, concluded "read is broken,"
+# and looped/bailed — penalizing correct chain-completion behavior. Rewritten as
+# a deterministic 3-round chain (mirrors search-then-read-chain) with
+# sequentialMockResponses so the api-redesign read returns real api content.
 - name: multi-intent-single-message
   description: User asks multiple things in one message — model needs multiple agents
   toolSet: meta
+  excludeFromBoard: true
+  allowReorder: true
+  sequentialMockResponses: true
   turns:
     - userMessage: "Read my todo list and also search for any notes about the API redesign"
       expectedTools:
@@ -217,6 +239,7 @@
                 examples:
                   - 'search content "query-value"'
 
+    # Round 1: read the todo list + search for the api-redesign notes.
     - expectedTools:
         - name: useTools
           params:
@@ -236,3 +259,18 @@
                   results:
                     - path: engineering/api-redesign.md
                       score: 0.91
+
+    # Round 2 (optional follow-up): if the model reads the file the search
+    # surfaced, it now gets the REAL api-redesign content — not the todo again.
+    # expectedTools is empty so this round is tolerated but not required; with
+    # sequentialMockResponses the queued response feeds this read.
+    - expectedTools: []
+      mockResponses:
+        useTools:
+          success: true
+          result:
+            results:
+              - tool: read
+                success: true
+                data:
+                  content: "# API Redesign\n\n- Move auth to OAuth2\n- Versioned endpoints under /v2\n- Deprecate /legacy by Q3"

--- a/tests/eval/types.ts
+++ b/tests/eval/types.ts
@@ -131,6 +131,13 @@ export interface EvalScenario {
    * default; existing scenarios are unaffected.
    */
   sequentialMockResponses?: boolean;
+  /**
+   * Exclude this scenario from leaderboard (byModel) aggregation. The result is
+   * still run and reported, but does not count toward a model's pass rate. Use
+   * for scenarios with a known fixture/scenario bug that would unfairly penalize
+   * correct model behavior until the fixture is re-verified.
+   */
+  excludeFromBoard?: boolean;
   turns: EvalTurn[];
 }
 
@@ -178,6 +185,8 @@ export interface ScenarioResult {
   retryCount: number;
   error?: string;
   tracePath?: string;
+  /** Run + reported, but excluded from byModel leaderboard aggregation (known fixture bug). */
+  excludedFromBoard?: boolean;
 }
 
 export interface EvalRunResult {

--- a/tests/eval/types.ts
+++ b/tests/eval/types.ts
@@ -103,6 +103,34 @@ export interface EvalScenario {
    * execute search before read or vice versa.
    */
   allowReorder?: boolean;
+  /**
+   * Enforce the production context contract (memory + goal required) on useTools
+   * execution in mock mode. A bad context block gets the shared steering error
+   * so we can grade whether the model recovers. Also enabled globally via
+   * EVAL_ENFORCE_CONTEXT=1.
+   */
+  enforceContextContract?: boolean;
+  /**
+   * Max number of context steering errors tolerated before recovery is judged
+   * failed. Default 3. Only meaningful with enforceContextContract /
+   * forceContextSteering.
+   */
+  maxRecoveryRounds?: number;
+  /**
+   * Deterministically reject the first N useTools calls with a real context
+   * steering error (regardless of input), then grade whether the model
+   * re-issues a valid call. Use this to test recovery reliably — unlike
+   * enforceContextContract, it does not depend on the model first making a
+   * mistake. Implies recovery grading.
+   */
+  forceContextSteering?: number;
+  /**
+   * Consume mockResponses per round (FIFO) instead of last-write-wins, so the
+   * SAME tool can return different results across rounds — enabling recovery
+   * patterns like tool→error (round 0) then tool→success (round 1). Off by
+   * default; existing scenarios are unaffected.
+   */
+  sequentialMockResponses?: boolean;
   turns: EvalTurn[];
 }
 

--- a/tests/unit/ToolManagerContextContract.test.ts
+++ b/tests/unit/ToolManagerContextContract.test.ts
@@ -1,0 +1,129 @@
+/**
+ * tests/unit/ToolManagerContextContract.test.ts — pins the required context
+ * contract for useTools execution. memory + goal are hard-required (steer on
+ * empty/placeholder); workspaceId + sessionId default silently and only steer
+ * when present-but-junk; getTools (discovery) is exempt.
+ *
+ * These helpers are SHARED with the eval harness recovery grading, so the
+ * steering behavior must stay stable.
+ */
+import {
+  ToolCliNormalizer,
+  collectContextContractViolations,
+  formatContextContractError,
+} from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+
+const FILLED = {
+  workspaceId: 'default',
+  sessionId: 'my-session',
+  memory: 'Summarized the conversation so far.',
+  goal: 'Create a note.',
+};
+
+describe('useTools context contract', () => {
+  const normalizer = new ToolCliNormalizer(new Map<string, IAgent>());
+
+  describe('collectContextContractViolations', () => {
+    it('passes a fully-filled context block', () => {
+      expect(collectContextContractViolations(FILLED)).toEqual([]);
+    });
+
+    it('flags empty memory', () => {
+      const v = collectContextContractViolations({ ...FILLED, memory: '' });
+      expect(v.map((x) => x.field)).toEqual(['memory']);
+      expect(v[0].message).toMatch(/memory/i);
+    });
+
+    it('flags empty goal', () => {
+      const v = collectContextContractViolations({ ...FILLED, goal: '   ' });
+      expect(v.map((x) => x.field)).toEqual(['goal']);
+    });
+
+    it('flags placeholder memory/goal values', () => {
+      const v = collectContextContractViolations({ ...FILLED, memory: 'string', goal: 'TODO' });
+      expect(v.map((x) => x.field).sort()).toEqual(['goal', 'memory']);
+    });
+
+    it('flags dismissive memory fillers (N/A, N/A (First turn), None yet, TBD)', () => {
+      for (const filler of ['N/A', 'N/A (First turn)', 'None yet', 'TBD', 'n/a', 'nothing yet', 'not applicable']) {
+        const v = collectContextContractViolations({ ...FILLED, memory: filler });
+        expect(v.map((x) => x.field)).toEqual(['memory']);
+      }
+    });
+
+    it('does NOT flag real summaries that merely contain such words', () => {
+      const real = [
+        'The user wants to create a note at ideas/feature-requests.md with a heading.',
+        'Searched for the roadmap; none of the results matched, so trying a broader query.',
+        'Read notes/today.md and summarized the three action items.',
+      ];
+      for (const memory of real) {
+        expect(collectContextContractViolations({ ...FILLED, memory })).toEqual([]);
+      }
+    });
+
+    it('treats "default" workspaceId and a normal sessionId as valid (not dismissive)', () => {
+      expect(
+        collectContextContractViolations({ memory: 'm summary', goal: 'g objective', workspaceId: 'default', sessionId: 'note-cleanup' })
+      ).toEqual([]);
+    });
+
+    it('reports both missing reasoning fields at once', () => {
+      const v = collectContextContractViolations({ ...FILLED, memory: '', goal: '' });
+      expect(v.map((x) => x.field).sort()).toEqual(['goal', 'memory']);
+    });
+
+    it('does NOT flag absent/empty workspaceId or sessionId (silent defaults)', () => {
+      expect(collectContextContractViolations({ memory: 'm', goal: 'g' })).toEqual([]);
+      expect(
+        collectContextContractViolations({ memory: 'm', goal: 'g', workspaceId: '', sessionId: '' })
+      ).toEqual([]);
+    });
+
+    it('accepts "default" workspaceId as a real value', () => {
+      expect(collectContextContractViolations({ ...FILLED, workspaceId: 'default' })).toEqual([]);
+    });
+
+    it('flags present-but-junk workspaceId / sessionId', () => {
+      const v = collectContextContractViolations({
+        ...FILLED,
+        workspaceId: 'placeholder',
+        sessionId: 'string',
+      });
+      expect(v.map((x) => x.field).sort()).toEqual(['sessionId', 'workspaceId']);
+    });
+  });
+
+  describe('formatContextContractError', () => {
+    it('returns empty string for no violations', () => {
+      expect(formatContextContractError([])).toBe('');
+    });
+
+    it('renders a single violation inline', () => {
+      const msg = formatContextContractError(collectContextContractViolations({ ...FILLED, memory: '' }));
+      expect(msg).toMatch(/^Context incomplete — /);
+      expect(msg).toMatch(/memory/i);
+    });
+
+    it('renders multiple violations as a bulleted list', () => {
+      const msg = formatContextContractError(
+        collectContextContractViolations({ ...FILLED, memory: '', goal: '' })
+      );
+      expect(msg).toMatch(/Fix the following/);
+      expect(msg.split('\n- ').length).toBe(3); // header + 2 bullets
+    });
+  });
+
+  describe('ToolCliNormalizer.validateExecutionContext', () => {
+    it('throws a recoverable steering error when memory is empty', () => {
+      expect(() => normalizer.validateExecutionContext({ ...FILLED, memory: '', tool: 'content read --path a.md' }))
+        .toThrow(/memory/i);
+    });
+
+    it('does not throw for a filled context block', () => {
+      expect(() => normalizer.validateExecutionContext({ ...FILLED, tool: 'content read --path a.md' }))
+        .not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Two-part feature arc on model tool-use grading + the production fixes it surfaced.

## Part 1 — useTools context contract + recovery testing (commit 717fd03d)
- `UseToolTool.execute()` now enforces the context contract the schema *declared* but nothing enforced (schema `required` is doc-only — no ajv). New shared helpers `collectContextContractViolations` / `formatContextContractError` + `validateExecutionContext` in `ToolCliNormalizer`. memory + goal hard-required (empty/placeholder → recoverable steering error); workspaceId/sessionId keep silent defaults; constraints optional. Enforced on useTools only (getTools exempt).
- Eval harness imports the SAME validator (single source). Recovery knobs: `enforceContextContract`, `forceContextSteering: N` (deterministic), `sequentialMockResponses` (per-round FIFO). `EvalRunner` grades recovery within `maxRecoveryRounds`.

## Part 2 — failure-pattern analysis → prompt iteration + harness hardening (commit 9333bba6)
Measured the cloud + local grading sweep, bucketed the failures, and fixed what they exposed.

**Production**
- `SystemPromptBuilder`: two-phase EXPLORE/ACT → three buckets (exploration → inspection → exploitation) + a light "after search, read the relevant file(s)" nudge. Net-positive on discovery/protocol scenarios in the targeted retest.

**Harness**
- JSON report output (`generateReportJson`/`saveReportJson`) beside every MD report — untruncated tool-call args as objects, sorted `byModel` leaderboard, full turns/errors.
- Report-save is timeout-resilient: `allResults` populated incrementally in `finish()`, so a mid-run test-timeout still yields a partial report (previously lost ALL reports — twice).
- `EVAL_TEMP` env override (per-scenario temperature still wins).
- `excludeFromBoard` scenario flag — run + reported, not counted in the leaderboard (known fixture bugs).

**Fixtures**
- `vague-organize-request`: getTools mock exposes storage **and** search so a search-planning model isn't trapped in an infinite getTools loop (scripted mock is selector-insensitive); domain-tool-keyed result mocks; relaxed expectations so list→move **and** search→move pass. Verified: gemma-4-31b 1307s loop → 102s PASS.
- `multi-intent-single-message`: deterministic 3-round chain (was a fixture trap); `excludeFromBoard` until re-verified.

**Docs**
- `docs/plans/gettools-loop-breaker-plan.md`: scoped production loop-breaker + tool-result decoration (not yet built).

## Findings (single-sample, mock)
- Cloud app-faithful: gemma-4-31b 91% · gemma-4-26b 89% · qwen3.6 83% · qwen3.5-9b 80% · laguna 80%.
- qwen3.5:4b **local**: ~57% board (21/37). The 4B wall is protocol comprehension (skips getTools, wrong agent/selector, malformed context envelope) — not the chain-completion satisfice that limits the big models. search→read satisfice resists system-prompt nudges (→ motivates the loop-breaker plan).

## Verification
Full suite 3647 passed; the only failure is the pre-existing `TaskBoardEditCoordinator` jsdom-Modal import (unrelated). Lint + tsc + production build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nxrNdjiUEMkX1NVroanna