### PR TITLE
Fix single wikilink corruption in setProperty/array CLI coercion

### DIFF
--- a/src/agents/contentManager/tools/setProperty.ts
+++ b/src/agents/contentManager/tools/setProperty.ts
@@ -177,7 +177,7 @@ export class SetPropertyTool extends BaseTool<SetPropertyParams, SetPropertyResu
             { type: 'boolean' },
             { type: 'array', items: { type: 'string' } }
           ],
-          description: 'Value to set. Can be a string, number, boolean, or array of strings.'
+          description: 'Value to set: a string, number, boolean, or array of strings. Pass a single value (including an Obsidian wikilink) verbatim — e.g. --value "[[Note]]" — do NOT add wrapping brackets. For multiple values use a comma-separated list: --value "[[A]],[[B]]". The CLI parses these reliably; no bracket-escaping is needed.'
         },
         mode: {
           type: 'string',

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -366,8 +366,6 @@ function coerceValue(raw: string, type: string): unknown {
  * Bare CSV like `[[A]],[[B]]` (no outer wrapper) is preserved: depth zeroes
  * out mid-string at the close of the first wikilink, so the function bails
  * and returns `raw` unchanged.
- *
- * Issue: ProfSynapse/nexus#TBD.
  */
 export function stripOuterArrayBrackets(raw: string): string {
   const trimmed = raw.trim();
@@ -474,8 +472,6 @@ export function splitCsvRespectingQuotes(input: string): string[] {
  * write the corrupted `[Note]` to frontmatter. Gating on comma presence keeps
  * `[[Note]]` intact (no comma → scalar) while still unwrapping a real wrapped
  * array like `[[[A]],[[B]],[[C]]]` (has commas → unwrap → 3 items).
- *
- * Issue: ProfSynapse/nexus#TBD.
  */
 export function splitArrayInput(raw: string): string[] {
   const direct = splitCsvRespectingQuotes(raw);

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -312,7 +312,7 @@ function coerceValue(raw: string, type: string): unknown {
     if (jsonItems !== null) {
       return jsonItems.map((item: unknown) => coerceArrayItem(item, itemType));
     }
-    return splitCsvRespectingQuotes(stripOuterArrayBrackets(raw)).map(item => coerceValue(item, itemType));
+    return splitArrayInput(raw).map(item => coerceValue(item, itemType));
   }
 
   if (type === 'object') {
@@ -340,7 +340,7 @@ function coerceValue(raw: string, type: string): unknown {
         // Malformed JSON → fall through to CSV split.
       }
     }
-    const items = splitCsvRespectingQuotes(stripOuterArrayBrackets(raw));
+    const items = splitArrayInput(raw);
     if (items.length >= 2) return items;
     if (items.length === 1) return items[0];
     return raw;
@@ -459,6 +459,34 @@ export function splitCsvRespectingQuotes(input: string): string[] {
   const trimmed = current.trim();
   if (trimmed.length > 0) items.push(trimmed);
   return items;
+}
+
+/**
+ * Split a raw CLI value into array items for an `array<...>` / `oneOfArray`
+ * slot. Bracket-unwrapping (`stripOuterArrayBrackets`) is only meaningful for a
+ * MULTI-item array, and a multi-item array always carries a top-level comma.
+ * So if the raw value has no top-level comma it is a single scalar and is
+ * returned verbatim — never unwrapped.
+ *
+ * Bug this guards: a lone Obsidian wikilink `[[Note]]` is structurally
+ * indistinguishable from a one-element array literal `[ ... ]` — both open `[`,
+ * close `]`, and balance. `stripOuterArrayBrackets` would eat the outer pair and
+ * write the corrupted `[Note]` to frontmatter. Gating on comma presence keeps
+ * `[[Note]]` intact (no comma → scalar) while still unwrapping a real wrapped
+ * array like `[[[A]],[[B]],[[C]]]` (has commas → unwrap → 3 items).
+ *
+ * Issue: ProfSynapse/nexus#TBD.
+ */
+export function splitArrayInput(raw: string): string[] {
+  const direct = splitCsvRespectingQuotes(raw);
+  // Fewer than 2 top-level items ⇒ not a multi-item array, so the outer-bracket
+  // wrapper semantics don't apply. Return the UN-stripped split: a single
+  // `[[Note]]` stays intact (brackets kept), and a zero-item empty/whitespace
+  // value yields `[]` so callers fall through to their raw-scalar handling.
+  if (direct.length < 2) return direct;
+  // 2+ items ⇒ a real array; unwrap a single outer `[...]` pair (if any) and
+  // re-split so `[[[A]],[[B]],[[C]]]` recovers its three wikilinks.
+  return splitCsvRespectingQuotes(stripOuterArrayBrackets(raw));
 }
 
 /**

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -783,7 +783,7 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       // Regression: `set-property --value "[[Note]]"` is a lone wikilink, not a
       // one-element array literal. With no top-level comma it must be treated as
       // a scalar and returned verbatim. The old strip-then-split path ate the
-      // outer pair and wrote the corrupted `[Note]`. Issue: ProfSynapse/nexus#TBD.
+      // outer pair and wrote the corrupted `[Note]`.
       const [call] = makeNormalizer().normalizeExecutionCalls({
         tool: 'one-of set-prop "[[wikilink]]"',
       });

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -779,6 +779,17 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
       expect(call.params.value).toEqual(['[[A]]', '[[B]]']);
     });
 
+    it('single Obsidian wikilink stays a scalar — both bracket pairs kept', () => {
+      // Regression: `set-property --value "[[Note]]"` is a lone wikilink, not a
+      // one-element array literal. With no top-level comma it must be treated as
+      // a scalar and returned verbatim. The old strip-then-split path ate the
+      // outer pair and wrote the corrupted `[Note]`. Issue: ProfSynapse/nexus#TBD.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'one-of set-prop "[[wikilink]]"',
+      });
+      expect(call.params.value).toBe('[[wikilink]]');
+    });
+
     it('bracket-prefix-only (no closing bracket) skips JSON and splits as CSV', () => {
       // Starts with `[` but doesn't end with `]` → the JSON branch's
       // startsWith/endsWith gate is not satisfied, so JSON.parse is never
@@ -1005,6 +1016,16 @@ describe('ToolCliNormalizer — direct parser coverage', () => {
         tool: 'storage archive --paths "[[[A]],[[B]]]"',
       });
       expect(call.params.paths).toEqual(['[[A]]', '[[B]]']);
+    });
+
+    it('single wikilink into array<string> slot — one intact element', () => {
+      // Regression: a lone `[[A]]` in an explicit array<string> slot must yield
+      // a one-element array with the wikilink intact, not the stripped `[A]`.
+      // No top-level comma ⇒ scalar ⇒ wrapped as a single item, brackets kept.
+      const [call] = makeNormalizer().normalizeExecutionCalls({
+        tool: 'storage archive --paths "[[A]]"',
+      });
+      expect(call.params.paths).toEqual(['[[A]]']);
     });
   });
 });


### PR DESCRIPTION
## Problem

A lone Obsidian wikilink passed to a CLI array/oneOf slot was being corrupted:

```
content set-property --value "[[Note]]"   →   wrote  [Note]   (one bracket pair eaten)
```

`stripOuterArrayBrackets` can't structurally distinguish a single wikilink `[[X]]` from a one-element array literal `[ ... ]` — both open `[`, close `]`, and balance — so it stripped the outer pair. The model then read the broken single-bracket link back, assumed its escaping was wrong, and looped re-trying different quotings instead of trusting the parse.

## Fix

Gate bracket-unwrapping on **multi-item** arrays. A value with fewer than two top-level comma items is a scalar and is returned verbatim (brackets kept); a real wrapped array like `[[[A]],[[B]],[[C]]]` still unwraps to its three wikilinks. Implemented as a shared `splitArrayInput` helper applied at both the `array<…>` and `oneOfArray` coercion paths in `ToolCliNormalizer`.

Verified behavior:

| input | before | after |
|---|---|---|
| `[[Note]]` | `[Note]` ❌ | `[[Note]]` ✅ |
| `[[A]],[[B]]` | `["[[A]]","[[B]]"]` | `["[[A]]","[[B]]"]` |
| `[[[A]],[[B]],[[C]]]` | `["[[A]]","[[B]]","[[C]]"]` | `["[[A]]","[[B]]","[[C]]"]` |
| `a,b,c` | `["a","b","c"]` | `["a","b","c"]` |

## Also

Documented the wikilink contract on the `setProperty.value` schema description so the model emits the right shape first time — single values (incl. wikilinks) verbatim, multiples as a comma-separated list, no bracket-escaping needed.

## Tests

Added regression cases for a single wikilink as a scalar (`oneOfArray`) and a single wikilink in an `array<string>` slot; existing multi-item and bare-CSV cases unchanged. `ToolManagerCliSyntax.test.ts` 176/176, SetProperty 21/21, build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oozmhjmbQo1xV3xXjpfED

---
_Generated by [Claude Code](https://claude.ai/code/session_019oozmhjmbQo1xV3xXjpfED)_