### PR TITLE
feat(notes-index): SQL query engine over notes + frontmatter

### DIFF
--- a/docs/plans/notes-query-index-plan.md
+++ b/docs/plans/notes-query-index-plan.md
@@ -219,15 +219,16 @@ evaluation may diverge from Bases-rendered output.) Not required for the core go
 
 ## 10. Phasing
 
-- **Phase 0 — `NotesIndexService`:** create tables in the in-memory DB, typed walk + upsert +
-  prune, `metadataCache` freshness, graceful-degrade cap. No tool yet — verify via direct SQL +
-  unit tests on a fixture vault.
-- **Phase 1 — `queryNotes` tool:** read-only SQL execution + guard + schema/describe in the tool
-  description, registered on SearchManager. **This is the usable MVP** — "get notes with these
-  properties, filter, and compute" all via agent SQL.
-- **Phase 2 — ergonomics & scale polish:** `describe` mode (distinct keys), example-query
-  library in the description, convenience SQL views for common shapes, mobile cap tuning,
-  optional separate-blob persistence if cold-rebuild proves slow.
+- **Phase 0 — DONE:** `NotesIndexService` (in-memory tables via `ensureSchema`, typed walk +
+  upsert + prune, `metadataCache` freshness, degrade cap) + pure `notesIndexMapping`. Unit-tested.
+- **Phase 1 — DONE:** `QueryNotesTool` on SearchManager (`search query-notes --sql …`) —
+  read-only SQL + guard + `describe`; `notesIndex` core service (BACKGROUND stage) runs the
+  builder at boot. **The usable MVP.** ⚠️ Unit-tested + builds, but NOT yet manually verified in
+  a live Obsidian session (startup → background walk → round-trip).
+- **Phase 2 — PARTIAL:** done — `describe` mode, transaction-wrapped per-note upsert,
+  mobile-aware degrade cap (50k mobile / 250k desktop), string/comment-stripping SQL guard.
+  Remaining — example-query library / convenience views, optional separate-blob persistence if
+  cold-rebuild proves slow, `fullRebuild` hook (the index already rebuilds at every startup).
 - **Phase 3 (optional) — `.base` interop:** `baseSet` CRUA + a `baseFile` path that loads a
   `.base` filter and runs the equivalent SQL.
 

--- a/docs/plans/notes-query-index-plan.md
+++ b/docs/plans/notes-query-index-plan.md
@@ -1,0 +1,245 @@
+# Notes Query Index — Implementation Plan
+
+**Status:** Proposed
+**Author:** research + plan, 2026-06-21
+**Branch:** `claude/practical-shannon-xbylz1`
+
+## 1. Goal
+
+Give Nexus (and the AI surface) a **database-style query over vault notes**: "get all
+notes with these frontmatter properties, filter by this, calculate that." Concretely:
+
+```
+SELECT <props/computed> FROM notes WHERE <filter on file.* + frontmatter> ORDER BY … LIMIT …
+```
+
+This is the structured/metadata query axis that complements the existing `searchContent`
+(semantic/keyword over body text) and `searchDirectory` (path/name) tools.
+
+## 2. Why not just use Obsidian's Bases API
+
+Researched and ruled out as the *query backend* (kept as an optional interop surface):
+
+- **No headless execution.** The official Bases plugin API (`obsidian.d.ts`) only lets a
+  plugin **register a custom view** (`BasesViewFactory = (controller, containerEl) => BasesView`);
+  the framework runs the query and pushes results into `view.data`. `QueryController` is not
+  plugin-instantiable. There is **no** "run this `.base` and hand me rows" call. The
+  "API access to Bases results" forum request is open, not shipped.
+- **IndexedDB is not queryable.** It only persists the serialized sql.js blob; queries run
+  against in-memory WASM SQLite hydrated from it.
+- **The SQLite cache doesn't contain notes.** Its ~20 tables (`workspaces`, `sessions`,
+  `memory_traces`, `conversations`, `tasks`, `embedding_metadata`, `skills`, …) are Nexus's
+  own event store. **There is no `notes`/frontmatter table** — the dataset Bases queries over
+  lives in Obsidian's in-memory `metadataCache`, not in our DB.
+
+**Conclusion:** the SQL engine and the freshness plumbing already exist; the missing piece is
+a *notes + frontmatter index* as SQL rows. Build that, and a query tool is a thin layer on top —
+fully headless, cross-platform (works on mobile, unlike reaching into Bases internals), and able
+to JOIN against `embedding_metadata` (semantic axis Bases can't touch).
+
+## 3. What already exists (reuse, don't rebuild)
+
+| Capability | Where | Reuse |
+|---|---|---|
+| Vault walk + frontmatter/tags/links read + **live freshness** via `metadataCache.on('changed'|'resolved')` + rename/delete handlers | `src/database/services/cache/VaultFileIndex.ts` (live service, owned by `CacheManager`, registered `cacheManager` in `ServiceDefinitions.ts:149`) | **Freshness pattern** (`setupMetadataCacheEvents`, `handleMetadataChanged`). It is in-memory Maps + lazy frontmatter, so not the storage layer — but it's the proven precedent. |
+| "Walk vault → upsert into SQLite → prune missing, preserving owned columns" | `src/agents/apps/skills/services/SkillScanner.ts` + `SkillIndexService.ts` (`syncFromScan` UPSERT + scoped prune) | **Template** for `NotesIndexService`. |
+| Debounced + coalesced vault watcher | `src/agents/apps/skills/services/SkillSyncWatcher.ts` (2000ms debounce, run-coalescing) | **Template** for the freshness loop. |
+| Schema migration | `SchemaMigrator.ts:76` (`CURRENT_SCHEMA_VERSION = 13`), `Migration { version, description, sql[], migrationFn? }`, idempotent `CREATE TABLE IF NOT EXISTS`; mirror into `schema.ts` SCHEMA_SQL for fresh installs | Add v14. |
+| Backend query API | `IStorageBackend.ts:88` `query<T>(sql, params?)`, `queryOne<T>`, `run`, `transaction`; positional `?` params | Query compiler target. Reach it the way repositories do (`BaseRepository` → `sqliteCache.query`). |
+| Full rebuild | `SyncCoordinator.fullRebuild()` clears + replays JSONL | Add a **vault-reindex step** (notes index is derived from the vault, not JSONL, so rebuild must re-walk). |
+| Tool patterns | `src/agents/searchManager/` — `BaseTool`, constructor `Plugin` injection (`this.plugin.app.metadataCache`), lazy service resolvers, `registerLazyTool`; array/object params handled by `ToolCliNormalizer` (CSV/JSON coercion) | Home + shape for `queryNotes`. |
+
+> Pinned gotcha (CLAUDE.md): tool-schema `required`/`enum` is **not** runtime-validated.
+> All field/shape guards must live in the service/normalizer layer, never the schema.
+
+## 4. Architecture decision
+
+**Chosen: SQL-backed index (`notes` + `note_properties`) + a JS formula evaluator.**
+
+Split that mirrors how Bases itself works (filters can reference formulas):
+
+- **SQL does the coarse work** — `WHERE` over file.* columns and frontmatter props
+  (existence, equality, comparison, contains), `ORDER BY`, `LIMIT`, grouping. Scales to
+  large vaults; this is the "get notes with these properties + filter" half.
+- **A small JS expression evaluator does formulas** — `if()`, date math, `number()`,
+  string/list methods — over the fetched rows. Bases formulas use method-dispatch
+  (`value.method(...)`) that doesn't translate cleanly to SQLite; this is the "calculate that" half.
+
+Rejected alternative — *extend VaultFileIndex in-memory* (eager-load all frontmatter + JS
+predicate filter): smaller, no migration, but no real aggregation, recomputed per query, no
+embeddings JOIN, weaker at scale. Keep as the fallback if Phase 0 proves the SQL index too heavy.
+
+## 5. Schema (v13 → v14)
+
+EAV model so arbitrary frontmatter keys are queryable without per-property columns.
+
+```sql
+-- one row per note
+CREATE TABLE IF NOT EXISTS notes (
+  path        TEXT PRIMARY KEY,      -- vault-relative, normalized
+  basename    TEXT NOT NULL,
+  folder      TEXT NOT NULL,
+  ext         TEXT NOT NULL,
+  title       TEXT,                  -- frontmatter title || basename
+  ctime       INTEGER NOT NULL,      -- file.stat.ctime (epoch ms)
+  mtime       INTEGER NOT NULL,      -- file.stat.mtime
+  size        INTEGER NOT NULL,
+  tags_json   TEXT,                  -- JSON array (merged frontmatter + inline tags)
+  links_json  TEXT,                  -- JSON array of outgoing link targets
+  content_hash TEXT NOT NULL,        -- hash(frontmatter + stat) — change-gate reindex
+  indexed_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_folder ON notes(folder);
+CREATE INDEX IF NOT EXISTS idx_notes_mtime  ON notes(mtime);
+
+-- one row per frontmatter property (per list element for arrays)
+CREATE TABLE IF NOT EXISTS note_properties (
+  note_path   TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
+  key         TEXT NOT NULL,         -- frontmatter key (lowercased for match; original in key_raw)
+  key_raw     TEXT NOT NULL,
+  value_text  TEXT,                  -- normalized string form (for =, contains, sort)
+  value_num   REAL,                  -- populated when numeric or date-coercible (epoch ms)
+  value_type  TEXT NOT NULL,         -- 'string'|'number'|'boolean'|'date'|'list'|'object'|'null'
+  position    INTEGER                -- list element index, else NULL
+);
+CREATE INDEX IF NOT EXISTS idx_np_key_text ON note_properties(key, value_text);
+CREATE INDEX IF NOT EXISTS idx_np_key_num  ON note_properties(key, value_num);
+CREATE INDEX IF NOT EXISTS idx_np_path     ON note_properties(note_path);
+```
+
+Add to both `SchemaMigrator.MIGRATIONS` (v14) and `schema.ts` SCHEMA_SQL; bump
+`CURRENT_SCHEMA_VERSION` to 14. Pure `CREATE TABLE/INDEX IF NOT EXISTS` (no data migration —
+the index is rebuilt from the vault on first run).
+
+**Typing pass** (the load-bearing detail): YAML frontmatter is untyped. On upsert, coerce each
+value → detect number, ISO-8601 date (→ epoch ms in `value_num`), boolean, list, object; always
+store a `value_text` for equality/contains/sort. This is what makes `due < today()` and numeric
+comparisons work in SQL.
+
+## 6. Index population & freshness — `NotesIndexService`
+
+New service modeled on `SkillIndexService` + `SkillSyncWatcher`, owning the two tables.
+
+- **Initial build (background, non-blocking):** after cache ready, walk
+  `vault.getMarkdownFiles()`, read `metadataCache.getFileCache(file)` (frontmatter + tags +
+  links), upsert `notes` + `note_properties`, content-hash-gated (skip unchanged). Batch like
+  the embeddings backfill so it doesn't stall boot on large vaults.
+- **Freshness:** subscribe to `metadataCache.on('changed')` and the vault `rename`/`delete`
+  events (same pattern as `VaultFileIndex.setupMetadataCacheEvents`), debounced + coalesced
+  (reuse `SkillSyncWatcher` shape). On change: re-upsert that note's rows; on delete: cascade.
+- **Prune:** periodic / on full rebuild — drop `notes` rows whose path no longer exists.
+- **Rebuild hook:** add a vault-reindex step to `SyncCoordinator.fullRebuild()` (and the
+  "Nexus: Rebuild cache" command) since this table is derived from the vault, not JSONL.
+- **Mobile:** `vault.getMarkdownFiles()`, `metadataCache`, sql.js all work on mobile; no Node
+  built-ins — keep it that way (no top-level npm/Node imports).
+
+## 7. Query surface (mapped to the real Bases spec)
+
+Grounded in kepano/obsidian-skills (Obsidian's official agent reference). Property namespaces:
+**note/frontmatter** (bare name), **file.*** (`name basename path folder ext ctime mtime size
+tags links`), **formula.*** (computed).
+
+**Tier 1 — ship first (pure SQL compile):**
+- Filter object `and` / `or` / `not` (recursive) + comparisons `== != > < >= <=`
+- Conditions on `file.*` columns and frontmatter props (equality, comparison, existence)
+- Functions: `file.hasTag`, `file.inFolder`, `file.hasProperty`, `string.contains`,
+  `list.contains`, `isEmpty`
+- `select` properties, `sort`, `limit`
+
+Compilation: file.* → `notes` columns; frontmatter condition → correlated
+`EXISTS (SELECT 1 FROM note_properties p WHERE p.note_path = n.path AND p.key = ? AND <op>)`;
+`and/or/not` → nested boolean SQL; numeric/date ops use `value_num`, text ops use `value_text`.
+
+**Tier 2 — formula evaluator + aggregation (JS over fetched rows):**
+- Expression evaluator with a **type-dispatched method table** (string/number/date/list/file/
+  link/object) — `if`, `date`, `today`, `now`, arithmetic, `number`, date subtraction → `.days`,
+  then `string.startsWith/endsWith/lower/replace/slice/split`, `number.round/abs/floor/ceil`,
+  `list.map/filter/join/sort/unique`, `link`/`linksTo`
+- Computed columns + filters that reference `formula.*`
+- `groupBy` + `summaries`: `Sum Average Min Max Count`
+- **Security:** a small AST parser/interpreter over a fixed function table — **never `eval()`**.
+  This is the largest build cost; scope it deliberately.
+
+**Tier 3 — later:** `cards`/`list` output shapes, `reduce`, `regexp.matches`,
+`properties.displayName`, `relative()`/`format()` date formatting, custom summary expressions.
+
+> Tolerate both filter dialects when ingesting wild `.base` files: current method forms
+> (`file.hasTag`) and older global forms (`taggedWith(...)`) from early betas.
+
+## 8. Tool: `queryNotes` (SearchManager)
+
+`BaseTool`, constructor-injected `Plugin` + a `NotesIndexService` resolver; registered via
+`registerLazyTool`. Structured params (CLI-normalizer handles array/object coercion). Validation
+guards in the service, not the schema.
+
+```jsonc
+{
+  "from": "Projects",                       // optional folder scope; default whole vault
+  "where": {                                // Bases-shaped filter object
+    "and": [
+      { "prop": "status", "op": "!=", "value": "done" },
+      { "fn": "file.hasTag", "args": ["task"] },
+      { "or": [ { "prop": "priority", "op": ">=", "value": 2 },
+                { "fn": "file.inFolder", "args": ["Urgent"] } ] }
+    ]
+  },
+  "select": ["file.name", "status", "due", "formula.days_until_due"],
+  "compute": { "days_until_due": "if(due, (date(due) - today()).days, \"\")" },
+  "sort":   [{ "by": "due", "dir": "ASC" }],
+  "groupBy": { "property": "status" },      // Tier 2
+  "limit": 100,
+  "baseFile": "Tasks.base"                  // Tier 3 alt: load filters/formulas from a .base
+}
+```
+
+Result: `{ success, rows: [{ path, ...selected, ...computed }], groups?, count }`.
+
+## 9. Optional companion: `.base` round-trip (`baseSet`)
+
+Independent, cheap, zero Bases-API dependency — a `.base` is just a YAML file
+(`vault.create`/`modify`/archive). Lets the agent author a persistent, **user-visible** database
+view the human opens in Obsidian's native Bases UI, while `queryNotes`/`baseFile` re-runs the same
+`.base` headlessly through our engine. Slot in any time after Tier 1. (Document that our evaluation
+of a `.base` may diverge from Bases-rendered output on unsupported functions.)
+
+## 10. Phasing
+
+- **Phase 0** — v14 schema + `NotesIndexService` (walk, typed upsert, prune, freshness, rebuild
+  hook). No tool. Verify via direct SQL + unit tests on a fixture vault.
+- **Phase 1** — `queryNotes` Tier 1 (SQL compile: file.* + frontmatter filters, and/or/not, sort,
+  limit, select). The usable MVP for "get notes with these properties, filter by this."
+- **Phase 2** — formula evaluator (AST interpreter) + computed columns + groupBy/summaries.
+  Delivers "calculate that."
+- **Phase 3** — `.base` ingestion (`baseFile`) + Tier 2/3 functions + `baseSet` CRUA companion.
+
+## 11. Risks & open questions
+
+- **EAV row count** — one row per property (per list element) per note. Index carefully; this is
+  the same order of data Dataview holds in memory. Validate on a large vault in Phase 0.
+- **Type coercion fidelity** — date/number detection drives all comparison correctness; needs a
+  tested coercion module (ISO dates → epoch, `value_num`).
+- **Formula evaluator scope/security** — biggest cost; fixed-function AST interpreter, no `eval`.
+  Keep Tier 1 SQL-only so the MVP ships without it.
+- **Freshness races** — `changed` fires before `resolved`; debounce/coalesce (SkillSyncWatcher).
+- **Rebuild semantics** — index is vault-derived, so `fullRebuild` must re-walk, not replay JSONL.
+- **Divergence from native Bases output** — acceptable and documented; we mirror a subset.
+- **Boot cost** — initial walk must be background + hash-gated; never block startup.
+
+## 12. Testing
+
+- Unit: typing/coercion module; filter→SQL compiler (each operator + and/or/not nesting);
+  formula evaluator per method-table type; upsert/prune/freshness on a fixture vault.
+- Integration: cold build → query; metadataCache change → re-query reflects update; rename/delete
+  cascade; `fullRebuild` repopulates; mobile (vault.adapter) smoke.
+- Eval: a few `queryNotes` cases in the LLM eval harness once Tier 1 lands.
+
+## Sources (research)
+
+- Obsidian Bases dev API surface — `obsidianmd/obsidian-api` (`obsidian.d.ts`); forum "Provide API
+  access to the results of Bases view" (open request).
+- `.base` format + functions — kepano/obsidian-skills `obsidian-bases/SKILL.md` +
+  `references/FUNCTIONS_REFERENCE.md` (Obsidian's official agent reference); Obsidian Help
+  Bases syntax/functions.
+- Codebase — `VaultFileIndex.ts`, `CacheManager.ts`, `SkillScanner/SkillIndexService/SkillSyncWatcher`,
+  `SchemaMigrator.ts:76`, `schema.ts`, `IStorageBackend.ts:88`, `SyncCoordinator.fullRebuild`,
+  `src/agents/searchManager/` tool patterns, `ToolCliNormalizer`.

--- a/docs/plans/notes-query-index-plan.md
+++ b/docs/plans/notes-query-index-plan.md
@@ -1,245 +1,222 @@
 # Notes Query Index — Implementation Plan
 
-**Status:** Proposed
-**Author:** research + plan, 2026-06-21
+**Status:** Committed design
+**Author:** research + plan, 2026-06-21 (rev. 2)
 **Branch:** `claude/practical-shannon-xbylz1`
 
 ## 1. Goal
 
-Give Nexus (and the AI surface) a **database-style query over vault notes**: "get all
-notes with these frontmatter properties, filter by this, calculate that." Concretely:
+Let the agent **return and compute data from a database** of vault notes: "get all notes
+with these frontmatter properties, filter by this, calculate that." Concretely, expose the
+vault's notes + frontmatter as **indexed SQL rows** the agent can query directly, so it can
+filter and aggregate without Nexus reimplementing a query language.
 
-```
-SELECT <props/computed> FROM notes WHERE <filter on file.* + frontmatter> ORDER BY … LIMIT …
-```
+This is the structured/metadata query axis, complementing `searchContent` (semantic/keyword
+over body text) and `searchDirectory` (path/name).
 
-This is the structured/metadata query axis that complements the existing `searchContent`
-(semantic/keyword over body text) and `searchDirectory` (path/name) tools.
+## 2. Core decisions (the short version)
 
-## 2. Why not just use Obsidian's Bases API
+1. **Index notes + frontmatter only — never body content.** Content stays on disk, read on
+   demand via `ContentManager`. Tiny rows → far higher scale ceiling.
+2. **EAV schema** (`notes` + `note_properties`) so *arbitrary* frontmatter keys are **indexed**.
+   This is the only model that gives O(log n) lookup for any property (generated columns need
+   keys known up front; a JSON column can't be indexed for arbitrary keys → full scan).
+3. **Agent writes SQL; SQLite computes.** No filter→SQL compiler, no formula evaluator. The
+   consumer is an LLM fluent in SQL, and SQLite already does `CASE`/arithmetic/aggregates/
+   `date()`. Dropping these two components removes the entire maintenance sink (no tracking of
+   Bases' evolving function set).
+4. **In-memory, rebuilt at startup, kept fresh via `metadataCache` events — not persisted in
+   the cache blob.** The index is 100% derived from the vault (like the existing
+   `VaultFileIndex`), so persistence is optional. Skipping it sidesteps the one thing that
+   actually breaks at scale (whole-DB blob serialization on save).
+5. **Right-sized to ~100–200k notes** comfortably, graceful degrade beyond. Real 1M is a
+   separate storage-engine project, explicitly out of scope.
 
-Researched and ruled out as the *query backend* (kept as an optional interop surface):
+## 3. Why not Obsidian's Bases API
 
-- **No headless execution.** The official Bases plugin API (`obsidian.d.ts`) only lets a
-  plugin **register a custom view** (`BasesViewFactory = (controller, containerEl) => BasesView`);
-  the framework runs the query and pushes results into `view.data`. `QueryController` is not
-  plugin-instantiable. There is **no** "run this `.base` and hand me rows" call. The
-  "API access to Bases results" forum request is open, not shipped.
-- **IndexedDB is not queryable.** It only persists the serialized sql.js blob; queries run
-  against in-memory WASM SQLite hydrated from it.
-- **The SQLite cache doesn't contain notes.** Its ~20 tables (`workspaces`, `sessions`,
-  `memory_traces`, `conversations`, `tasks`, `embedding_metadata`, `skills`, …) are Nexus's
-  own event store. **There is no `notes`/frontmatter table** — the dataset Bases queries over
-  lives in Obsidian's in-memory `metadataCache`, not in our DB.
+- **No headless execution.** The official Bases plugin API (`obsidian.d.ts`) only lets a plugin
+  register a *view* (`BasesViewFactory = (controller, containerEl) => BasesView`); the framework
+  runs the query and pushes results into `view.data`. `QueryController` is not plugin-instantiable.
+  There is no "run this `.base` and hand me rows." (Forum request open, not shipped.)
+- **The SQLite cache doesn't contain notes.** Its ~20 tables are Nexus's own event store; the
+  notes/frontmatter dataset lives only in Obsidian's in-memory `metadataCache`.
 
-**Conclusion:** the SQL engine and the freshness plumbing already exist; the missing piece is
-a *notes + frontmatter index* as SQL rows. Build that, and a query tool is a thin layer on top —
-fully headless, cross-platform (works on mobile, unlike reaching into Bases internals), and able
-to JOIN against `embedding_metadata` (semantic axis Bases can't touch).
+Bases is kept as an optional *interop* surface (§9), not the query backend.
 
-## 3. What already exists (reuse, don't rebuild)
+## 4. Scale analysis (why the limits are where they are)
 
-| Capability | Where | Reuse |
+Per note: one `notes` row (~300–500 B incl. `frontmatter_json`) + ~6 EAV rows (~150 B each).
+With indexes, ~2.5–3.5 KB/note all-in.
+
+| Notes | ~DB size | Status |
 |---|---|---|
-| Vault walk + frontmatter/tags/links read + **live freshness** via `metadataCache.on('changed'|'resolved')` + rename/delete handlers | `src/database/services/cache/VaultFileIndex.ts` (live service, owned by `CacheManager`, registered `cacheManager` in `ServiceDefinitions.ts:149`) | **Freshness pattern** (`setupMetadataCacheEvents`, `handleMetadataChanged`). It is in-memory Maps + lazy frontmatter, so not the storage layer — but it's the proven precedent. |
-| "Walk vault → upsert into SQLite → prune missing, preserving owned columns" | `src/agents/apps/skills/services/SkillScanner.ts` + `SkillIndexService.ts` (`syncFromScan` UPSERT + scoped prune) | **Template** for `NotesIndexService`. |
-| Debounced + coalesced vault watcher | `src/agents/apps/skills/services/SkillSyncWatcher.ts` (2000ms debounce, run-coalescing) | **Template** for the freshness loop. |
-| Schema migration | `SchemaMigrator.ts:76` (`CURRENT_SCHEMA_VERSION = 13`), `Migration { version, description, sql[], migrationFn? }`, idempotent `CREATE TABLE IF NOT EXISTS`; mirror into `schema.ts` SCHEMA_SQL for fresh installs | Add v14. |
-| Backend query API | `IStorageBackend.ts:88` `query<T>(sql, params?)`, `queryOne<T>`, `run`, `transaction`; positional `?` params | Query compiler target. Reach it the way repositories do (`BaseRepository` → `sqliteCache.query`). |
-| Full rebuild | `SyncCoordinator.fullRebuild()` clears + replays JSONL | Add a **vault-reindex step** (notes index is derived from the vault, not JSONL, so rebuild must re-walk). |
-| Tool patterns | `src/agents/searchManager/` — `BaseTool`, constructor `Plugin` injection (`this.plugin.app.metadataCache`), lazy service resolvers, `registerLazyTool`; array/object params handled by `ToolCliNormalizer` (CSV/JSON coercion) | Home + shape for `queryNotes`. |
+| 50k | ~150 MB | comfortable |
+| 100k | ~300 MB | **comfortable ceiling** |
+| 300k | ~1 GB | risky |
+| 1M | ~3 GB | different architecture |
 
-> Pinned gotcha (CLAUDE.md): tool-schema `required`/`enum` is **not** runtime-validated.
-> All field/shape guards must live in the service/normalizer layer, never the schema.
+What breaks, in order:
 
-## 4. Architecture decision
+1. **Query — not the limit.** EAV indexed on `(key, value_text)`/`(key, value_num)` → filters
+   are index seeks, single-digit-ms even at 500k+ rows.
+2. **In-memory size (~100–200k).** sql.js holds the whole DB in WASM linear memory (≈4 GB hard
+   cap, unhappy well before). → comfortable to ~100–200k.
+3. **Blob save (~300–500k) — the hard wall, which we avoid.** Persisting sql.js rewrites the
+   *entire* DB blob to IndexedDB on every save. **Decision #4 removes this** by not persisting
+   the notes tables — they rebuild in memory at startup.
 
-**Chosen: SQL-backed index (`notes` + `note_properties`) + a JS formula evaluator.**
+Obsidian itself (metadataCache/explorer/graph) strains well before 1M, so ~100–200k covers
+essentially every real vault, power users included.
 
-Split that mirrors how Bases itself works (filters can reference formulas):
-
-- **SQL does the coarse work** — `WHERE` over file.* columns and frontmatter props
-  (existence, equality, comparison, contains), `ORDER BY`, `LIMIT`, grouping. Scales to
-  large vaults; this is the "get notes with these properties + filter" half.
-- **A small JS expression evaluator does formulas** — `if()`, date math, `number()`,
-  string/list methods — over the fetched rows. Bases formulas use method-dispatch
-  (`value.method(...)`) that doesn't translate cleanly to SQLite; this is the "calculate that" half.
-
-Rejected alternative — *extend VaultFileIndex in-memory* (eager-load all frontmatter + JS
-predicate filter): smaller, no migration, but no real aggregation, recomputed per query, no
-embeddings JOIN, weaker at scale. Keep as the fallback if Phase 0 proves the SQL index too heavy.
-
-## 5. Schema (v13 → v14)
-
-EAV model so arbitrary frontmatter keys are queryable without per-property columns.
+## 5. Schema (in-memory tables; not in the persisted blob)
 
 ```sql
--- one row per note
+-- one row per note. integer id keeps the EAV table small (no repeated TEXT path).
 CREATE TABLE IF NOT EXISTS notes (
-  path        TEXT PRIMARY KEY,      -- vault-relative, normalized
+  id          INTEGER PRIMARY KEY,    -- surrogate; FK target for note_properties
+  path        TEXT NOT NULL UNIQUE,   -- vault-relative, normalized
   basename    TEXT NOT NULL,
   folder      TEXT NOT NULL,
   ext         TEXT NOT NULL,
-  title       TEXT,                  -- frontmatter title || basename
-  ctime       INTEGER NOT NULL,      -- file.stat.ctime (epoch ms)
-  mtime       INTEGER NOT NULL,      -- file.stat.mtime
+  title       TEXT,                   -- frontmatter title || basename
+  ctime       INTEGER NOT NULL,       -- epoch ms
+  mtime       INTEGER NOT NULL,
   size        INTEGER NOT NULL,
-  tags_json   TEXT,                  -- JSON array (merged frontmatter + inline tags)
-  links_json  TEXT,                  -- JSON array of outgoing link targets
-  content_hash TEXT NOT NULL,        -- hash(frontmatter + stat) — change-gate reindex
-  indexed_at  INTEGER NOT NULL
+  tags_json   TEXT,                   -- JSON array (frontmatter + inline tags)
+  links_json  TEXT,                   -- JSON array of outgoing link targets
+  frontmatter_json TEXT,              -- whole frontmatter as JSON (for projection via json_extract)
+  content_hash TEXT NOT NULL          -- hash(frontmatter + stat) → change-gate re-index
 );
 CREATE INDEX IF NOT EXISTS idx_notes_folder ON notes(folder);
 CREATE INDEX IF NOT EXISTS idx_notes_mtime  ON notes(mtime);
 
--- one row per frontmatter property (per list element for arrays)
+-- one row per frontmatter property (per list element for arrays). THE indexed filter path.
 CREATE TABLE IF NOT EXISTS note_properties (
-  note_path   TEXT NOT NULL REFERENCES notes(path) ON DELETE CASCADE,
-  key         TEXT NOT NULL,         -- frontmatter key (lowercased for match; original in key_raw)
-  key_raw     TEXT NOT NULL,
-  value_text  TEXT,                  -- normalized string form (for =, contains, sort)
-  value_num   REAL,                  -- populated when numeric or date-coercible (epoch ms)
-  value_type  TEXT NOT NULL,         -- 'string'|'number'|'boolean'|'date'|'list'|'object'|'null'
-  position    INTEGER                -- list element index, else NULL
+  note_id     INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+  key         TEXT NOT NULL,          -- lowercased for matching
+  key_raw     TEXT NOT NULL,          -- original case
+  value_text  TEXT,                   -- normalized string form (=, contains, sort)
+  value_num   REAL,                   -- numeric or date-coerced (epoch ms)
+  value_type  TEXT NOT NULL,          -- 'string'|'number'|'boolean'|'date'|'list'|'object'|'null'
+  position    INTEGER                 -- list element index, else NULL
 );
 CREATE INDEX IF NOT EXISTS idx_np_key_text ON note_properties(key, value_text);
 CREATE INDEX IF NOT EXISTS idx_np_key_num  ON note_properties(key, value_num);
-CREATE INDEX IF NOT EXISTS idx_np_path     ON note_properties(note_path);
+CREATE INDEX IF NOT EXISTS idx_np_note     ON note_properties(note_id);
 ```
 
-Add to both `SchemaMigrator.MIGRATIONS` (v14) and `schema.ts` SCHEMA_SQL; bump
-`CURRENT_SCHEMA_VERSION` to 14. Pure `CREATE TABLE/INDEX IF NOT EXISTS` (no data migration —
-the index is rebuilt from the vault on first run).
+- **Division of labour:** filter via **EAV** (indexed, any key); project/return via
+  **`frontmatter_json`** + `json_extract` on the already-filtered small set; compute via SQL.
+- **Typing pass (load-bearing):** YAML frontmatter is untyped — on upsert, coerce each value
+  (number; ISO-8601 date → epoch ms in `value_num`; boolean; list → one row per element; object),
+  always storing a `value_text`. This is what makes `due < <epoch>` and numeric comparisons work.
+- **No schema migration / `CURRENT_SCHEMA_VERSION` bump:** these tables are created in the
+  in-memory DB at startup, not part of the persisted v-schema. (`CREATE TABLE IF NOT EXISTS`.)
 
-**Typing pass** (the load-bearing detail): YAML frontmatter is untyped. On upsert, coerce each
-value → detect number, ISO-8601 date (→ epoch ms in `value_num`), boolean, list, object; always
-store a `value_text` for equality/contains/sort. This is what makes `due < today()` and numeric
-comparisons work in SQL.
+## 6. `NotesIndexService` — build, freshness, lifecycle
 
-## 6. Index population & freshness — `NotesIndexService`
+Modeled on the live `VaultFileIndex` (freshness) + `SkillIndexService`/`SkillSyncWatcher`
+(upsert/prune/debounce). Owns the two tables in the existing in-memory sql.js instance.
 
-New service modeled on `SkillIndexService` + `SkillSyncWatcher`, owning the two tables.
+- **Startup build (background, non-blocking):** after cache ready, create the tables, walk
+  `vault.getMarkdownFiles()`, read `metadataCache.getFileCache()` (frontmatter + tags + links),
+  typed-upsert `notes` + `note_properties`. Batched so it never stalls boot. A few seconds at
+  100k is acceptable.
+- **Freshness:** subscribe to `metadataCache.on('changed')` + vault `rename`/`delete`
+  (the `VaultFileIndex.setupMetadataCacheEvents` pattern), debounced + coalesced
+  (`SkillSyncWatcher` shape). On change → re-upsert that note; on delete/rename → cascade.
+- **Not persisted:** the notes tables are excluded from the cache blob save; they rebuild from
+  the vault each launch. (If cold-rebuild time ever bites on huge vaults, persist them in a
+  *separate* sql.js blob on an idle debounce — deferred, not built now.)
+- **Graceful degrade:** above a configurable cap (default ~250k notes) skip the persistent index
+  build and warn; queries can fall back to bounded on-demand scans. Never crash.
+- **Mobile:** `getMarkdownFiles()`, `metadataCache`, sql.js all run on mobile; no Node built-ins,
+  no top-level npm imports. Lower comfortable cap on mobile (~25–50k) via the same setting.
 
-- **Initial build (background, non-blocking):** after cache ready, walk
-  `vault.getMarkdownFiles()`, read `metadataCache.getFileCache(file)` (frontmatter + tags +
-  links), upsert `notes` + `note_properties`, content-hash-gated (skip unchanged). Batch like
-  the embeddings backfill so it doesn't stall boot on large vaults.
-- **Freshness:** subscribe to `metadataCache.on('changed')` and the vault `rename`/`delete`
-  events (same pattern as `VaultFileIndex.setupMetadataCacheEvents`), debounced + coalesced
-  (reuse `SkillSyncWatcher` shape). On change: re-upsert that note's rows; on delete: cascade.
-- **Prune:** periodic / on full rebuild — drop `notes` rows whose path no longer exists.
-- **Rebuild hook:** add a vault-reindex step to `SyncCoordinator.fullRebuild()` (and the
-  "Nexus: Rebuild cache" command) since this table is derived from the vault, not JSONL.
-- **Mobile:** `vault.getMarkdownFiles()`, `metadataCache`, sql.js all work on mobile; no Node
-  built-ins — keep it that way (no top-level npm/Node imports).
-
-## 7. Query surface (mapped to the real Bases spec)
-
-Grounded in kepano/obsidian-skills (Obsidian's official agent reference). Property namespaces:
-**note/frontmatter** (bare name), **file.*** (`name basename path folder ext ctime mtime size
-tags links`), **formula.*** (computed).
-
-**Tier 1 — ship first (pure SQL compile):**
-- Filter object `and` / `or` / `not` (recursive) + comparisons `== != > < >= <=`
-- Conditions on `file.*` columns and frontmatter props (equality, comparison, existence)
-- Functions: `file.hasTag`, `file.inFolder`, `file.hasProperty`, `string.contains`,
-  `list.contains`, `isEmpty`
-- `select` properties, `sort`, `limit`
-
-Compilation: file.* → `notes` columns; frontmatter condition → correlated
-`EXISTS (SELECT 1 FROM note_properties p WHERE p.note_path = n.path AND p.key = ? AND <op>)`;
-`and/or/not` → nested boolean SQL; numeric/date ops use `value_num`, text ops use `value_text`.
-
-**Tier 2 — formula evaluator + aggregation (JS over fetched rows):**
-- Expression evaluator with a **type-dispatched method table** (string/number/date/list/file/
-  link/object) — `if`, `date`, `today`, `now`, arithmetic, `number`, date subtraction → `.days`,
-  then `string.startsWith/endsWith/lower/replace/slice/split`, `number.round/abs/floor/ceil`,
-  `list.map/filter/join/sort/unique`, `link`/`linksTo`
-- Computed columns + filters that reference `formula.*`
-- `groupBy` + `summaries`: `Sum Average Min Max Count`
-- **Security:** a small AST parser/interpreter over a fixed function table — **never `eval()`**.
-  This is the largest build cost; scope it deliberately.
-
-**Tier 3 — later:** `cards`/`list` output shapes, `reduce`, `regexp.matches`,
-`properties.displayName`, `relative()`/`format()` date formatting, custom summary expressions.
-
-> Tolerate both filter dialects when ingesting wild `.base` files: current method forms
-> (`file.hasTag`) and older global forms (`taggedWith(...)`) from early betas.
-
-## 8. Tool: `queryNotes` (SearchManager)
+## 7. Tool: `queryNotes` (SearchManager) — read-only SQL
 
 `BaseTool`, constructor-injected `Plugin` + a `NotesIndexService` resolver; registered via
-`registerLazyTool`. Structured params (CLI-normalizer handles array/object coercion). Validation
-guards in the service, not the schema.
+`registerLazyTool`. The agent passes SQL; the tool runs it read-only and returns rows.
 
 ```jsonc
-{
-  "from": "Projects",                       // optional folder scope; default whole vault
-  "where": {                                // Bases-shaped filter object
-    "and": [
-      { "prop": "status", "op": "!=", "value": "done" },
-      { "fn": "file.hasTag", "args": ["task"] },
-      { "or": [ { "prop": "priority", "op": ">=", "value": 2 },
-                { "fn": "file.inFolder", "args": ["Urgent"] } ] }
-    ]
-  },
-  "select": ["file.name", "status", "due", "formula.days_until_due"],
-  "compute": { "days_until_due": "if(due, (date(due) - today()).days, \"\")" },
-  "sort":   [{ "by": "due", "dir": "ASC" }],
-  "groupBy": { "property": "status" },      // Tier 2
-  "limit": 100,
-  "baseFile": "Tasks.base"                  // Tier 3 alt: load filters/formulas from a .base
-}
+// execute params
+{ "sql": "SELECT n.path, json_extract(n.frontmatter_json,'$.status') AS status FROM notes n WHERE EXISTS (SELECT 1 FROM note_properties p WHERE p.note_id=n.id AND p.key='status' AND p.value_text='active') ORDER BY n.mtime DESC LIMIT 50",
+  "params": [] }
+// result
+{ "success": true, "columns": [...], "rows": [...], "rowCount": N }
 ```
 
-Result: `{ success, rows: [{ path, ...selected, ...computed }], groups?, count }`.
+- **Read-only guard (in the service, never the schema — per the no-runtime-schema-validation
+  rule):** reject anything that isn't a single `SELECT`/`WITH` statement; block
+  `INSERT/UPDATE/DELETE/DROP/ALTER/CREATE/ATTACH/PRAGMA` and multiple statements. The notes
+  tables live in the shared cache DB, so this guard protects the *whole* cache. (Upside of the
+  shared instance: the agent can JOIN notes against `tasks`/`conversations`/`embedding_metadata`.)
+  The index is rebuildable anyway, so worst case is recoverable — but guard regardless.
+- **Agent ergonomics:** the tool description carries the schema (column list + "filter via
+  `note_properties`, project via `json_extract(frontmatter_json,'$.key')`, dates are epoch ms in
+  `value_num`") and 2–3 example queries. Optionally a `describe` mode returns the live schema +
+  the set of distinct `key`s present. LLMs drive SQLite reliably; SQL errors self-correct on retry.
+- **Compute is free:** `CASE`/arithmetic for `if`-style derivations, `SUM/AVG/MIN/MAX/COUNT … GROUP BY`
+  for rollups, `julianday()`/`date()` for date math — all native SQLite, nothing for us to maintain.
+
+## 8. What we deliberately do NOT build
+
+- ❌ Filter→SQL compiler (agent writes the `WHERE`).
+- ❌ Formula/expression evaluator + Bases function table (SQLite + agent SQL replace it).
+- ❌ Schema migration / blob persistence for the index (in-memory rebuild instead).
+- ❌ Body-content indexing (`searchContent` owns that; content read on demand).
 
 ## 9. Optional companion: `.base` round-trip (`baseSet`)
 
 Independent, cheap, zero Bases-API dependency — a `.base` is just a YAML file
 (`vault.create`/`modify`/archive). Lets the agent author a persistent, **user-visible** database
-view the human opens in Obsidian's native Bases UI, while `queryNotes`/`baseFile` re-runs the same
-`.base` headlessly through our engine. Slot in any time after Tier 1. (Document that our evaluation
-of a `.base` may diverge from Bases-rendered output on unsupported functions.)
+view the human opens in Obsidian's native Bases UI. Slot in any time. (Document that our SQL
+evaluation may diverge from Bases-rendered output.) Not required for the core goal.
 
 ## 10. Phasing
 
-- **Phase 0** — v14 schema + `NotesIndexService` (walk, typed upsert, prune, freshness, rebuild
-  hook). No tool. Verify via direct SQL + unit tests on a fixture vault.
-- **Phase 1** — `queryNotes` Tier 1 (SQL compile: file.* + frontmatter filters, and/or/not, sort,
-  limit, select). The usable MVP for "get notes with these properties, filter by this."
-- **Phase 2** — formula evaluator (AST interpreter) + computed columns + groupBy/summaries.
-  Delivers "calculate that."
-- **Phase 3** — `.base` ingestion (`baseFile`) + Tier 2/3 functions + `baseSet` CRUA companion.
+- **Phase 0 — `NotesIndexService`:** create tables in the in-memory DB, typed walk + upsert +
+  prune, `metadataCache` freshness, graceful-degrade cap. No tool yet — verify via direct SQL +
+  unit tests on a fixture vault.
+- **Phase 1 — `queryNotes` tool:** read-only SQL execution + guard + schema/describe in the tool
+  description, registered on SearchManager. **This is the usable MVP** — "get notes with these
+  properties, filter, and compute" all via agent SQL.
+- **Phase 2 — ergonomics & scale polish:** `describe` mode (distinct keys), example-query
+  library in the description, convenience SQL views for common shapes, mobile cap tuning,
+  optional separate-blob persistence if cold-rebuild proves slow.
+- **Phase 3 (optional) — `.base` interop:** `baseSet` CRUA + a `baseFile` path that loads a
+  `.base` filter and runs the equivalent SQL.
 
 ## 11. Risks & open questions
 
-- **EAV row count** — one row per property (per list element) per note. Index carefully; this is
-  the same order of data Dataview holds in memory. Validate on a large vault in Phase 0.
-- **Type coercion fidelity** — date/number detection drives all comparison correctness; needs a
-  tested coercion module (ISO dates → epoch, `value_num`).
-- **Formula evaluator scope/security** — biggest cost; fixed-function AST interpreter, no `eval`.
-  Keep Tier 1 SQL-only so the MVP ships without it.
-- **Freshness races** — `changed` fires before `resolved`; debounce/coalesce (SkillSyncWatcher).
-- **Rebuild semantics** — index is vault-derived, so `fullRebuild` must re-walk, not replay JSONL.
-- **Divergence from native Bases output** — acceptable and documented; we mirror a subset.
-- **Boot cost** — initial walk must be background + hash-gated; never block startup.
+- **Typing/coercion fidelity** drives all comparison correctness (ISO date → epoch). Needs a
+  tested coercion module — the main correctness surface now that there's no evaluator.
+- **Cold-rebuild time** at the top of the range (100–200k): must be background + hash-gated;
+  measure, and only add separate-blob persistence if it actually bites.
+- **Agent SQL quality:** EAV `EXISTS` filters are slightly verbose; mitigate with schema docs,
+  examples, and optional views. SQL errors self-correct — a better failure mode than a DSL
+  silently returning wrong numbers.
+- **Shared-DB blast radius:** read-only guard must be airtight since the notes tables share the
+  cache instance. (Alternative: isolate in a separate sql.js instance — costs the cross-table
+  JOIN upside; default to shared + strict guard.)
+- **List/object properties:** lists → one EAV row per element (enables `contains`); deeply nested
+  objects stay in `frontmatter_json` only (queried via `json_extract`).
 
 ## 12. Testing
 
-- Unit: typing/coercion module; filter→SQL compiler (each operator + and/or/not nesting);
-  formula evaluator per method-table type; upsert/prune/freshness on a fixture vault.
-- Integration: cold build → query; metadataCache change → re-query reflects update; rename/delete
-  cascade; `fullRebuild` repopulates; mobile (vault.adapter) smoke.
-- Eval: a few `queryNotes` cases in the LLM eval harness once Tier 1 lands.
+- Unit: typing/coercion module; upsert/prune/freshness on a fixture vault; read-only SQL guard
+  (accept SELECT/WITH, reject writes/PRAGMA/ATTACH/multi-statement).
+- Integration: cold build → query; `metadataCache` change → re-query reflects update;
+  rename/delete cascade; graceful-degrade cap; mobile (`vault.adapter`) smoke.
+- Eval: a few `queryNotes` cases in the LLM eval harness once Phase 1 lands.
 
 ## Sources (research)
 
-- Obsidian Bases dev API surface — `obsidianmd/obsidian-api` (`obsidian.d.ts`); forum "Provide API
-  access to the results of Bases view" (open request).
-- `.base` format + functions — kepano/obsidian-skills `obsidian-bases/SKILL.md` +
-  `references/FUNCTIONS_REFERENCE.md` (Obsidian's official agent reference); Obsidian Help
-  Bases syntax/functions.
-- Codebase — `VaultFileIndex.ts`, `CacheManager.ts`, `SkillScanner/SkillIndexService/SkillSyncWatcher`,
-  `SchemaMigrator.ts:76`, `schema.ts`, `IStorageBackend.ts:88`, `SyncCoordinator.fullRebuild`,
+- Bases dev API surface — `obsidianmd/obsidian-api` (`obsidian.d.ts`); forum "Provide API access
+  to the results of Bases view" (open).
+- `.base` format/functions — kepano/obsidian-skills `obsidian-bases` SKILL + FUNCTIONS_REFERENCE
+  (Obsidian's official agent reference); Obsidian Help.
+- Codebase — `VaultFileIndex.ts` (live freshness precedent, `CacheManager`/`ServiceDefinitions.ts:149`),
+  `SkillScanner`/`SkillIndexService`/`SkillSyncWatcher` (walk→upsert→prune→debounce),
+  `IStorageBackend.ts:88` (`query`/`queryOne`/`run`), `SyncCoordinator.fullRebuild`,
   `src/agents/searchManager/` tool patterns, `ToolCliNormalizer`.

--- a/docs/plans/notes-query-index-plan.md
+++ b/docs/plans/notes-query-index-plan.md
@@ -159,6 +159,50 @@ Modeled on the live `VaultFileIndex` (freshness) + `SkillIndexService`/`SkillSyn
 - **Compute is free:** `CASE`/arithmetic for `if`-style derivations, `SUM/AVG/MIN/MAX/COUNT … GROUP BY`
   for rollups, `julianday()`/`date()` for date math — all native SQLite, nothing for us to maintain.
 
+## 7.1 Tool surface & placement (call shape + home)
+
+Grounded in the live CLI-first contract (`ToolCliNormalizer.buildCliSchema:745`,
+`normalizeExecutionCalls:732`; example invocation `tests/eval/fixtures/mock-responses.ts:141`).
+
+**Call shape — CLI-first.** The agent calls `useTools` with a top-level `tool` **string that is
+a CLI command**, context fields alongside it (not a JSON args object):
+
+```jsonc
+useTools({
+  tool: "search query-notes --sql \"SELECT n.path, json_extract(n.frontmatter_json,'$.status') AS status FROM notes n WHERE EXISTS (SELECT 1 FROM note_properties p WHERE p.note_id=n.id AND p.key='status' AND p.value_text='active') ORDER BY n.mtime DESC LIMIT 50\"",
+  workspaceId: "...", sessionId: "...", memory: "...", goal: "..."   // context stays top-level
+})
+```
+
+- **Base command** = `<agent-alias> <tool-slug-kebab>`. SearchManager's alias is `search`
+  (cf. `contentManager` → `content`), so `queryNotes` → **`search query-notes`**.
+- **`--sql` is a flag, not positional.** `buildCliSchema:755` makes a `required` string param
+  *positional*; a SQL blob full of quotes is awkward positionally, so `sql` is declared
+  **not-required** in the schema and presence is enforced in the service. This matches the house
+  rule (schema `required` is not runtime-validated — guards live in the service/normalizer).
+- **Internal id** (appears in results) = `searchManager_queryNotes` (cf. `contentManager_read`).
+- **Result** stays in the `{ success, … }` convention: `{ success, columns, rows, rowCount }`.
+  Per-tool `getResultSchema()` means this tool's arbitrary-column shape doesn't conflict with the
+  file/snippet shapes of its SearchManager siblings.
+
+**Home — SearchManager (tool) + core service (index).**
+
+- **Tool on SearchManager.** It is the retrieval/query agent (`searchContent` semantic,
+  `searchDirectory` path/name, `searchMemory` SQLite-backed). `queryNotes` is the 4th modality —
+  structured frontmatter query — and matches the agent's discovery mental model. `searchMemory`
+  already establishes the "SearchManager tool runs SQL via an injected resolver" precedent.
+- **Not StorageManager** — that agent is filesystem *mutation* (list/move/copy/archive); a
+  read-only query is a poor fit.
+- **Not its own agent yet** — a dedicated `DatabaseManager` costs `AgentInitializationService` +
+  `AgentRegistrationService` wiring for a single tool. Justified only once a *family* emerges
+  (`queryNotes` + `describe` + `baseSet` + cross-table `runSql`); promotion is cheap because the
+  service is independent.
+- **`NotesIndexService` is a core service, not inside the agent.** It has a real lifecycle
+  (startup build, `metadataCache` subscriptions, degrade cap), so it registers in
+  `ServiceDefinitions.ts` like `cacheManager`, and the tool receives it via a lazy resolver —
+  the same pattern `SearchMemoryTool` uses for its storage adapter (`searchManager.ts:154`
+  `registerLazyTool`). Keeps the agent a thin tool host.
+
 ## 8. What we deliberately do NOT build
 
 - ❌ Filter→SQL compiler (agent writes the `WHERE`).

--- a/src/agents/searchManager/searchManager.ts
+++ b/src/agents/searchManager/searchManager.ts
@@ -3,8 +3,10 @@ import { BaseAgent } from '../baseAgent';
 import {
   SearchContentTool,
   SearchDirectoryTool,
-  SearchMemoryTool
+  SearchMemoryTool,
+  QueryNotesTool
 } from './tools';
+import type { SQLiteCacheManager } from '../../database/storage/SQLiteCacheManager';
 import { MemorySettings, DEFAULT_MEMORY_SETTINGS } from '../../types';
 import { MemoryService } from "../memoryManager/services/MemoryService";
 import { WorkspaceService } from '../../services/WorkspaceService';
@@ -162,6 +164,22 @@ export class SearchManagerAgent extends BaseAgent {
         this.storageAdapterResolver || undefined
       ),
     });
+
+    this.registerLazyTool({
+      slug: 'queryNotes', name: 'Query Notes',
+      description: 'Run a read-only SQL SELECT over the notes index — your vault\'s notes + frontmatter as a queryable database. Filter by arbitrary frontmatter properties, compute aggregates, and sort/group, all in SQL (SQLite does the work; there is no separate query language).\n\nTABLES:\n- notes(n): id, path, basename, folder, ext, title, ctime, mtime, size, tags_json, links_json, frontmatter_json (ctime/mtime are epoch ms).\n- note_properties(p): note_id, key, key_raw, value_text, value_num, value_type, position — one row per frontmatter property (per list element). This is the INDEXED filter path.\n\nPATTERNS:\n- Filter by a property: ... WHERE EXISTS (SELECT 1 FROM note_properties p WHERE p.note_id = n.id AND p.key = \'status\' AND p.value_text = \'active\').\n- Dates/numbers: compare p.value_num (dates stored as epoch ms).\n- Project a value: SELECT json_extract(n.frontmatter_json, \'$.status\') AS status FROM notes n.\n\nOnly a single SELECT/WITH statement is allowed. Pass describe=true to get live columns + the distinct property keys present in the vault.',
+      version: '1.0.0',
+      factory: () => new QueryNotesTool(
+        () => this.resolveSqliteCache()
+      ),
+    });
+  }
+
+  /** Resolve the shared SQLite cache from the storage adapter, for QueryNotesTool. */
+  private resolveSqliteCache(): SQLiteCacheManager | undefined {
+    const adapter = this.storageAdapterResolver?.();
+    const provider = adapter as unknown as { getSqliteCache?: () => SQLiteCacheManager } | undefined;
+    return typeof provider?.getSqliteCache === 'function' ? provider.getSqliteCache() : undefined;
   }
 
   private setStorageAdapterResolver(storageAdapter?: StorageAdapterResolver | null): void {

--- a/src/agents/searchManager/tools/index.ts
+++ b/src/agents/searchManager/tools/index.ts
@@ -2,3 +2,4 @@
 export * from './searchContent';
 export * from './searchDirectory';
 export * from './searchMemory';
+export * from './queryNotes';

--- a/src/agents/searchManager/tools/queryNotes.ts
+++ b/src/agents/searchManager/tools/queryNotes.ts
@@ -1,0 +1,180 @@
+/**
+ * QueryNotesTool — read-only SQL over the notes query index.
+ *
+ * Located at: src/agents/searchManager/tools/queryNotes.ts
+ * The agent writes a SELECT against the `notes` + `note_properties` tables (and
+ * may JOIN other cache tables); SQLite does the filtering + computation. There
+ * is deliberately NO query DSL or formula evaluator — see
+ * docs/plans/notes-query-index-plan.md §2 / §7 / §7.1.
+ *
+ * Safety: a read-only guard (single SELECT/WITH statement, no write/DDL/PRAGMA)
+ * lives here in the tool, NOT in the schema — schema `required`/`enum` is not
+ * runtime-validated in this codebase, so all guards must be code.
+ */
+
+import { BaseTool } from '../../baseTool';
+import { CommonParameters, CommonResult } from '../../../types';
+import { JSONSchema } from '../../../types/schema/JSONSchemaTypes';
+import type { SQLiteCacheManager } from '../../../database/storage/SQLiteCacheManager';
+
+/** Resolver for the shared SQLite cache (same instance the index lives in). */
+export type SqliteResolver = () => SQLiteCacheManager | undefined;
+
+export interface QueryNotesParams extends CommonParameters {
+  /** A single read-only SELECT / WITH statement. */
+  sql?: string;
+  /** Positional bind parameters for `?` placeholders. */
+  params?: Array<string | number | boolean | null>;
+  /** Cap on returned rows (default 500, max 5000). Excess sets `truncated`. */
+  maxRows?: number;
+  /** When true, return the index schema + distinct property keys instead of running `sql`. */
+  describe?: boolean;
+}
+
+const DEFAULT_MAX_ROWS = 500;
+const HARD_MAX_ROWS = 5000;
+
+/** Statements other than a leading SELECT/WITH, or these keywords anywhere, are rejected. */
+const FORBIDDEN = /\b(insert|update|delete|drop|alter|create|attach|detach|pragma|reindex|vacuum|replace|truncate|grant|revoke|begin|commit|rollback)\b/i;
+
+export class QueryNotesTool extends BaseTool<QueryNotesParams, CommonResult> {
+  constructor(private readonly sqliteResolver: SqliteResolver) {
+    super(
+      'queryNotes',
+      'Query Notes',
+      'Run a read-only SQL SELECT over the notes index (frontmatter as a database).',
+      '1.0.0'
+    );
+  }
+
+  async execute(params: QueryNotesParams): Promise<CommonResult> {
+    const sqlite = this.sqliteResolver();
+    if (!sqlite) {
+      return this.prepareResult(false, undefined, 'Notes index is unavailable (storage still initializing). Try again in a moment.');
+    }
+
+    try {
+      if (params.describe) {
+        return this.prepareResult(true, await this.describe(sqlite));
+      }
+
+      const sql = typeof params.sql === 'string' ? params.sql.trim() : '';
+      if (!sql) {
+        return this.prepareResult(false, undefined, 'sql is required. Example: search query-notes --sql "SELECT path FROM notes LIMIT 10". Use --describe to see the schema.');
+      }
+
+      const guard = assertReadOnlySelect(sql);
+      if (!guard.ok) {
+        return this.prepareResult(false, undefined, guard.error);
+      }
+
+      const maxRows = clampRows(params.maxRows);
+      const bind = Array.isArray(params.params) ? params.params : [];
+      const all = await sqlite.query<Record<string, unknown>>(sql, bind);
+      const rows = all.slice(0, maxRows);
+      const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
+
+      return this.prepareResult(true, {
+        columns,
+        rows,
+        rowCount: rows.length,
+        truncated: all.length > rows.length,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const hint = /no such table/i.test(message)
+        ? ' (the notes index may not be built yet — try again shortly)'
+        : '';
+      return this.prepareResult(false, undefined, `Query failed: ${message}${hint}`);
+    }
+  }
+
+  /** Schema + distinct property keys, so the agent can author queries without guessing. */
+  private async describe(sqlite: SQLiteCacheManager): Promise<Record<string, unknown>> {
+    let noteCount = 0;
+    let keys: string[] = [];
+    try {
+      noteCount = (await sqlite.queryOne<{ n: number }>('SELECT COUNT(*) AS n FROM notes', []))?.n ?? 0;
+      const rows = await sqlite.query<{ key: string }>('SELECT DISTINCT key FROM note_properties ORDER BY key LIMIT 500', []);
+      keys = rows.map((r) => r.key);
+    } catch {
+      // tables not built yet — return the static shape with an empty key set
+    }
+
+    return {
+      tables: {
+        notes: ['id', 'path', 'basename', 'folder', 'ext', 'title', 'ctime', 'mtime', 'size', 'tags_json', 'links_json', 'frontmatter_json', 'content_hash'],
+        note_properties: ['note_id', 'key', 'key_raw', 'value_text', 'value_num', 'value_type', 'position'],
+      },
+      usage: [
+        'Filter on arbitrary frontmatter via note_properties (indexed): EXISTS (SELECT 1 FROM note_properties p WHERE p.note_id = n.id AND p.key = ? AND p.value_text = ?).',
+        'Dates/numbers compare on value_num (dates are epoch ms). List elements are one row each (position).',
+        "Project frontmatter via json_extract(n.frontmatter_json, '$.key'). ctime/mtime are epoch ms.",
+      ],
+      noteCount,
+      distinctKeys: keys,
+    };
+  }
+
+  getParameterSchema(): JSONSchema {
+    const schema: JSONSchema = {
+      type: 'object',
+      title: 'Query Notes',
+      description:
+        'Run a read-only SQL SELECT over the notes index. Tables: notes(n) with columns ' +
+        '(id, path, basename, folder, ext, title, ctime, mtime, size, tags_json, links_json, frontmatter_json) ' +
+        'and note_properties(note_id, key, key_raw, value_text, value_num, value_type, position). ' +
+        'Filter arbitrary frontmatter via note_properties (indexed); dates/numbers use value_num (dates = epoch ms); ' +
+        "project values via json_extract(frontmatter_json, '$.key'). Only a single SELECT/WITH is allowed. " +
+        'Pass describe=true to see live columns + the distinct property keys present.',
+      properties: {
+        sql: {
+          type: 'string',
+          description: 'A single read-only SELECT/WITH statement. Example: "SELECT path, json_extract(frontmatter_json,\'$.status\') AS status FROM notes LIMIT 20".',
+        },
+        params: {
+          type: 'array',
+          items: {},
+          description: 'Optional positional bind values for ? placeholders.',
+        },
+        maxRows: {
+          type: 'number',
+          description: `Max rows to return (default ${DEFAULT_MAX_ROWS}, hard cap ${HARD_MAX_ROWS}).`,
+          minimum: 1,
+          maximum: HARD_MAX_ROWS,
+        },
+        describe: {
+          type: 'boolean',
+          description: 'Return the index schema + distinct frontmatter keys instead of running sql.',
+        },
+      },
+      // `sql` is intentionally NOT required: required→positional in the CLI, and a
+      // SQL blob reads better as a flag. Presence is enforced in execute().
+      required: [],
+    };
+    return this.getMergedSchema(schema);
+  }
+}
+
+function clampRows(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 1) {
+    return DEFAULT_MAX_ROWS;
+  }
+  return Math.min(Math.floor(value), HARD_MAX_ROWS);
+}
+
+/** Allow exactly one leading SELECT/WITH statement with no write/DDL/PRAGMA keywords. */
+export function assertReadOnlySelect(sql: string): { ok: true } | { ok: false; error: string } {
+  // Strip a single trailing semicolon, then reject any further statement separator.
+  const trimmed = sql.replace(/;\s*$/, '').trim();
+  if (trimmed.includes(';')) {
+    return { ok: false, error: 'Only a single SQL statement is allowed.' };
+  }
+  if (!/^(select|with)\b/i.test(trimmed)) {
+    return { ok: false, error: 'Only read-only SELECT/WITH queries are allowed.' };
+  }
+  if (FORBIDDEN.test(trimmed)) {
+    return { ok: false, error: 'Query contains a disallowed keyword; only read-only SELECT/WITH is permitted.' };
+  }
+  return { ok: true };
+}

--- a/src/agents/searchManager/tools/queryNotes.ts
+++ b/src/agents/searchManager/tools/queryNotes.ts
@@ -34,8 +34,12 @@ export interface QueryNotesParams extends CommonParameters {
 const DEFAULT_MAX_ROWS = 500;
 const HARD_MAX_ROWS = 5000;
 
-/** Statements other than a leading SELECT/WITH, or these keywords anywhere, are rejected. */
-const FORBIDDEN = /\b(insert|update|delete|drop|alter|create|attach|detach|pragma|reindex|vacuum|replace|truncate|grant|revoke|begin|commit|rollback)\b/i;
+/**
+ * Statements other than a leading SELECT/WITH, or these keywords anywhere, are
+ * rejected. `replace` is matched only as the `REPLACE INTO` statement form — a
+ * bare `replace(` is SQLite's string function and must stay allowed.
+ */
+const FORBIDDEN = /\b(insert|update|delete|drop|alter|create|attach|detach|pragma|reindex|vacuum|replace\s+into|truncate|grant|revoke|begin|commit|rollback)\b/i;
 
 export class QueryNotesTool extends BaseTool<QueryNotesParams, CommonResult> {
   constructor(private readonly sqliteResolver: SqliteResolver) {
@@ -69,8 +73,21 @@ export class QueryNotesTool extends BaseTool<QueryNotesParams, CommonResult> {
       }
 
       const maxRows = clampRows(params.maxRows);
-      const bind = Array.isArray(params.params) ? params.params : [];
-      const all = await sqlite.query<Record<string, unknown>>(sql, bind);
+      // SQLite oo1 does not bind JS booleans — coerce to 1/0 to match its
+      // truthiness convention (the rest pass through unchanged).
+      const rawBind = Array.isArray(params.params) ? params.params : [];
+      const bind = rawBind.map((v) => (typeof v === 'boolean' ? (v ? 1 : 0) : v));
+
+      // Wrap the (validated) query in an outer LIMIT so SQLite stops pulling
+      // rows once the cap is reached instead of materializing the whole result
+      // first. This is the real guard against a runaway read — an unbounded
+      // recursive CTE or a cartesian join — freezing the synchronous,
+      // main-thread WASM engine. maxRows+1 still lets us detect truncation.
+      // Strip a trailing `;` (already validated as a single statement) so it
+      // nests as a subquery.
+      const inner = sql.replace(/;\s*$/, '');
+      const bounded = `SELECT * FROM (${inner}) LIMIT ?`;
+      const all = await sqlite.query<Record<string, unknown>>(bounded, [...bind, maxRows + 1]);
       const rows = all.slice(0, maxRows);
       const columns = rows.length > 0 ? Object.keys(rows[0]) : [];
 
@@ -93,15 +110,24 @@ export class QueryNotesTool extends BaseTool<QueryNotesParams, CommonResult> {
   private async describe(sqlite: SQLiteCacheManager): Promise<Record<string, unknown>> {
     let noteCount = 0;
     let keys: string[] = [];
+    let built = true;
     try {
       noteCount = (await sqlite.queryOne<{ n: number }>('SELECT COUNT(*) AS n FROM notes', []))?.n ?? 0;
       const rows = await sqlite.query<{ key: string }>('SELECT DISTINCT key FROM note_properties ORDER BY key LIMIT 500', []);
       keys = rows.map((r) => r.key);
     } catch {
-      // tables not built yet — return the static shape with an empty key set
+      // Tables not materialized yet — distinguish "not built" from "built but
+      // empty" so callers don't read an empty index as a built one.
+      built = false;
     }
 
     return {
+      // `built:false` ⇒ the index tables do not exist yet (build still running or
+      // skipped); `built:true` with noteCount 0 ⇒ a genuinely empty vault.
+      built,
+      status: built
+        ? (noteCount > 0 ? 'ready' : 'empty')
+        : 'building (index not materialized yet — retry shortly)',
       tables: {
         notes: ['id', 'path', 'basename', 'folder', 'ext', 'title', 'ctime', 'mtime', 'size', 'tags_json', 'links_json', 'frontmatter_json', 'content_hash'],
         note_properties: ['note_id', 'key', 'key_raw', 'value_text', 'value_num', 'value_type', 'position'],
@@ -126,6 +152,7 @@ export class QueryNotesTool extends BaseTool<QueryNotesParams, CommonResult> {
         'and note_properties(note_id, key, key_raw, value_text, value_num, value_type, position). ' +
         'Filter arbitrary frontmatter via note_properties (indexed); dates/numbers use value_num (dates = epoch ms); ' +
         "project values via json_extract(frontmatter_json, '$.key'). Only a single SELECT/WITH is allowed. " +
+        'Rows are keyed by column name, so alias duplicate/computed columns (AS) to avoid collisions. ' +
         'Pass describe=true to see live columns + the distinct property keys present.',
       properties: {
         sql: {
@@ -179,7 +206,9 @@ export function assertReadOnlySelect(sql: string): { ok: true } | { ok: false; e
   if (normalized.includes(';')) {
     return { ok: false, error: 'Only a single SQL statement is allowed.' };
   }
-  if (!/^(select|with)\b/i.test(normalized)) {
+  // Allow a leading `(` so a parenthesized compound read — `(SELECT …) UNION
+  // (SELECT …)` — is not mistaken for a non-SELECT leader.
+  if (!/^\(*\s*(select|with)\b/i.test(normalized)) {
     return { ok: false, error: 'Only read-only SELECT/WITH queries are allowed.' };
   }
   if (FORBIDDEN.test(normalized)) {

--- a/src/agents/searchManager/tools/queryNotes.ts
+++ b/src/agents/searchManager/tools/queryNotes.ts
@@ -165,15 +165,24 @@ function clampRows(value: unknown): number {
 
 /** Allow exactly one leading SELECT/WITH statement with no write/DDL/PRAGMA keywords. */
 export function assertReadOnlySelect(sql: string): { ok: true } | { ok: false; error: string } {
+  // Strip string literals, quoted identifiers, and comments BEFORE the structural
+  // checks so a value or alias (e.g. `status = 'delete'`, `-- delete old`) is not
+  // mistaken for a write keyword — while `WITH x AS (...) DELETE ...` (keyword
+  // outside any literal) is still caught.
+  const stripped = sql
+    .replace(/'(?:''|[^'])*'/g, "''")
+    .replace(/"(?:""|[^"])*"/g, '""')
+    .replace(/--[^\n]*/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ');
   // Strip a single trailing semicolon, then reject any further statement separator.
-  const trimmed = sql.replace(/;\s*$/, '').trim();
-  if (trimmed.includes(';')) {
+  const normalized = stripped.replace(/;\s*$/, '').trim();
+  if (normalized.includes(';')) {
     return { ok: false, error: 'Only a single SQL statement is allowed.' };
   }
-  if (!/^(select|with)\b/i.test(trimmed)) {
+  if (!/^(select|with)\b/i.test(normalized)) {
     return { ok: false, error: 'Only read-only SELECT/WITH queries are allowed.' };
   }
-  if (FORBIDDEN.test(trimmed)) {
+  if (FORBIDDEN.test(normalized)) {
     return { ok: false, error: 'Query contains a disallowed keyword; only read-only SELECT/WITH is permitted.' };
   }
   return { ok: true };

--- a/src/core/services/ServiceDefinitions.ts
+++ b/src/core/services/ServiceDefinitions.ts
@@ -10,7 +10,7 @@
  */
 
 import type { App, Plugin, PluginManifest } from 'obsidian';
-import { Events } from 'obsidian';
+import { Events, Platform } from 'obsidian';
 import type { ServiceManager } from '../ServiceManager';
 import type { Settings } from '../../settings';
 import type { IStorageAdapter } from '../../database/interfaces/IStorageAdapter';
@@ -195,7 +195,10 @@ export const CORE_SERVICE_DEFINITIONS: ServiceDefinition[] = [
             }
 
             const service = new NotesIndexService(sqlite);
-            const builder = new NotesIndexBuilder(context.plugin.app, service);
+            // Lower the degrade cap on mobile (tighter memory) than desktop.
+            const builder = new NotesIndexBuilder(context.plugin.app, service, {
+                maxNotes: Platform.isMobile ? 50_000 : 250_000,
+            });
             void builder.startInBackground();
             return builder;
         })

--- a/src/core/services/ServiceDefinitions.ts
+++ b/src/core/services/ServiceDefinitions.ts
@@ -170,6 +170,37 @@ export const CORE_SERVICE_DEFINITIONS: ServiceDefinition[] = [
         })
     },
 
+    // Notes query index — vault notes + frontmatter as queryable SQL rows.
+    // In-memory, rebuilt at startup from the vault, kept fresh via metadataCache
+    // events; NOT persisted in the cache blob. See
+    // docs/plans/notes-query-index-plan.md. Background stage (default) — never
+    // blocks boot; nothing depends on it.
+    {
+        name: 'notesIndex',
+        dependencies: ['hybridStorageAdapter'],
+        create: defineService(async (context) => {
+            const { NotesIndexService } = await import('../../database/services/notesIndex/NotesIndexService');
+            const { NotesIndexBuilder } = await import('../../database/services/notesIndex/NotesIndexBuilder');
+
+            const adapter = await context.serviceManager.getService<IStorageAdapter>('hybridStorageAdapter');
+            const readyable = adapter as unknown as { waitForQueryReady?: () => Promise<boolean> };
+            if (typeof readyable.waitForQueryReady === 'function') {
+                await readyable.waitForQueryReady();
+            }
+
+            const provider = adapter as unknown as { getSqliteCache?: () => import('../../database/storage/SQLiteCacheManager').SQLiteCacheManager };
+            const sqlite = typeof provider.getSqliteCache === 'function' ? provider.getSqliteCache() : undefined;
+            if (!sqlite) {
+                throw new Error('notesIndex: SQLite cache unavailable');
+            }
+
+            const service = new NotesIndexService(sqlite);
+            const builder = new NotesIndexBuilder(context.plugin.app, service);
+            void builder.startInBackground();
+            return builder;
+        })
+    },
+
     // Session service for session persistence
     {
         name: 'sessionService',

--- a/src/core/services/ServiceRegistrar.ts
+++ b/src/core/services/ServiceRegistrar.ts
@@ -178,6 +178,15 @@ export class ServiceRegistrar {
             await this.context.serviceManager.getService('toolCallTraceService');
             await this.context.serviceManager.getService('conversationService');
 
+            // Notes query index — fire-and-forget so it never gates boot. Nothing
+            // depends on it, and it is NOT reached by any other getService() path,
+            // so it must be explicitly kicked off here or it never instantiates
+            // (and its `notes`/`note_properties` tables never get created). The
+            // service's create() backgrounds the actual vault walk internally.
+            void this.context.serviceManager.getService('notesIndex').catch((error) => {
+                console.error('[ServiceRegistrar] notesIndex initialization failed:', error);
+            });
+
             // ChatService initialization deferred - will be called after agents are registered
         } catch (error) {
             console.error('[ServiceRegistrar] Business service initialization failed:', error);

--- a/src/database/services/notesIndex/NotesIndexBuilder.ts
+++ b/src/database/services/notesIndex/NotesIndexBuilder.ts
@@ -67,6 +67,18 @@ export class NotesIndexBuilder {
     this.subscribe();
   }
 
+  /**
+   * Boot variant for startup wiring: ensure the schema and subscribe to
+   * freshness synchronously, but run the (potentially large) initial walk in
+   * the background so it never blocks service initialization. Change events
+   * that arrive mid-build are safe — upserts are idempotent.
+   */
+  async startInBackground(): Promise<void> {
+    await this.service.ensureSchema();
+    this.subscribe();
+    void this.buildAll();
+  }
+
   /** Full (re)build: hash-gated upsert of every markdown note, then prune. */
   async buildAll(): Promise<void> {
     const files = this.app.vault.getMarkdownFiles();

--- a/src/database/services/notesIndex/NotesIndexBuilder.ts
+++ b/src/database/services/notesIndex/NotesIndexBuilder.ts
@@ -1,0 +1,229 @@
+/**
+ * NotesIndexBuilder — walks the vault into the notes index and keeps it fresh.
+ *
+ * Located at: src/database/services/notesIndex/NotesIndexBuilder.ts
+ * The Obsidian-coupled half of the notes query index (the SQL half is
+ * NotesIndexService). On start it ensures the schema, builds the index in the
+ * background (hash-gated, batched), then subscribes to `metadataCache`/vault
+ * events to stay current — the same freshness model the live VaultFileIndex
+ * already uses. See docs/plans/notes-query-index-plan.md §6.
+ *
+ * Graceful degrade: above `maxNotes` the build is SKIPPED (tables stay empty,
+ * queries simply return nothing) rather than risk the in-memory ceiling.
+ */
+
+import { TFile } from 'obsidian';
+import type { App, EventRef, TAbstractFile } from 'obsidian';
+import { NotesIndexService, type NoteIndexInput } from './NotesIndexService';
+import { computeContentHash } from './notesIndexMapping';
+
+export interface NotesIndexBuilderOptions {
+  /** Skip indexing entirely above this note count (graceful degrade). */
+  maxNotes?: number;
+  /** Debounce window (ms) for coalescing metadata-change bursts. */
+  debounceMs?: number;
+  /** Notes processed between cooperative yields during the full build. */
+  batchSize?: number;
+}
+
+const DEFAULT_MAX_NOTES = 250_000;
+const DEFAULT_DEBOUNCE_MS = 500;
+const DEFAULT_BATCH_SIZE = 200;
+
+export class NotesIndexBuilder {
+  private readonly maxNotes: number;
+  private readonly debounceMs: number;
+  private readonly batchSize: number;
+
+  private eventRefs: EventRef[] = [];
+  private dirtyPaths = new Set<string>();
+  private flushTimer: number | null = null;
+
+  private ready = false;
+  private degraded = false;
+
+  constructor(
+    private readonly app: App,
+    private readonly service: NotesIndexService,
+    options: NotesIndexBuilderOptions = {}
+  ) {
+    this.maxNotes = options.maxNotes ?? DEFAULT_MAX_NOTES;
+    this.debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  }
+
+  isReady(): boolean {
+    return this.ready;
+  }
+
+  isDegraded(): boolean {
+    return this.degraded;
+  }
+
+  /** Ensure schema, build in the background, then wire freshness. */
+  async start(): Promise<void> {
+    await this.service.ensureSchema();
+    await this.buildAll();
+    this.subscribe();
+  }
+
+  /** Full (re)build: hash-gated upsert of every markdown note, then prune. */
+  async buildAll(): Promise<void> {
+    const files = this.app.vault.getMarkdownFiles();
+
+    if (files.length > this.maxNotes) {
+      this.degraded = true;
+      this.ready = false;
+      console.warn(
+        `[NotesIndex] ${files.length} notes exceeds maxNotes=${this.maxNotes}; skipping index build (queries will return no notes).`
+      );
+      return;
+    }
+    this.degraded = false;
+
+    const existing = await this.service.getExistingHashes();
+    const present = new Set<string>();
+
+    let processed = 0;
+    for (const file of files) {
+      const input = this.noteFromFile(file);
+      present.add(input.path);
+      if (existing.get(input.path) !== input.contentHash) {
+        await this.service.upsertNote(input);
+      }
+      if (++processed % this.batchSize === 0) {
+        await yieldToEventLoop();
+      }
+    }
+
+    await this.service.pruneMissing(present);
+    this.ready = true;
+  }
+
+  /** Tear down timers + event listeners. */
+  stop(): void {
+    if (this.flushTimer !== null) {
+      window.clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    for (const ref of this.eventRefs) {
+      if (ref) {
+        this.app.metadataCache.offref(ref);
+        this.app.vault.offref(ref);
+      }
+    }
+    this.eventRefs = [];
+    this.dirtyPaths.clear();
+  }
+
+  // -- freshness -------------------------------------------------------------
+
+  private subscribe(): void {
+    this.eventRefs.push(
+      this.app.metadataCache.on('changed', (file: TFile) => {
+        this.markDirty(file.path);
+      })
+    );
+    this.eventRefs.push(
+      this.app.vault.on('delete', (file: TAbstractFile) => {
+        if (isMarkdown(file)) {
+          this.dirtyPaths.delete(file.path);
+          void this.service.deleteNote(file.path);
+        }
+      })
+    );
+    this.eventRefs.push(
+      this.app.vault.on('rename', (file: TAbstractFile, oldPath: string) => {
+        if (isMarkdown(file)) {
+          void this.service.deleteNote(oldPath);
+          this.markDirty(file.path);
+        }
+      })
+    );
+  }
+
+  private markDirty(path: string): void {
+    if (this.degraded) {
+      return;
+    }
+    this.dirtyPaths.add(path);
+    if (this.flushTimer === null) {
+      this.flushTimer = window.setTimeout(() => void this.flush(), this.debounceMs);
+    }
+  }
+
+  /** Reconcile the dirty set: re-upsert existing notes, delete vanished ones. */
+  private async flush(): Promise<void> {
+    this.flushTimer = null;
+    const paths = Array.from(this.dirtyPaths);
+    this.dirtyPaths.clear();
+
+    for (const path of paths) {
+      const file = this.app.vault.getAbstractFileByPath(path);
+      if (file && isMarkdown(file)) {
+        await this.service.upsertNote(this.noteFromFile(file));
+      } else {
+        await this.service.deleteNote(path);
+      }
+    }
+  }
+
+  // -- mapping ---------------------------------------------------------------
+
+  /** Extract the indexable surface of a note from the metadata cache. */
+  private noteFromFile(file: TFile): NoteIndexInput {
+    const cache = this.app.metadataCache.getFileCache(file);
+    const rawFm = (cache?.frontmatter ?? {}) as Record<string, unknown>;
+    const frontmatter: Record<string, unknown> = { ...rawFm };
+    // `position` is the metadata cache's internal source-range marker, not data.
+    delete frontmatter.position;
+
+    const tags = mergeTags(cache?.tags, frontmatter.tags);
+    const links = Array.isArray(cache?.links)
+      ? (cache?.links as Array<{ link?: string }>).map((l) => l.link).filter((l): l is string => typeof l === 'string')
+      : [];
+    const title = typeof frontmatter.title === 'string' ? frontmatter.title : file.basename;
+
+    return {
+      path: file.path,
+      basename: file.basename,
+      folder: file.parent?.path || '/',
+      ext: file.extension,
+      title,
+      ctime: file.stat.ctime,
+      mtime: file.stat.mtime,
+      size: file.stat.size,
+      tags,
+      links,
+      frontmatter,
+      contentHash: computeContentHash(frontmatter, file.stat.mtime, file.stat.size),
+    };
+  }
+}
+
+/** True for markdown TFiles (guards delete/rename events that also fire for folders). */
+function isMarkdown(file: TAbstractFile): file is TFile {
+  return file instanceof TFile && file.extension === 'md';
+}
+
+/** Merge inline (`cache.tags`) + frontmatter tags, strip leading `#`, dedupe. */
+function mergeTags(cacheTags: Array<{ tag: string }> | undefined, fmTags: unknown): string[] {
+  const out = new Set<string>();
+  for (const t of cacheTags ?? []) {
+    if (typeof t?.tag === 'string') {
+      out.add(t.tag.replace(/^#/, ''));
+    }
+  }
+  const fm = Array.isArray(fmTags) ? fmTags : typeof fmTags === 'string' ? [fmTags] : [];
+  for (const t of fm) {
+    if (typeof t === 'string') {
+      out.add(t.replace(/^#/, ''));
+    }
+  }
+  return Array.from(out);
+}
+
+/** Cooperative yield so a large build doesn't monopolize the main thread. */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0));
+}

--- a/src/database/services/notesIndex/NotesIndexService.ts
+++ b/src/database/services/notesIndex/NotesIndexService.ts
@@ -1,0 +1,175 @@
+/**
+ * NotesIndexService — SQLite CRUD over the `notes` + `note_properties` tables.
+ *
+ * Located at: src/database/services/notesIndex/NotesIndexService.ts
+ * The vault is the source of truth; these two tables are a rebuildable, derived,
+ * IN-MEMORY index (created via `ensureSchema()` at startup, NOT a persisted
+ * v-schema migration — see docs/plans/notes-query-index-plan.md §5 / §6). EAV
+ * (`note_properties`) gives indexed lookup for arbitrary frontmatter keys;
+ * `notes.frontmatter_json` is kept for cheap projection via `json_extract`.
+ *
+ * This service is storage-only (mirrors SkillIndexService): it issues SQL and
+ * knows nothing about Obsidian. The vault walk + freshness live in
+ * NotesIndexBuilder.
+ */
+
+import type { SQLiteCacheManager } from '../../storage/SQLiteCacheManager';
+import { coerceFrontmatterValue } from './notesIndexMapping';
+
+/** Everything the builder extracts from one note for indexing. */
+export interface NoteIndexInput {
+  path: string;
+  basename: string;
+  folder: string;
+  ext: string;
+  title: string | null;
+  ctime: number;
+  mtime: number;
+  size: number;
+  tags: string[];
+  links: string[];
+  frontmatter: Record<string, unknown>;
+  contentHash: string;
+}
+
+/** DDL for the in-memory index. Idempotent; run on every startup. */
+export const NOTES_INDEX_DDL = `
+CREATE TABLE IF NOT EXISTS notes (
+  id INTEGER PRIMARY KEY,
+  path TEXT NOT NULL UNIQUE,
+  basename TEXT NOT NULL,
+  folder TEXT NOT NULL,
+  ext TEXT NOT NULL,
+  title TEXT,
+  ctime INTEGER NOT NULL,
+  mtime INTEGER NOT NULL,
+  size INTEGER NOT NULL,
+  tags_json TEXT,
+  links_json TEXT,
+  frontmatter_json TEXT,
+  content_hash TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_notes_folder ON notes(folder);
+CREATE INDEX IF NOT EXISTS idx_notes_mtime ON notes(mtime);
+CREATE TABLE IF NOT EXISTS note_properties (
+  note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+  key TEXT NOT NULL,
+  key_raw TEXT NOT NULL,
+  value_text TEXT,
+  value_num REAL,
+  value_type TEXT NOT NULL,
+  position INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_np_key_text ON note_properties(key, value_text);
+CREATE INDEX IF NOT EXISTS idx_np_key_num ON note_properties(key, value_num);
+CREATE INDEX IF NOT EXISTS idx_np_note ON note_properties(note_id);
+`;
+
+const UPSERT_NOTE_SQL =
+  `INSERT INTO notes (path, basename, folder, ext, title, ctime, mtime, size, tags_json, links_json, frontmatter_json, content_hash) ` +
+  `VALUES (?,?,?,?,?,?,?,?,?,?,?,?) ` +
+  `ON CONFLICT(path) DO UPDATE SET ` +
+  `basename=excluded.basename, folder=excluded.folder, ext=excluded.ext, title=excluded.title, ` +
+  `ctime=excluded.ctime, mtime=excluded.mtime, size=excluded.size, tags_json=excluded.tags_json, ` +
+  `links_json=excluded.links_json, frontmatter_json=excluded.frontmatter_json, content_hash=excluded.content_hash`;
+
+export class NotesIndexService {
+  constructor(private readonly sqlite: SQLiteCacheManager) {}
+
+  /** Create the index tables + indexes if absent. Idempotent. */
+  async ensureSchema(): Promise<void> {
+    await this.sqlite.exec(NOTES_INDEX_DDL);
+  }
+
+  /** path → content_hash for every indexed note (drives skip-unchanged on re-scan). */
+  async getExistingHashes(): Promise<Map<string, string>> {
+    const rows = await this.sqlite.query<{ path: string; content_hash: string }>(
+      'SELECT path, content_hash FROM notes',
+      []
+    );
+    return new Map(rows.map((r) => [r.path, r.content_hash]));
+  }
+
+  /** Number of indexed notes. */
+  async count(): Promise<number> {
+    const row = await this.sqlite.queryOne<{ n: number }>('SELECT COUNT(*) AS n FROM notes', []);
+    return row?.n ?? 0;
+  }
+
+  /**
+   * Upsert one note and fully replace its property rows. The frontmatter EAV is
+   * delete-then-insert (simplest correct reconciliation — a property removed
+   * from the note must vanish from the index).
+   */
+  async upsertNote(input: NoteIndexInput): Promise<void> {
+    await this.sqlite.run(UPSERT_NOTE_SQL, [
+      input.path,
+      input.basename,
+      input.folder,
+      input.ext,
+      input.title,
+      input.ctime,
+      input.mtime,
+      input.size,
+      JSON.stringify(input.tags ?? []),
+      JSON.stringify(input.links ?? []),
+      JSON.stringify(input.frontmatter ?? {}),
+      input.contentHash,
+    ]);
+
+    const noteId = await this.noteId(input.path);
+    if (noteId === null) {
+      return;
+    }
+
+    await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
+
+    for (const [keyRaw, value] of Object.entries(input.frontmatter ?? {})) {
+      for (const r of coerceFrontmatterValue(keyRaw, value)) {
+        await this.sqlite.run(
+          `INSERT INTO note_properties (note_id, key, key_raw, value_text, value_num, value_type, position) VALUES (?,?,?,?,?,?,?)`,
+          [noteId, r.key, r.keyRaw, r.valueText, r.valueNum, r.valueType, r.position]
+        );
+      }
+    }
+  }
+
+  /** Remove a note and its property rows by path. No-op if absent. */
+  async deleteNote(path: string): Promise<void> {
+    const noteId = await this.noteId(path);
+    if (noteId === null) {
+      return;
+    }
+    await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
+    await this.sqlite.run('DELETE FROM notes WHERE id = ?', [noteId]);
+  }
+
+  /** Rename = delete the old path then upsert the new one (paths are the identity). */
+  async renameNote(oldPath: string, input: NoteIndexInput): Promise<void> {
+    await this.deleteNote(oldPath);
+    await this.upsertNote(input);
+  }
+
+  /**
+   * Drop index rows for notes whose path is no longer present in the vault.
+   * Conservative, mirroring SkillIndexService: an EMPTY `presentPaths` prunes
+   * NOTHING (a failed/empty walk must not wipe the whole index).
+   */
+  async pruneMissing(presentPaths: Set<string>): Promise<void> {
+    if (presentPaths.size === 0) {
+      return;
+    }
+    const rows = await this.sqlite.query<{ path: string }>('SELECT path FROM notes', []);
+    for (const { path } of rows) {
+      if (!presentPaths.has(path)) {
+        await this.deleteNote(path);
+      }
+    }
+  }
+
+  /** Resolve a note's surrogate id by path, or null when not indexed. */
+  private async noteId(path: string): Promise<number | null> {
+    const row = await this.sqlite.queryOne<{ id: number }>('SELECT id FROM notes WHERE path = ?', [path]);
+    return row?.id ?? null;
+  }
+}

--- a/src/database/services/notesIndex/NotesIndexService.ts
+++ b/src/database/services/notesIndex/NotesIndexService.ts
@@ -52,7 +52,11 @@ CREATE TABLE IF NOT EXISTS notes (
 CREATE INDEX IF NOT EXISTS idx_notes_folder ON notes(folder);
 CREATE INDEX IF NOT EXISTS idx_notes_mtime ON notes(mtime);
 CREATE TABLE IF NOT EXISTS note_properties (
-  note_id INTEGER NOT NULL REFERENCES notes(id) ON DELETE CASCADE,
+  -- FK enforcement is OFF on the shared connection (SQLite's per-connection
+  -- default), so this relationship is documented but NOT cascaded. deleteNote()
+  -- removes property rows explicitly before the note row, so no orphans result;
+  -- enabling cascade here would be inert and misleading.
+  note_id INTEGER NOT NULL REFERENCES notes(id),
   key TEXT NOT NULL,
   key_raw TEXT NOT NULL,
   value_text TEXT,

--- a/src/database/services/notesIndex/NotesIndexService.ts
+++ b/src/database/services/notesIndex/NotesIndexService.ts
@@ -102,46 +102,52 @@ export class NotesIndexService {
    * from the note must vanish from the index).
    */
   async upsertNote(input: NoteIndexInput): Promise<void> {
-    await this.sqlite.run(UPSERT_NOTE_SQL, [
-      input.path,
-      input.basename,
-      input.folder,
-      input.ext,
-      input.title,
-      input.ctime,
-      input.mtime,
-      input.size,
-      JSON.stringify(input.tags ?? []),
-      JSON.stringify(input.links ?? []),
-      JSON.stringify(input.frontmatter ?? {}),
-      input.contentHash,
-    ]);
+    // One transaction per note so the row + its property rows are always
+    // consistent (nesting-safe — the coordinator tracks depth).
+    await this.sqlite.transaction(async () => {
+      await this.sqlite.run(UPSERT_NOTE_SQL, [
+        input.path,
+        input.basename,
+        input.folder,
+        input.ext,
+        input.title,
+        input.ctime,
+        input.mtime,
+        input.size,
+        JSON.stringify(input.tags ?? []),
+        JSON.stringify(input.links ?? []),
+        JSON.stringify(input.frontmatter ?? {}),
+        input.contentHash,
+      ]);
 
-    const noteId = await this.noteId(input.path);
-    if (noteId === null) {
-      return;
-    }
-
-    await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
-
-    for (const [keyRaw, value] of Object.entries(input.frontmatter ?? {})) {
-      for (const r of coerceFrontmatterValue(keyRaw, value)) {
-        await this.sqlite.run(
-          `INSERT INTO note_properties (note_id, key, key_raw, value_text, value_num, value_type, position) VALUES (?,?,?,?,?,?,?)`,
-          [noteId, r.key, r.keyRaw, r.valueText, r.valueNum, r.valueType, r.position]
-        );
+      const noteId = await this.noteId(input.path);
+      if (noteId === null) {
+        return;
       }
-    }
+
+      await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
+
+      for (const [keyRaw, value] of Object.entries(input.frontmatter ?? {})) {
+        for (const r of coerceFrontmatterValue(keyRaw, value)) {
+          await this.sqlite.run(
+            `INSERT INTO note_properties (note_id, key, key_raw, value_text, value_num, value_type, position) VALUES (?,?,?,?,?,?,?)`,
+            [noteId, r.key, r.keyRaw, r.valueText, r.valueNum, r.valueType, r.position]
+          );
+        }
+      }
+    });
   }
 
   /** Remove a note and its property rows by path. No-op if absent. */
   async deleteNote(path: string): Promise<void> {
-    const noteId = await this.noteId(path);
-    if (noteId === null) {
-      return;
-    }
-    await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
-    await this.sqlite.run('DELETE FROM notes WHERE id = ?', [noteId]);
+    await this.sqlite.transaction(async () => {
+      const noteId = await this.noteId(path);
+      if (noteId === null) {
+        return;
+      }
+      await this.sqlite.run('DELETE FROM note_properties WHERE note_id = ?', [noteId]);
+      await this.sqlite.run('DELETE FROM notes WHERE id = ?', [noteId]);
+    });
   }
 
   /** Rename = delete the old path then upsert the new one (paths are the identity). */

--- a/src/database/services/notesIndex/notesIndexMapping.ts
+++ b/src/database/services/notesIndex/notesIndexMapping.ts
@@ -1,0 +1,152 @@
+/**
+ * notesIndexMapping — pure coercion + hashing for the notes query index.
+ *
+ * Located at: src/database/services/notesIndex/notesIndexMapping.ts
+ * No Obsidian / SQLite imports — just the typed transform from raw frontmatter
+ * values into `note_properties` rows, plus a stable change-detection hash. Kept
+ * pure so it is exhaustively unit-testable in isolation (this is the main
+ * correctness surface now that there is no query-time formula evaluator — see
+ * docs/plans/notes-query-index-plan.md §5 / §11).
+ *
+ * Mobile-safe: no Node `crypto`, no top-level npm deps.
+ */
+
+/** A single `note_properties` row, sans the `note_id` FK (filled in by the service). */
+export interface NotePropertyRow {
+  /** Lowercased key for matching. */
+  key: string;
+  /** Original-case key. */
+  keyRaw: string;
+  /** Normalized string form — drives `=`, `contains`, sort. */
+  valueText: string | null;
+  /** Numeric or date-coerced (epoch ms) value, else null — drives `<`/`>`/range. */
+  valueNum: number | null;
+  /** 'string' | 'number' | 'boolean' | 'date' | 'list' | 'object' | 'null'. */
+  valueType: NotePropertyType;
+  /** List-element index when the source value was an array, else null. */
+  position: number | null;
+}
+
+export type NotePropertyType =
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'date'
+  | 'list'
+  | 'object'
+  | 'null';
+
+/** ISO-8601 date / datetime, e.g. `2026-06-21` or `2026-06-21T09:30:00`. */
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/;
+
+/** FNV-1a (32-bit) hex hash. Mobile-safe (no Node crypto). Mirrors skillHash. */
+export function fnv1aHex(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/**
+ * Stable change-detection hash over the indexed surface of a note: its
+ * frontmatter (key-sorted so ordering noise doesn't churn the hash) plus the
+ * stat fields we store. Used to skip re-indexing unchanged notes on a re-scan.
+ */
+export function computeContentHash(
+  frontmatter: Record<string, unknown>,
+  mtime: number,
+  size: number
+): string {
+  return fnv1aHex(`${stableStringify(frontmatter)}|${mtime}|${size}`);
+}
+
+/**
+ * Coerce one frontmatter value into the `note_properties` rows it produces.
+ * Arrays expand to one row per element (so `list.contains` is an indexed lookup
+ * on `value_text`); empty arrays yield a single `list` marker row so existence /
+ * `isEmpty` still work; objects are stored as JSON in `value_text`.
+ */
+export function coerceFrontmatterValue(keyRaw: string, value: unknown): NotePropertyRow[] {
+  const key = keyRaw.toLowerCase();
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return [row(key, keyRaw, null, null, 'list', null)];
+    }
+    return value.map((element, position) => {
+      const scalar = coerceScalar(element);
+      return row(key, keyRaw, scalar.valueText, scalar.valueNum, scalar.valueType, position);
+    });
+  }
+
+  const scalar = coerceScalar(value);
+  return [row(key, keyRaw, scalar.valueText, scalar.valueNum, scalar.valueType, null)];
+}
+
+/** Coerce a single (non-array) value to its text/num/type triple. */
+function coerceScalar(value: unknown): Pick<NotePropertyRow, 'valueText' | 'valueNum' | 'valueType'> {
+  if (value === null || value === undefined) {
+    return { valueText: null, valueNum: null, valueType: 'null' };
+  }
+  if (typeof value === 'boolean') {
+    return { valueText: value ? 'true' : 'false', valueNum: value ? 1 : 0, valueType: 'boolean' };
+  }
+  if (typeof value === 'number') {
+    return { valueText: Number.isFinite(value) ? String(value) : null, valueNum: Number.isFinite(value) ? value : null, valueType: 'number' };
+  }
+  if (value instanceof Date) {
+    const ms = value.getTime();
+    return { valueText: Number.isNaN(ms) ? null : value.toISOString(), valueNum: Number.isNaN(ms) ? null : ms, valueType: 'date' };
+  }
+  if (typeof value === 'string') {
+    if (ISO_DATE_RE.test(value)) {
+      const ms = Date.parse(value);
+      if (!Number.isNaN(ms)) {
+        return { valueText: value, valueNum: ms, valueType: 'date' };
+      }
+    }
+    return { valueText: value, valueNum: null, valueType: 'string' };
+  }
+  // Nested object (or any other type) → JSON blob, queryable via json_extract.
+  return { valueText: safeJson(value), valueNum: null, valueType: 'object' };
+}
+
+function row(
+  key: string,
+  keyRaw: string,
+  valueText: string | null,
+  valueNum: number | null,
+  valueType: NotePropertyType,
+  position: number | null
+): NotePropertyRow {
+  return { key, keyRaw, valueText, valueNum, valueType, position };
+}
+
+/** JSON.stringify with sorted object keys, so equal content hashes equally. */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value && typeof value === 'object' && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function safeJson(value: unknown): string | null {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/NotesIndexBuilder.test.ts
+++ b/tests/unit/NotesIndexBuilder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * NotesIndexBuilder unit tests — the vault walk, hash-gated skip, conservative
+ * prune, graceful-degrade cap, and metadataCache/vault freshness. A hand-rolled
+ * fake `app` + a mocked NotesIndexService (no Obsidian runtime, no real DB).
+ */
+
+import { TFile } from 'obsidian';
+import { NotesIndexBuilder } from '../../src/database/services/notesIndex/NotesIndexBuilder';
+import { computeContentHash } from '../../src/database/services/notesIndex/notesIndexMapping';
+import type { NotesIndexService } from '../../src/database/services/notesIndex/NotesIndexService';
+
+type FakeFile = TFile;
+
+/** Build a real mock-TFile instance (needed so `instanceof TFile` holds in the builder). */
+function makeFile(path: string, ext = 'md'): FakeFile {
+  const name = path.split('/').pop() as string;
+  const f = new TFile(name, path) as unknown as Record<string, unknown>;
+  f.extension = ext;
+  f.parent = { path: 'Projects' };
+  f.stat = { ctime: 1, mtime: 2, size: 3 };
+  return f as unknown as FakeFile;
+}
+
+function file(path: string, frontmatter: Record<string, unknown> = {}): { f: FakeFile; cache: { frontmatter?: unknown } } {
+  return { f: makeFile(path), cache: { frontmatter } };
+}
+
+function makeApp(entries: Array<{ f: FakeFile; cache: { frontmatter?: unknown } }>) {
+  const byPath = new Map(entries.map((e) => [e.f.path, e]));
+  const handlers: Record<string, (...args: unknown[]) => void> = {};
+  const app = {
+    vault: {
+      getMarkdownFiles: () => entries.map((e) => e.f),
+      getAbstractFileByPath: (p: string) => byPath.get(p)?.f ?? null,
+      on: (name: string, cb: (...args: unknown[]) => void) => {
+        handlers[`vault:${name}`] = cb;
+        return { name };
+      },
+      offref: () => undefined,
+    },
+    metadataCache: {
+      getFileCache: (f: FakeFile) => byPath.get(f.path)?.cache ?? {},
+      on: (name: string, cb: (...args: unknown[]) => void) => {
+        handlers[`mc:${name}`] = cb;
+        return { name };
+      },
+      offref: () => undefined,
+    },
+  };
+  return { app, handlers };
+}
+
+function mockService(existing: Map<string, string> = new Map()) {
+  return {
+    ensureSchema: jest.fn().mockResolvedValue(undefined),
+    getExistingHashes: jest.fn().mockResolvedValue(existing),
+    upsertNote: jest.fn().mockResolvedValue(undefined),
+    deleteNote: jest.fn().mockResolvedValue(undefined),
+    pruneMissing: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 5));
+
+describe('NotesIndexBuilder', () => {
+  it('builds the index from every markdown file and prunes against the present set', async () => {
+    const entries = [file('Projects/a.md', { status: 'active' }), file('Projects/b.md')];
+    const { app } = makeApp(entries);
+    const service = mockService();
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService);
+
+    await builder.buildAll();
+
+    expect(service.upsertNote).toHaveBeenCalledTimes(2);
+    const present = service.pruneMissing.mock.calls[0][0] as Set<string>;
+    expect(present).toEqual(new Set(['Projects/a.md', 'Projects/b.md']));
+    expect(builder.isReady()).toBe(true);
+  });
+
+  it('skips notes whose content hash is unchanged', async () => {
+    const entries = [file('Projects/a.md', { status: 'active' }), file('Projects/b.md')];
+    const { app } = makeApp(entries);
+    // a.md already indexed with a matching hash → should be skipped.
+    const aHash = computeContentHash({ status: 'active' }, 2, 3);
+    const service = mockService(new Map([['Projects/a.md', aHash]]));
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService);
+
+    await builder.buildAll();
+
+    const upserted = service.upsertNote.mock.calls.map((c) => (c[0] as { path: string }).path);
+    expect(upserted).toEqual(['Projects/b.md']);
+  });
+
+  it('degrades (skips the build) above maxNotes', async () => {
+    const entries = [file('a.md'), file('b.md'), file('c.md')];
+    const { app } = makeApp(entries);
+    const service = mockService();
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService, { maxNotes: 2 });
+
+    await builder.buildAll();
+
+    expect(builder.isDegraded()).toBe(true);
+    expect(builder.isReady()).toBe(false);
+    expect(service.upsertNote).not.toHaveBeenCalled();
+    expect(service.pruneMissing).not.toHaveBeenCalled();
+  });
+
+  it('re-upserts a note on a debounced metadataCache change', async () => {
+    const entries = [file('Projects/a.md', { status: 'active' })];
+    const { app, handlers } = makeApp(entries);
+    const service = mockService(new Map([['Projects/a.md', computeContentHash({ status: 'active' }, 2, 3)]]));
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService, { debounceMs: 0 });
+
+    await builder.start();
+    service.upsertNote.mockClear(); // ignore the initial build
+
+    handlers['mc:changed']({ path: 'Projects/a.md' });
+    await tick();
+
+    expect(service.upsertNote).toHaveBeenCalledTimes(1);
+    expect((service.upsertNote.mock.calls[0][0] as { path: string }).path).toBe('Projects/a.md');
+
+    builder.stop();
+  });
+
+  it('deletes a note immediately on a vault delete event', async () => {
+    const entries = [file('Projects/a.md')];
+    const { app, handlers } = makeApp(entries);
+    const service = mockService();
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService);
+
+    await builder.start();
+
+    handlers['vault:delete'](makeFile('Projects/a.md'));
+
+    expect(service.deleteNote).toHaveBeenCalledWith('Projects/a.md');
+    builder.stop();
+  });
+
+  it('ignores non-markdown files on delete', async () => {
+    const { app, handlers } = makeApp([]);
+    const service = mockService();
+    const builder = new NotesIndexBuilder(app as never, service as unknown as NotesIndexService);
+
+    await builder.start();
+    handlers['vault:delete'](makeFile('Attachments/pic.png', 'png'));
+
+    expect(service.deleteNote).not.toHaveBeenCalled();
+    builder.stop();
+  });
+});

--- a/tests/unit/NotesIndexMapping.test.ts
+++ b/tests/unit/NotesIndexMapping.test.ts
@@ -1,0 +1,102 @@
+/**
+ * notesIndexMapping unit tests — the typed frontmatter→property-row coercion and
+ * the change-detection hash. Pure, no Obsidian/SQLite. This is the main
+ * correctness surface of the notes index (no query-time evaluator).
+ */
+
+import {
+  coerceFrontmatterValue,
+  computeContentHash,
+  type NotePropertyRow,
+} from '../../src/database/services/notesIndex/notesIndexMapping';
+
+function one(key: string, value: unknown): NotePropertyRow {
+  const rows = coerceFrontmatterValue(key, value);
+  expect(rows).toHaveLength(1);
+  return rows[0];
+}
+
+describe('coerceFrontmatterValue', () => {
+  it('lowercases the match key but preserves the raw key', () => {
+    const r = one('Status', 'active');
+    expect(r.key).toBe('status');
+    expect(r.keyRaw).toBe('Status');
+  });
+
+  it('coerces strings', () => {
+    const r = one('status', 'active');
+    expect(r).toMatchObject({ valueText: 'active', valueNum: null, valueType: 'string', position: null });
+  });
+
+  it('coerces numbers into both text and num', () => {
+    const r = one('priority', 3);
+    expect(r).toMatchObject({ valueText: '3', valueNum: 3, valueType: 'number' });
+  });
+
+  it('coerces booleans into 1/0', () => {
+    expect(one('done', true)).toMatchObject({ valueText: 'true', valueNum: 1, valueType: 'boolean' });
+    expect(one('done', false)).toMatchObject({ valueText: 'false', valueNum: 0, valueType: 'boolean' });
+  });
+
+  it('coerces ISO date strings to epoch ms in value_num', () => {
+    const r = one('due', '2026-06-21');
+    expect(r.valueType).toBe('date');
+    expect(r.valueText).toBe('2026-06-21');
+    expect(r.valueNum).toBe(Date.parse('2026-06-21'));
+  });
+
+  it('coerces Date objects to epoch ms', () => {
+    const d = new Date('2026-01-02T03:04:05Z');
+    const r = one('due', d);
+    expect(r.valueType).toBe('date');
+    expect(r.valueNum).toBe(d.getTime());
+  });
+
+  it('does not treat a non-date string as a date', () => {
+    const r = one('title', '2026 roadmap');
+    expect(r.valueType).toBe('string');
+    expect(r.valueNum).toBeNull();
+  });
+
+  it('coerces null/undefined to a null-typed row', () => {
+    expect(one('x', null)).toMatchObject({ valueType: 'null', valueText: null, valueNum: null });
+    expect(one('x', undefined)).toMatchObject({ valueType: 'null' });
+  });
+
+  it('expands arrays to one positioned row per element', () => {
+    const rows = coerceFrontmatterValue('tags', ['a', 'b', 'c']);
+    expect(rows.map((r) => [r.valueText, r.position])).toEqual([
+      ['a', 0],
+      ['b', 1],
+      ['c', 2],
+    ]);
+    expect(rows.every((r) => r.key === 'tags')).toBe(true);
+  });
+
+  it('emits a single list marker row for an empty array', () => {
+    const rows = coerceFrontmatterValue('tags', []);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ valueType: 'list', valueText: null, position: null });
+  });
+
+  it('stores nested objects as JSON in value_text', () => {
+    const r = one('meta', { a: 1, b: 2 });
+    expect(r.valueType).toBe('object');
+    expect(JSON.parse(r.valueText as string)).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe('computeContentHash', () => {
+  it('is stable across key ordering', () => {
+    const a = computeContentHash({ status: 'active', priority: 2 }, 100, 10);
+    const b = computeContentHash({ priority: 2, status: 'active' }, 100, 10);
+    expect(a).toBe(b);
+  });
+
+  it('changes when frontmatter, mtime, or size change', () => {
+    const base = computeContentHash({ status: 'active' }, 100, 10);
+    expect(computeContentHash({ status: 'done' }, 100, 10)).not.toBe(base);
+    expect(computeContentHash({ status: 'active' }, 101, 10)).not.toBe(base);
+    expect(computeContentHash({ status: 'active' }, 100, 11)).not.toBe(base);
+  });
+});

--- a/tests/unit/NotesIndexService.test.ts
+++ b/tests/unit/NotesIndexService.test.ts
@@ -12,6 +12,7 @@ type MockSqlite = {
   run: jest.Mock;
   query: jest.Mock;
   queryOne: jest.Mock;
+  transaction: jest.Mock;
 };
 
 function createMockSqlite(): MockSqlite {
@@ -20,6 +21,8 @@ function createMockSqlite(): MockSqlite {
     run: jest.fn().mockResolvedValue({ changes: 1, lastInsertRowid: 0 }),
     query: jest.fn().mockResolvedValue([]),
     queryOne: jest.fn().mockResolvedValue({ id: 1 }),
+    // Run the callback inline so SQL assertions see the issued statements.
+    transaction: jest.fn(async (fn: () => Promise<unknown>) => fn()),
   };
 }
 

--- a/tests/unit/NotesIndexService.test.ts
+++ b/tests/unit/NotesIndexService.test.ts
@@ -1,0 +1,134 @@
+/**
+ * NotesIndexService unit tests — verifies the SQL issued for schema creation,
+ * note upsert + property reconciliation, delete, and conservative prune. SQLite
+ * is mocked per the repository test convention (no real DB).
+ */
+
+import { NotesIndexService, type NoteIndexInput } from '../../src/database/services/notesIndex/NotesIndexService';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+
+type MockSqlite = {
+  exec: jest.Mock;
+  run: jest.Mock;
+  query: jest.Mock;
+  queryOne: jest.Mock;
+};
+
+function createMockSqlite(): MockSqlite {
+  return {
+    exec: jest.fn().mockResolvedValue(undefined),
+    run: jest.fn().mockResolvedValue({ changes: 1, lastInsertRowid: 0 }),
+    query: jest.fn().mockResolvedValue([]),
+    queryOne: jest.fn().mockResolvedValue({ id: 1 }),
+  };
+}
+
+function makeService(mock: MockSqlite): NotesIndexService {
+  return new NotesIndexService(mock as unknown as SQLiteCacheManager);
+}
+
+function sampleInput(overrides: Partial<NoteIndexInput> = {}): NoteIndexInput {
+  return {
+    path: 'Projects/alpha.md',
+    basename: 'alpha',
+    folder: 'Projects',
+    ext: 'md',
+    title: 'Alpha',
+    ctime: 1,
+    mtime: 2,
+    size: 3,
+    tags: ['task'],
+    links: [],
+    frontmatter: { status: 'active', priority: 2, tags: ['x', 'y'] },
+    contentHash: 'hash-a',
+    ...overrides,
+  };
+}
+
+const runsMatching = (mock: MockSqlite, needle: string) =>
+  mock.run.mock.calls.filter(([sql]) => typeof sql === 'string' && sql.includes(needle));
+
+describe('NotesIndexService', () => {
+  it('ensureSchema creates both tables', async () => {
+    const mock = createMockSqlite();
+    await makeService(mock).ensureSchema();
+    const [ddl] = mock.exec.mock.calls[0];
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS notes');
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS note_properties');
+    expect(ddl).toContain('idx_np_key_text');
+  });
+
+  describe('upsertNote', () => {
+    it('upserts the note row then replaces its property rows', async () => {
+      const mock = createMockSqlite();
+      await makeService(mock).upsertNote(sampleInput());
+
+      // 1 note upsert
+      expect(runsMatching(mock, 'INSERT INTO notes')).toHaveLength(1);
+      // old properties cleared exactly once
+      expect(runsMatching(mock, 'DELETE FROM note_properties')).toHaveLength(1);
+      // status(1) + priority(1) + tags x,y(2) = 4 property inserts
+      expect(runsMatching(mock, 'INSERT INTO note_properties')).toHaveLength(4);
+    });
+
+    it('threads the resolved note_id into the property rows', async () => {
+      const mock = createMockSqlite();
+      mock.queryOne.mockResolvedValue({ id: 42 });
+      await makeService(mock).upsertNote(sampleInput());
+
+      for (const [, params] of runsMatching(mock, 'INSERT INTO note_properties')) {
+        expect((params as unknown[])[0]).toBe(42);
+      }
+    });
+
+    it('skips property work when the note row cannot be resolved', async () => {
+      const mock = createMockSqlite();
+      mock.queryOne.mockResolvedValue(null);
+      await makeService(mock).upsertNote(sampleInput());
+
+      expect(runsMatching(mock, 'INSERT INTO notes')).toHaveLength(1);
+      expect(runsMatching(mock, 'INSERT INTO note_properties')).toHaveLength(0);
+    });
+  });
+
+  describe('deleteNote', () => {
+    it('removes properties then the note row', async () => {
+      const mock = createMockSqlite();
+      await makeService(mock).deleteNote('Projects/alpha.md');
+      expect(runsMatching(mock, 'DELETE FROM note_properties')).toHaveLength(1);
+      expect(runsMatching(mock, 'DELETE FROM notes')).toHaveLength(1);
+    });
+
+    it('is a no-op when the note is not indexed', async () => {
+      const mock = createMockSqlite();
+      mock.queryOne.mockResolvedValue(null);
+      await makeService(mock).deleteNote('nope.md');
+      expect(mock.run).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pruneMissing', () => {
+    it('prunes nothing for an empty present-set (failed-walk guard)', async () => {
+      const mock = createMockSqlite();
+      await makeService(mock).pruneMissing(new Set());
+      expect(mock.query).not.toHaveBeenCalled();
+      expect(mock.run).not.toHaveBeenCalled();
+    });
+
+    it('deletes only notes absent from the present-set', async () => {
+      const mock = createMockSqlite();
+      mock.query.mockResolvedValueOnce([{ path: 'a.md' }, { path: 'gone.md' }]);
+      mock.queryOne.mockResolvedValue({ id: 7 });
+
+      await makeService(mock).pruneMissing(new Set(['a.md']));
+
+      expect(runsMatching(mock, 'DELETE FROM notes')).toHaveLength(1);
+    });
+  });
+
+  it('count returns the scalar', async () => {
+    const mock = createMockSqlite();
+    mock.queryOne.mockResolvedValue({ n: 5 });
+    expect(await makeService(mock).count()).toBe(5);
+  });
+});

--- a/tests/unit/QueryNotesTool.test.ts
+++ b/tests/unit/QueryNotesTool.test.ts
@@ -1,0 +1,115 @@
+/**
+ * QueryNotesTool unit tests — the read-only SQL guard and the execute paths
+ * (describe, missing/blocked/valid sql, row cap, friendly errors). SQLite is
+ * mocked; no real DB.
+ */
+
+import { QueryNotesTool, assertReadOnlySelect } from '../../src/agents/searchManager/tools/queryNotes';
+import type { QueryNotesParams } from '../../src/agents/searchManager/tools/queryNotes';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+
+type MockSqlite = { query: jest.Mock; queryOne: jest.Mock };
+
+function makeTool(mock: MockSqlite | null) {
+  return new QueryNotesTool(() => (mock as unknown as SQLiteCacheManager) ?? undefined);
+}
+
+const run = (tool: QueryNotesTool, params: Partial<QueryNotesParams>) =>
+  tool.execute(params as QueryNotesParams);
+
+describe('assertReadOnlySelect', () => {
+  it('accepts SELECT and WITH', () => {
+    expect(assertReadOnlySelect('SELECT * FROM notes').ok).toBe(true);
+    expect(assertReadOnlySelect('WITH x AS (SELECT 1) SELECT * FROM x').ok).toBe(true);
+    expect(assertReadOnlySelect('select path from notes;').ok).toBe(true); // trailing ; ok
+  });
+
+  it('rejects multiple statements', () => {
+    expect(assertReadOnlySelect('SELECT 1; SELECT 2').ok).toBe(false);
+    expect(assertReadOnlySelect('SELECT 1; DROP TABLE notes').ok).toBe(false);
+  });
+
+  it('rejects non-select leading statements', () => {
+    expect(assertReadOnlySelect('UPDATE notes SET x=1').ok).toBe(false);
+    expect(assertReadOnlySelect('PRAGMA table_info(notes)').ok).toBe(false);
+  });
+
+  it('rejects write/DDL keywords anywhere', () => {
+    for (const sql of ['SELECT 1 WHERE 1=1 OR delete', 'SELECT * FROM notes; insert']) {
+      expect(assertReadOnlySelect(sql).ok).toBe(false);
+    }
+  });
+
+  it('does not false-positive on column names containing a keyword', () => {
+    // `created` contains "create" but is a distinct word → allowed.
+    expect(assertReadOnlySelect('SELECT created FROM notes').ok).toBe(true);
+  });
+});
+
+describe('QueryNotesTool.execute', () => {
+  it('errors when the cache is unavailable', async () => {
+    const res = await run(makeTool(null), { sql: 'SELECT 1' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/unavailable/i);
+  });
+
+  it('errors when sql is missing', async () => {
+    const mock: MockSqlite = { query: jest.fn(), queryOne: jest.fn() };
+    const res = await run(makeTool(mock), {});
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/sql is required/i);
+  });
+
+  it('blocks a non-read-only query before touching the DB', async () => {
+    const mock: MockSqlite = { query: jest.fn(), queryOne: jest.fn() };
+    const res = await run(makeTool(mock), { sql: 'DELETE FROM notes' });
+    expect(res.success).toBe(false);
+    expect(mock.query).not.toHaveBeenCalled();
+  });
+
+  it('runs a valid SELECT and returns columns + rows', async () => {
+    const mock: MockSqlite = {
+      query: jest.fn().mockResolvedValue([{ path: 'a.md', status: 'active' }]),
+      queryOne: jest.fn(),
+    };
+    const res = await run(makeTool(mock), { sql: 'SELECT path, status FROM notes' });
+    expect(res.success).toBe(true);
+    const data = res.data as { columns: string[]; rowCount: number; truncated: boolean };
+    expect(data.columns).toEqual(['path', 'status']);
+    expect(data.rowCount).toBe(1);
+    expect(data.truncated).toBe(false);
+  });
+
+  it('caps rows at maxRows and flags truncation', async () => {
+    const mock: MockSqlite = {
+      query: jest.fn().mockResolvedValue([{ p: 1 }, { p: 2 }, { p: 3 }]),
+      queryOne: jest.fn(),
+    };
+    const res = await run(makeTool(mock), { sql: 'SELECT p FROM notes', maxRows: 2 });
+    const data = res.data as { rowCount: number; truncated: boolean };
+    expect(data.rowCount).toBe(2);
+    expect(data.truncated).toBe(true);
+  });
+
+  it('describe returns schema, note count, and distinct keys', async () => {
+    const mock: MockSqlite = {
+      query: jest.fn().mockResolvedValue([{ key: 'due' }, { key: 'status' }]),
+      queryOne: jest.fn().mockResolvedValue({ n: 7 }),
+    };
+    const res = await run(makeTool(mock), { describe: true });
+    const schema = res.data as { noteCount: number; distinctKeys: string[] };
+    expect(res.success).toBe(true);
+    expect(schema.noteCount).toBe(7);
+    expect(schema.distinctKeys).toEqual(['due', 'status']);
+  });
+
+  it('adds a hint when the table is not built yet', async () => {
+    const mock: MockSqlite = {
+      query: jest.fn().mockRejectedValue(new Error('no such table: notes')),
+      queryOne: jest.fn(),
+    };
+    const res = await run(makeTool(mock), { sql: 'SELECT * FROM notes' });
+    expect(res.success).toBe(false);
+    expect(res.error).toMatch(/not be built yet/i);
+  });
+});

--- a/tests/unit/QueryNotesTool.test.ts
+++ b/tests/unit/QueryNotesTool.test.ts
@@ -57,6 +57,16 @@ describe('assertReadOnlySelect', () => {
   it('still blocks a DML keyword outside any literal (WITH ... DELETE)', () => {
     expect(assertReadOnlySelect('WITH x AS (SELECT 1) DELETE FROM notes').ok).toBe(false);
   });
+
+  it('allows the replace() string function but blocks REPLACE INTO', () => {
+    expect(assertReadOnlySelect("SELECT replace(title, 'a', 'b') FROM notes").ok).toBe(true);
+    expect(assertReadOnlySelect('REPLACE INTO notes VALUES (1)').ok).toBe(false);
+    expect(assertReadOnlySelect("SELECT 1 WHERE 1=1; replace into notes values(1)").ok).toBe(false);
+  });
+
+  it('allows a parenthesized compound read', () => {
+    expect(assertReadOnlySelect('(SELECT 1) UNION (SELECT 2)').ok).toBe(true);
+  });
 });
 
 describe('QueryNotesTool.execute', () => {
@@ -104,16 +114,54 @@ describe('QueryNotesTool.execute', () => {
     expect(data.truncated).toBe(true);
   });
 
+  it('wraps the query in an outer LIMIT (maxRows+1) to bound runaway reads', async () => {
+    const mock: MockSqlite = { query: jest.fn().mockResolvedValue([]), queryOne: jest.fn() };
+    await run(makeTool(mock), { sql: 'SELECT * FROM notes', maxRows: 10 });
+    const [sqlArg, bindArg] = mock.query.mock.calls[0];
+    expect(sqlArg).toMatch(/^SELECT \* FROM \(/i);
+    expect(sqlArg).toMatch(/\) LIMIT \?$/);
+    expect(bindArg).toEqual([11]); // maxRows + 1
+  });
+
+  it('strips a trailing semicolon before nesting the query', async () => {
+    const mock: MockSqlite = { query: jest.fn().mockResolvedValue([]), queryOne: jest.fn() };
+    await run(makeTool(mock), { sql: 'SELECT 1;' });
+    const [sqlArg] = mock.query.mock.calls[0];
+    expect(sqlArg).toBe('SELECT * FROM (SELECT 1) LIMIT ?');
+  });
+
+  it('coerces boolean bind params to 1/0 and appends the row cap', async () => {
+    const mock: MockSqlite = { query: jest.fn().mockResolvedValue([]), queryOne: jest.fn() };
+    await run(makeTool(mock), { sql: 'SELECT * FROM notes WHERE a = ? AND b = ?', params: [true, false] });
+    const bindArg = mock.query.mock.calls[0][1];
+    expect(bindArg).toEqual([1, 0, 501]); // booleans coerced, default maxRows(500)+1
+  });
+
   it('describe returns schema, note count, and distinct keys', async () => {
     const mock: MockSqlite = {
       query: jest.fn().mockResolvedValue([{ key: 'due' }, { key: 'status' }]),
       queryOne: jest.fn().mockResolvedValue({ n: 7 }),
     };
     const res = await run(makeTool(mock), { describe: true });
-    const schema = res.data as { noteCount: number; distinctKeys: string[] };
+    const schema = res.data as { noteCount: number; distinctKeys: string[]; built: boolean; status: string };
     expect(res.success).toBe(true);
     expect(schema.noteCount).toBe(7);
     expect(schema.distinctKeys).toEqual(['due', 'status']);
+    expect(schema.built).toBe(true);
+    expect(schema.status).toBe('ready');
+  });
+
+  it('describe reports built:false when the index tables do not exist yet', async () => {
+    const mock: MockSqlite = {
+      query: jest.fn().mockRejectedValue(new Error('no such table: notes')),
+      queryOne: jest.fn().mockRejectedValue(new Error('no such table: notes')),
+    };
+    const res = await run(makeTool(mock), { describe: true });
+    const schema = res.data as { built: boolean; status: string; noteCount: number };
+    expect(res.success).toBe(true);
+    expect(schema.built).toBe(false);
+    expect(schema.status).toMatch(/building/i);
+    expect(schema.noteCount).toBe(0);
   });
 
   it('adds a hint when the table is not built yet', async () => {

--- a/tests/unit/QueryNotesTool.test.ts
+++ b/tests/unit/QueryNotesTool.test.ts
@@ -44,6 +44,19 @@ describe('assertReadOnlySelect', () => {
     // `created` contains "create" but is a distinct word → allowed.
     expect(assertReadOnlySelect('SELECT created FROM notes').ok).toBe(true);
   });
+
+  it('allows a write keyword inside a string literal value', () => {
+    expect(assertReadOnlySelect("SELECT path FROM notes WHERE status = 'delete'").ok).toBe(true);
+    expect(assertReadOnlySelect("SELECT path FROM notes WHERE title = 'drop everything'").ok).toBe(true);
+  });
+
+  it('allows a leading comment before SELECT', () => {
+    expect(assertReadOnlySelect('-- find active\nSELECT path FROM notes').ok).toBe(true);
+  });
+
+  it('still blocks a DML keyword outside any literal (WITH ... DELETE)', () => {
+    expect(assertReadOnlySelect('WITH x AS (SELECT 1) DELETE FROM notes').ok).toBe(false);
+  });
 });
 
 describe('QueryNotesTool.execute', () => {


### PR DESCRIPTION
## Summary

Adds a **notes query index** — your vault's notes + frontmatter exposed as queryable SQL rows via a new read-only `search query-notes` tool. SQLite does the filtering, aggregation, and sorting; there is deliberately no separate query DSL or formula evaluator.

- **`notes`** table: one row per markdown file (`path, basename, folder, ext, title, ctime, mtime, size, tags_json, links_json, frontmatter_json, content_hash`).
- **`note_properties`** (EAV): one indexed row per frontmatter property (per list element) — `key, key_raw, value_text, value_num, value_type, position`. This is the indexed filter path for arbitrary frontmatter.
- In-memory, rebuildable: built at startup by walking the vault (hash-gated, batched, backgrounded), kept fresh via `metadataCache`/vault events. The vault is the source of truth.
- Graceful degrade above `maxNotes` (250k desktop / 50k mobile); mobile-safe (no Node built-ins, FNV-1a hash).

Design notes: `docs/plans/notes-query-index-plan.md`.

## Review hardening (this branch's final commit)

All verified against a live **15,773-note** vault:

- **Critical startup wiring fix** — the `notesIndex` service was registered but never instantiated (boot uses an explicit `getService` list, not BACKGROUND-stage auto-init, and nothing requested it), so the tables never got created. Now kicked off fire-and-forget in `initializeBusinessServices` without gating boot.
- **Runaway-read guard** — the validated query is wrapped as `SELECT * FROM (<sql>) LIMIT maxRows+1` so SQLite stops early instead of materializing everything. A 15773³ (~3.9T-row) cross-join now returns capped at 500 instead of freezing the synchronous WASM engine.
- **`replace()` no longer false-rejected** — `FORBIDDEN` matches `replace\s+into`, not the bare string function.
- **`describe` honesty** — reports `built` + `status` (`ready`/`empty`/`building`) so "not materialized yet" ≠ "built but empty".
- Boolean bind coercion, parenthesized-compound reads allowed, inert FK `ON DELETE CASCADE` dropped.

## Read-only guarantee

`queryNotes` is read/compute only. A code-level guard (not schema — schemas aren't runtime-validated here) requires a single `SELECT`/`WITH`, rejects multiple statements and all write/DDL/PRAGMA keywords outside literals, and the bridge only `step()`s one prepared statement. Nothing in the feature edits or deletes notes; the index tables are derived from vault contents only.

## Test plan

- Unit: `tests/unit/NotesIndex*.test.ts` + `QueryNotesTool.test.ts` (21 query-tool tests incl. guard, LIMIT-wrap, boolean coercion, describe states). Build + lint clean.
- Manual (live vault, all green): folder aggregates, status distribution, EAV `status`/`area` filters, `year >= 2023` numeric ordering, `essay_number` sort, tags top-20 + two-EXISTS intersection, `json_extract` recency projection, `replace()`, runaway cross-join cap, and a `DELETE` write attempt correctly refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)