### PR TITLE
fix(taskmanager): drain all pages for workspace/board snapshots (#272)

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -33,6 +33,14 @@ import { PaginatedResult } from '../../../types/pagination/PaginationTypes';
 import { logger } from '../../../utils/logger';
 import { formatTaskRef, taskRefToIdPrefix } from '../utils/taskRefs';
 
+/**
+ * Page size used when draining a paginated repository query to build a
+ * full-workspace snapshot. Matches BaseRepository's hard cap
+ * (Math.min(pageSize ?? 25, 200)) so each drained page is the largest the
+ * repository will actually return — minimizing the number of round-trips.
+ */
+const SNAPSHOT_PAGE_SIZE = 200;
+
 export interface TaskBoardEventPayload {
   workspaceId: string;
   entity: 'task' | 'project';
@@ -754,6 +762,38 @@ export class TaskService {
     return this.taskRepo.getByLinkedNote(notePath);
   }
 
+  /**
+   * Drain every page of a paginated repository query into a single array.
+   *
+   * The underlying repository hard-caps pageSize at SNAPSHOT_PAGE_SIZE
+   * (BaseRepository.queryPaginated), so a single large-pageSize request
+   * silently returns only the first page while totalItems still reports the
+   * true count — the root cause of issue #272's undercount. This walks
+   * pages sequentially until hasNextPage is false so callers see the whole set.
+   *
+   * @param loadPage - loads a single 0-indexed page
+   * @returns all items across pages plus the repository's reported totalItems
+   */
+  private async collectAllPages<T>(
+    loadPage: (page: number) => Promise<PaginatedResult<T>>
+  ): Promise<{ items: T[]; totalItems: number }> {
+    const items: T[] = [];
+    let page = 0;
+    let totalItems = 0;
+
+    for (;;) {
+      const result = await loadPage(page);
+      if (page === 0) {
+        totalItems = result.totalItems;
+      }
+      items.push(...result.items);
+      if (!result.hasNextPage) {
+        return { items, totalItems };
+      }
+      page += 1;
+    }
+  }
+
   // ────────────────────────────────────────────────────────────────
   // Workspace Summary (for loadWorkspace integration)
   // ────────────────────────────────────────────────────────────────
@@ -762,16 +802,40 @@ export class TaskService {
     await this.ensureQueryReady();
 
     workspaceId = await this.resolveWorkspaceId(workspaceId);
-    const projects = await this.projectRepo.getByWorkspace(workspaceId, { pageSize: 1000 });
-    const allTasks = await this.taskRepo.getByWorkspace(workspaceId, { pageSize: 10000 });
+    // Drain all pages — a single large-pageSize request would clamp to
+    // SNAPSHOT_PAGE_SIZE and silently truncate workspaces with >200 tasks
+    // (issue #272). projectSnapshot.totalItems / taskSnapshot.totalItems
+    // remain the true repository-reported totals.
+    const [projectSnapshot, taskSnapshot] = await Promise.all([
+      this.collectAllPages(page =>
+        this.projectRepo.getByWorkspace(workspaceId, { page, pageSize: SNAPSHOT_PAGE_SIZE })
+      ),
+      this.collectAllPages(page =>
+        this.taskRepo.getByWorkspace(workspaceId, { page, pageSize: SNAPSHOT_PAGE_SIZE })
+      )
+    ]);
+
+    const projects = projectSnapshot.items;
+    const allTasks = taskSnapshot.items;
+
+    // Visible projects exclude archived ones. A task is visible iff it has no
+    // owning project (orphan) OR its owning project is not archived. Filtering
+    // at the TASK level (rather than "if any projects exist, filter; else keep
+    // all") means: when every project is archived, only genuinely orphan tasks
+    // survive — archived-project tasks are never silently counted, and
+    // legitimate projectless tasks are never wrongly hidden (issue #272 MINOR-2).
+    const archivedProjectIds = new Set(
+      projects.filter(project => project.status === 'archived').map(project => project.id)
+    );
+    const visibleTasks = allTasks.filter(task => !archivedProjectIds.has(task.projectId));
 
     // Build project summaries
     const projectItems: ProjectSummary[] = [];
     const taskCountByProject = new Map<string, number>();
-    for (const task of allTasks.items) {
+    for (const task of visibleTasks) {
       taskCountByProject.set(task.projectId, (taskCountByProject.get(task.projectId) ?? 0) + 1);
     }
-    for (const project of projects.items) {
+    for (const project of projects) {
       if (project.status !== 'archived') {
         projectItems.push({
           id: project.id,
@@ -786,7 +850,7 @@ export class TaskService {
     const byStatus: Record<TaskStatus, number> = { todo: 0, in_progress: 0, done: 0, cancelled: 0 };
     let overdue = 0;
     const now = Date.now();
-    for (const task of allTasks.items) {
+    for (const task of visibleTasks) {
       byStatus[task.status] = (byStatus[task.status] ?? 0) + 1;
       if (task.dueDate && task.dueDate < now && task.status !== 'done' && task.status !== 'cancelled') {
         overdue++;
@@ -796,14 +860,14 @@ export class TaskService {
     // Compute next actions in-memory from already-fetched workspace tasks.
     // Fetch edges per active project in parallel (avoids N+1 sequential getNextActions calls
     // that each re-fetched all tasks + edges independently).
-    const activeProjects = projects.items.filter(p => p.status === 'active');
+    const activeProjects = projects.filter(p => p.status === 'active');
     const edgeArrays = await Promise.all(
       activeProjects.map(p => this.taskRepo.getAllDependencyEdges(p.id))
     );
     const allEdges: Edge[] = edgeArrays.flat();
 
     const activeProjectIds = new Set(activeProjects.map(p => p.id));
-    const activeTasks = allTasks.items.filter(t => activeProjectIds.has(t.projectId));
+    const activeTasks = visibleTasks.filter(t => activeProjectIds.has(t.projectId));
     const nodes: TaskNode[] = activeTasks.map(t => ({ id: t.id, status: t.status }));
     const readyNodes = this.dagService.getNextActions(nodes, allEdges);
     const readyIds = new Set(readyNodes.map(n => n.id));
@@ -818,7 +882,7 @@ export class TaskService {
       .slice(0, 5);
 
     // Recently completed (last 5)
-    const completed = allTasks.items
+    const completed = visibleTasks
       .filter(t => t.status === 'done' && t.completedAt)
       .sort((a, b) => (b.completedAt ?? 0) - (a.completedAt ?? 0))
       .slice(0, 5);
@@ -831,14 +895,22 @@ export class TaskService {
       this.attachNoteLinks(completed)
     ]);
 
+    // INTENTIONAL ASYMMETRY (issue #272, user-confirmed):
+    //  - projects.total stays the TRUE repository count (includes archived
+    //    projects) so any "N projects" header keeps showing the real total.
+    //  - tasks.total becomes the VISIBLE-only count (excludes archived-project
+    //    tasks) so it is consistent with byStatus/nextActions/recentlyCompleted,
+    //    which are all computed from visibleTasks. #272 is specifically a
+    //    task-undercount bug; flipping projects.total to visible-only would be
+    //    an unflagged scope expansion. Documented here + in the PR description.
     return {
       projects: {
-        total: projects.totalItems,
+        total: projectSnapshot.totalItems,
         active: projectItems.filter(p => p.status === 'active').length,
         items: projectItems
       },
       tasks: {
-        total: allTasks.totalItems,
+        total: visibleTasks.length,
         byStatus,
         overdue,
         nextActions: nextActionsWithLinks,

--- a/src/ui/tasks/services/TaskBoardDataController.ts
+++ b/src/ui/tasks/services/TaskBoardDataController.ts
@@ -11,6 +11,14 @@ import type { TaskBoardViewState } from '../taskBoardNavigation';
 import type { TaskBoardTask } from '../taskBoardTypes';
 import { TaskBoardFilterController } from './TaskBoardFilterController';
 
+/**
+ * Page size used when draining paginated task/project queries for the board.
+ * Matches BaseRepository's hard cap so each drained page is the largest the
+ * repository will return (see issue #272 — a single large-pageSize request
+ * silently truncates to this cap).
+ */
+const BOARD_PAGE_SIZE = 200;
+
 interface TaskManagerAgentLike {
   getTaskService?: () => TaskService;
 }
@@ -84,6 +92,31 @@ export class TaskBoardDataController {
     }
   }
 
+  /**
+   * Drain every page of a paginated query into a single array. The repository
+   * caps pageSize at BOARD_PAGE_SIZE, so a single large-pageSize request would
+   * silently return only the first page (issue #272). Walk pages sequentially
+   * until hasNextPage is false.
+   *
+   * @param loadPage - loads a single 0-indexed page
+   * @returns all items across pages
+   */
+  private async loadAllPages<T>(
+    loadPage: (page: number) => Promise<{ items: T[]; hasNextPage: boolean }>
+  ): Promise<T[]> {
+    const items: T[] = [];
+    let page = 0;
+
+    for (;;) {
+      const result = await loadPage(page);
+      items.push(...result.items);
+      if (!result.hasNextPage) {
+        return items;
+      }
+      page += 1;
+    }
+  }
+
   async loadBoardData(filterState: TaskBoardViewState): Promise<TaskBoardDataSnapshot> {
     const workspaceService = this.workspaceService;
     const taskService = this.taskService;
@@ -106,15 +139,33 @@ export class TaskBoardDataController {
 
     const workspaceData = await Promise.all(
       workspaces.map(async workspace => {
-        const [projectsResult, tasksResult] = await Promise.all([
-          taskService.listProjects(workspace.id, { pageSize: 1000 }),
-          taskService.listWorkspaceTasks(workspace.id, { pageSize: 10000 })
-        ]);
+        // Drain all project pages, then filter out archived projects BEFORE
+        // loading their tasks. This both fixes the >200 truncation (issue #272)
+        // and excludes archived-project tasks from the board snapshot by never
+        // fetching them — replacing the old workspace-wide listWorkspaceTasks
+        // (which pulled archived-project tasks too) with per-visible-project
+        // listTasks. includeSubtasks:true preserves the prior default
+        // (listWorkspaceTasks only excluded subtasks when includeSubtasks===false).
+        const projects = (await this.loadAllPages(page =>
+          taskService.listProjects(workspace.id, { page, pageSize: BOARD_PAGE_SIZE })
+        )).filter(project => project.status !== 'archived');
+
+        const tasksByProject = await Promise.all(
+          projects.map(project =>
+            this.loadAllPages(page =>
+              taskService.listTasks(project.id, {
+                page,
+                pageSize: BOARD_PAGE_SIZE,
+                includeSubtasks: true
+              })
+            )
+          )
+        );
 
         return {
           workspace,
-          projects: projectsResult.items.filter(project => project.status !== 'archived'),
-          tasks: tasksResult.items
+          projects,
+          tasks: tasksByProject.flat()
         };
       })
     );

--- a/tests/unit/TaskBoardDataController.test.ts
+++ b/tests/unit/TaskBoardDataController.test.ts
@@ -317,6 +317,115 @@ describe('TaskBoardDataController', () => {
     expect(snapshot.tasks.map(task => task.id)).toEqual(['parent', 'child']);
   });
 
+  it('omits orphan / archived-parent tasks whose project is not visible from the board (board-vs-summary divergence)', async () => {
+    const workspaceService = {
+      getWorkspaces: jest.fn().mockResolvedValue([createWorkspace({ id: 'ws-1' })]),
+      getActiveWorkspace: jest.fn().mockResolvedValue(createWorkspace({ id: 'ws-1' }))
+    } as unknown as WorkspaceService;
+
+    // The visible project's page returns a normal task plus a task whose
+    // projectId points at a non-visible (e.g. archived/removed) project —
+    // standing in for an orphan / archived-parent task. The board must drop it:
+    // unlike getWorkspaceSummary (which keeps orphans visible), the board only
+    // surfaces tasks belonging to a visible project (projectMap guard +
+    // per-visible-project loading). This pins that intentional divergence.
+    const taskService = {
+      listProjects: jest.fn().mockResolvedValue({
+        items: [createProject({ id: 'proj-1', workspaceId: 'ws-1', name: 'Project One' })],
+        hasNextPage: false
+      }),
+      listTasks: jest.fn().mockResolvedValue({
+        items: [
+          createTask({ id: 'visible-task', projectId: 'proj-1', workspaceId: 'ws-1' }),
+          createTask({ id: 'orphan-task', projectId: 'proj-not-visible', workspaceId: 'ws-1' })
+        ],
+        hasNextPage: false
+      }),
+      listWorkspaceTasks: jest.fn(),
+      getNoteLinks: jest.fn().mockResolvedValue([])
+    } as unknown as TaskService;
+
+    const plugin = {
+      getService: jest.fn(async (name: string) => {
+        switch (name) {
+          case 'workspaceService':
+            return workspaceService;
+          case 'agentRegistrationService':
+            return { initializeAllAgents: jest.fn().mockResolvedValue(undefined) };
+          case 'agentManager':
+            return {
+              getAgent: jest.fn().mockReturnValue({
+                getTaskService: () => taskService
+              })
+            };
+          default:
+            return null;
+        }
+      })
+    } as unknown as NexusPlugin;
+
+    const controller = new TaskBoardDataController(plugin);
+
+    await controller.ensureServices();
+    const snapshot = await controller.loadBoardData({});
+
+    expect(snapshot.tasks.map(task => task.id)).toEqual(['visible-task']);
+    expect(snapshot.tasks.map(task => task.id)).not.toContain('orphan-task');
+  });
+
+  it('falls back to empty note links when getNoteLinks rejects for a visible task (.catch path)', async () => {
+    const workspaceService = {
+      getWorkspaces: jest.fn().mockResolvedValue([createWorkspace({ id: 'ws-1' })]),
+      getActiveWorkspace: jest.fn().mockResolvedValue(createWorkspace({ id: 'ws-1' }))
+    } as unknown as WorkspaceService;
+
+    // getNoteLinks rejects for the (now visible) task — the controller's .catch
+    // must swallow the rejection and leave noteLinks as []. Previously this path
+    // was exercised via an archived-project task, which is no longer fetched.
+    const taskService = {
+      listProjects: jest.fn().mockResolvedValue({
+        items: [createProject({ id: 'proj-1', workspaceId: 'ws-1', name: 'Project One' })],
+        hasNextPage: false
+      }),
+      listTasks: jest.fn().mockResolvedValue({
+        items: [createTask({ id: 'visible-task', projectId: 'proj-1', workspaceId: 'ws-1' })],
+        hasNextPage: false
+      }),
+      listWorkspaceTasks: jest.fn(),
+      getNoteLinks: jest.fn().mockRejectedValue(new Error('note link lookup failed'))
+    } as unknown as TaskService;
+
+    const plugin = {
+      getService: jest.fn(async (name: string) => {
+        switch (name) {
+          case 'workspaceService':
+            return workspaceService;
+          case 'agentRegistrationService':
+            return { initializeAllAgents: jest.fn().mockResolvedValue(undefined) };
+          case 'agentManager':
+            return {
+              getAgent: jest.fn().mockReturnValue({
+                getTaskService: () => taskService
+              })
+            };
+          default:
+            return null;
+        }
+      })
+    } as unknown as NexusPlugin;
+
+    const controller = new TaskBoardDataController(plugin);
+
+    await controller.ensureServices();
+    const snapshot = await controller.loadBoardData({});
+
+    expect(taskService.getNoteLinks).toHaveBeenCalledWith('visible-task');
+    expect(snapshot.tasks).toHaveLength(1);
+    expect(snapshot.tasks[0]).toEqual(
+      expect.objectContaining({ id: 'visible-task', noteLinks: [] })
+    );
+  });
+
   it('throws when the task manager agent is unavailable', async () => {
     const plugin = {
       getService: jest.fn(async (name: string) => {

--- a/tests/unit/TaskBoardDataController.test.ts
+++ b/tests/unit/TaskBoardDataController.test.ts
@@ -73,17 +73,20 @@ describe('TaskBoardDataController', () => {
         items: [
           createProject({ id: 'proj-1', workspaceId: 'ws-1', name: 'Project One' }),
           createProject({ id: 'proj-archived', workspaceId: 'ws-1', status: 'archived' })
-        ]
+        ],
+        hasNextPage: false
       }),
-      listWorkspaceTasks: jest.fn().mockResolvedValue({
+      // Per-visible-project task loading: only proj-1 is queried; the archived
+      // project's tasks are never fetched (issue #272 archived-before-snapshot).
+      listTasks: jest.fn().mockResolvedValue({
         items: [
-          createTask({ id: 'task-1', projectId: 'proj-1', workspaceId: 'ws-1', title: 'Task One' }),
-          createTask({ id: 'task-2', projectId: 'proj-archived', workspaceId: 'ws-1', title: 'Archived project task' })
-        ]
+          createTask({ id: 'task-1', projectId: 'proj-1', workspaceId: 'ws-1', title: 'Task One' })
+        ],
+        hasNextPage: false
       }),
+      listWorkspaceTasks: jest.fn(),
       getNoteLinks: jest.fn()
         .mockResolvedValueOnce([createLink({ taskId: 'task-1' })])
-        .mockRejectedValueOnce(new Error('note link lookup failed'))
     } as unknown as TaskService;
 
     const agentManager = {
@@ -130,6 +133,188 @@ describe('TaskBoardDataController', () => {
       })
     );
     expect(snapshot.filterState.workspaceId).toBe('ws-1');
+    expect(taskService.listTasks).toHaveBeenCalledWith('proj-1', {
+      page: 0,
+      pageSize: 200,
+      includeSubtasks: true
+    });
+    expect(taskService.listTasks).not.toHaveBeenCalledWith('proj-archived', expect.anything());
+    expect(taskService.listWorkspaceTasks).not.toHaveBeenCalled();
+  });
+
+  it('drains all task pages for visible projects instead of treating the first page as the whole set', async () => {
+    const workspaceService = {
+      getWorkspaces: jest.fn().mockResolvedValue([createWorkspace({ id: 'ws-1' })]),
+      getActiveWorkspace: jest.fn().mockResolvedValue(createWorkspace({ id: 'ws-1' }))
+    } as unknown as WorkspaceService;
+
+    const taskService = {
+      listProjects: jest.fn().mockResolvedValue({
+        items: [createProject({ id: 'proj-1', workspaceId: 'ws-1' })],
+        hasNextPage: false
+      }),
+      // Two pages of tasks for the same project — the controller must walk
+      // both rather than stopping after the first (issue #272 truncation).
+      listTasks: jest.fn()
+        .mockResolvedValueOnce({
+          items: [createTask({ id: 'task-page-1', projectId: 'proj-1', workspaceId: 'ws-1' })],
+          hasNextPage: true
+        })
+        .mockResolvedValueOnce({
+          items: [createTask({ id: 'task-page-2', projectId: 'proj-1', workspaceId: 'ws-1' })],
+          hasNextPage: false
+        }),
+      listWorkspaceTasks: jest.fn(),
+      getNoteLinks: jest.fn().mockResolvedValue([])
+    } as unknown as TaskService;
+
+    const plugin = {
+      getService: jest.fn(async (name: string) => {
+        switch (name) {
+          case 'workspaceService':
+            return workspaceService;
+          case 'agentRegistrationService':
+            return { initializeAllAgents: jest.fn().mockResolvedValue(undefined) };
+          case 'agentManager':
+            return {
+              getAgent: jest.fn().mockReturnValue({
+                getTaskService: () => taskService
+              })
+            };
+          default:
+            return null;
+        }
+      })
+    } as unknown as NexusPlugin;
+
+    const controller = new TaskBoardDataController(plugin);
+
+    await controller.ensureServices();
+    const snapshot = await controller.loadBoardData({});
+
+    expect(taskService.listTasks).toHaveBeenCalledTimes(2);
+    expect(taskService.listTasks).toHaveBeenNthCalledWith(1, 'proj-1', {
+      page: 0,
+      pageSize: 200,
+      includeSubtasks: true
+    });
+    expect(taskService.listTasks).toHaveBeenNthCalledWith(2, 'proj-1', {
+      page: 1,
+      pageSize: 200,
+      includeSubtasks: true
+    });
+    expect(snapshot.tasks.map(task => task.id)).toEqual(['task-page-1', 'task-page-2']);
+  });
+
+  it('drains all project pages so projects beyond the first page are still loaded', async () => {
+    const workspaceService = {
+      getWorkspaces: jest.fn().mockResolvedValue([createWorkspace({ id: 'ws-1' })]),
+      getActiveWorkspace: jest.fn().mockResolvedValue(createWorkspace({ id: 'ws-1' }))
+    } as unknown as WorkspaceService;
+
+    const taskService = {
+      // Two pages of projects — the controller must walk both.
+      listProjects: jest.fn()
+        .mockResolvedValueOnce({
+          items: [createProject({ id: 'proj-page-1', workspaceId: 'ws-1' })],
+          hasNextPage: true
+        })
+        .mockResolvedValueOnce({
+          items: [createProject({ id: 'proj-page-2', workspaceId: 'ws-1' })],
+          hasNextPage: false
+        }),
+      listTasks: jest.fn().mockResolvedValue({ items: [], hasNextPage: false }),
+      listWorkspaceTasks: jest.fn(),
+      getNoteLinks: jest.fn().mockResolvedValue([])
+    } as unknown as TaskService;
+
+    const plugin = {
+      getService: jest.fn(async (name: string) => {
+        switch (name) {
+          case 'workspaceService':
+            return workspaceService;
+          case 'agentRegistrationService':
+            return { initializeAllAgents: jest.fn().mockResolvedValue(undefined) };
+          case 'agentManager':
+            return {
+              getAgent: jest.fn().mockReturnValue({
+                getTaskService: () => taskService
+              })
+            };
+          default:
+            return null;
+        }
+      })
+    } as unknown as NexusPlugin;
+
+    const controller = new TaskBoardDataController(plugin);
+
+    await controller.ensureServices();
+    const snapshot = await controller.loadBoardData({});
+
+    expect(taskService.listProjects).toHaveBeenCalledTimes(2);
+    expect(snapshot.projects.map(project => project.id)).toEqual(['proj-page-1', 'proj-page-2']);
+    expect(taskService.listTasks).toHaveBeenCalledWith('proj-page-1', expect.anything());
+    expect(taskService.listTasks).toHaveBeenCalledWith('proj-page-2', expect.anything());
+  });
+
+  it('requests subtasks (includeSubtasks:true) so a parent and its subtask both appear (parity with listWorkspaceTasks)', async () => {
+    const workspaceService = {
+      getWorkspaces: jest.fn().mockResolvedValue([createWorkspace({ id: 'ws-1' })]),
+      getActiveWorkspace: jest.fn().mockResolvedValue(createWorkspace({ id: 'ws-1' }))
+    } as unknown as WorkspaceService;
+
+    const parentTask = createTask({ id: 'parent', projectId: 'proj-1', workspaceId: 'ws-1' });
+    const subtask = createTask({
+      id: 'child',
+      projectId: 'proj-1',
+      workspaceId: 'ws-1',
+      parentTaskId: 'parent'
+    });
+
+    const taskService = {
+      listProjects: jest.fn().mockResolvedValue({
+        items: [createProject({ id: 'proj-1', workspaceId: 'ws-1' })],
+        hasNextPage: false
+      }),
+      listTasks: jest.fn().mockResolvedValue({
+        items: [parentTask, subtask],
+        hasNextPage: false
+      }),
+      listWorkspaceTasks: jest.fn(),
+      getNoteLinks: jest.fn().mockResolvedValue([])
+    } as unknown as TaskService;
+
+    const plugin = {
+      getService: jest.fn(async (name: string) => {
+        switch (name) {
+          case 'workspaceService':
+            return workspaceService;
+          case 'agentRegistrationService':
+            return { initializeAllAgents: jest.fn().mockResolvedValue(undefined) };
+          case 'agentManager':
+            return {
+              getAgent: jest.fn().mockReturnValue({
+                getTaskService: () => taskService
+              })
+            };
+          default:
+            return null;
+        }
+      })
+    } as unknown as NexusPlugin;
+
+    const controller = new TaskBoardDataController(plugin);
+
+    await controller.ensureServices();
+    const snapshot = await controller.loadBoardData({});
+
+    expect(taskService.listTasks).toHaveBeenCalledWith('proj-1', {
+      page: 0,
+      pageSize: 200,
+      includeSubtasks: true
+    });
+    expect(snapshot.tasks.map(task => task.id)).toEqual(['parent', 'child']);
   });
 
   it('throws when the task manager agent is unavailable', async () => {

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -44,14 +44,25 @@ function createMockTask(overrides: Partial<TaskMetadata> = {}): TaskMetadata {
   };
 }
 
-function paginatedResult<T>(items: T[]): PaginatedResult<T> {
+function paginatedResult<T>(
+  items: T[],
+  overrides: Partial<Omit<PaginatedResult<T>, 'items'>> = {}
+): PaginatedResult<T> {
+  const page = overrides.page ?? 0;
+  const pageSize = overrides.pageSize ?? 100;
+  const totalItems = overrides.totalItems ?? items.length;
+  const totalPages = overrides.totalPages ?? Math.ceil(totalItems / pageSize);
+
   return {
     items,
-    totalItems: items.length,
-    totalPages: 1,
-    currentPage: 1,
-    pageSize: 100,
-    hasNextPage: false
+    page,
+    pageSize,
+    totalItems,
+    totalPages,
+    hasNextPage: overrides.hasNextPage ?? page < totalPages - 1,
+    hasPreviousPage: overrides.hasPreviousPage ?? page > 0,
+    nextCursor: overrides.nextCursor,
+    previousCursor: overrides.previousCursor
   };
 }
 
@@ -1255,6 +1266,99 @@ describe('TaskService', () => {
       expect(result.projects.total).toBe(3);          // all projects including archived
       expect(result.projects.active).toBe(1);          // only status === 'active'
       expect(result.projects.items).toHaveLength(2);   // active + completed visible, archived excluded
+    });
+
+    it('should drain all task pages before computing counts and summaries (>200 truncation guard)', async () => {
+      const activeProject = createMockProject({ id: 'active-project', status: 'active' });
+      const archivedProject = createMockProject({ id: 'archived-project', status: 'archived' });
+      const archivedTask = createMockTask({
+        id: 'archived-task',
+        projectId: 'archived-project',
+        status: 'done',
+        completedAt: 1000
+      });
+      const activeTask = createMockTask({
+        id: 'active-task',
+        projectId: 'active-project',
+        status: 'todo',
+        priority: 'high',
+        created: 1
+      });
+
+      projectRepo.getByWorkspace.mockResolvedValue(paginatedResult([activeProject, archivedProject]));
+      // Two task pages: the archived-project task lands on page 0, the active task
+      // on page 1. A consumer that stopped after page 0 would miss the active task
+      // entirely (issue #272) and would wrongly count the archived-project task.
+      taskRepo.getByWorkspace
+        .mockResolvedValueOnce(paginatedResult([archivedTask], {
+          page: 0,
+          pageSize: 200,
+          totalItems: 2,
+          totalPages: 2,
+          hasNextPage: true
+        }))
+        .mockResolvedValueOnce(paginatedResult([activeTask], {
+          page: 1,
+          pageSize: 200,
+          totalItems: 2,
+          totalPages: 2,
+          hasNextPage: false,
+          hasPreviousPage: true
+        }));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([]);
+
+      const result = await service.getWorkspaceSummary('ws-1');
+
+      // Both pages were drained.
+      expect(taskRepo.getByWorkspace).toHaveBeenCalledTimes(2);
+      expect(taskRepo.getByWorkspace).toHaveBeenNthCalledWith(1, 'ws-1', { page: 0, pageSize: 200 });
+      expect(taskRepo.getByWorkspace).toHaveBeenNthCalledWith(2, 'ws-1', { page: 1, pageSize: 200 });
+      // Archived-project task excluded; per-project count reflects only the visible task.
+      expect(result.projects.items).toEqual([
+        expect.objectContaining({ id: 'active-project', taskCount: 1, status: 'active' })
+      ]);
+      // tasks.total is visible-only and consistent with byStatus.
+      expect(result.tasks.total).toBe(1);
+      expect(result.tasks.byStatus.todo).toBe(1);
+      expect(result.tasks.byStatus.done).toBe(0);
+      expect(result.tasks.nextActions.map(task => task.id)).toEqual(['active-task']);
+      expect(result.tasks.recentlyCompleted).toEqual([]);
+      // projects.total stays the TRUE count (includes the archived project).
+      expect(result.projects.total).toBe(2);
+    });
+
+    it('should keep projects.total as the true count while tasks.total is visible-only (intentional asymmetry)', async () => {
+      const activeProject = createMockProject({ id: 'active-project', status: 'active' });
+      const archivedProject = createMockProject({ id: 'archived-project', status: 'archived' });
+      const visibleTask = createMockTask({ id: 'visible', projectId: 'active-project', status: 'todo' });
+      const archivedProjectTask = createMockTask({ id: 'hidden', projectId: 'archived-project', status: 'todo' });
+
+      projectRepo.getByWorkspace.mockResolvedValue(paginatedResult([activeProject, archivedProject]));
+      taskRepo.getByWorkspace.mockResolvedValue(paginatedResult([visibleTask, archivedProjectTask]));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([]);
+
+      const result = await service.getWorkspaceSummary('ws-1');
+
+      expect(result.projects.total).toBe(2);  // includes archived project
+      expect(result.tasks.total).toBe(1);      // excludes archived-project task
+      expect(result.tasks.byStatus.todo).toBe(1);
+    });
+
+    it('should not count archived-project tasks when every project is archived (orphan-only visibility)', async () => {
+      const archivedProject = createMockProject({ id: 'archived-project', status: 'archived' });
+      const archivedProjectTask = createMockTask({ id: 'in-archived', projectId: 'archived-project', status: 'todo' });
+      const orphanTask = createMockTask({ id: 'orphan', projectId: 'no-such-project', status: 'todo' });
+
+      projectRepo.getByWorkspace.mockResolvedValue(paginatedResult([archivedProject]));
+      taskRepo.getByWorkspace.mockResolvedValue(paginatedResult([archivedProjectTask, orphanTask]));
+      taskRepo.getAllDependencyEdges.mockResolvedValue([]);
+
+      const result = await service.getWorkspaceSummary('ws-1');
+
+      // Archived-project task is excluded; the genuinely projectless task stays visible.
+      expect(result.tasks.total).toBe(1);
+      expect(result.tasks.byStatus.todo).toBe(1);
+      expect(result.projects.items).toHaveLength(0);  // no visible projects
     });
 
     it('should limit next actions to 5', async () => {


### PR DESCRIPTION
## Summary
Fixes the task-board / workspace-summary **undercount** reported in #272. Counts and status breakdowns were computed from a single 200-row page while totals reported the true count — so workspaces with >200 tasks (and archived-project tasks consuming page slots) showed wrong numbers.

Addresses #272. (Leaving the issue open for the author to close after manual verification.)

## Root cause (verified against current main)
- `BaseRepository.queryPaginated` hard-caps `pageSize` at `Math.min(pageSize ?? 25, 200)` with plain `LIMIT/OFFSET`. Requests for `pageSize: 10000` silently clamp to 200, but `totalItems` stays the true count.
- `TaskService.getWorkspaceSummary` and `TaskBoardDataController.loadBoardData` both treated that one clamped 200-row page as the whole set, computing per-project counts / `byStatus` / next-actions / recently-completed from ≤200 rows. Archived-project filtering happened **after** the fetch (truncate-before-filter), so archived tasks burned page slots.

## Fix
- Both consumers now **drain all pages** (`{page, pageSize: 200}` loop until `!hasNextPage`) via small helpers (`collectAllPages` / `loadAllPages`).
- Archived-project tasks are excluded at the **task level**: a task is visible iff it has no owning project **or** its project is not archived. `TaskBoardDataController` filters archived projects **first**, then drains only visible projects' tasks (archived-project tasks are never fetched).
- `BaseRepository`'s 200 cap is left intact (sane per-query cap); no cursor pagination introduced.

## Intentional semantic notes (please read)
1. **`tasks.total` is now visible-only** (`visibleTasks.length`) rather than the all-task `totalItems`, so it is consistent with `byStatus`/`nextActions` which are also visible-only.
2. **Asymmetry:** `projects.total` stays the **true** count (incl. archived); only `tasks.total` is visible-only. Documented at the return site. If the project header should also be visible-only, that's a scoped follow-up.

## Tests
6 regression tests + 2 added in review: >200 task-page drain, >200 project-page drain, archived-before-snapshot, all-projects-archived → orphan-only visibility, projects/tasks total asymmetry, subtask parity, **board orphan-task absence**, and the restored note-link `.catch` path on a visible task.

## Verification
- `npm run build` clean · `npm run lint` clean
- Full jest: **3706 pass / 21 skip / 1 fail** — the lone failure is the pre-existing, documented `TaskBoardEditCoordinator` jsdom-Modal issue (untouched files; not a regression).

## Non-blocking follow-ups (from peer review)
- Board double-fetches note links (`listTasks` already returns enriched `TaskWithNoteLinks`, then `loadBoardData` discards and re-fetches via `getNoteLinks`). Correctness fine; minor wasted work. Tracked as a follow-up, not changed here.
- `OFFSET` drain → cursor pagination only if workspaces ever reach tens of thousands of tasks.

## Review
Peer-reviewed (APPROVE, 0 blocking): `docs/review/issue-272-fix-review-2026-06-22.md`, `docs/review/test-coverage-271-272-2026-06-22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
