### PR TITLE
fix(chat): bound CLI runner with idle watchdog + clear stuck chat spinner (#271 a+b)

### DIFF
--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -18,7 +18,7 @@ import {
   TokenUsage
 } from '../types';
 import { ModelRegistry } from '../ModelRegistry';
-import { CliProcessResult, runCliProcess } from '../../../../utils/cliProcessRunner';
+import { CliProcessResult, PROVIDER_TIMEOUT_ERROR_CODE, runCliProcess } from '../../../../utils/cliProcessRunner';
 import { GOOGLE_GEMINI_CLI_DEFAULT_MODEL } from './GoogleGeminiCliModels';
 import {
   buildGeminiCliEnv,
@@ -340,6 +340,14 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
         'Gemini CLI could not start because the local CLI command was too long for this platform. Reduce attached context files or shorten the prompt and try again.',
         this.name,
         'REQUEST_TOO_LARGE'
+      );
+    }
+
+    if (result.errorCode === PROVIDER_TIMEOUT_ERROR_CODE) {
+      return new LLMProviderError(
+        result.stderr.trim() || 'Gemini CLI stopped responding and was terminated. Please try again.',
+        this.name,
+        PROVIDER_TIMEOUT_ERROR_CODE
       );
     }
 

--- a/src/ui/chat/services/MessageManager.ts
+++ b/src/ui/chat/services/MessageManager.ts
@@ -214,6 +214,9 @@ export class MessageManager {
         );
 
         if (!wasAborted) {
+          // Clear the assistant placeholder's loading spinner; a non-abort
+          // error before the first token otherwise leaves it stuck (#271).
+          await this.abortHandler.finalizeErroredPlaceholder(conversation, aiMessageId);
           this.events.onError(this.getUserVisibleErrorMessage(error, 'Failed to send message'));
         }
       } finally {
@@ -360,13 +363,17 @@ export class MessageManager {
 
     } catch (error) {
       // Handle abort scenario
+      const erroredMessageId = this.currentStreamingMessageId;
       const wasAborted = await this.abortHandler.handleIfAbortError(
         error,
         conversation,
-        this.currentStreamingMessageId
+        erroredMessageId
       );
 
       if (!wasAborted) {
+        // Clear the assistant placeholder's loading spinner; a non-abort
+        // error before the first token otherwise leaves it stuck (#271).
+        await this.abortHandler.finalizeErroredPlaceholder(conversation, erroredMessageId);
         this.events.onError(this.getUserVisibleErrorMessage(error, 'Failed to generate AI response'));
       }
     } finally {

--- a/src/ui/chat/services/MessageStreamHandler.ts
+++ b/src/ui/chat/services/MessageStreamHandler.ts
@@ -254,6 +254,12 @@ export class MessageStreamHandler {
               ...conversation.messages[placeholderMessageIndex],
             content: streamedContent,
             state: 'complete',
+            // Clear the loading spinner on completion. Without this, a
+            // complete-but-empty stream (no token ever arrived) leaves the
+            // placeholder's isLoading:true and the chat spins forever, because
+            // isLoading is otherwise only cleared on the first token
+            // (issue #271, claim b).
+            isLoading: false,
             toolCalls: toolCalls?.map(toConversationToolCall),
             // Persist reasoning for re-render from storage
             reasoning: reasoningAccumulator || undefined,
@@ -286,6 +292,11 @@ export class MessageStreamHandler {
           ...finalMsg,
           content: streamedContent,
           state: 'complete',
+          // Safety-net terminal path: clear the spinner here too, so a stream
+          // that exits without a final isFinalComplete (e.g. tool-execution
+          // error yielding complete:true) never leaves isLoading:true stuck
+          // (issue #271, claim b).
+          isLoading: false,
           toolCalls: toolCalls?.map(toConversationToolCall),
           reasoning: reasoningAccumulator || undefined,
           metadata: finalMetadata,

--- a/src/ui/chat/utils/AbortHandler.ts
+++ b/src/ui/chat/utils/AbortHandler.ts
@@ -107,4 +107,43 @@ export class AbortHandler {
     }
     return false;
   }
+
+  /**
+   * Finalize the assistant placeholder after a NON-abort generation error.
+   *
+   * Without this, an error (or empty completion) that happens before the first
+   * token leaves the placeholder with isLoading:true — isLoading is otherwise
+   * only cleared on the first streamed token — so the chat spinner spins
+   * forever (issue #271, claim b). This clears isLoading and marks the message
+   * invalid (filtered from future context), preserving any partial content
+   * already streamed. The genuine-abort path is handled separately by
+   * handleAbort and is intentionally left untouched.
+   *
+   * @param conversation - The conversation containing the placeholder
+   * @param aiMessageId - ID of the AI message being generated (may be null)
+   */
+  async finalizeErroredPlaceholder(
+    conversation: ConversationData,
+    aiMessageId: string | null
+  ): Promise<void> {
+    if (!aiMessageId) return;
+
+    const aiMessageIndex = conversation.messages.findIndex(msg => msg.id === aiMessageId);
+    if (aiMessageIndex < 0) return;
+
+    const aiMessage = conversation.messages[aiMessageIndex];
+
+    // Nothing to do if the spinner was already cleared (e.g. content streamed
+    // before the error). Leave a completed/aborted message as-is.
+    if (aiMessage.isLoading !== true) return;
+
+    aiMessage.isLoading = false;
+    aiMessage.state = 'invalid'; // Errored before completion - exclude from context
+
+    // Persist so a reload doesn't resurrect the stuck loading state.
+    await this.chatService.updateConversation(conversation);
+
+    // Re-render so the spinner disappears immediately.
+    this.events.onConversationUpdated(conversation);
+  }
 }

--- a/src/utils/cliProcessRunner.ts
+++ b/src/utils/cliProcessRunner.ts
@@ -42,10 +42,40 @@ export interface CliProcessHandle {
 }
 
 /**
+ * Default idle (inactivity) timeout for CLI processes, in milliseconds.
+ *
+ * This is an INACTIVITY watchdog, not a hard total-runtime cap: the timer is
+ * reset every time the process emits stdout/stderr, so a legitimately long
+ * local generation that keeps streaming output is never cut off. It only fires
+ * when the process goes silent for this long without exiting — the wedged-CLI
+ * case that left the chat spinner stuck forever (issue #271, claim a).
+ *
+ * 120s of silence is deliberately generous: local CLIs (gemini, Claude Code)
+ * can pause between planner/tool phases, and an idle timer that is too tight
+ * would regress those legitimate gaps. A truly hung process is still bounded.
+ */
+export const DEFAULT_CLI_IDLE_TIMEOUT_MS = 120_000;
+
+/**
+ * Error code surfaced when the idle watchdog kills a silent CLI process.
+ *
+ * Follows the inline string-literal convention used for `LLMProviderError.code`
+ * across the adapters (e.g. `PROVIDER_ERROR`, `CONFIGURATION_ERROR`). Adapters
+ * map this code to a user-visible `LLMProviderError`.
+ */
+export const PROVIDER_TIMEOUT_ERROR_CODE = 'PROVIDER_TIMEOUT';
+
+/**
  * Spawns a CLI process and collects stdout/stderr until it exits.
  *
  * Returns both the child process reference (for abort wiring) and a
  * promise that resolves with the collected output and exit code.
+ *
+ * An idle watchdog (see `idleTimeoutMs` / `DEFAULT_CLI_IDLE_TIMEOUT_MS`) bounds
+ * a process that goes silent without exiting: it is killed and the promise
+ * RESOLVES with `errorCode: PROVIDER_TIMEOUT_ERROR_CODE` (never rejects, so
+ * existing callers keep their resolve-only contract). The timer resets on every
+ * stdout/stderr chunk, so actively-streaming processes are not interrupted.
  *
  * Uses `spawnDesktopProcess` for cross-platform Windows .cmd/.bat handling.
  */
@@ -56,6 +86,12 @@ export function runCliProcess(
     cwd?: string;
     env?: NodeJS.ProcessEnv;
     stdinText?: string;
+    /**
+     * Inactivity timeout in milliseconds. The watchdog fires only after this
+     * long with NO stdout/stderr output. Defaults to
+     * `DEFAULT_CLI_IDLE_TIMEOUT_MS`. Pass `0` or a negative value to disable.
+     */
+    idleTimeoutMs?: number;
   }
 ): CliProcessHandle {
   const childProcess = loadDesktopModule('child_process');
@@ -68,13 +104,26 @@ export function runCliProcess(
 
   const child = spawnDesktopProcess(childProcess, command, args, spawnOptions);
 
+  const idleTimeoutMs = options?.idleTimeoutMs ?? DEFAULT_CLI_IDLE_TIMEOUT_MS;
+  const idleWatchdogEnabled = Number.isFinite(idleTimeoutMs) && idleTimeoutMs > 0;
+
   const result = new Promise<CliProcessResult>((resolve) => {
     let settled = false;
+    let idleTimer: number | undefined;
+
+    const clearIdleTimer = () => {
+      if (idleTimer !== undefined) {
+        window.clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+
     const resolveOnce = (value: CliProcessResult) => {
       if (settled) {
         return;
       }
       settled = true;
+      clearIdleTimer();
       resolve(value);
     };
 
@@ -90,12 +139,49 @@ export function runCliProcess(
     let stdout = '';
     let stderr = '';
 
+    // Idle (inactivity) watchdog: fires only after `idleTimeoutMs` with no
+    // output. Each stdout/stderr chunk re-arms it, so a streaming process is
+    // never cut off — only a wedged, silent one. On fire we kill the child and
+    // RESOLVE with PROVIDER_TIMEOUT (keeping the resolve-only contract); the
+    // subsequent 'close'/'error' event is a no-op because `settled` is set.
+    const handleIdleTimeout = () => {
+      if (settled) {
+        return;
+      }
+      try {
+        child.kill();
+      } catch {
+        // Best-effort kill; the resolve below still unblocks the awaiter.
+      }
+      const timeoutSeconds = Math.round(idleTimeoutMs / 1000);
+      const timeoutNotice = `CLI process produced no output for ${timeoutSeconds}s and was terminated.`;
+      resolveOnce({
+        stdout,
+        stderr: stderr ? `${stderr}\n${timeoutNotice}` : timeoutNotice,
+        exitCode: null,
+        errorCode: PROVIDER_TIMEOUT_ERROR_CODE
+      });
+    };
+
+    const armIdleTimer = () => {
+      if (!idleWatchdogEnabled || settled) {
+        return;
+      }
+      clearIdleTimer();
+      idleTimer = window.setTimeout(handleIdleTimeout, idleTimeoutMs);
+    };
+
+    // Arm immediately so a process that never emits anything is still bounded.
+    armIdleTimer();
+
     child.stdout.on('data', (chunk: Buffer | string) => {
       stdout += chunk.toString();
+      armIdleTimer();
     });
 
     child.stderr.on('data', (chunk: Buffer | string) => {
       stderr += chunk.toString();
+      armIdleTimer();
     });
 
     child.on('error', (error: NodeJS.ErrnoException) => {

--- a/tests/unit/AbortHandler.test.ts
+++ b/tests/unit/AbortHandler.test.ts
@@ -287,4 +287,84 @@ describe('AbortHandler', () => {
       expect(mockChatService.updateConversation).not.toHaveBeenCalled();
     });
   });
+
+  // ==========================================================================
+  // finalizeErroredPlaceholder (issue #271, claim b)
+  // A non-abort error before the first token must clear the stuck spinner.
+  // ==========================================================================
+
+  describe('finalizeErroredPlaceholder', () => {
+    it('clears isLoading and marks invalid when generation errors before any token', async () => {
+      const conversation = createConversation({
+        messages: [
+          createUserMessage(),
+          createAssistantMessage({
+            id: 'msg_ai',
+            content: '',
+            isLoading: true,
+            state: 'draft'
+          })
+        ]
+      });
+
+      await handler.finalizeErroredPlaceholder(conversation, 'msg_ai');
+
+      const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+      expect(aiMessage).toBeDefined();
+      expect(aiMessage?.isLoading).toBe(false);
+      expect(aiMessage?.state).toBe('invalid');
+      // Persists so a reload cannot resurrect the stuck loading state.
+      expect(mockChatService.updateConversation).toHaveBeenCalled();
+      expect(events.onConversationUpdated).toHaveBeenCalled();
+    });
+
+    it('preserves any partial content already streamed', async () => {
+      const conversation = createConversation({
+        messages: [
+          createUserMessage(),
+          createAssistantMessage({
+            id: 'msg_ai',
+            content: 'partial answer',
+            isLoading: true,
+            state: 'streaming'
+          })
+        ]
+      });
+
+      await handler.finalizeErroredPlaceholder(conversation, 'msg_ai');
+
+      const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+      expect(aiMessage?.content).toBe('partial answer');
+      expect(aiMessage?.isLoading).toBe(false);
+    });
+
+    it('is a no-op when the spinner was already cleared', async () => {
+      const conversation = createConversation({
+        messages: [
+          createUserMessage(),
+          createAssistantMessage({
+            id: 'msg_ai',
+            content: 'done',
+            isLoading: false,
+            state: 'complete'
+          })
+        ]
+      });
+
+      await handler.finalizeErroredPlaceholder(conversation, 'msg_ai');
+
+      const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+      // Completed message left untouched, no redundant save.
+      expect(aiMessage?.state).toBe('complete');
+      expect(mockChatService.updateConversation).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when aiMessageId is null', async () => {
+      const conversation = createConversation();
+
+      await handler.finalizeErroredPlaceholder(conversation, null);
+
+      expect(mockChatService.updateConversation).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -6,7 +6,10 @@ type VaultLike = {
 };
 
 jest.mock('../../src/utils/cliProcessRunner', () => ({
-  runCliProcess: jest.fn()
+  runCliProcess: jest.fn(),
+  // Re-export the real constants so the adapter's errorCode comparison works.
+  PROVIDER_TIMEOUT_ERROR_CODE: 'PROVIDER_TIMEOUT',
+  DEFAULT_CLI_IDLE_TIMEOUT_MS: 120_000
 }));
 
 jest.mock('../../src/utils/geminiCli', () => ({
@@ -174,6 +177,24 @@ describe('GoogleGeminiCliAdapter', () => {
       name: 'LLMProviderError',
       provider: 'google-gemini-cli',
       code: 'REQUEST_TOO_LARGE'
+    });
+  });
+
+  it('maps an idle-watchdog timeout result to PROVIDER_TIMEOUT (issue #271)', async () => {
+    runCliProcess.mockReturnValue({
+      child: { kill: jest.fn() },
+      result: Promise.resolve({
+        stdout: '',
+        stderr: 'CLI process produced no output for 120s and was terminated.',
+        exitCode: null,
+        errorCode: 'PROVIDER_TIMEOUT'
+      })
+    });
+
+    await expect(adapter.generateUncached('hello')).rejects.toMatchObject({
+      name: 'LLMProviderError',
+      provider: 'google-gemini-cli',
+      code: 'PROVIDER_TIMEOUT'
     });
   });
 });

--- a/tests/unit/MessageManager.test.ts
+++ b/tests/unit/MessageManager.test.ts
@@ -297,6 +297,141 @@ describe('MessageManager interrupt flow', () => {
     );
   });
 
+  // ==========================================================================
+  // Non-abort error wiring (issue #271, claim b)
+  // Verifies the REAL catch-branch seam in MessageManager fires
+  // finalizeErroredPlaceholder, so a non-abort error before the first token
+  // leaves the placeholder cleared (isLoading:false, state:'invalid') rather
+  // than spinning forever. finalizeErroredPlaceholder is unit-tested in
+  // isolation in AbortHandler.test.ts; these tests cover the WIRING.
+  // ==========================================================================
+
+  function createGenerationEvents() {
+    return {
+      onMessageAdded: jest.fn(),
+      onAIMessageStarted: jest.fn(),
+      onStreamingUpdate: jest.fn(),
+      onConversationUpdated: jest.fn(),
+      onLoadingStateChanged: jest.fn(),
+      onError: jest.fn(),
+      onToolCallsDetected: jest.fn(),
+      onToolExecutionStarted: jest.fn(),
+      onToolExecutionCompleted: jest.fn(),
+      onMessageIdUpdated: jest.fn(),
+      onGenerationAborted: jest.fn(),
+      onUsageAvailable: jest.fn()
+    };
+  }
+
+  it('clears the placeholder spinner on a non-abort send error before the first token', async () => {
+    const conversation = createConversation({ messages: [] });
+    const mockChatService = createMockChatService({ conversation });
+
+    mockChatService.getConversation.mockImplementation(async () => conversation);
+    mockChatService.generateResponseStreaming.mockImplementation(() => {
+      async function* stream() {
+        // Non-abort error before any chunk is yielded.
+        throw new LLMProviderError('Gemini CLI stopped responding.', 'google-gemini-cli', 'PROVIDER_TIMEOUT');
+        yield undefined;
+      }
+      return stream();
+    });
+
+    const events = createGenerationEvents();
+    const manager = new MessageManager(
+      mockChatService as unknown as ChatService,
+      createMockBranchManager() as unknown as BranchManager,
+      events
+    );
+
+    await manager.sendMessage(conversation, 'Explain the bug');
+
+    // index 0 = user message, index 1 = assistant placeholder
+    const placeholder = conversation.messages.find(m => m.role === 'assistant');
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.isLoading).toBe(false);
+    expect(placeholder?.state).toBe('invalid');
+    expect(events.onError).toHaveBeenCalledWith('Gemini CLI stopped responding.');
+    expect(manager.getIsLoading()).toBe(false);
+  });
+
+  it('preserves partial content when a non-abort send error happens mid-stream', async () => {
+    const conversation = createConversation({ messages: [] });
+    const mockChatService = createMockChatService({ conversation });
+
+    mockChatService.getConversation.mockImplementation(async () => conversation);
+    mockChatService.generateResponseStreaming.mockImplementation(
+      (_conversationId: string, _userMessage: string, options?: { messageId?: string }) => {
+        async function* stream() {
+          yield { chunk: 'Partial answer', complete: false, messageId: options?.messageId || 'msg_ai' };
+          // Error after a token streamed: the first-token path already cleared
+          // isLoading; finalizeErroredPlaceholder is then a no-op, so partial
+          // content must survive.
+          throw new LLMProviderError('Network dropped.', 'google-gemini-cli', 'PROVIDER_ERROR');
+        }
+        return stream();
+      }
+    );
+
+    const events = createGenerationEvents();
+    const manager = new MessageManager(
+      mockChatService as unknown as ChatService,
+      createMockBranchManager() as unknown as BranchManager,
+      events
+    );
+
+    await manager.sendMessage(conversation, 'Explain the bug');
+
+    const placeholder = conversation.messages.find(m => m.role === 'assistant');
+    expect(placeholder?.content).toBe('Partial answer');
+    expect(placeholder?.isLoading).toBe(false);
+    expect(events.onError).toHaveBeenCalledWith('Network dropped.');
+    expect(manager.getIsLoading()).toBe(false);
+  });
+
+  it('clears the placeholder spinner on a non-abort error in the regenerate path', async () => {
+    // A lone user message with no following assistant message routes
+    // handleRetryMessage -> regenerateAIResponse -> generateFreshAIResponse,
+    // exercising the SECOND new call site (the regenerate-internal catch).
+    const conversation = createConversation({
+      messages: [
+        {
+          id: 'msg_user',
+          role: 'user',
+          content: 'Retry me',
+          timestamp: Date.now(),
+          conversationId: 'conv_1',
+          state: 'complete'
+        }
+      ]
+    });
+    const mockChatService = createMockChatService({ conversation });
+
+    mockChatService.getConversation.mockImplementation(async () => conversation);
+    mockChatService.generateResponseStreaming.mockImplementation(() => {
+      async function* stream() {
+        throw new LLMProviderError('Regen failed.', 'google-gemini-cli', 'PROVIDER_TIMEOUT');
+        yield undefined;
+      }
+      return stream();
+    });
+
+    const events = createGenerationEvents();
+    const manager = new MessageManager(
+      mockChatService as unknown as ChatService,
+      createMockBranchManager() as unknown as BranchManager,
+      events
+    );
+
+    await manager.handleRetryMessage(conversation, 'msg_user');
+
+    const placeholder = conversation.messages.find(m => m.role === 'assistant');
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.isLoading).toBe(false);
+    expect(placeholder?.state).toBe('invalid');
+    expect(manager.getIsLoading()).toBe(false);
+  });
+
   it('second sendMessage waits for first to complete when interrupted', async () => {
     const conversation = createConversation({ messages: [] });
     const mockChatService = createMockChatService({ conversation });

--- a/tests/unit/MessageStreamHandler.test.ts
+++ b/tests/unit/MessageStreamHandler.test.ts
@@ -1,0 +1,100 @@
+/**
+ * MessageStreamHandler Unit Tests
+ *
+ * Regression coverage for issue #271, claim b: a stream that completes (or
+ * exits) WITHOUT ever emitting a token must clear the assistant placeholder's
+ * isLoading flag. Pre-fix, isLoading was only cleared on the first token
+ * (inside `if (chunk.chunk)`), so an empty completion left the chat spinner
+ * stuck forever. The spinner is driven by `message.isLoading && !content` in
+ * MessageBubble, so leaving isLoading:true on an empty message spins endlessly.
+ */
+
+import { MessageStreamHandler, StreamHandlerEvents } from '../../src/ui/chat/services/MessageStreamHandler';
+import { createConversation, createUserMessage, createAssistantMessage } from '../fixtures/chatBugs';
+import { createMockChatService } from '../mocks/chatService';
+import { ChatService } from '../../src/services/chat/ChatService';
+import { ConversationData } from '../../src/types/chat/ChatTypes';
+
+/**
+ * Build an async generator that yields the provided chunks, mimicking
+ * ChatService.generateResponseStreaming.
+ */
+function streamOf(chunks: Array<Record<string, unknown>>) {
+  return async function* () {
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  };
+}
+
+function conversationWithLoadingPlaceholder(): ConversationData {
+  return createConversation({
+    messages: [
+      createUserMessage({ id: 'msg_user', content: 'hi' }),
+      createAssistantMessage({
+        id: 'msg_ai',
+        content: '',
+        isLoading: true,
+        state: 'draft'
+      })
+    ]
+  });
+}
+
+describe('MessageStreamHandler - isLoading clearing (issue #271 claim b)', () => {
+  let handler: MessageStreamHandler;
+  let mockChatService: ReturnType<typeof createMockChatService>;
+  let events: StreamHandlerEvents;
+
+  beforeEach(() => {
+    mockChatService = createMockChatService();
+    events = {
+      onStreamingUpdate: jest.fn(),
+      onToolCallsDetected: jest.fn()
+    };
+    handler = new MessageStreamHandler(mockChatService as unknown as ChatService, events);
+  });
+
+  it('clears isLoading on an empty-complete stream (no token ever streamed)', async () => {
+    const conversation = conversationWithLoadingPlaceholder();
+    mockChatService.generateResponseStreaming.mockImplementation(
+      streamOf([{ complete: true }])
+    );
+
+    await handler.streamResponse(conversation, 'hi', 'msg_ai', {});
+
+    const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+    expect(aiMessage?.isLoading).toBe(false);
+    expect(aiMessage?.state).toBe('complete');
+    expect(aiMessage?.content).toBe('');
+  });
+
+  it('clears isLoading via the safety net when the stream ends without a complete chunk', async () => {
+    const conversation = conversationWithLoadingPlaceholder();
+    // No chunk has complete:true, so the loop exits and the post-loop safety
+    // net must finalize the placeholder.
+    mockChatService.generateResponseStreaming.mockImplementation(
+      streamOf([])
+    );
+
+    await handler.streamResponse(conversation, 'hi', 'msg_ai', {});
+
+    const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+    expect(aiMessage?.isLoading).toBe(false);
+    expect(aiMessage?.state).toBe('complete');
+  });
+
+  it('still clears isLoading the normal way once a token streams', async () => {
+    const conversation = conversationWithLoadingPlaceholder();
+    mockChatService.generateResponseStreaming.mockImplementation(
+      streamOf([{ chunk: 'Hello' }, { complete: true }])
+    );
+
+    const result = await handler.streamResponse(conversation, 'hi', 'msg_ai', {});
+
+    const aiMessage = conversation.messages.find(m => m.id === 'msg_ai');
+    expect(aiMessage?.isLoading).toBe(false);
+    expect(aiMessage?.content).toBe('Hello');
+    expect(result.streamedContent).toBe('Hello');
+  });
+});

--- a/tests/unit/cliProcessRunner.test.ts
+++ b/tests/unit/cliProcessRunner.test.ts
@@ -1,6 +1,10 @@
 import { EventEmitter } from 'events';
 import { PassThrough } from 'stream';
-import { runCliProcess } from '../../src/utils/cliProcessRunner';
+import {
+  runCliProcess,
+  PROVIDER_TIMEOUT_ERROR_CODE,
+  DEFAULT_CLI_IDLE_TIMEOUT_MS
+} from '../../src/utils/cliProcessRunner';
 
 jest.mock('../../src/utils/desktopProcess', () => ({
   spawnDesktopProcess: jest.fn()
@@ -10,6 +14,7 @@ type MockChildProcess = EventEmitter & {
   stdin: PassThrough;
   stdout: PassThrough;
   stderr: PassThrough;
+  kill: jest.Mock;
 };
 
 function createMockChildProcess(): MockChildProcess {
@@ -17,6 +22,7 @@ function createMockChildProcess(): MockChildProcess {
   child.stdin = new PassThrough();
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
+  child.kill = jest.fn();
   return child;
 }
 
@@ -111,6 +117,90 @@ describe('runCliProcess', () => {
       stderr: 'spawn E2BIG',
       exitCode: null,
       errorCode: 'E2BIG'
+    });
+  });
+
+  // ==========================================================================
+  // Idle watchdog (issue #271, claim a)
+  // A CLI that goes silent without exiting must be bounded, not hang forever.
+  // ==========================================================================
+
+  describe('idle watchdog', () => {
+    it('kills a silent process and resolves PROVIDER_TIMEOUT', async () => {
+      const child = createMockChildProcess();
+      spawnDesktopProcess.mockReturnValue(child);
+
+      const handle = runCliProcess('/mock/bin/gemini', ['--prompt', ''], {
+        cwd: '/mock/vault',
+        stdinText: 'Prompt from stdin',
+        idleTimeoutMs: 40
+      });
+
+      const result = await handle.result;
+
+      expect(child.kill).toHaveBeenCalledTimes(1);
+      expect(result.exitCode).toBeNull();
+      expect(result.errorCode).toBe(PROVIDER_TIMEOUT_ERROR_CODE);
+      expect(result.stderr).toMatch(/no output/i);
+    });
+
+    it('resets the idle timer on output and resolves normally when the process exits', async () => {
+      const child = createMockChildProcess();
+
+      spawnDesktopProcess.mockImplementation(() => {
+        // Emit output past the would-be idle window, then close normally.
+        setTimeout(() => child.stdout.write('chunk one'), 25);
+        setTimeout(() => child.stdout.write('chunk two'), 50);
+        setTimeout(() => {
+          child.stdout.end();
+          child.stderr.end();
+          child.emit('close', 0);
+        }, 75);
+        return child;
+      });
+
+      const handle = runCliProcess('/mock/bin/gemini', ['--prompt', ''], {
+        cwd: '/mock/vault',
+        stdinText: 'Prompt from stdin',
+        idleTimeoutMs: 40
+      });
+
+      const result = await handle.result;
+
+      // The watchdog must NOT have fired: output kept re-arming it.
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(result.errorCode).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe('chunk onechunk two');
+    });
+
+    it('exposes a generous default idle timeout', () => {
+      // Guards against an accidental tightening that would regress long runs.
+      expect(DEFAULT_CLI_IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(120_000);
+    });
+
+    it('disables the watchdog when idleTimeoutMs is 0', async () => {
+      const child = createMockChildProcess();
+
+      spawnDesktopProcess.mockImplementation(() => {
+        setTimeout(() => {
+          child.stdout.end();
+          child.stderr.end();
+          child.emit('close', 0);
+        }, 60);
+        return child;
+      });
+
+      const handle = runCliProcess('/mock/bin/claude', ['auth', 'status'], {
+        cwd: '/mock/vault',
+        idleTimeoutMs: 0
+      });
+
+      const result = await handle.result;
+
+      expect(child.kill).not.toHaveBeenCalled();
+      expect(result.exitCode).toBe(0);
+      expect(result.errorCode).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary
Two **provider-agnostic** chat-state bugs surfaced via #271 (the AGY work), but verified to affect **every** provider — not just gemini/AGY. This PR is the chat-state half of #271 only; the `gemini`→Antigravity (`agy`) runtime re-route is a separate follow-up.

Re: #271 (partial — chat-loading-state fixes a + b). Issue intentionally left open for the AGY re-route + manual verification.

## Fixes
### (a) Unbounded CLI process → idle watchdog
`runCliProcess` (`src/utils/cliProcessRunner.ts`) resolved only on child `close`/`error` — a CLI that streamed progress but never exited hung the awaiter forever.
- Added a configurable **idle/inactivity** watchdog (default **120s**, **re-armed on every stdout/stderr chunk** so legitimate long streaming runs are never cut; `0` disables).
- On fire: best-effort kill + **resolves** with `errorCode: 'PROVIDER_TIMEOUT'` — the resolve-only contract is preserved (no caller is converted to handle a rejection). The `LLMProviderError(PROVIDER_TIMEOUT)` is constructed in the gemini adapter's `mapCliProcessFailure`, not the runner. No `--print-timeout` arg added.

### (b) Stuck chat spinner on empty/error-before-first-token
The assistant placeholder inits `isLoading: true` and was only cleared inside the first-token branch — so empty-complete, the post-loop safety-net, and non-abort errors left the spinner frozen forever.
- `isLoading: false` is now set on the empty-complete branch + post-loop safety-net (`MessageStreamHandler`).
- New `AbortHandler.finalizeErroredPlaceholder` (sets `state: 'invalid'`, clears `isLoading`, preserves partial content) is called from both `MessageManager` non-abort catch branches.
- The **genuine-abort path is untouched** (byte-for-byte vs main), and this is distinct from the manager-level `setLoading` input spinner.

## Scope note — please read
The auth-status checks now also inherit the 120s idle watchdog (previously unbounded); both callers degrade gracefully on timeout.

## Known residual (tracked as a follow-up issue)
`AnthropicClaudeCodeAdapter`'s **streaming generation** spawns directly (bypasses `runCliProcess`), so a wedged-never-closing Claude Code process is guarded by neither fix. The chat-state clear still cures the common terminal-but-no-first-token case for all providers. Filing a separate issue to bring CC's own spawn under an idle timeout.

## Tests
New: idle-watchdog fires → `PROVIDER_TIMEOUT`, watchdog resets on output (no mid-stream cut), `isLoading` cleared on each terminal-without-first-token path, and 3 added in review covering the **MessageManager → finalizeErroredPlaceholder wiring** through the real catch branches (both call sites).

## Verification
- `npm run build` clean · `npm run lint` clean
- Full jest: **3713 pass / 21 skip / 1 fail** — the lone failure is the pre-existing, documented `TaskBoardEditCoordinator` jsdom-Modal issue (untouched files; not a regression).

## Review
Peer-reviewed (APPROVE, 0 blocking): `docs/review/pr271-chat-loading-state-2026-06-22.md`, `docs/review/pr271-fe-chat-state-lifecycle-2026-06-22.md`, `docs/review/test-coverage-271-272-2026-06-22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
