### PR TITLE
feat(agy): replace deprecated gemini CLI runtime with Google Antigravity (agy)

### DIFF
--- a/src/components/llm-provider/types.ts
+++ b/src/components/llm-provider/types.ts
@@ -88,7 +88,7 @@ export interface SecondaryOAuthProviderConfig {
   onConfigChange: (config: LLMProviderConfig) => Promise<void>;
   /** If true, render a CLI status indicator instead of OAuth connect/disconnect banner */
   statusOnly?: boolean;
-  /** Hint text shown when not authenticated (e.g., "run `gemini auth` in your terminal") */
+  /** Hint text shown when not authenticated (e.g., "run `agy` once in your terminal to sign in") */
   statusHint?: string;
 }
 

--- a/src/components/shared/ChatSettingsRenderer.ts
+++ b/src/components/shared/ChatSettingsRenderer.ts
@@ -36,6 +36,7 @@ import {
   ThinkingEffort
 } from '../../types/llm/ProviderTypes';
 import type { AppsSettings } from '../../types/apps/AppTypes';
+import { isTextOnlyProvider } from '../../services/llm/utils/ToolSchemaSupport';
 import { FilePickerRenderer } from '../workspace/FilePickerRenderer';
 import { isDesktop, isProviderCompatible } from '../../utils/platform';
 import { LLMSettingsNotifier } from '../../services/llm/LLMSettingsNotifier';
@@ -308,7 +309,7 @@ export class ChatSettingsRenderer {
       reRender: () => this.render(),
       onAfterRender: (content) => {
         this.renderReasoningControls(content);
-        this.renderPerplexityWarning(content, 'chat');
+        this.renderTextOnlyProviderWarning(content, 'chat');
       },
     });
   }
@@ -427,31 +428,55 @@ export class ChatSettingsRenderer {
       reRender: () => this.render(),
       onAfterRender: (content) => {
         this.renderReasoningControls(content, 'agent');
-        this.renderPerplexityWarning(content, 'agent');
+        this.renderTextOnlyProviderWarning(content, 'agent');
       },
     });
   }
 
-  private renderPerplexityWarning(content: HTMLElement, variant: 'chat' | 'agent'): void {
+  private renderTextOnlyProviderWarning(content: HTMLElement, variant: 'chat' | 'agent'): void {
     const provider = variant === 'agent' ? this.settings.agentProvider : this.settings.provider;
-    if (provider !== 'perplexity') {
+    if (!isTextOnlyProvider(provider)) {
       return;
     }
+
+    const { title, message } = this.getTextOnlyProviderWarningCopy(provider, variant);
 
     const warningEl = content.createDiv({ cls: 'csr-provider-warning' });
     warningEl.createDiv({
       cls: 'csr-provider-warning-title',
-      text: 'Perplexity cannot use Nexus tools'
+      text: title
     });
-
-    const message = variant === 'agent'
-      ? 'Prompt actions and subagents will run in text-only mode. Use another cloud model for vault edits or other tool-driven work.'
-      : 'Chat and subagents will not receive tool schemas with Perplexity. Use it for search-heavy, text-only work.'
-
     warningEl.createDiv({
       cls: 'csr-provider-warning-text',
       text: message
     });
+  }
+
+  /**
+   * Calm, factual copy for a text-completion-only provider. Antigravity mentions
+   * BOTH limitations (no tools/agents AND no streaming); Perplexity keeps its
+   * established search-focused wording.
+   */
+  private getTextOnlyProviderWarningCopy(
+    provider: string | undefined,
+    variant: 'chat' | 'agent'
+  ): { title: string; message: string } {
+    if (provider === 'google-gemini-cli') {
+      return {
+        title: 'Antigravity is text completions only',
+        message: variant === 'agent'
+          ? 'This provider can\'t call tools or agents, and replies arrive all at once (no streaming). Prompt actions and subagents run in text-only mode — use another cloud model for vault edits or other tool-driven work.'
+          : 'This provider can\'t call tools or agents, and replies arrive all at once (no streaming). Use it for plain text chat; switch providers for agentic, tool-driven work.'
+      };
+    }
+
+    // Perplexity (and any future search/text-only provider) — preserve prior copy.
+    return {
+      title: 'Perplexity cannot use Nexus tools',
+      message: variant === 'agent'
+        ? 'Prompt actions and subagents will run in text-only mode. Use another cloud model for vault edits or other tool-driven work.'
+        : 'Chat and subagents will not receive tool schemas with Perplexity. Use it for search-heavy, text-only work.'
+    };
   }
 
   // ========== TEMPERATURE SECTION ==========

--- a/src/components/shared/ModelDropdownRenderer.ts
+++ b/src/components/shared/ModelDropdownRenderer.ts
@@ -20,7 +20,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   anthropic: 'Anthropic',
   'anthropic-claude-code': 'Claude Code',
   google: 'Google AI',
-  'google-gemini-cli': 'Gemini CLI',
+  'google-gemini-cli': 'Antigravity CLI',
   mistral: 'Mistral AI',
   groq: 'Groq',
   deepseek: 'DeepSeek',
@@ -253,7 +253,7 @@ function renderModelDropdown(
           const geminiCliModels = await config.providerManager.getModelsForProvider('google-gemini-cli');
           models = [
             ...models,
-            ...geminiCliModels.map(model => ({ ...model, name: `${model.name} (Gemini CLI)` }))
+            ...geminiCliModels.map(model => ({ ...model, name: `${model.name} (Antigravity CLI)` }))
           ];
         }
 

--- a/src/components/shared/OAuthBannerComponent.ts
+++ b/src/components/shared/OAuthBannerComponent.ts
@@ -83,11 +83,11 @@ export function renderOAuthBanner(
  * Configuration for rendering a CLI status banner
  */
 export interface CliStatusBannerConfig {
-  /** The provider label to display (e.g., "Gemini CLI") */
+  /** The provider label to display (e.g., "Antigravity CLI") */
   providerLabel: string;
   /** Whether the provider is currently authenticated */
   isAuthenticated: boolean;
-  /** Error/instruction text when not authenticated (e.g., "run `gemini auth` in your terminal") */
+  /** Error/instruction text when not authenticated (e.g., "run `agy` once in your terminal to sign in") */
   notAuthenticatedHint?: string;
   /** Called when the "Check status" button is clicked */
   onCheckStatus: () => void | Promise<void>;

--- a/src/services/chat/SubagentExecutor.ts
+++ b/src/services/chat/SubagentExecutor.ts
@@ -32,7 +32,7 @@ import type { BranchService } from './BranchService';
 import type { MessageQueueService } from './MessageQueueService';
 import type { DirectToolExecutor } from './DirectToolExecutor';
 import { formatWorkspaceDataForPrompt } from '../../utils/WorkspaceDataFormatter';
-import { isPerplexityProvider } from '../llm/utils/ToolSchemaSupport';
+import { isTextOnlyProvider } from '../llm/utils/ToolSchemaSupport';
 
 export interface SubagentExecutorDependencies {
   branchService: BranchService;
@@ -468,7 +468,7 @@ export class SubagentExecutor {
   ): string {
     // Determine if tools were pre-loaded by parent
     const hasPreloadedTools = toolSchemas && toolSchemas.length > 0;
-    const toolsUnavailable = isPerplexityProvider(params.provider);
+    const toolsUnavailable = isTextOnlyProvider(params.provider);
 
     // Start with inherited agent prompt if available
     const promptParts: string[] = [];
@@ -495,7 +495,7 @@ ${params.task}
 1. **NEVER ask questions or seek clarification** - You are autonomous. Make reasonable assumptions and proceed.
 
 2. **${toolsUnavailable ? 'Do not attempt Nexus tool calls' : 'ALWAYS use tools'}** - ${toolsUnavailable
-    ? 'The selected Perplexity model cannot execute Nexus tools in subagent mode. Work in text only and clearly report any tool-dependent step you could not perform.'
+    ? 'The selected provider is text-completion only and cannot execute Nexus tools in subagent mode. Work in text only and clearly report any tool-dependent step you could not perform.'
     : 'Your first response MUST include tool calls.'}
 
 3. **Text-only response = Task complete** - Only respond with plain text (no tool calls) when you have FINISHED the task and are reporting results.

--- a/src/services/external/GeminiCliAuthService.ts
+++ b/src/services/external/GeminiCliAuthService.ts
@@ -87,10 +87,19 @@ export class GeminiCliAuthService {
     }
 
     /**
-     * Check authentication by reading the Gemini CLI credential file at
-     * ~/.gemini/oauth_creds.json. This avoids launching an actual LLM call
-     * (which fails when the MCP server is not running) and instead verifies
+     * Check authentication by reading the Antigravity/Gemini CLI credential
+     * file at ~/.gemini/oauth_creds.json. This avoids launching an actual LLM
+     * call (which fails when the MCP server is not running) and instead verifies
      * that valid OAuth credentials are present on disk.
+     *
+     * Tolerant by design: agy may write the credential file as a single JSON
+     * object OR as concatenated/NDJSON records, so a strict whole-file
+     * `JSON.parse` would spuriously fail. We try a whole-file parse first, then
+     * fall back to scanning for a non-empty `access_token` field.
+     *
+     * SECURITY INVARIANT: this probe extracts PRESENCE only and returns a
+     * boolean-equivalent exitCode. It MUST NEVER read, log, or return the token
+     * VALUE — only whether a non-empty `access_token` exists.
      *
      * Returns exitCode 0 if credentials exist and contain an access token,
      * non-zero otherwise.
@@ -133,21 +142,10 @@ export class GeminiCliAuthService {
             };
         }
 
-        // Parse and confirm an access token is present
-        try {
-            const creds = JSON.parse(raw) as unknown;
-            const hasToken = isRecord(creds) && typeof creds.access_token === 'string' && creds.access_token.length > 0;
-            if (!hasToken) {
-                return {
-                    stdout: '',
-                    stderr: 'Credential file does not contain a valid access_token.',
-                    exitCode: 1
-                };
-            }
-        } catch {
+        if (!hasNonEmptyAccessToken(raw)) {
             return {
                 stdout: '',
-                stderr: 'Credential file is not valid JSON.',
+                stderr: 'Credential file does not contain a valid access_token.',
                 exitCode: 1
             };
         }
@@ -158,4 +156,59 @@ export class GeminiCliAuthService {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Determine, tolerantly, whether the raw credential file contents contain a
+ * non-empty `access_token`. Tries (1) a whole-file JSON parse, then (2) a
+ * per-line / per-record JSON parse (handles NDJSON or concatenated objects),
+ * then (3) a structural regex existence check for an `access_token` key with a
+ * non-empty string value.
+ *
+ * SECURITY: returns a boolean ONLY. The token value is inspected for
+ * non-emptiness but is never captured, returned, or logged.
+ */
+function hasNonEmptyAccessToken(raw: string): boolean {
+    // (1) Whole-file JSON object — the common single-record case.
+    const whole = tryParseAccessToken(raw);
+    if (whole !== null) {
+        return whole;
+    }
+
+    // (2) NDJSON / concatenated records — parse each non-empty line.
+    for (const line of raw.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+            continue;
+        }
+        if (tryParseAccessToken(trimmed) === true) {
+            return true;
+        }
+    }
+
+    // (3) Structural fallback — a JSON `access_token` key bound to a non-empty
+    // string literal anywhere in the file. Matches the presence of the field
+    // without extracting (or capturing) its value.
+    return /"access_token"\s*:\s*"[^"]+"/.test(raw);
+}
+
+/**
+ * Parse `text` as a JSON object and report whether it has a non-empty
+ * `access_token` string field. Returns:
+ *   true  — parsed and has a non-empty access_token
+ *   false — parsed but no valid access_token
+ *   null  — not parseable as a JSON object (caller should try a fallback)
+ *
+ * SECURITY: the token value is only length-checked; it is never returned.
+ */
+function tryParseAccessToken(text: string): boolean | null {
+    try {
+        const creds = JSON.parse(text) as unknown;
+        if (!isRecord(creds)) {
+            return null;
+        }
+        return typeof creds.access_token === 'string' && creds.access_token.length > 0;
+    } catch {
+        return null;
+    }
 }

--- a/src/services/external/GeminiCliAuthService.ts
+++ b/src/services/external/GeminiCliAuthService.ts
@@ -32,7 +32,7 @@ export class GeminiCliAuthService {
                 loggedIn: false,
                 authMethod: 'none',
                 geminiPath: null,
-                error: 'Gemini CLI is only available on desktop.'
+                error: 'Antigravity CLI (agy) is only available on desktop.'
             };
         }
 
@@ -43,7 +43,7 @@ export class GeminiCliAuthService {
                 loggedIn: false,
                 authMethod: 'none',
                 geminiPath: null,
-                error: 'Gemini CLI was not found on PATH. Install it from https://github.com/google-gemini/gemini-cli'
+                error: 'Antigravity CLI (agy) was not found on PATH. Install the Antigravity CLI, then run `agy` once in your terminal to complete Google browser sign-in. (There is no `agy auth` command.)'
             };
         }
 
@@ -55,7 +55,7 @@ export class GeminiCliAuthService {
             geminiPath: runtime.geminiPath,
             error: probe.exitCode === 0
                 ? undefined
-                : 'Gemini CLI is not authenticated. Run `gemini` in your terminal and choose "Login with Google" to authenticate.'
+                : 'Antigravity CLI (agy) is not authenticated. Run `agy` once in your terminal to complete Google browser sign-in. (There is no `agy auth` command.)'
         };
     }
 

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -144,7 +144,10 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
       // agy print mode emits plain text only — there is no structured JSON output mode.
       supportsJSON: false,
       supportsImages: true,
-      supportsFunctions: true,
+      // agy is text-completion only — no tool/function calling (investigation
+      // #62/#64/#66). Matches the now-honest ModelSpecs; gating is via the
+      // provider seam (isTextOnlyProvider), not this provider-level flag.
+      supportsFunctions: false,
       supportsThinking: true,
       maxContextWindow: 1048576,
       supportedFeatures: ['gemini-cli', 'mcp', 'google-login']

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -1,8 +1,10 @@
 /**
  * src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
  *
- * LLM adapter for Google Gemini CLI. Runs the CLI as a child process in
- * non-streaming (JSON output) mode and parses the result.
+ * LLM adapter for the Antigravity CLI (`agy`), wired into the legacy
+ * `google-gemini-cli` provider slot. Runs the CLI as a child process in
+ * non-streaming print mode. agy emits PLAIN TEXT (not JSON), so the response is
+ * the trimmed stdout; no structured token usage is available from the CLI.
  */
 import { Platform, Vault } from 'obsidian';
 import type { DesktopChildProcess } from '../../../../utils/desktopProcess';
@@ -14,12 +16,12 @@ import {
   ModelInfo,
   ProviderCapabilities,
   ModelPricing,
-  LLMProviderError,
-  TokenUsage
+  LLMProviderError
 } from '../types';
 import { ModelRegistry } from '../ModelRegistry';
 import { CliProcessResult, runCliProcess } from '../../../../utils/cliProcessRunner';
 import { GOOGLE_GEMINI_CLI_DEFAULT_MODEL } from './GoogleGeminiCliModels';
+import { normalizeModelToAgyLabel } from './geminiCliModelNormalize';
 import {
   buildGeminiCliEnv,
   buildGeminiCliSystemSettings,
@@ -31,21 +33,6 @@ type GeminiCliDesktopModuleMap = {
   os: typeof import('os');
   path: typeof import('path');
 };
-
-interface GeminiCliJsonResponse {
-  response?: string;
-  text?: string;
-  content?: string;
-  output?: string;
-  result?: {
-    text?: string;
-  };
-  stats?: {
-    models?: Array<Record<string, unknown>>;
-    tools?: unknown;
-  };
-  error?: string | { message?: string };
-}
 
 export class GoogleGeminiCliAdapter extends BaseAdapter {
   readonly name = 'google-gemini-cli';
@@ -87,13 +74,14 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
       );
 
       const combinedPrompt = this.buildPrompt(prompt, options?.systemPrompt);
+      // Fail-closed model resolution: agy --model silently defaults on an unknown
+      // value, so reject anything not in the allowlist before spawning.
+      const agyModel = normalizeModelToAgyLabel(options?.model || this.currentModel);
       const args = [
         '--prompt',
         '',
         '--model',
-        options?.model || this.currentModel,
-        '--output-format',
-        'json'
+        agyModel
       ];
 
       const handle = runCliProcess(runtime.geminiPath, args, {
@@ -109,33 +97,24 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
         throw this.mapCliProcessFailure(result);
       }
 
-      const parsed = this.parseOutput(result.stdout);
-      if (!parsed) {
+      // agy print mode emits plain text — the response is the trimmed stdout.
+      const text = this.parseAgyOutput(result.stdout);
+      if (!text) {
         throw new LLMProviderError(
-          'Gemini CLI returned an unreadable JSON response.',
+          'Antigravity CLI returned an empty response.',
           this.name,
           'PROVIDER_ERROR'
         );
       }
 
-      const errorMessage = typeof parsed.error === 'string'
-        ? parsed.error
-        : parsed.error?.message;
-      if (errorMessage) {
-        throw new LLMProviderError(errorMessage, this.name, 'PROVIDER_ERROR');
-      }
-
-      const text = this.extractText(parsed);
-      const usage = this.extractUsageFromStats(parsed);
-
+      // agy does not report token usage; omit it (buildLLMResponse defaults to zero).
       return this.buildLLMResponse(
         text,
-        options?.model || this.currentModel,
-        usage || { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+        agyModel,
+        undefined,
         {
           localCli: true,
-          outputFormat: 'json',
-          toolSummary: parsed.stats?.tools
+          outputFormat: 'text'
         },
         'stop'
       );
@@ -161,7 +140,8 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
   getCapabilities(): ProviderCapabilities {
     return {
       supportsStreaming: false,
-      supportsJSON: true,
+      // agy print mode emits plain text only — there is no structured JSON output mode.
+      supportsJSON: false,
       supportsImages: true,
       supportsFunctions: true,
       supportsThinking: true,
@@ -216,122 +196,15 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
     return `System instructions:\n${systemPrompt.trim()}\n\nUser request:\n${prompt}`;
   }
 
-  private parseOutput(stdout: string): GeminiCliJsonResponse | null {
-    const trimmed = stdout.trim();
-    if (!trimmed) {
-      return null;
-    }
-
-    try {
-      return JSON.parse(trimmed) as GeminiCliJsonResponse;
-    } catch {
-      const lastJsonLine = trimmed
-        .split(/\r?\n/)
-        .map((line) => line.trim())
-        .filter(Boolean)
-        .reverse()
-        .find((line) => line.startsWith('{') && line.endsWith('}'));
-
-      if (!lastJsonLine) {
-        return this.parseTrailingJsonBlock(trimmed);
-      }
-
-      try {
-        return JSON.parse(lastJsonLine) as GeminiCliJsonResponse;
-      } catch {
-        return this.parseTrailingJsonBlock(trimmed);
-      }
-    }
-  }
-
-  private extractText(parsed: GeminiCliJsonResponse): string {
-    if (typeof parsed.response === 'string') return parsed.response;
-    if (typeof parsed.text === 'string') return parsed.text;
-    if (typeof parsed.content === 'string') return parsed.content;
-    if (typeof parsed.output === 'string') return parsed.output;
-    if (typeof parsed.result?.text === 'string') return parsed.result.text;
-    return '';
-  }
-
-  private extractUsageFromStats(parsed: GeminiCliJsonResponse): TokenUsage | undefined {
-    const modelStats = this.extractModelStats(parsed.stats?.models);
-    if (!modelStats || typeof modelStats !== 'object') {
-      return undefined;
-    }
-
-    const tokenStats = this.extractTokenStats(modelStats);
-    const promptTokens = this.readNumber(tokenStats, ['prompt', 'promptTokens', 'inputTokens']);
-    const completionTokens = this.readNumber(tokenStats, ['candidates', 'candidatesTokens', 'outputTokens', 'completionTokens']);
-    const totalTokens = this.readNumber(tokenStats, ['total', 'totalTokens']);
-
-    if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) {
-      return undefined;
-    }
-
-    return {
-      promptTokens: promptTokens || 0,
-      completionTokens: completionTokens || 0,
-      totalTokens: totalTokens || ((promptTokens || 0) + (completionTokens || 0))
-    };
-  }
-
-  private readNumber(record: Record<string, unknown>, keys: string[]): number | undefined {
-    for (const key of keys) {
-      const value = record[key];
-      if (typeof value === 'number' && Number.isFinite(value)) {
-        return value;
-      }
-    }
-    return undefined;
-  }
-
-  private parseTrailingJsonBlock(output: string): GeminiCliJsonResponse | null {
-    const lines = output
-      .split(/\r?\n/)
-      .map((line) => line.trimEnd())
-      .filter(Boolean);
-
-    for (let index = lines.length - 1; index >= 0; index--) {
-      if (lines[index].trim() !== '{') {
-        continue;
-      }
-
-      try {
-        return JSON.parse(lines.slice(index).join('\n')) as GeminiCliJsonResponse;
-      } catch {
-        continue;
-      }
-    }
-
-    return null;
-  }
-
-  private extractModelStats(
-    modelStats: Record<string, unknown>[] | Record<string, unknown> | undefined
-  ): Record<string, unknown> | undefined {
-    if (Array.isArray(modelStats)) {
-      const firstEntry = modelStats[0];
-      return firstEntry && typeof firstEntry === 'object' ? firstEntry : undefined;
-    }
-
-    if (!modelStats || typeof modelStats !== 'object') {
-      return undefined;
-    }
-
-    const firstEntry = Object.values(modelStats).find(
-      (value) => value && typeof value === 'object' && !Array.isArray(value)
-    );
-
-    return firstEntry ? firstEntry as Record<string, unknown> : undefined;
-  }
-
-  private extractTokenStats(modelStats: Record<string, unknown>): Record<string, unknown> {
-    const tokens = modelStats.tokens;
-    if (tokens && typeof tokens === 'object' && !Array.isArray(tokens)) {
-      return tokens as Record<string, unknown>;
-    }
-
-    return modelStats;
+  /**
+   * Extract the assistant response from agy print-mode stdout.
+   *
+   * agy `--prompt` emits PLAIN TEXT (no JSON, no banner/footer noise), so the
+   * response is simply the trimmed stdout. Returns an empty string for
+   * empty/whitespace-only output; the caller treats that as a provider error.
+   */
+  private parseAgyOutput(stdout: string): string {
+    return stdout.trim();
   }
 
   private mapCliProcessFailure(result: CliProcessResult): LLMProviderError {

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -210,14 +210,14 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
   private mapCliProcessFailure(result: CliProcessResult): LLMProviderError {
     if (result.errorCode === 'ENAMETOOLONG' || result.errorCode === 'E2BIG') {
       return new LLMProviderError(
-        'Gemini CLI could not start because the local CLI command was too long for this platform. Reduce attached context files or shorten the prompt and try again.',
+        'Antigravity CLI (agy) could not start because the local CLI command was too long for this platform. Reduce attached context files or shorten the prompt and try again.',
         this.name,
         'REQUEST_TOO_LARGE'
       );
     }
 
     return new LLMProviderError(
-      result.stderr.trim() || result.stdout.trim() || `Gemini CLI exited with status ${result.exitCode ?? 'unknown'}`,
+      result.stderr.trim() || result.stdout.trim() || `Antigravity CLI (agy) exited with status ${result.exitCode ?? 'unknown'}`,
       this.name,
       result.exitCode === null ? 'CONFIGURATION_ERROR' : 'PROVIDER_ERROR'
     );

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -24,15 +24,23 @@ import { GOOGLE_GEMINI_CLI_DEFAULT_MODEL } from './GoogleGeminiCliModels';
 import { normalizeModelToAgyLabel } from './geminiCliModelNormalize';
 import {
   buildGeminiCliEnv,
-  buildGeminiCliSystemSettings,
   resolveGeminiCliRuntime
 } from '../../../../utils/geminiCli';
 
-type GeminiCliDesktopModuleMap = {
-  'fs/promises': typeof import('fs/promises');
-  os: typeof import('os');
-  path: typeof import('path');
-};
+/**
+ * agy `--print-timeout` accepts a Go-duration string (e.g. `60s`, `5m0s`), NOT
+ * milliseconds — a raw integer is rejected ("missing unit in duration").
+ *
+ * SECURITY-LOAD-BEARING: this is the bounded kill-switch for a hung headless
+ * tool-permission block. We never pass `--dangerously-skip-permissions`, so a
+ * built-in-tool call would otherwise wait for an interactive approval that can
+ * never arrive in print mode; this branch also has no inactivity watchdog, so
+ * `--print-timeout` is the ONLY upper bound on a stuck process. Do NOT raise it
+ * without restoring an idle/inactivity watchdog (e.g. after rebasing onto the
+ * PR #276 watchdog). Trade-off: 60s may cut very-long thinking-model
+ * completions on this interim branch — revisit the value once the watchdog lands.
+ */
+const AGY_PRINT_TIMEOUT = '60s';
 
 export class GoogleGeminiCliAdapter extends BaseAdapter {
   readonly name = 'google-gemini-cli';
@@ -47,51 +55,45 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
   async generateUncached(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
     const runtime = resolveGeminiCliRuntime(this.vault);
     if (!runtime.geminiPath) {
-      throw new LLMProviderError('Gemini CLI was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
+      throw new LLMProviderError('Antigravity CLI (agy) was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
     }
     if (!runtime.nodePath) {
       throw new LLMProviderError('Node.js was not found on PATH.', this.name, 'CONFIGURATION_ERROR');
-    }
-    if (!runtime.connectorPath) {
-      throw new LLMProviderError('Nexus connector.js was not found for this vault.', this.name, 'CONFIGURATION_ERROR');
     }
     if (!runtime.vaultPath) {
       throw new LLMProviderError('Vault filesystem path is unavailable.', this.name, 'CONFIGURATION_ERROR');
     }
 
-    const fsPromises = this.loadDesktopModule('fs/promises');
-    const osMod = this.loadDesktopModule('os');
-    const pathMod = this.loadDesktopModule('path');
+    const combinedPrompt = this.buildPrompt(prompt, options?.systemPrompt);
+    // Fail-closed model resolution: agy --model silently defaults on an unknown
+    // value, so reject anything not in the allowlist before spawning.
+    const agyModel = normalizeModelToAgyLabel(options?.model || this.currentModel);
 
-    const tempDir = await fsPromises.mkdtemp(pathMod.join(osMod.tmpdir(), 'nexus-gemini-cli-'));
-    const settingsPath = pathMod.join(tempDir, 'system-settings.json');
+    // Scenario A invocation: no config write, no --dangerously-skip-permissions.
+    // Print mode (--print) with the prompt delivered on stdin (stdinText below);
+    // --print-timeout is the bounded security kill-switch; --sandbox is additive
+    // defense-in-depth, added only where the sandbox backend is verified
+    // (see shouldUseSandbox).
+    const args = [
+      '--print',
+      '--model',
+      agyModel,
+      '--print-timeout',
+      AGY_PRINT_TIMEOUT
+    ];
+    if (this.shouldUseSandbox()) {
+      args.push('--sandbox');
+    }
+
+    const handle = runCliProcess(runtime.geminiPath, args, {
+      cwd: runtime.vaultPath,
+      env: buildGeminiCliEnv(runtime.nodePath),
+      stdinText: combinedPrompt
+    });
+    this.activeProcess = handle.child;
 
     try {
-      await fsPromises.writeFile(
-        settingsPath,
-        JSON.stringify(buildGeminiCliSystemSettings(runtime), null, 2),
-        'utf8'
-      );
-
-      const combinedPrompt = this.buildPrompt(prompt, options?.systemPrompt);
-      // Fail-closed model resolution: agy --model silently defaults on an unknown
-      // value, so reject anything not in the allowlist before spawning.
-      const agyModel = normalizeModelToAgyLabel(options?.model || this.currentModel);
-      const args = [
-        '--prompt',
-        '',
-        '--model',
-        agyModel
-      ];
-
-      const handle = runCliProcess(runtime.geminiPath, args, {
-        cwd: runtime.vaultPath,
-        env: buildGeminiCliEnv(settingsPath, runtime.nodePath),
-        stdinText: combinedPrompt
-      });
-      this.activeProcess = handle.child;
       const result = await handle.result;
-      this.activeProcess = null;
 
       if (result.exitCode !== 0) {
         throw this.mapCliProcessFailure(result);
@@ -120,7 +122,6 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
       );
     } finally {
       this.activeProcess = null;
-      await fsPromises.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
     }
   }
 
@@ -170,22 +171,21 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
     }
   }
 
-  private loadDesktopModule<TModuleName extends keyof GeminiCliDesktopModuleMap>(
-    moduleName: TModuleName
-  ): GeminiCliDesktopModuleMap[TModuleName] {
-    if (!Platform.isDesktop) {
-      throw new Error(`${moduleName} is only available on desktop.`);
-    }
-
-    const maybeRequire = (window.activeWindow as Window & {
-      require?: (moduleId: string) => unknown;
-    }).require;
-
-    if (typeof maybeRequire !== 'function') {
-      throw new Error('Desktop module loader is unavailable.');
-    }
-
-    return maybeRequire(moduleName) as GeminiCliDesktopModuleMap[TModuleName];
+  /**
+   * Decide whether to pass agy's `--sandbox` flag.
+   *
+   * --sandbox is additive defense-in-depth (NOT the security foundation — that
+   * is the no-MCP + no-skip-perms posture, which holds on every platform).
+   *
+   * On macOS it is verified to use the OS-native sandbox-exec/Seatbelt backend
+   * (Docker-free, headless-safe). On other platforms the sandbox backend is
+   * UNVERIFIED — upstream gemini-cli historically used gVisor/Docker on Linux,
+   * which could fail (no daemon) and break an otherwise-valid completion. So we
+   * pass --sandbox ONLY on darwin and fall back to the no-MCP + no-skip-perms
+   * floor elsewhere. Revisit per-platform once non-darwin backends are verified.
+   */
+  private shouldUseSandbox(): boolean {
+    return Platform.isMacOS === true;
   }
 
   private buildPrompt(prompt: string, systemPrompt?: string): string {

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter.ts
@@ -21,7 +21,7 @@ import {
 import { ModelRegistry } from '../ModelRegistry';
 import { CliProcessResult, runCliProcess } from '../../../../utils/cliProcessRunner';
 import { GOOGLE_GEMINI_CLI_DEFAULT_MODEL } from './GoogleGeminiCliModels';
-import { normalizeModelToAgyLabel } from './geminiCliModelNormalize';
+import { composeAgyModelLabel } from './geminiCliModelNormalize';
 import {
   buildGeminiCliEnv,
   resolveGeminiCliRuntime
@@ -66,8 +66,11 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
 
     const combinedPrompt = this.buildPrompt(prompt, options?.systemPrompt);
     // Fail-closed model resolution: agy --model silently defaults on an unknown
-    // value, so reject anything not in the allowlist before spawning.
-    const agyModel = normalizeModelToAgyLabel(options?.model || this.currentModel);
+    // value, so reject anything not in the allowlist before spawning. The agy
+    // "Base (Effort)" label is composed here from the base model + the thinking/
+    // effort slider value (options.thinkingEffort); legacy effort-variant slugs
+    // carry their own explicit effort. See geminiCliModelNormalize.composeAgyModelLabel.
+    const agyModel = composeAgyModelLabel(options?.model || this.currentModel, options?.thinkingEffort);
 
     // Scenario A invocation: no config write, no --dangerously-skip-permissions.
     // Print mode (--print) with the prompt delivered on stdin (stdinText below);
@@ -172,6 +175,23 @@ export class GoogleGeminiCliAdapter extends BaseAdapter {
       this.activeProcess.kill();
       this.activeProcess = null;
     }
+  }
+
+  /**
+   * Effort now lives on the slider (options.thinkingEffort), not in the model
+   * slug, so the base BaseAdapter cache key (which keys on model but not effort)
+   * would collide two different efforts on the same base model + prompt. Fold the
+   * composed agy "Base (Effort)" label into the key so each effort caches
+   * distinctly. Falls back to the base key shape on any resolution error.
+   */
+  protected generateCacheKey(prompt: string, options?: GenerateOptions): string {
+    let effortModel: string;
+    try {
+      effortModel = composeAgyModelLabel(options?.model || this.currentModel, options?.thinkingEffort);
+    } catch {
+      effortModel = `${options?.model || this.currentModel}::${options?.thinkingEffort ?? 'default'}`;
+    }
+    return super.generateCacheKey(prompt, { ...options, model: effortModel });
   }
 
   /**

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
@@ -1,10 +1,23 @@
 import { ModelSpec } from '../modelTypes';
 
+/**
+ * Catalog of Gemini models exposed by the Antigravity CLI (`agy`) for the
+ * `google-gemini-cli` provider.
+ *
+ * The `name` fields are the verbatim human labels emitted by `agy models` and
+ * accepted by `agy --model` (see geminiCliModelNormalize.ts, which maps each
+ * `apiName` slug below to its exact label). Keep this catalog and that allowlist
+ * in LOCKSTEP — every `apiName` here must have a mapping there, or resolving the
+ * model will throw fail-closed.
+ *
+ * Non-Gemini agy models (Claude Sonnet/Opus, GPT-OSS) are intentionally excluded
+ * per product decision: this provider is Gemini-only.
+ */
 export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   {
     provider: 'google-gemini-cli',
-    name: 'Gemini 3.1 Flash-Lite Preview',
-    apiName: 'gemini-3.1-flash-lite-preview',
+    name: 'Gemini 3.5 Flash (Low)',
+    apiName: 'gemini-3.5-flash-low',
     contextWindow: 1048576,
     maxTokens: 65536,
     inputCostPerMillion: 0,
@@ -19,8 +32,56 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   },
   {
     provider: 'google-gemini-cli',
-    name: 'Gemini 3 Flash Preview',
-    apiName: 'gemini-3-flash-preview',
+    name: 'Gemini 3.5 Flash (Medium)',
+    apiName: 'gemini-3.5-flash-medium',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: false,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'google-gemini-cli',
+    name: 'Gemini 3.5 Flash (High)',
+    apiName: 'gemini-3.5-flash-high',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: false,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'google-gemini-cli',
+    name: 'Gemini 3.1 Pro (Low)',
+    apiName: 'gemini-3.1-pro-low',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: false,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'google-gemini-cli',
+    name: 'Gemini 3.1 Pro (High)',
+    apiName: 'gemini-3.1-pro-high',
     contextWindow: 1048576,
     maxTokens: 65536,
     inputCostPerMillion: 0,
@@ -35,4 +96,4 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   }
 ];
 
-export const GOOGLE_GEMINI_CLI_DEFAULT_MODEL = 'gemini-3-flash-preview';
+export const GOOGLE_GEMINI_CLI_DEFAULT_MODEL = 'gemini-3.5-flash-medium';

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
@@ -12,6 +12,14 @@ import { ModelSpec } from '../modelTypes';
  *
  * Non-Gemini agy models (Claude Sonnet/Opus, GPT-OSS) are intentionally excluded
  * per product decision: this provider is Gemini-only.
+ *
+ * CAPABILITY NOTE — text-completion only. The Antigravity `agy --print` surface
+ * supports NEITHER tool/function calling NOR streaming (investigation #62/#64/#66
+ * proved every tool-use path NOT-FEASIBLE, and `--print` buffers one response).
+ * So `supportsFunctions` and `supportsStreaming` are BOTH false here — this is the
+ * single source of truth for the limitation; the user-facing warning surfaces
+ * (settings notice + runtime guard) and the chat tool-schema suppression all key
+ * off the text-only provider seam (see isTextOnlyProvider in ToolSchemaSupport.ts).
  */
 export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   {
@@ -25,7 +33,7 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
-      supportsFunctions: true,
+      supportsFunctions: false,
       supportsStreaming: false,
       supportsThinking: true
     }
@@ -41,7 +49,7 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
-      supportsFunctions: true,
+      supportsFunctions: false,
       supportsStreaming: false,
       supportsThinking: true
     }
@@ -57,7 +65,7 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
-      supportsFunctions: true,
+      supportsFunctions: false,
       supportsStreaming: false,
       supportsThinking: true
     }
@@ -73,7 +81,7 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
-      supportsFunctions: true,
+      supportsFunctions: false,
       supportsStreaming: false,
       supportsThinking: true
     }
@@ -89,7 +97,7 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
     capabilities: {
       supportsJSON: true,
       supportsImages: true,
-      supportsFunctions: true,
+      supportsFunctions: false,
       supportsStreaming: false,
       supportsThinking: true
     }

--- a/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
+++ b/src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels.ts
@@ -1,14 +1,17 @@
 import { ModelSpec } from '../modelTypes';
 
 /**
- * Catalog of Gemini models exposed by the Antigravity CLI (`agy`) for the
+ * Catalog of BASE Gemini models exposed by the Antigravity CLI (`agy`) for the
  * `google-gemini-cli` provider.
  *
- * The `name` fields are the verbatim human labels emitted by `agy models` and
- * accepted by `agy --model` (see geminiCliModelNormalize.ts, which maps each
- * `apiName` slug below to its exact label). Keep this catalog and that allowlist
- * in LOCKSTEP — every `apiName` here must have a mapping there, or resolving the
- * model will throw fail-closed.
+ * Effort is NOT baked into the catalog. agy exposes each base model at several
+ * effort levels (`agy models`: Gemini 3.5 Flash = Low/Medium/High; Gemini 3.1
+ * Pro = Low/High — no Medium), but that effort comes from Nexus's existing
+ * thinking/effort SLIDER, not from distinct model entries. So the catalog lists
+ * just the 2 BASE models; the adapter composes the agy `--model "Base (Effort)"`
+ * label at invocation time from base slug + slider effort (see
+ * geminiCliModelNormalize.ts `composeAgyModelLabel`). Keep this catalog and that
+ * module in LOCKSTEP — every base `apiName` here must be a known base there.
  *
  * Non-Gemini agy models (Claude Sonnet/Opus, GPT-OSS) are intentionally excluded
  * per product decision: this provider is Gemini-only.
@@ -24,8 +27,8 @@ import { ModelSpec } from '../modelTypes';
 export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   {
     provider: 'google-gemini-cli',
-    name: 'Gemini 3.5 Flash (Low)',
-    apiName: 'gemini-3.5-flash-low',
+    name: 'Gemini 3.5 Flash',
+    apiName: 'gemini-3.5-flash',
     contextWindow: 1048576,
     maxTokens: 65536,
     inputCostPerMillion: 0,
@@ -40,56 +43,8 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   },
   {
     provider: 'google-gemini-cli',
-    name: 'Gemini 3.5 Flash (Medium)',
-    apiName: 'gemini-3.5-flash-medium',
-    contextWindow: 1048576,
-    maxTokens: 65536,
-    inputCostPerMillion: 0,
-    outputCostPerMillion: 0,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: false,
-      supportsStreaming: false,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'google-gemini-cli',
-    name: 'Gemini 3.5 Flash (High)',
-    apiName: 'gemini-3.5-flash-high',
-    contextWindow: 1048576,
-    maxTokens: 65536,
-    inputCostPerMillion: 0,
-    outputCostPerMillion: 0,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: false,
-      supportsStreaming: false,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'google-gemini-cli',
-    name: 'Gemini 3.1 Pro (Low)',
-    apiName: 'gemini-3.1-pro-low',
-    contextWindow: 1048576,
-    maxTokens: 65536,
-    inputCostPerMillion: 0,
-    outputCostPerMillion: 0,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: false,
-      supportsStreaming: false,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'google-gemini-cli',
-    name: 'Gemini 3.1 Pro (High)',
-    apiName: 'gemini-3.1-pro-high',
+    name: 'Gemini 3.1 Pro',
+    apiName: 'gemini-3.1-pro',
     contextWindow: 1048576,
     maxTokens: 65536,
     inputCostPerMillion: 0,
@@ -104,4 +59,4 @@ export const GOOGLE_GEMINI_CLI_MODELS: ModelSpec[] = [
   }
 ];
 
-export const GOOGLE_GEMINI_CLI_DEFAULT_MODEL = 'gemini-3.5-flash-medium';
+export const GOOGLE_GEMINI_CLI_DEFAULT_MODEL = 'gemini-3.5-flash';

--- a/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
+++ b/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
@@ -1,69 +1,180 @@
 /**
  * src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
  *
- * Maps Nexus's `google-gemini-cli` model slugs (see GoogleGeminiCliModels.ts)
- * to the human-label model names the Antigravity CLI (`agy`) expects on `--model`.
+ * Composes the human-label model name the Antigravity CLI (`agy`) expects on
+ * `--model` from a Nexus BASE model slug + the thinking/effort SLIDER value.
  *
  * Why this exists: `agy --model` FAILS OPEN — given an unknown value it does NOT
  * error, it silently runs a default model and returns exit 0. If Nexus passed a
- * slug (e.g. `gemini-3.5-flash-medium`) straight through, the user would get a
- * different model than they selected with no signal. So this module is a
- * FAIL-CLOSED allowlist: a slug must be explicitly mapped, otherwise we throw a
- * clear error rather than let agy pick something arbitrary. Legacy `*-preview`
- * slugs are retained as aliases so pre-refresh saved selections still resolve.
+ * slug (e.g. `gemini-3.5-flash`) or a malformed label straight through, the user
+ * would get a different model than they selected with no signal. So this module
+ * is a FAIL-CLOSED resolver: the base must be a known base model and the composed
+ * "Base (Effort)" label must be in the known agy label set, otherwise we throw a
+ * clear error rather than let agy pick something arbitrary.
+ *
+ * Effort source: the catalog lists only the 2 BASE models (no -low/-medium/-high
+ * entries). Effort comes from the slider (`options.thinkingEffort`) at invocation
+ * time. Legacy effort-variant slugs and older `*-preview` slugs are still accepted
+ * (settings-compat): they carry an EXPLICIT effort that overrides the slider, so a
+ * user's saved selection still resolves to the model+effort they chose.
+ *
+ * agy effort matrix (`agy models`, verified live):
+ *   - Gemini 3.5 Flash → Low / Medium / High
+ *   - Gemini 3.1 Pro   → Low / High        (NO Medium)
+ * Clamp rule (team-lead ruling, task #75): a requested Medium on a base that lacks
+ * Medium (Pro) clamps UP to the nearest available (High) — never silently DOWN, so
+ * we never give less reasoning than the user asked for. Pro thus defaults to High
+ * when the slider is untouched (effort defaults to 'medium' → clamps to High); this
+ * is a deliberate, ruled choice (premium model, capability-by-default).
  *
  * Used by: GoogleGeminiCliAdapter.generateUncached, at the point the model string
- * is resolved (before it is placed into the agy `--model` argument).
+ * + effort are resolved (before the composed label is placed into the agy
+ * `--model` argument).
  */
 import { LLMProviderError } from '../types';
 
 const PROVIDER_NAME = 'google-gemini-cli';
 
-/**
- * Allowlist mapping Nexus model slugs → the verbatim `agy models` human labels
- * accepted by `agy --model`. Keep entries in sync with GoogleGeminiCliModels.ts;
- * an entry must exist here for every shipped spec, or resolving that model will
- * throw fail-closed.
- *
- * Two groups:
- *  - CURRENT slugs (1:1 with the shipped catalog in GoogleGeminiCliModels.ts).
- *  - LEGACY aliases retained for settings-compat: an existing user's saved model
- *    selection (a pre-refresh `*-preview` slug) must still resolve to a live agy
- *    label rather than throw. Each legacy alias points at the closest current
- *    agy label.
- */
-const SLUG_TO_AGY_LABEL: Readonly<Record<string, string>> = Object.freeze({
-  // Current catalog slugs (verbatim `agy models` labels).
-  'gemini-3.5-flash-low': 'Gemini 3.5 Flash (Low)',
-  'gemini-3.5-flash-medium': 'Gemini 3.5 Flash (Medium)',
-  'gemini-3.5-flash-high': 'Gemini 3.5 Flash (High)',
-  'gemini-3.1-pro-low': 'Gemini 3.1 Pro (Low)',
-  'gemini-3.1-pro-high': 'Gemini 3.1 Pro (High)',
+export type AgyEffort = 'low' | 'medium' | 'high';
 
-  // Legacy aliases (settings-compat for pre-refresh saved selections).
-  'gemini-3-flash-preview': 'Gemini 3.5 Flash (Medium)',
-  'gemini-3.1-flash-lite-preview': 'Gemini 3.5 Flash (Low)'
+/** Default effort when the slider is untouched / thinking is off (mirrors GoogleAdapter). */
+const DEFAULT_EFFORT: AgyEffort = 'medium';
+
+/**
+ * Base model slug → its verbatim `agy models` base label + the effort levels that
+ * base supports. The composed `--model` label is `"<baseLabel> (<Effort>)"`.
+ */
+interface BaseModelSpec {
+  readonly baseLabel: string;
+  readonly supportedEfforts: ReadonlySet<AgyEffort>;
+}
+
+const BASE_MODELS: Readonly<Record<string, BaseModelSpec>> = Object.freeze({
+  'gemini-3.5-flash': {
+    baseLabel: 'Gemini 3.5 Flash',
+    supportedEfforts: new Set<AgyEffort>(['low', 'medium', 'high'])
+  },
+  'gemini-3.1-pro': {
+    baseLabel: 'Gemini 3.1 Pro',
+    supportedEfforts: new Set<AgyEffort>(['low', 'high'])
+  }
 });
 
 /**
- * The set of agy labels we knowingly support (the values of the allowlist). An
- * already-mapped agy label is allowed to pass through unchanged so callers can
- * be idempotent without re-mapping.
+ * Legacy slug → (base slug, EXPLICIT effort). These are saved selections from
+ * earlier builds that must still resolve. The explicit effort here OVERRIDES the
+ * slider, preserving exactly what the user picked.
+ *  - the 5 effort-variant slugs shipped this branch
+ *  - the older `*-preview` slugs that predate the effort-variant catalog
  */
-const KNOWN_AGY_LABELS: ReadonlySet<string> = new Set(Object.values(SLUG_TO_AGY_LABEL));
+const LEGACY_SLUG_TO_BASE_EFFORT: Readonly<Record<string, { base: string; effort: AgyEffort }>> = Object.freeze({
+  // Effort-variant slugs (this branch).
+  'gemini-3.5-flash-low': { base: 'gemini-3.5-flash', effort: 'low' },
+  'gemini-3.5-flash-medium': { base: 'gemini-3.5-flash', effort: 'medium' },
+  'gemini-3.5-flash-high': { base: 'gemini-3.5-flash', effort: 'high' },
+  'gemini-3.1-pro-low': { base: 'gemini-3.1-pro', effort: 'low' },
+  'gemini-3.1-pro-high': { base: 'gemini-3.1-pro', effort: 'high' },
+
+  // Older preview slugs (pre-effort-variant catalog).
+  'gemini-3-flash-preview': { base: 'gemini-3.5-flash', effort: 'medium' },
+  'gemini-3.1-flash-lite-preview': { base: 'gemini-3.5-flash', effort: 'low' }
+});
+
+/** Title-case effort for the agy parenthetical (low → Low). */
+function effortToLabel(effort: AgyEffort): string {
+  return effort.charAt(0).toUpperCase() + effort.slice(1);
+}
+
+/** The set of fully-composed agy labels we knowingly support (every base × its supported efforts). */
+const KNOWN_AGY_LABELS: ReadonlySet<string> = new Set(
+  Object.values(BASE_MODELS).flatMap((spec) =>
+    [...spec.supportedEfforts].map((effort) => `${spec.baseLabel} (${effortToLabel(effort)})`)
+  )
+);
+
+function isAgyEffort(value: unknown): value is AgyEffort {
+  return value === 'low' || value === 'medium' || value === 'high';
+}
 
 /**
- * Resolve a Nexus model identifier to the agy `--model` label, fail-closed.
+ * Clamp a requested effort to the nearest available level on a base model, rounding
+ * UP (never down) per the team-lead ruling. Today the only gap is Pro's missing
+ * Medium → High; the candidate order generalizes to any future asymmetry.
+ */
+function clampEffort(requested: AgyEffort, supported: ReadonlySet<AgyEffort>): AgyEffort {
+  if (supported.has(requested)) {
+    return requested;
+  }
+  // Prefer rounding UP (more reasoning); fall back to rounding down only if needed.
+  const preference: AgyEffort[] = requested === 'low'
+    ? ['low', 'medium', 'high']
+    : requested === 'medium'
+      ? ['high', 'low'] // Medium unavailable → prefer High over Low (never silently less).
+      : ['high', 'medium', 'low'];
+  for (const candidate of preference) {
+    if (supported.has(candidate)) {
+      return candidate;
+    }
+  }
+  // Unreachable for the current matrix (every base supports at least one effort).
+  throw new LLMProviderError(
+    'No supported effort level for the Antigravity CLI base model.',
+    PROVIDER_NAME,
+    'CONFIGURATION_ERROR'
+  );
+}
+
+/** Compose + clamp + validate a (base slug, effort) pair into the final agy label. */
+function composeFromBase(baseSlug: string, effort: AgyEffort): string {
+  const spec = BASE_MODELS[baseSlug];
+  if (!spec) {
+    throw new LLMProviderError(
+      `Base model "${baseSlug}" is not supported by the Antigravity CLI provider.`,
+      PROVIDER_NAME,
+      'CONFIGURATION_ERROR'
+    );
+  }
+
+  const resolvedEffort = clampEffort(effort, spec.supportedEfforts);
+  const label = `${spec.baseLabel} (${effortToLabel(resolvedEffort)})`;
+
+  // Defense-in-depth: the composed label goes into argv (Windows .cmd metachar
+  // sink). It is built only from the frozen base label + a fixed effort word, but
+  // re-validate against the known set so a future edit can't leak an arbitrary
+  // string into the command line.
+  if (!KNOWN_AGY_LABELS.has(label)) {
+    throw new LLMProviderError(
+      `Composed Antigravity model label "${label}" is not in the supported set.`,
+      PROVIDER_NAME,
+      'CONFIGURATION_ERROR'
+    );
+  }
+
+  return label;
+}
+
+/**
+ * Resolve a Nexus model identifier + slider effort to the agy `--model` label,
+ * fail-closed.
  *
- * Accepts either a legacy Nexus slug (mapped via the allowlist) or an already
- * normalized agy label (passed through). Any other value throws an
- * LLMProviderError — agy would otherwise silently default, masking the mismatch.
+ * Accepts:
+ *  - a BASE slug (`gemini-3.5-flash`, `gemini-3.1-pro`) → effort from `sliderEffort`
+ *  - a LEGACY slug (effort-variant or preview) → its explicit effort (overrides slider)
+ *  - an already-composed agy label (e.g. `Gemini 3.5 Flash (High)`) → idempotent pass-through
  *
- * @param model - the model identifier resolved by the adapter (legacy slug or agy label)
+ * Any other value throws — agy would otherwise silently default, masking the
+ * mismatch. The composed label is allowlist-validated before it can reach argv
+ * (Windows `.cmd` metachar sink defense).
+ *
+ * @param model - the model identifier resolved by the adapter (base slug, legacy slug, or agy label)
+ * @param sliderEffort - the thinking/effort slider value (`options.thinkingEffort`); undefined → default
  * @returns the verbatim agy human label to pass to `--model`
  * @throws LLMProviderError when the model is missing or not in the allowlist
  */
-export function normalizeModelToAgyLabel(model: string | undefined | null): string {
+export function composeAgyModelLabel(
+  model: string | undefined | null,
+  sliderEffort?: string | null
+): string {
   const trimmed = typeof model === 'string' ? model.trim() : '';
   if (!trimmed) {
     throw new LLMProviderError(
@@ -73,19 +184,26 @@ export function normalizeModelToAgyLabel(model: string | undefined | null): stri
     );
   }
 
-  const mapped = SLUG_TO_AGY_LABEL[trimmed];
-  if (mapped) {
-    return mapped;
-  }
-
-  // Already an agy label — allow idempotent pass-through.
+  // Already a composed agy label — allow idempotent pass-through.
   if (KNOWN_AGY_LABELS.has(trimmed)) {
     return trimmed;
   }
 
+  // Legacy slug: explicit effort overrides the slider.
+  const legacy = LEGACY_SLUG_TO_BASE_EFFORT[trimmed];
+  if (legacy) {
+    return composeFromBase(legacy.base, legacy.effort);
+  }
+
+  // Base slug: effort comes from the slider (default when unset).
+  if (BASE_MODELS[trimmed]) {
+    const effort = isAgyEffort(sliderEffort) ? sliderEffort : DEFAULT_EFFORT;
+    return composeFromBase(trimmed, effort);
+  }
+
   throw new LLMProviderError(
     `Model "${trimmed}" is not supported by the Antigravity CLI provider. ` +
-      `Supported models: ${[...KNOWN_AGY_LABELS].join(', ')}.`,
+      `Supported base models: ${Object.keys(BASE_MODELS).join(', ')}.`,
     PROVIDER_NAME,
     'CONFIGURATION_ERROR'
   );

--- a/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
+++ b/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
@@ -1,15 +1,16 @@
 /**
  * src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
  *
- * Maps Nexus's legacy `google-gemini-cli` model slugs (see GoogleGeminiCliModels.ts)
+ * Maps Nexus's `google-gemini-cli` model slugs (see GoogleGeminiCliModels.ts)
  * to the human-label model names the Antigravity CLI (`agy`) expects on `--model`.
  *
  * Why this exists: `agy --model` FAILS OPEN — given an unknown value it does NOT
  * error, it silently runs a default model and returns exit 0. If Nexus passed a
- * legacy slug (e.g. `gemini-3-flash-preview`) straight through, the user would get
- * a different model than they selected with no signal. So this module is a
+ * slug (e.g. `gemini-3.5-flash-medium`) straight through, the user would get a
+ * different model than they selected with no signal. So this module is a
  * FAIL-CLOSED allowlist: a slug must be explicitly mapped, otherwise we throw a
- * clear error rather than let agy pick something arbitrary.
+ * clear error rather than let agy pick something arbitrary. Legacy `*-preview`
+ * slugs are retained as aliases so pre-refresh saved selections still resolve.
  *
  * Used by: GoogleGeminiCliAdapter.generateUncached, at the point the model string
  * is resolved (before it is placed into the agy `--model` argument).
@@ -19,12 +20,27 @@ import { LLMProviderError } from '../types';
 const PROVIDER_NAME = 'google-gemini-cli';
 
 /**
- * Allowlist mapping legacy Nexus model slugs → the verbatim `agy models` human
- * labels accepted by `agy --model`. Keep entries in sync with
- * GoogleGeminiCliModels.ts; an entry must exist here for every shipped spec, or
- * resolving that model will throw.
+ * Allowlist mapping Nexus model slugs → the verbatim `agy models` human labels
+ * accepted by `agy --model`. Keep entries in sync with GoogleGeminiCliModels.ts;
+ * an entry must exist here for every shipped spec, or resolving that model will
+ * throw fail-closed.
+ *
+ * Two groups:
+ *  - CURRENT slugs (1:1 with the shipped catalog in GoogleGeminiCliModels.ts).
+ *  - LEGACY aliases retained for settings-compat: an existing user's saved model
+ *    selection (a pre-refresh `*-preview` slug) must still resolve to a live agy
+ *    label rather than throw. Each legacy alias points at the closest current
+ *    agy label.
  */
-const LEGACY_SLUG_TO_AGY_LABEL: Readonly<Record<string, string>> = Object.freeze({
+const SLUG_TO_AGY_LABEL: Readonly<Record<string, string>> = Object.freeze({
+  // Current catalog slugs (verbatim `agy models` labels).
+  'gemini-3.5-flash-low': 'Gemini 3.5 Flash (Low)',
+  'gemini-3.5-flash-medium': 'Gemini 3.5 Flash (Medium)',
+  'gemini-3.5-flash-high': 'Gemini 3.5 Flash (High)',
+  'gemini-3.1-pro-low': 'Gemini 3.1 Pro (Low)',
+  'gemini-3.1-pro-high': 'Gemini 3.1 Pro (High)',
+
+  // Legacy aliases (settings-compat for pre-refresh saved selections).
   'gemini-3-flash-preview': 'Gemini 3.5 Flash (Medium)',
   'gemini-3.1-flash-lite-preview': 'Gemini 3.5 Flash (Low)'
 });
@@ -34,7 +50,7 @@ const LEGACY_SLUG_TO_AGY_LABEL: Readonly<Record<string, string>> = Object.freeze
  * already-mapped agy label is allowed to pass through unchanged so callers can
  * be idempotent without re-mapping.
  */
-const KNOWN_AGY_LABELS: ReadonlySet<string> = new Set(Object.values(LEGACY_SLUG_TO_AGY_LABEL));
+const KNOWN_AGY_LABELS: ReadonlySet<string> = new Set(Object.values(SLUG_TO_AGY_LABEL));
 
 /**
  * Resolve a Nexus model identifier to the agy `--model` label, fail-closed.
@@ -57,7 +73,7 @@ export function normalizeModelToAgyLabel(model: string | undefined | null): stri
     );
   }
 
-  const mapped = LEGACY_SLUG_TO_AGY_LABEL[trimmed];
+  const mapped = SLUG_TO_AGY_LABEL[trimmed];
   if (mapped) {
     return mapped;
   }

--- a/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
+++ b/src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
@@ -1,0 +1,76 @@
+/**
+ * src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize.ts
+ *
+ * Maps Nexus's legacy `google-gemini-cli` model slugs (see GoogleGeminiCliModels.ts)
+ * to the human-label model names the Antigravity CLI (`agy`) expects on `--model`.
+ *
+ * Why this exists: `agy --model` FAILS OPEN — given an unknown value it does NOT
+ * error, it silently runs a default model and returns exit 0. If Nexus passed a
+ * legacy slug (e.g. `gemini-3-flash-preview`) straight through, the user would get
+ * a different model than they selected with no signal. So this module is a
+ * FAIL-CLOSED allowlist: a slug must be explicitly mapped, otherwise we throw a
+ * clear error rather than let agy pick something arbitrary.
+ *
+ * Used by: GoogleGeminiCliAdapter.generateUncached, at the point the model string
+ * is resolved (before it is placed into the agy `--model` argument).
+ */
+import { LLMProviderError } from '../types';
+
+const PROVIDER_NAME = 'google-gemini-cli';
+
+/**
+ * Allowlist mapping legacy Nexus model slugs → the verbatim `agy models` human
+ * labels accepted by `agy --model`. Keep entries in sync with
+ * GoogleGeminiCliModels.ts; an entry must exist here for every shipped spec, or
+ * resolving that model will throw.
+ */
+const LEGACY_SLUG_TO_AGY_LABEL: Readonly<Record<string, string>> = Object.freeze({
+  'gemini-3-flash-preview': 'Gemini 3.5 Flash (Medium)',
+  'gemini-3.1-flash-lite-preview': 'Gemini 3.5 Flash (Low)'
+});
+
+/**
+ * The set of agy labels we knowingly support (the values of the allowlist). An
+ * already-mapped agy label is allowed to pass through unchanged so callers can
+ * be idempotent without re-mapping.
+ */
+const KNOWN_AGY_LABELS: ReadonlySet<string> = new Set(Object.values(LEGACY_SLUG_TO_AGY_LABEL));
+
+/**
+ * Resolve a Nexus model identifier to the agy `--model` label, fail-closed.
+ *
+ * Accepts either a legacy Nexus slug (mapped via the allowlist) or an already
+ * normalized agy label (passed through). Any other value throws an
+ * LLMProviderError — agy would otherwise silently default, masking the mismatch.
+ *
+ * @param model - the model identifier resolved by the adapter (legacy slug or agy label)
+ * @returns the verbatim agy human label to pass to `--model`
+ * @throws LLMProviderError when the model is missing or not in the allowlist
+ */
+export function normalizeModelToAgyLabel(model: string | undefined | null): string {
+  const trimmed = typeof model === 'string' ? model.trim() : '';
+  if (!trimmed) {
+    throw new LLMProviderError(
+      'No model was specified for the Antigravity CLI provider.',
+      PROVIDER_NAME,
+      'CONFIGURATION_ERROR'
+    );
+  }
+
+  const mapped = LEGACY_SLUG_TO_AGY_LABEL[trimmed];
+  if (mapped) {
+    return mapped;
+  }
+
+  // Already an agy label — allow idempotent pass-through.
+  if (KNOWN_AGY_LABELS.has(trimmed)) {
+    return trimmed;
+  }
+
+  throw new LLMProviderError(
+    `Model "${trimmed}" is not supported by the Antigravity CLI provider. ` +
+      `Supported models: ${[...KNOWN_AGY_LABELS].join(', ')}.`,
+    PROVIDER_NAME,
+    'CONFIGURATION_ERROR'
+  );
+}

--- a/src/services/llm/providers/ProviderManager.ts
+++ b/src/services/llm/providers/ProviderManager.ts
@@ -324,8 +324,8 @@ export class LLMProviderManager {
       },
       {
         id: 'google-gemini-cli',
-        name: 'Gemini CLI',
-        description: 'Gemini models via your local Gemini CLI Google login — desktop only'
+        name: 'Antigravity CLI',
+        description: 'Gemini models via your local Antigravity CLI Google login — desktop only'
       },
       {
         id: 'mistral',

--- a/src/services/llm/utils/ToolSchemaSupport.ts
+++ b/src/services/llm/utils/ToolSchemaSupport.ts
@@ -1,12 +1,32 @@
 const PROVIDERS_WITHOUT_EXPLICIT_TOOL_SCHEMAS = new Set([
   'webllm',
-  'perplexity'
+  'perplexity',
+  'google-gemini-cli'
+]);
+
+/**
+ * Providers that are text-completion only in Nexus chat: they cannot call Nexus
+ * tools/agents at all, so tool schemas are pointless and any tool the user
+ * requests will not run. Distinct from `webllm`, which is ALSO in the
+ * no-explicit-schemas set above but for the opposite reason (its tool behavior is
+ * baked into the model, so it stays agentic). Keep `webllm` OUT of this set.
+ *
+ * - `perplexity`: search/text provider, no Nexus tool calling.
+ * - `google-gemini-cli` (Antigravity): the `agy --print` surface supports neither
+ *   tool/function calling nor streaming (investigation #62/#64/#66). Capability
+ *   source of truth lives in GoogleGeminiCliModels.ts (supportsFunctions:false,
+ *   supportsStreaming:false); this set is the provider-level seam consumed by the
+ *   user-facing warning surfaces.
+ */
+const TEXT_ONLY_PROVIDERS = new Set([
+  'perplexity',
+  'google-gemini-cli'
 ]);
 
 /**
  * Return whether a provider should receive explicit tool schemas in chat flows.
- * WebLLM has tool behavior baked into the model, while Perplexity does not
- * support Nexus tool calling at all.
+ * WebLLM has tool behavior baked into the model, while Perplexity and the
+ * Antigravity CLI provider do not support Nexus tool calling at all.
  */
 export function shouldPassToolSchemasToProvider(providerId?: string | null): boolean {
   if (!providerId) {
@@ -14,6 +34,19 @@ export function shouldPassToolSchemasToProvider(providerId?: string | null): boo
   }
 
   return !PROVIDERS_WITHOUT_EXPLICIT_TOOL_SCHEMAS.has(providerId);
+}
+
+/**
+ * Whether the provider is text-completion only — cannot execute Nexus tools or
+ * agents. Drives the text-only user warnings (settings notice + runtime guard)
+ * and the subagent text-only prompt branch.
+ */
+export function isTextOnlyProvider(providerId?: string | null): boolean {
+  if (!providerId) {
+    return false;
+  }
+
+  return TEXT_ONLY_PROVIDERS.has(providerId);
 }
 
 /**

--- a/src/services/llm/utils/ToolSchemaSupport.ts
+++ b/src/services/llm/utils/ToolSchemaSupport.ts
@@ -51,6 +51,11 @@ export function isTextOnlyProvider(providerId?: string | null): boolean {
 
 /**
  * Perplexity is intentionally limited to text/search behavior in Nexus chat.
+ *
+ * Deliberate narrow predicate, kept intentionally: it is currently consumer-less
+ * in src/ (the text-only seam moved to isTextOnlyProvider), but is retained as a
+ * Perplexity-specific check for any future Perplexity-only branch — do NOT
+ * broaden it to other providers, and do NOT delete it.
  */
 export function isPerplexityProvider(providerId?: string | null): boolean {
   return providerId === 'perplexity';

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -111,7 +111,9 @@ export class ProvidersTab {
         'google-gemini-cli': {
             name: 'Antigravity CLI',
             keyFormat: 'Local Antigravity CLI Google login required',
-            signupUrl: 'https://github.com/google-gemini/gemini-cli',
+            // TODO: set to the authoritative Antigravity CLI docs/install URL once published (TBD).
+            // Dropped the deprecated google-gemini/gemini-cli link rather than guess an agy URL.
+            signupUrl: '',
             category: 'cloud'
         },
         mistral: {
@@ -667,7 +669,7 @@ export class ProvidersTab {
             secondaryOAuthProvider = {
                 providerId: 'google-gemini-cli',
                 providerLabel: 'Antigravity CLI',
-                description: 'Use Gemini models through the desktop CLI. Authenticate by running `gemini` in your terminal first.',
+                description: 'Use Gemini models through the Antigravity CLI. Install the Antigravity CLI, then run `agy` once in your terminal to complete Google browser sign-in. (There is no `agy auth` command.)',
                 config: { ...geminiCliConfig },
                 oauthConfig: {
                     providerLabel: 'Antigravity CLI',
@@ -677,7 +679,7 @@ export class ProvidersTab {
                     await this.persistSecondaryProviderConfig(settings, 'google-gemini-cli', updatedGeminiCliConfig);
                 },
                 statusOnly: true,
-                statusHint: 'run `gemini auth` in your terminal',
+                statusHint: 'run `agy` once in your terminal to sign in (no `agy auth` command)',
             };
         }
 

--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -109,8 +109,8 @@ export class ProvidersTab {
             category: 'cloud'
         },
         'google-gemini-cli': {
-            name: 'Gemini CLI',
-            keyFormat: 'Local Gemini CLI Google login required',
+            name: 'Antigravity CLI',
+            keyFormat: 'Local Antigravity CLI Google login required',
             signupUrl: 'https://github.com/google-gemini/gemini-cli',
             category: 'cloud'
         },
@@ -666,11 +666,11 @@ export class ProvidersTab {
 
             secondaryOAuthProvider = {
                 providerId: 'google-gemini-cli',
-                providerLabel: 'Gemini CLI',
+                providerLabel: 'Antigravity CLI',
                 description: 'Use Gemini models through the desktop CLI. Authenticate by running `gemini` in your terminal first.',
                 config: { ...geminiCliConfig },
                 oauthConfig: {
-                    providerLabel: 'Gemini CLI',
+                    providerLabel: 'Antigravity CLI',
                     startFlow: () => this.startGeminiCliConnectFlow(),
                 },
                 onConfigChange: async (updatedGeminiCliConfig: LLMProviderConfig) => {

--- a/src/ui/chat/services/ChatSendCoordinator.ts
+++ b/src/ui/chat/services/ChatSendCoordinator.ts
@@ -12,6 +12,7 @@ import type { ConversationData, ConversationMessage } from '../../../types/chat/
 import type { MessageEnhancement } from '../components/suggesters/base/SuggesterInterfaces';
 import type { ReferenceMetadata } from '../utils/ReferenceExtractor';
 import { GLOBAL_WORKSPACE_ID } from '../../../services/WorkspaceService';
+import { isTextOnlyProvider } from '../../../services/llm/utils/ToolSchemaSupport';
 
 export interface MessageExecutionOptions {
   provider?: string;
@@ -155,6 +156,12 @@ export class ChatSendCoordinator {
 
       let messageOptions = await modelAgentManager.getMessageOptions();
 
+      // Runtime guard: a text-completion-only provider (e.g. Antigravity) cannot
+      // execute Nexus tools/agents. If the user invoked tools/prompt-actions for
+      // this send, the tool calls would silently no-op — surface a clear Notice
+      // instead so the limitation is never silent.
+      this.warnIfTextOnlyProviderWithTools(messageOptions.provider, enhancement);
+
       if (modelAgentManager.shouldCompactBeforeSending(
         currentConversation,
         message,
@@ -176,6 +183,32 @@ export class ChatSendCoordinator {
       modelAgentManager.clearMessageEnhancement();
       chatInput?.clearMessageEnhancer();
     }
+  }
+
+  /**
+   * Surface a non-silent Notice when the active provider is text-completion only
+   * (cannot call Nexus tools/agents) AND the user invoked tools or prompt actions
+   * for this send — those calls would otherwise silently no-op. Stays quiet on
+   * plain text chats, where the settings notice already communicates the limit.
+   */
+  private warnIfTextOnlyProviderWithTools(
+    provider: string | undefined,
+    enhancement?: MessageEnhancement
+  ): void {
+    if (!isTextOnlyProvider(provider)) {
+      return;
+    }
+
+    const requestedTools = (enhancement?.tools?.length ?? 0) > 0;
+    const requestedPrompts = (enhancement?.prompts?.length ?? 0) > 0;
+    if (!requestedTools && !requestedPrompts) {
+      return;
+    }
+
+    new Notice(
+      'This provider is text completions only — it can\'t run tools or agents, so the requested tool calls won\'t execute. Switch providers for agentic, tool-driven work.',
+      6000
+    );
   }
 
   async compactCurrentConversation(): Promise<void> {

--- a/src/ui/chat/utils/ProviderUtils.ts
+++ b/src/ui/chat/utils/ProviderUtils.ts
@@ -11,7 +11,7 @@ export class ProviderUtils {
       'openai': 'OpenAI',
       'anthropic': 'Anthropic',
       'anthropic-claude-code': 'Anthropic (Claude Code)',
-      'google-gemini-cli': 'Google (Gemini CLI)',
+      'google-gemini-cli': 'Google (Antigravity)',
       'mistral': 'Mistral AI',
       'deepgram': 'Deepgram',
       'assemblyai': 'AssemblyAI',

--- a/src/utils/geminiCli.ts
+++ b/src/utils/geminiCli.ts
@@ -1,27 +1,12 @@
 import { Platform, Vault } from 'obsidian';
-import { getPrimaryServerKey } from '../constants/branding';
 import { resolveDesktopBinaryPath } from './binaryDiscovery';
-import { getVaultBasePath, getConnectorPath } from './cliPathUtils';
+import { getVaultBasePath } from './cliPathUtils';
 
 export interface GeminiCliRuntime {
     geminiPath: string | null;
     nodePath: string | null;
-    connectorPath: string | null;
     vaultPath: string | null;
-    serverKey: string;
 }
-
-const BUILT_IN_TOOL_EXCLUSIONS = [
-    'edit',
-    'list_directory',
-    'read_file',
-    'read_many_files',
-    'run_shell_command',
-    'save_memory',
-    'web_fetch',
-    'write_file',
-    'google_web_search'
-];
 
 type GeminiCliDesktopModuleMap = {
     path: typeof import('path');
@@ -53,30 +38,27 @@ export function resolveGeminiCliRuntime(vault: Vault): GeminiCliRuntime {
     return {
         geminiPath,
         nodePath,
-        connectorPath: getConnectorPath(vaultPath),
-        vaultPath,
-        serverKey: getPrimaryServerKey(vault.getName())
+        vaultPath
     };
 }
 
-export function buildGeminiCliEnv(systemSettingsPath?: string, nodePath?: string | null): NodeJS.ProcessEnv {
+export function buildGeminiCliEnv(nodePath?: string | null): NodeJS.ProcessEnv {
     const env = { ...process.env };
 
+    // Strip provider credentials from the child's environment so agy uses its
+    // own file-based OAuth (~/.gemini) and never an ambient API key. agy fronts
+    // Google, Anthropic, and OpenAI models, so strip all three families.
     delete env.GEMINI_API_KEY;
     delete env.GOOGLE_API_KEY;
     delete env.GOOGLE_GENAI_USE_VERTEXAI;
     delete env.GOOGLE_CLOUD_PROJECT;
     delete env.GOOGLE_APPLICATION_CREDENTIALS;
-
-    if (systemSettingsPath) {
-        env.GEMINI_CLI_SYSTEM_SETTINGS_PATH = systemSettingsPath;
-    } else {
-        delete env.GEMINI_CLI_SYSTEM_SETTINGS_PATH;
-    }
+    delete env.ANTHROPIC_API_KEY;
+    delete env.OPENAI_API_KEY;
 
     // Prepend the node binary's directory to PATH so that subprocess spawns
-    // (e.g. `node connector.js`) succeed when Obsidian runs with a restricted
-    // PATH that omits nvm/homebrew/system node locations.
+    // succeed when Obsidian runs with a restricted PATH that omits
+    // nvm/homebrew/system node locations.
     if (nodePath) {
         const pathMod = loadDesktopModule('path');
         const nodeDir = pathMod.dirname(nodePath);
@@ -87,46 +69,4 @@ export function buildGeminiCliEnv(systemSettingsPath?: string, nodePath?: string
     return env;
 }
 
-export function buildGeminiCliSystemSettings(runtime: GeminiCliRuntime): Record<string, unknown> {
-    return {
-        general: {
-            disableAutoUpdate: true,
-            disableUpdateNag: true
-        },
-        privacy: {
-            usageStatisticsEnabled: false
-        },
-        security: {
-            folderTrust: {
-                enabled: false
-            }
-        },
-        ui: {
-            hideBanner: true,
-            hideFooter: true,
-            hideTips: true
-        },
-        output: {
-            format: 'json'
-        },
-        tools: {
-            sandbox: false,
-            core: [],
-            exclude: BUILT_IN_TOOL_EXCLUSIONS
-        },
-        mcp: {
-            allowed: [runtime.serverKey]
-        },
-        mcpServers: runtime.nodePath && runtime.connectorPath ? {
-            [runtime.serverKey]: {
-                command: runtime.nodePath,
-                args: [runtime.connectorPath],
-                cwd: runtime.vaultPath || undefined,
-                timeout: 600000,
-                trust: true,
-                includeTools: ['getTools', 'useTools']
-            }
-        } : {}
-    };
-}
 

--- a/src/utils/geminiCli.ts
+++ b/src/utils/geminiCli.ts
@@ -46,7 +46,7 @@ function loadDesktopModule<TModuleName extends keyof GeminiCliDesktopModuleMap>(
 }
 
 export function resolveGeminiCliRuntime(vault: Vault): GeminiCliRuntime {
-    const geminiPath = resolveDesktopBinaryPath('gemini');
+    const geminiPath = resolveDesktopBinaryPath('agy');
     const nodePath = resolveDesktopBinaryPath('node');
     const vaultPath = getVaultBasePath(vault);
 

--- a/tests/unit/ChatSendCoordinator.test.ts
+++ b/tests/unit/ChatSendCoordinator.test.ts
@@ -1,5 +1,22 @@
+// Notice-spy: preserve the full real obsidian mock (ContextCompactionService and
+// other transitive imports depend on it) and swap ONLY Notice for a constructor
+// spy that records {message, timeout} into a shared array. Mirrors the
+// established DataTab.test.ts pattern.
+const mockNotices: Array<{ message: string; timeout?: number }> = [];
+jest.mock('obsidian', () => {
+  const actual = jest.requireActual('obsidian');
+  return {
+    ...actual,
+    Notice: jest.fn().mockImplementation((message: string, timeout?: number) => {
+      mockNotices.push({ message, timeout });
+      return { message, timeout, hide: jest.fn() };
+    })
+  };
+});
+
 import { ChatSendCoordinator } from '../../src/ui/chat/services/ChatSendCoordinator';
 import type { ConversationData, ConversationMessage } from '../../src/types/chat/ChatTypes';
+import type { MessageEnhancement } from '../../src/ui/chat/components/suggesters/base/SuggesterInterfaces';
 
 function createMessage(
   id: string,
@@ -30,7 +47,7 @@ function createConversation(messages: ConversationMessage[]): ConversationData {
   };
 }
 
-function createHarness() {
+function createHarness(provider = 'github-copilot') {
   const conversation = createConversation([
     createMessage('u1', 'user', 'first request'),
     createMessage('a1', 'assistant', 'partial response'),
@@ -71,7 +88,7 @@ function createHarness() {
     setMessageEnhancement: jest.fn(),
     clearMessageEnhancement: jest.fn(),
     getMessageOptions: jest.fn().mockResolvedValue({
-      provider: 'github-copilot',
+      provider,
       model: 'copilot-model',
       systemPrompt: 'System prompt'
     }),
@@ -160,7 +177,31 @@ function createHarness() {
   };
 }
 
+/**
+ * Build a minimal MessageEnhancement carrying only the fields the text-only
+ * runtime guard inspects (tools / prompts lengths). Other required fields are
+ * filled with empty defaults and cast — the guard never reads them.
+ */
+function enhancementWith(
+  parts: { tools?: unknown[]; prompts?: unknown[] }
+): MessageEnhancement {
+  return {
+    originalMessage: '',
+    cleanedMessage: '',
+    tools: parts.tools ?? [],
+    prompts: parts.prompts ?? [],
+    notes: [],
+    workspaces: [],
+    totalTokens: 0
+  } as unknown as MessageEnhancement;
+}
+
 describe('ChatSendCoordinator', () => {
+  beforeEach(() => {
+    mockNotices.length = 0;
+    jest.clearAllMocks();
+  });
+
   it('compacts context before sending when the selected model requires it', async () => {
     const harness = createHarness();
     // Return true only for the first call (user's message).
@@ -204,5 +245,75 @@ describe('ChatSendCoordinator', () => {
     expect(harness.bubble.stopLoadingAnimation).toHaveBeenCalledTimes(1);
     expect(harness.streamingController.stopLoadingAnimation).toHaveBeenCalledWith(harness.contentEl);
     expect(harness.streamingController.finalizeStreaming).toHaveBeenCalledWith('a1', 'partial response');
+  });
+});
+
+describe('ChatSendCoordinator text-only provider runtime guard', () => {
+  beforeEach(() => {
+    mockNotices.length = 0;
+    jest.clearAllMocks();
+  });
+
+  const TEXT_ONLY_NOTICE =
+    "This provider is text completions only — it can't run tools or agents, so the requested tool calls won't execute. Switch providers for agentic, tool-driven work.";
+
+  it('fires a Notice when a text-only provider (Antigravity) is active AND tools were invoked', async () => {
+    const harness = createHarness('google-gemini-cli');
+
+    await harness.coordinator.handleSendMessage(
+      'edit my note',
+      enhancementWith({ tools: [{ id: 'content_read' }] })
+    );
+
+    expect(mockNotices).toHaveLength(1);
+    expect(mockNotices[0].message).toBe(TEXT_ONLY_NOTICE);
+    expect(mockNotices[0].timeout).toBe(6000);
+    // The guard is a warning only — it must NOT block the send.
+    expect(harness.messageManager.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires a Notice when a text-only provider is active AND prompt actions were invoked', async () => {
+    const harness = createHarness('perplexity');
+
+    await harness.coordinator.handleSendMessage(
+      'run my prompt',
+      enhancementWith({ prompts: [{ id: 'summarize' }] })
+    );
+
+    expect(mockNotices).toHaveLength(1);
+    expect(mockNotices[0].message).toBe(TEXT_ONLY_NOTICE);
+  });
+
+  it('stays SILENT on a plain-text send (no tools/prompts) for a text-only provider', async () => {
+    const harness = createHarness('google-gemini-cli');
+
+    // No enhancement at all — the settings notice already communicates the limit.
+    await harness.coordinator.handleSendMessage('just chatting');
+
+    expect(mockNotices).toHaveLength(0);
+    expect(harness.messageManager.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays SILENT for a text-only provider when enhancement has empty tools/prompts arrays', async () => {
+    const harness = createHarness('google-gemini-cli');
+
+    await harness.coordinator.handleSendMessage(
+      'just chatting',
+      enhancementWith({ tools: [], prompts: [] })
+    );
+
+    expect(mockNotices).toHaveLength(0);
+  });
+
+  it('stays SILENT for a normal tool-capable provider even when tools were invoked', async () => {
+    const harness = createHarness('openai');
+
+    await harness.coordinator.handleSendMessage(
+      'edit my note',
+      enhancementWith({ tools: [{ id: 'content_read' }] })
+    );
+
+    expect(mockNotices).toHaveLength(0);
+    expect(harness.messageManager.sendMessage).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/ChatSettingsRendererTextOnlyWarning.test.ts
+++ b/tests/unit/ChatSettingsRendererTextOnlyWarning.test.ts
@@ -1,0 +1,146 @@
+/**
+ * tests/unit/ChatSettingsRendererTextOnlyWarning.test.ts
+ *
+ * Render coverage for ChatSettingsRenderer.renderTextOnlyProviderWarning — the
+ * settings-panel notice that warns when a text-completion-only provider is
+ * selected. Complements TextOnlyProviderSeam.test.ts (which pins the SSOT +
+ * seam classification): this file pins the *rendered copy* surface.
+ *
+ * For Antigravity (google-gemini-cli) the copy MUST name BOTH limitations
+ * (no tools/agents AND no streaming), for both the 'chat' and 'agent' variants.
+ * Perplexity copy must remain unchanged after the renderPerplexityWarning ->
+ * renderTextOnlyProviderWarning generalization (regression guard), and a normal
+ * tool-capable provider must render nothing.
+ *
+ * The renderer constructor instantiates heavy LLM services, so we exercise the
+ * two private copy/render methods directly over the real prototype with a
+ * minimal `this` carrying only the `settings` field they read. This keeps the
+ * test coupled to the REAL copy SSOT (getTextOnlyProviderWarningCopy) — not a
+ * re-typed fixture — so a copy change in source turns it red.
+ */
+import { ChatSettingsRenderer } from '../../src/components/shared/ChatSettingsRenderer';
+import { createMockElement } from '../helpers/mockFactories';
+
+type RendererInternals = {
+  settings: { provider?: string; agentProvider?: string };
+  renderTextOnlyProviderWarning(content: unknown, variant: 'chat' | 'agent'): void;
+};
+
+/**
+ * Build a minimal `this` for the private render method. Only `settings` is read
+ * by renderTextOnlyProviderWarning / getTextOnlyProviderWarningCopy.
+ */
+function rendererWith(settings: { provider?: string; agentProvider?: string }): RendererInternals {
+  return {
+    settings,
+    // Bind the real prototype methods so getTextOnlyProviderWarningCopy resolves
+    // on `this` — both are private, hence the prototype indexing cast.
+    renderTextOnlyProviderWarning: (
+      ChatSettingsRenderer.prototype as unknown as RendererInternals
+    ).renderTextOnlyProviderWarning,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    getTextOnlyProviderWarningCopy: (ChatSettingsRenderer.prototype as any).getTextOnlyProviderWarningCopy
+  } as unknown as RendererInternals;
+}
+
+/**
+ * Returns the {title, message} actually rendered into `content`, or null if the
+ * warning short-circuited (no warning div created). Reads the mock's recorded
+ * createDiv calls: content.createDiv({cls:'csr-provider-warning'}) -> warningEl,
+ * then warningEl.createDiv({cls:'...-title', text}) and (...-text, text).
+ */
+function renderAndExtract(
+  provider: string | undefined,
+  variant: 'chat' | 'agent'
+): { title: string; message: string } | null {
+  const content = createMockElement('div');
+  const settings = variant === 'agent' ? { agentProvider: provider } : { provider };
+  const self = rendererWith(settings);
+
+  self.renderTextOnlyProviderWarning(content, variant);
+
+  const createDiv = content.createDiv as jest.Mock;
+  // Find the warning wrapper creation; if absent the method short-circuited.
+  const wrapperCall = createDiv.mock.results.find((result, index) => {
+    const arg = createDiv.mock.calls[index]?.[0];
+    return typeof arg === 'object' && arg?.cls === 'csr-provider-warning';
+  });
+  if (!wrapperCall) {
+    return null;
+  }
+
+  const warningEl = wrapperCall.value as { createDiv: jest.Mock };
+  const childCalls = warningEl.createDiv.mock.calls.map((args) => args[0]);
+  const titleArg = childCalls.find((arg) => arg?.cls === 'csr-provider-warning-title');
+  const messageArg = childCalls.find((arg) => arg?.cls === 'csr-provider-warning-text');
+
+  return {
+    title: titleArg?.text ?? '',
+    message: messageArg?.text ?? ''
+  };
+}
+
+describe('ChatSettingsRenderer text-only provider warning copy', () => {
+  describe('Antigravity (google-gemini-cli) names BOTH limitations', () => {
+    it.each(['chat', 'agent'] as const)(
+      'renders the no-tools AND no-streaming warning for the %s variant',
+      (variant) => {
+        const rendered = renderAndExtract('google-gemini-cli', variant);
+
+        expect(rendered).not.toBeNull();
+        expect(rendered!.title).toBe('Antigravity is text completions only');
+        // Limitation 1: cannot call tools/agents.
+        expect(rendered!.message).toContain("can't call tools or agents");
+        // Limitation 2: no streaming (replies arrive all at once).
+        expect(rendered!.message).toContain('no streaming');
+        expect(rendered!.message).toContain('all at once');
+      }
+    );
+
+    it('uses agent-specific guidance for the agent variant only', () => {
+      const chat = renderAndExtract('google-gemini-cli', 'chat');
+      const agent = renderAndExtract('google-gemini-cli', 'agent');
+
+      // Agent copy speaks to prompt actions + subagents; chat copy does not.
+      expect(agent!.message).toContain('Prompt actions and subagents');
+      expect(chat!.message).not.toContain('Prompt actions and subagents');
+      // Both still carry the two-limitation lead sentence.
+      expect(chat!.message).toContain("can't call tools or agents");
+      expect(agent!.message).toContain("can't call tools or agents");
+    });
+  });
+
+  describe('Perplexity copy is unchanged (no regression from the generalization)', () => {
+    it.each(['chat', 'agent'] as const)(
+      'renders the established Perplexity wording for the %s variant',
+      (variant) => {
+        const rendered = renderAndExtract('perplexity', variant);
+
+        expect(rendered).not.toBeNull();
+        expect(rendered!.title).toBe('Perplexity cannot use Nexus tools');
+        // Perplexity copy must NOT have acquired Antigravity's Antigravity title.
+        expect(rendered!.title).not.toContain('Antigravity');
+      }
+    );
+
+    it('keeps the search-focused chat wording and text-only agent wording', () => {
+      expect(renderAndExtract('perplexity', 'chat')!.message).toBe(
+        'Chat and subagents will not receive tool schemas with Perplexity. Use it for search-heavy, text-only work.'
+      );
+      expect(renderAndExtract('perplexity', 'agent')!.message).toBe(
+        'Prompt actions and subagents will run in text-only mode. Use another cloud model for vault edits or other tool-driven work.'
+      );
+    });
+  });
+
+  describe('tool-capable providers render no warning', () => {
+    it.each([
+      ['a normal cloud provider (chat)', 'openai', 'chat'],
+      ['a normal cloud provider (agent)', 'openai', 'agent'],
+      ['webllm (tools baked in)', 'webllm', 'chat'],
+      ['an undefined provider', undefined, 'chat']
+    ] as const)('stays silent for %s', (_label, provider, variant) => {
+      expect(renderAndExtract(provider, variant)).toBeNull();
+    });
+  });
+});

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -209,25 +209,48 @@ describe('GoogleGeminiCliAdapter (agy slice-d invocation)', () => {
     expect(runCliProcess).not.toHaveBeenCalled();
   });
 
-  it('lists exactly the refreshed 5-entry Gemini catalog', async () => {
+  it('lists exactly the 2 BASE Gemini models (effort comes from the slider)', async () => {
     const models = await adapter.listModels();
 
-    // Mirrors GoogleGeminiCliModels.ts (catalog declaration order): three
-    // 3.5 Flash effort tiers + two 3.1 Pro tiers. Gemini-only — the non-Gemini
-    // agy models (Claude Sonnet/Opus, GPT-OSS) are intentionally excluded.
+    // Mirrors GoogleGeminiCliModels.ts: just the 2 base models. Effort is NOT a
+    // catalog entry anymore — it comes from the thinking/effort slider and is
+    // composed into the agy label at invocation. Gemini-only.
     expect(models.map((model) => model.id)).toEqual([
-      'gemini-3.5-flash-low',
-      'gemini-3.5-flash-medium',
-      'gemini-3.5-flash-high',
-      'gemini-3.1-pro-low',
-      'gemini-3.1-pro-high'
+      'gemini-3.5-flash',
+      'gemini-3.1-pro'
     ]);
-    // Legacy *-preview slugs are NOT catalog entries (they survive only as
-    // normalize aliases for settings-compat, not as listable models).
+    // The retired effort-variant slugs are NOT catalog entries (they survive only
+    // as normalize aliases for settings-compat, not as listable models).
+    expect(models.map((model) => model.id)).not.toContain('gemini-3.5-flash-low');
+    expect(models.map((model) => model.id)).not.toContain('gemini-3.5-flash-medium');
+    expect(models.map((model) => model.id)).not.toContain('gemini-3.1-pro-high');
+    // Legacy *-preview slugs are likewise normalize-only aliases.
     expect(models.map((model) => model.id)).not.toContain('gemini-3-flash-preview');
-    expect(models.map((model) => model.id)).not.toContain('gemini-3.1-flash-lite-preview');
     // Stale specs that were never part of this provider's catalog.
     expect(models.map((model) => model.id)).not.toContain('gemini-2.5-pro');
+  });
+
+  it('composes the agy --model label from the base model + the effort slider', async () => {
+    let capturedArgs: string[] = [];
+    runCliProcess.mockImplementation((_command, args) => {
+      capturedArgs = args;
+      return {
+        child: { kill: jest.fn() },
+        result: Promise.resolve({ stdout: 'ok', stderr: '', exitCode: 0 })
+      };
+    });
+
+    // Base Flash + slider High → "Gemini 3.5 Flash (High)".
+    await adapter.generateUncached('x', { model: 'gemini-3.5-flash', thinkingEffort: 'high' });
+    expect(capturedArgs[capturedArgs.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (High)');
+
+    // Pro + slider Medium → clamps UP to "Gemini 3.1 Pro (High)" (Pro lacks Medium).
+    await adapter.generateUncached('x', { model: 'gemini-3.1-pro', thinkingEffort: 'medium' });
+    expect(capturedArgs[capturedArgs.indexOf('--model') + 1]).toBe('Gemini 3.1 Pro (High)');
+
+    // A saved legacy effort-variant slug still resolves (explicit effort wins).
+    await adapter.generateUncached('x', { model: 'gemini-3.5-flash-low', thinkingEffort: 'high' });
+    expect(capturedArgs[capturedArgs.indexOf('--model') + 1]).toBe('Gemini 3.5 Flash (Low)');
   });
 
   it('maps oversized CLI startup failures to REQUEST_TOO_LARGE', async () => {

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -209,15 +209,24 @@ describe('GoogleGeminiCliAdapter (agy slice-d invocation)', () => {
     expect(runCliProcess).not.toHaveBeenCalled();
   });
 
-  it('lists only the validated Gemini CLI models', async () => {
+  it('lists exactly the refreshed 5-entry Gemini catalog', async () => {
     const models = await adapter.listModels();
 
+    // Mirrors GoogleGeminiCliModels.ts (catalog declaration order): three
+    // 3.5 Flash effort tiers + two 3.1 Pro tiers. Gemini-only — the non-Gemini
+    // agy models (Claude Sonnet/Opus, GPT-OSS) are intentionally excluded.
     expect(models.map((model) => model.id)).toEqual([
-      'gemini-3.1-flash-lite-preview',
-      'gemini-3-flash-preview'
+      'gemini-3.5-flash-low',
+      'gemini-3.5-flash-medium',
+      'gemini-3.5-flash-high',
+      'gemini-3.1-pro-low',
+      'gemini-3.1-pro-high'
     ]);
-    expect(models.map((model) => model.id)).not.toContain('gemini-3.1-pro-preview');
-    expect(models.map((model) => model.id)).not.toContain('gemini-3-flash');
+    // Legacy *-preview slugs are NOT catalog entries (they survive only as
+    // normalize aliases for settings-compat, not as listable models).
+    expect(models.map((model) => model.id)).not.toContain('gemini-3-flash-preview');
+    expect(models.map((model) => model.id)).not.toContain('gemini-3.1-flash-lite-preview');
+    // Stale specs that were never part of this provider's catalog.
     expect(models.map((model) => model.id)).not.toContain('gemini-2.5-pro');
   });
 

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -1,4 +1,4 @@
-import * as fsPromises from 'fs/promises';
+import { Platform } from 'obsidian';
 import { GoogleGeminiCliAdapter } from '../../src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliAdapter';
 
 type VaultLike = {
@@ -13,45 +13,45 @@ jest.mock('../../src/utils/geminiCli', () => ({
   resolveGeminiCliRuntime: jest.fn(() => ({
     geminiPath: '/mock/bin/agy',
     nodePath: '/mock/bin/node',
-    connectorPath: '/mock/connector.js',
-    vaultPath: '/mock/vault',
-    serverKey: 'nexus-test-vault'
+    vaultPath: '/mock/vault'
   })),
-  buildGeminiCliEnv: jest.fn((settingsPath: string, nodePath: string) => ({
-    GEMINI_CLI_SYSTEM_SETTINGS_PATH: settingsPath,
+  // Slice d: buildGeminiCliEnv takes only nodePath; no system-settings path.
+  buildGeminiCliEnv: jest.fn((nodePath: string) => ({
     PATH: nodePath
-  })),
-  buildGeminiCliSystemSettings: jest.fn(() => ({
-    output: { format: 'json' }
   }))
 }));
 
-describe('GoogleGeminiCliAdapter (agy plain-text contract)', () => {
+describe('GoogleGeminiCliAdapter (agy slice-d invocation)', () => {
   const { runCliProcess } = jest.requireMock('../../src/utils/cliProcessRunner') as {
     runCliProcess: jest.Mock;
   };
+
+  // Platform.isMacOS is mutated by the sandbox-guard test; restore it after each.
+  const mutablePlatform = Platform as unknown as { isMacOS: boolean };
+  const originalIsMacOS = mutablePlatform.isMacOS;
 
   let adapter: GoogleGeminiCliAdapter;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mutablePlatform.isMacOS = originalIsMacOS;
     adapter = new GoogleGeminiCliAdapter({
       getName: () => 'Test Vault'
     } as VaultLike);
   });
 
-  it('moves the combined prompt to stdin and normalizes the model to its agy label', async () => {
+  afterEach(() => {
+    mutablePlatform.isMacOS = originalIsMacOS;
+  });
+
+  it('invokes agy with print/model/print-timeout/sandbox and the prompt on stdin', async () => {
+    // The obsidian test mock sets Platform.isMacOS = true, so --sandbox is passed.
     let capturedArgs: string[] = [];
     let capturedOptions: { cwd?: string; env?: NodeJS.ProcessEnv; stdinText?: string } | undefined;
-    let settingsPath = '';
 
     runCliProcess.mockImplementation((_command, args, options) => {
       capturedArgs = args;
       capturedOptions = options;
-      settingsPath = options?.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH || '';
-
-      expect(settingsPath).toBeTruthy();
-
       return {
         child: { kill: jest.fn() },
         // agy emits plain text — the response is the trimmed stdout.
@@ -67,13 +67,19 @@ describe('GoogleGeminiCliAdapter (agy plain-text contract)', () => {
       systemPrompt: 'Use the MCP tools if needed.'
     });
 
-    // Default model slug maps fail-closed to its agy human label; no --output-format flag.
+    // Default model slug maps fail-closed to its agy human label; no config write,
+    // no --output-format, no --dangerously-skip-permissions. --print-timeout is a
+    // Go-duration string (NOT ms). --sandbox is present on darwin.
     expect(capturedArgs).toEqual([
-      '--prompt',
-      '',
+      '--print',
       '--model',
-      'Gemini 3.5 Flash (Medium)'
+      'Gemini 3.5 Flash (Medium)',
+      '--print-timeout',
+      '60s',
+      '--sandbox'
     ]);
+    expect(capturedArgs).not.toContain('--dangerously-skip-permissions');
+    expect(capturedOptions?.cwd).toBe('/mock/vault');
     expect(capturedOptions?.stdinText).toBe(
       'System instructions:\nUse the MCP tools if needed.\n\nUser request:\nSummarize the regression'
     );
@@ -84,8 +90,32 @@ describe('GoogleGeminiCliAdapter (agy plain-text contract)', () => {
       completionTokens: 0,
       totalTokens: 0
     });
+  });
 
-    await expect(fsPromises.access(settingsPath)).rejects.toThrow();
+  it('omits --sandbox on non-darwin platforms (platform guard)', async () => {
+    mutablePlatform.isMacOS = false;
+    let capturedArgs: string[] = [];
+
+    runCliProcess.mockImplementation((_command, args) => {
+      capturedArgs = args;
+      return {
+        child: { kill: jest.fn() },
+        result: Promise.resolve({ stdout: 'ok', stderr: '', exitCode: 0 })
+      };
+    });
+
+    await adapter.generateUncached('Anything');
+
+    expect(capturedArgs).not.toContain('--sandbox');
+    // The security floor (print/model/print-timeout, no skip-perms) still holds.
+    expect(capturedArgs).toEqual([
+      '--print',
+      '--model',
+      'Gemini 3.5 Flash (Medium)',
+      '--print-timeout',
+      '60s'
+    ]);
+    expect(capturedArgs).not.toContain('--dangerously-skip-permissions');
   });
 
   it('returns the trimmed stdout verbatim as plain text (no JSON parsing)', async () => {

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -162,6 +162,24 @@ describe('GoogleGeminiCliAdapter (agy slice-d invocation)', () => {
     expect(response.text).toBe('OK');
   });
 
+  it('preserves internal newlines in a multi-paragraph response (trim strips only the edges)', async () => {
+    // The common real agy response is multi-line/multi-paragraph. parseAgyOutput
+    // is stdout.trim(), so leading/trailing whitespace is stripped but INTERNAL
+    // newlines (incl. the blank line between paragraphs) must be preserved verbatim.
+    runCliProcess.mockReturnValue({
+      child: { kill: jest.fn() },
+      result: Promise.resolve({
+        stdout: '\n  Line one.\n\nLine two.\n  ',
+        stderr: '',
+        exitCode: 0
+      })
+    });
+
+    const response = await adapter.generateUncached('Write two short paragraphs.');
+
+    expect(response.text).toBe('Line one.\n\nLine two.');
+  });
+
   it('throws a PROVIDER_ERROR on empty/whitespace-only output', async () => {
     runCliProcess.mockReturnValue({
       child: { kill: jest.fn() },

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -92,6 +92,33 @@ describe('GoogleGeminiCliAdapter (agy slice-d invocation)', () => {
     });
   });
 
+  it('writes no temp settings file and threads no settings-path env (Scenario A)', async () => {
+    // Scenario A = zero persistent/temp config footprint. The old gemini runtime
+    // wrote a temp system-settings.json (via mkdtemp/writeFile) and pointed agy at
+    // it with GEMINI_CLI_SYSTEM_SETTINGS_PATH. That flow must be entirely gone:
+    // no settings-path env var, and no --output-format / settings args.
+    let capturedArgs: string[] = [];
+    let capturedOptions: { cwd?: string; env?: NodeJS.ProcessEnv; stdinText?: string } | undefined;
+
+    runCliProcess.mockImplementation((_command, args, options) => {
+      capturedArgs = args;
+      capturedOptions = options;
+      return {
+        child: { kill: jest.fn() },
+        result: Promise.resolve({ stdout: 'ok', stderr: '', exitCode: 0 })
+      };
+    });
+
+    await adapter.generateUncached('Anything');
+
+    // No settings-path env var is threaded to the child process.
+    expect(capturedOptions?.env?.GEMINI_CLI_SYSTEM_SETTINGS_PATH).toBeUndefined();
+    // No JSON-output / settings-injection args survive from the gemini runtime.
+    expect(capturedArgs).not.toContain('--output-format');
+    expect(capturedArgs.some((arg) => arg.includes('system-settings'))).toBe(false);
+    expect(capturedArgs.some((arg) => arg.includes('.json'))).toBe(false);
+  });
+
   it('omits --sandbox on non-darwin platforms (platform guard)', async () => {
     mutablePlatform.isMacOS = false;
     let capturedArgs: string[] = [];

--- a/tests/unit/GoogleGeminiCliAdapter.test.ts
+++ b/tests/unit/GoogleGeminiCliAdapter.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../src/utils/cliProcessRunner', () => ({
 
 jest.mock('../../src/utils/geminiCli', () => ({
   resolveGeminiCliRuntime: jest.fn(() => ({
-    geminiPath: '/mock/bin/gemini',
+    geminiPath: '/mock/bin/agy',
     nodePath: '/mock/bin/node',
     connectorPath: '/mock/connector.js',
     vaultPath: '/mock/vault',
@@ -26,7 +26,7 @@ jest.mock('../../src/utils/geminiCli', () => ({
   }))
 }));
 
-describe('GoogleGeminiCliAdapter', () => {
+describe('GoogleGeminiCliAdapter (agy plain-text contract)', () => {
   const { runCliProcess } = jest.requireMock('../../src/utils/cliProcessRunner') as {
     runCliProcess: jest.Mock;
   };
@@ -40,7 +40,7 @@ describe('GoogleGeminiCliAdapter', () => {
     } as VaultLike);
   });
 
-  it('moves the combined prompt to stdin while preserving temp settings and usage extraction', async () => {
+  it('moves the combined prompt to stdin and normalizes the model to its agy label', async () => {
     let capturedArgs: string[] = [];
     let capturedOptions: { cwd?: string; env?: NodeJS.ProcessEnv; stdinText?: string } | undefined;
     let settingsPath = '';
@@ -54,29 +54,11 @@ describe('GoogleGeminiCliAdapter', () => {
 
       return {
         child: { kill: jest.fn() },
-        result: fsPromises.readFile(settingsPath, 'utf8').then((contents) => {
-          expect(JSON.parse(contents)).toEqual({
-            output: { format: 'json' }
-          });
-
-          return {
-            stdout: JSON.stringify({
-              response: 'Gemini output',
-              stats: {
-                models: {
-                  'gemini-3-flash-preview': {
-                    tokens: {
-                      prompt: 12,
-                      candidates: 7,
-                      total: 19
-                    }
-                  }
-                }
-              }
-            }),
-            stderr: '',
-            exitCode: 0
-          };
+        // agy emits plain text — the response is the trimmed stdout.
+        result: Promise.resolve({
+          stdout: 'Antigravity output\n',
+          stderr: '',
+          exitCode: 0
         })
       };
     });
@@ -85,49 +67,32 @@ describe('GoogleGeminiCliAdapter', () => {
       systemPrompt: 'Use the MCP tools if needed.'
     });
 
+    // Default model slug maps fail-closed to its agy human label; no --output-format flag.
     expect(capturedArgs).toEqual([
       '--prompt',
       '',
       '--model',
-      'gemini-3-flash-preview',
-      '--output-format',
-      'json'
+      'Gemini 3.5 Flash (Medium)'
     ]);
     expect(capturedOptions?.stdinText).toBe(
       'System instructions:\nUse the MCP tools if needed.\n\nUser request:\nSummarize the regression'
     );
-    expect(response.text).toBe('Gemini output');
+    expect(response.text).toBe('Antigravity output');
+    // agy reports no token usage — buildLLMResponse defaults to zero.
     expect(response.usage).toEqual({
-      promptTokens: 12,
-      completionTokens: 7,
-      totalTokens: 19
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0
     });
 
     await expect(fsPromises.access(settingsPath)).rejects.toThrow();
   });
 
-  it('parses CLI output with leading logs before the final JSON block', async () => {
+  it('returns the trimmed stdout verbatim as plain text (no JSON parsing)', async () => {
     runCliProcess.mockReturnValue({
       child: { kill: jest.fn() },
       result: Promise.resolve({
-        stdout: [
-          'Loaded cached credentials.',
-          'Attempt 2 failed with status 429. Retrying with backoff...',
-          '{',
-          '  "response": "OK",',
-          '  "stats": {',
-          '    "models": {',
-          '      "gemini-3.1-flash-lite-preview": {',
-          '        "tokens": {',
-          '          "prompt": 8045,',
-          '          "candidates": 1,',
-          '          "total": 8046',
-          '        }',
-          '      }',
-          '    }',
-          '  }',
-          '}'
-        ].join('\n'),
+        stdout: '  OK  \n',
         stderr: '',
         exitCode: 0
       })
@@ -138,11 +103,35 @@ describe('GoogleGeminiCliAdapter', () => {
     });
 
     expect(response.text).toBe('OK');
-    expect(response.usage).toEqual({
-      promptTokens: 8045,
-      completionTokens: 1,
-      totalTokens: 8046
+  });
+
+  it('throws a PROVIDER_ERROR on empty/whitespace-only output', async () => {
+    runCliProcess.mockReturnValue({
+      child: { kill: jest.fn() },
+      result: Promise.resolve({
+        stdout: '   \n  ',
+        stderr: '',
+        exitCode: 0
+      })
     });
+
+    await expect(adapter.generateUncached('Anything')).rejects.toMatchObject({
+      name: 'LLMProviderError',
+      provider: 'google-gemini-cli',
+      code: 'PROVIDER_ERROR'
+    });
+  });
+
+  it('rejects an unknown model fail-closed before spawning the CLI', async () => {
+    await expect(
+      adapter.generateUncached('Anything', { model: 'not-a-real-model' })
+    ).rejects.toMatchObject({
+      name: 'LLMProviderError',
+      provider: 'google-gemini-cli',
+      code: 'CONFIGURATION_ERROR'
+    });
+
+    expect(runCliProcess).not.toHaveBeenCalled();
   });
 
   it('lists only the validated Gemini CLI models', async () => {
@@ -155,8 +144,6 @@ describe('GoogleGeminiCliAdapter', () => {
     expect(models.map((model) => model.id)).not.toContain('gemini-3.1-pro-preview');
     expect(models.map((model) => model.id)).not.toContain('gemini-3-flash');
     expect(models.map((model) => model.id)).not.toContain('gemini-2.5-pro');
-    expect(models.map((model) => model.id)).not.toContain('gemini-2.5-flash');
-    expect(models.map((model) => model.id)).not.toContain('gemini-2.5-flash-lite');
   });
 
   it('maps oversized CLI startup failures to REQUEST_TOO_LARGE', async () => {

--- a/tests/unit/TextOnlyProviderSeam.test.ts
+++ b/tests/unit/TextOnlyProviderSeam.test.ts
@@ -1,0 +1,63 @@
+/**
+ * tests/unit/TextOnlyProviderSeam.test.ts
+ *
+ * Verifies the single source of truth for the Antigravity (google-gemini-cli)
+ * text-completion-only limitation:
+ *  - the model catalog declares supportsFunctions:false + supportsStreaming:false
+ *  - the provider seam (isTextOnlyProvider / shouldPassToolSchemasToProvider)
+ *    classifies it as text-only and suppresses tool schemas.
+ *
+ * Background: agy tool-use + streaming proven NOT-FEASIBLE (investigation
+ * #62/#64/#66). These guards keep the catalog honest and drive the user-facing
+ * warning surfaces (settings notice + runtime guard).
+ */
+import { GOOGLE_GEMINI_CLI_MODELS } from '../../src/services/llm/adapters/google-gemini-cli/GoogleGeminiCliModels';
+import {
+  isTextOnlyProvider,
+  shouldPassToolSchemasToProvider,
+  isPerplexityProvider
+} from '../../src/services/llm/utils/ToolSchemaSupport';
+
+describe('Antigravity text-only capability (SSOT)', () => {
+  it('declares every agy model as no-tools, no-streaming', () => {
+    expect(GOOGLE_GEMINI_CLI_MODELS.length).toBeGreaterThan(0);
+    for (const model of GOOGLE_GEMINI_CLI_MODELS) {
+      expect(model.provider).toBe('google-gemini-cli');
+      expect(model.capabilities.supportsFunctions).toBe(false);
+      expect(model.capabilities.supportsStreaming).toBe(false);
+    }
+  });
+});
+
+describe('text-only provider seam', () => {
+  it('classifies google-gemini-cli (Antigravity) as text-only', () => {
+    expect(isTextOnlyProvider('google-gemini-cli')).toBe(true);
+  });
+
+  it('classifies perplexity as text-only', () => {
+    expect(isTextOnlyProvider('perplexity')).toBe(true);
+  });
+
+  it('does NOT classify webllm as text-only (tools are baked in)', () => {
+    expect(isTextOnlyProvider('webllm')).toBe(false);
+  });
+
+  it('does NOT classify a normal cloud provider as text-only', () => {
+    expect(isTextOnlyProvider('openai')).toBe(false);
+    expect(isTextOnlyProvider(undefined)).toBe(false);
+    expect(isTextOnlyProvider(null)).toBe(false);
+  });
+
+  it('suppresses tool schemas for Antigravity', () => {
+    expect(shouldPassToolSchemasToProvider('google-gemini-cli')).toBe(false);
+  });
+
+  it('still passes tool schemas to a normal tool-capable provider', () => {
+    expect(shouldPassToolSchemasToProvider('openai')).toBe(true);
+  });
+
+  it('keeps isPerplexityProvider perplexity-specific (not broadened)', () => {
+    expect(isPerplexityProvider('perplexity')).toBe(true);
+    expect(isPerplexityProvider('google-gemini-cli')).toBe(false);
+  });
+});

--- a/tests/unit/geminiCliEnv.test.ts
+++ b/tests/unit/geminiCliEnv.test.ts
@@ -1,0 +1,84 @@
+import { buildGeminiCliEnv } from '../../src/utils/geminiCli';
+
+/**
+ * Direct unit tests for the agy child-process env-strip.
+ *
+ * SECURITY-LOAD-BEARING: buildGeminiCliEnv removes ambient provider credentials
+ * from the spawned agy process's environment so agy falls back to its own
+ * file-based OAuth (~/.gemini) and never silently authenticates with an
+ * ambient API key. agy fronts Google, Anthropic, AND OpenAI models, so all
+ * three credential families must be stripped.
+ *
+ * These call buildGeminiCliEnv() WITHOUT a nodePath so the PATH-prepend branch
+ * (which needs the desktop `path` module via window.require) is skipped — the
+ * key-strip logic runs unconditionally and is what we assert here.
+ */
+describe('buildGeminiCliEnv (credential strip)', () => {
+  const STRIPPED_KEYS = [
+    'GEMINI_API_KEY',
+    'GOOGLE_API_KEY',
+    'GOOGLE_GENAI_USE_VERTEXAI',
+    'GOOGLE_CLOUD_PROJECT',
+    'GOOGLE_APPLICATION_CREDENTIALS',
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY'
+  ];
+
+  // Snapshot + restore the real process.env keys we mutate, so the suite is isolated.
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of [...STRIPPED_KEYS, 'NEXUS_UNRELATED_TEST_KEY']) {
+      saved[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of [...STRIPPED_KEYS, 'NEXUS_UNRELATED_TEST_KEY']) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  it('strips all Google, Anthropic, and OpenAI credential keys', () => {
+    for (const key of STRIPPED_KEYS) {
+      process.env[key] = `sentinel-${key}`;
+    }
+
+    const env = buildGeminiCliEnv();
+
+    for (const key of STRIPPED_KEYS) {
+      expect(env[key]).toBeUndefined();
+    }
+  });
+
+  it('explicitly strips ANTHROPIC_API_KEY and OPENAI_API_KEY (agy fronts Claude/GPT too)', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-sentinel';
+    process.env.OPENAI_API_KEY = 'sk-openai-sentinel';
+
+    const env = buildGeminiCliEnv();
+
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+
+  it('preserves unrelated environment variables', () => {
+    process.env.NEXUS_UNRELATED_TEST_KEY = 'keep-me';
+
+    const env = buildGeminiCliEnv();
+
+    expect(env.NEXUS_UNRELATED_TEST_KEY).toBe('keep-me');
+  });
+
+  it('returns a copy — does not mutate the real process.env', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-sentinel';
+
+    buildGeminiCliEnv();
+
+    // The strip happens on the returned copy, not the live process env.
+    expect(process.env.ANTHROPIC_API_KEY).toBe('sk-ant-sentinel');
+  });
+});

--- a/tests/unit/geminiCliModelNormalize.test.ts
+++ b/tests/unit/geminiCliModelNormalize.test.ts
@@ -1,48 +1,83 @@
-import { normalizeModelToAgyLabel } from '../../src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize';
+import { composeAgyModelLabel } from '../../src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize';
 
 /**
- * Direct unit tests for the fail-closed model-label allowlist.
+ * Direct unit tests for the fail-closed agy `--model` label composer.
+ *
+ * The catalog now lists only the 2 BASE models; effort comes from the thinking/
+ * effort slider, and the adapter composes the "Base (Effort)" agy label at
+ * invocation. These tests pin: base+effort composition, the Pro-no-Medium clamp
+ * (Medium → High, round UP), default-effort behavior, legacy-slug explicit-effort
+ * resolution (settings-compat), idempotent pass-through, and fail-closed rejection.
  *
  * Why fail-closed matters: `agy --model` FAILS OPEN — given an unknown value it
  * silently runs a default model and returns exit 0. So Nexus must reject any
- * slug not in the allowlist BEFORE spawning, or the user silently gets a model
- * they did not select. These tests pin both the mapping fidelity and the
- * rejection behavior.
+ * unknown base / malformed composed label BEFORE spawning.
  */
-describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
-  describe('current catalog slug → agy label mapping (refreshed 5-entry catalog)', () => {
-    // Mirrors GoogleGeminiCliModels.ts + the SLUG_TO_AGY_LABEL current group;
-    // every shipped catalog slug must resolve to its verbatim agy label.
+describe('composeAgyModelLabel (fail-closed agy label composition)', () => {
+  describe('base slug + slider effort → composed agy label', () => {
+    it.each([
+      ['gemini-3.5-flash', 'low', 'Gemini 3.5 Flash (Low)'],
+      ['gemini-3.5-flash', 'medium', 'Gemini 3.5 Flash (Medium)'],
+      ['gemini-3.5-flash', 'high', 'Gemini 3.5 Flash (High)'],
+      ['gemini-3.1-pro', 'low', 'Gemini 3.1 Pro (Low)'],
+      ['gemini-3.1-pro', 'high', 'Gemini 3.1 Pro (High)']
+    ])('composes %s @ %s → %s', (slug, effort, label) => {
+      expect(composeAgyModelLabel(slug, effort)).toBe(label);
+    });
+  });
+
+  describe('Pro-no-Medium clamp rule (Medium → High, round UP, never down)', () => {
+    it('clamps Gemini 3.1 Pro + Medium up to High', () => {
+      expect(composeAgyModelLabel('gemini-3.1-pro', 'medium')).toBe('Gemini 3.1 Pro (High)');
+    });
+
+    it('does NOT clamp Flash (it natively supports Medium)', () => {
+      expect(composeAgyModelLabel('gemini-3.5-flash', 'medium')).toBe('Gemini 3.5 Flash (Medium)');
+    });
+  });
+
+  describe('default effort when slider is unset (undefined/invalid → medium, then clamp)', () => {
+    it('Flash defaults to Medium', () => {
+      expect(composeAgyModelLabel('gemini-3.5-flash')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(composeAgyModelLabel('gemini-3.5-flash', undefined)).toBe('Gemini 3.5 Flash (Medium)');
+      expect(composeAgyModelLabel('gemini-3.5-flash', null)).toBe('Gemini 3.5 Flash (Medium)');
+    });
+
+    it('Pro defaults to High (deliberate: default medium clamps up on Pro)', () => {
+      expect(composeAgyModelLabel('gemini-3.1-pro')).toBe('Gemini 3.1 Pro (High)');
+      expect(composeAgyModelLabel('gemini-3.1-pro', undefined)).toBe('Gemini 3.1 Pro (High)');
+    });
+
+    it('treats an unrecognized effort string as default (medium)', () => {
+      expect(composeAgyModelLabel('gemini-3.5-flash', 'bogus')).toBe('Gemini 3.5 Flash (Medium)');
+    });
+  });
+
+  describe('legacy slug → (base, EXPLICIT effort) settings-compat (overrides slider)', () => {
     it.each([
       ['gemini-3.5-flash-low', 'Gemini 3.5 Flash (Low)'],
       ['gemini-3.5-flash-medium', 'Gemini 3.5 Flash (Medium)'],
       ['gemini-3.5-flash-high', 'Gemini 3.5 Flash (High)'],
       ['gemini-3.1-pro-low', 'Gemini 3.1 Pro (Low)'],
-      ['gemini-3.1-pro-high', 'Gemini 3.1 Pro (High)']
-    ])('maps %s to %s', (slug, label) => {
-      expect(normalizeModelToAgyLabel(slug)).toBe(label);
+      ['gemini-3.1-pro-high', 'Gemini 3.1 Pro (High)'],
+      // Older preview slugs.
+      ['gemini-3-flash-preview', 'Gemini 3.5 Flash (Medium)'],
+      ['gemini-3.1-flash-lite-preview', 'Gemini 3.5 Flash (Low)']
+    ])('resolves legacy %s → %s regardless of slider', (slug, label) => {
+      // Pass a conflicting slider effort to prove the legacy explicit effort wins.
+      expect(composeAgyModelLabel(slug, 'low')).toBe(label);
+    });
+
+    it('trims surrounding whitespace before resolving', () => {
+      expect(composeAgyModelLabel('  gemini-3.5-flash-high  ', 'low')).toBe('Gemini 3.5 Flash (High)');
     });
   });
 
-  describe('legacy slug → agy label mapping (settings-compat aliases retained)', () => {
-    it('maps gemini-3-flash-preview to its agy label', () => {
-      expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
-    });
-
-    it('maps gemini-3.1-flash-lite-preview to its agy label', () => {
-      expect(normalizeModelToAgyLabel('gemini-3.1-flash-lite-preview')).toBe('Gemini 3.5 Flash (Low)');
-    });
-
-    it('trims surrounding whitespace before mapping', () => {
-      expect(normalizeModelToAgyLabel('  gemini-3-flash-preview  ')).toBe('Gemini 3.5 Flash (Medium)');
-    });
-  });
-
-  describe('idempotent pass-through of already-normalized labels', () => {
+  describe('idempotent pass-through of already-composed labels', () => {
     it('returns a known agy label unchanged', () => {
-      expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Medium)')).toBe('Gemini 3.5 Flash (Medium)');
-      expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Low)')).toBe('Gemini 3.5 Flash (Low)');
-      expect(normalizeModelToAgyLabel('Gemini 3.1 Pro (High)')).toBe('Gemini 3.1 Pro (High)');
+      expect(composeAgyModelLabel('Gemini 3.5 Flash (Medium)')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(composeAgyModelLabel('Gemini 3.5 Flash (Low)', 'high')).toBe('Gemini 3.5 Flash (Low)');
+      expect(composeAgyModelLabel('Gemini 3.1 Pro (High)')).toBe('Gemini 3.1 Pro (High)');
     });
   });
 
@@ -53,9 +88,9 @@ describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
       ['empty string', ''],
       ['whitespace only', '   ']
     ])('throws when the model is %s', (_label, value) => {
-      expect(() => normalizeModelToAgyLabel(value as string | undefined | null)).toThrow();
+      expect(() => composeAgyModelLabel(value as string | undefined | null)).toThrow();
       try {
-        normalizeModelToAgyLabel(value as string | undefined | null);
+        composeAgyModelLabel(value as string | undefined | null);
       } catch (err) {
         expect(err).toMatchObject({
           name: 'LLMProviderError',
@@ -65,55 +100,48 @@ describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
       }
     });
 
-    it('throws for an unknown/unmapped slug — never silently defaults', () => {
-      expect(() => normalizeModelToAgyLabel('not-a-real-model')).toThrow();
+    it('throws for an unknown base slug — never silently defaults', () => {
+      expect(() => composeAgyModelLabel('not-a-real-model', 'high')).toThrow();
       try {
-        normalizeModelToAgyLabel('not-a-real-model');
+        composeAgyModelLabel('not-a-real-model', 'high');
       } catch (err) {
         expect(err).toMatchObject({
           name: 'LLMProviderError',
           provider: 'google-gemini-cli',
           code: 'CONFIGURATION_ERROR'
         });
-        // The error names the supported models so the user can recover.
-        expect((err as Error).message).toContain('Gemini 3.5 Flash (Medium)');
-        expect((err as Error).message).toContain('Gemini 3.5 Flash (Low)');
+        // The error names the supported BASE models so the user can recover.
+        expect((err as Error).message).toContain('gemini-3.5-flash');
+        expect((err as Error).message).toContain('gemini-3.1-pro');
       }
     });
 
-    it('rejects a legacy gemini slug that has no allowlist entry (e.g. a 2.5 spec)', () => {
-      // Guards against a future GoogleGeminiCliModels.ts spec being added without
-      // a matching allowlist entry — it must throw, not pass through.
-      expect(() => normalizeModelToAgyLabel('gemini-2.5-pro')).toThrow();
+    it('rejects a non-allowlisted gemini base (e.g. a 2.5 spec)', () => {
+      expect(() => composeAgyModelLabel('gemini-2.5-pro', 'high')).toThrow();
+    });
+
+    it('rejects a Pro composed label that does not exist (Pro Medium is not a valid pass-through)', () => {
+      // 'Gemini 3.1 Pro (Medium)' is NOT a known agy label, so passing it through
+      // must NOT silently succeed — it falls through to the unknown-model throw.
+      expect(() => composeAgyModelLabel('Gemini 3.1 Pro (Medium)')).toThrow();
     });
   });
 
-  describe('live-fidelity anchor (auditor YELLOW carry-forward)', () => {
+  describe('live-fidelity anchor (verified vs `agy models`)', () => {
     /**
-     * These five labels were live-verified against `agy models` (v1.0.10) on
-     * 2026-06-22: each appears VERBATIM in the real agy catalog. This anchor
-     * fails loudly if a future edit drifts a mapping target away from the real
-     * agy label — a mismatch would make `agy --model` fail open and silently
-     * run the wrong model.
-     *
-     * Live `agy models` output included, verbatim (Gemini lines):
-     *   Gemini 3.5 Flash (Medium)
-     *   Gemini 3.5 Flash (High)
-     *   Gemini 3.5 Flash (Low)
-     *   Gemini 3.1 Pro (Low)
-     *   Gemini 3.1 Pro (High)
+     * Composed labels verified VERBATIM against `agy models` (v1.0.10) on
+     * 2026-06-23: Flash = Low/Medium/High; Pro = Low/High (NO Medium). This anchor
+     * fails loudly if a future edit drifts a composed label away from a real agy
+     * label — a mismatch would make `agy --model` fail open.
      */
-    it('pins the current catalog slugs to their verbatim live agy catalog labels', () => {
-      expect(normalizeModelToAgyLabel('gemini-3.5-flash-low')).toBe('Gemini 3.5 Flash (Low)');
-      expect(normalizeModelToAgyLabel('gemini-3.5-flash-medium')).toBe('Gemini 3.5 Flash (Medium)');
-      expect(normalizeModelToAgyLabel('gemini-3.5-flash-high')).toBe('Gemini 3.5 Flash (High)');
-      expect(normalizeModelToAgyLabel('gemini-3.1-pro-low')).toBe('Gemini 3.1 Pro (Low)');
-      expect(normalizeModelToAgyLabel('gemini-3.1-pro-high')).toBe('Gemini 3.1 Pro (High)');
-    });
-
-    it('still resolves the retained legacy aliases (settings-compat)', () => {
-      expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
-      expect(normalizeModelToAgyLabel('gemini-3.1-flash-lite-preview')).toBe('Gemini 3.5 Flash (Low)');
+    it('every composed base+effort matches a live agy label', () => {
+      expect(composeAgyModelLabel('gemini-3.5-flash', 'low')).toBe('Gemini 3.5 Flash (Low)');
+      expect(composeAgyModelLabel('gemini-3.5-flash', 'medium')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(composeAgyModelLabel('gemini-3.5-flash', 'high')).toBe('Gemini 3.5 Flash (High)');
+      expect(composeAgyModelLabel('gemini-3.1-pro', 'low')).toBe('Gemini 3.1 Pro (Low)');
+      expect(composeAgyModelLabel('gemini-3.1-pro', 'high')).toBe('Gemini 3.1 Pro (High)');
+      // Pro Medium is NOT a live label → must clamp to the live High label.
+      expect(composeAgyModelLabel('gemini-3.1-pro', 'medium')).toBe('Gemini 3.1 Pro (High)');
     });
   });
 });

--- a/tests/unit/geminiCliModelNormalize.test.ts
+++ b/tests/unit/geminiCliModelNormalize.test.ts
@@ -1,0 +1,93 @@
+import { normalizeModelToAgyLabel } from '../../src/services/llm/adapters/google-gemini-cli/geminiCliModelNormalize';
+
+/**
+ * Direct unit tests for the fail-closed model-label allowlist.
+ *
+ * Why fail-closed matters: `agy --model` FAILS OPEN — given an unknown value it
+ * silently runs a default model and returns exit 0. So Nexus must reject any
+ * slug not in the allowlist BEFORE spawning, or the user silently gets a model
+ * they did not select. These tests pin both the mapping fidelity and the
+ * rejection behavior.
+ */
+describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
+  describe('legacy slug → agy label mapping', () => {
+    it('maps gemini-3-flash-preview to its agy label', () => {
+      expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
+    });
+
+    it('maps gemini-3.1-flash-lite-preview to its agy label', () => {
+      expect(normalizeModelToAgyLabel('gemini-3.1-flash-lite-preview')).toBe('Gemini 3.5 Flash (Low)');
+    });
+
+    it('trims surrounding whitespace before mapping', () => {
+      expect(normalizeModelToAgyLabel('  gemini-3-flash-preview  ')).toBe('Gemini 3.5 Flash (Medium)');
+    });
+  });
+
+  describe('idempotent pass-through of already-normalized labels', () => {
+    it('returns a known agy label unchanged', () => {
+      expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Medium)')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Low)')).toBe('Gemini 3.5 Flash (Low)');
+    });
+  });
+
+  describe('fail-closed rejections (CONFIGURATION_ERROR before any spawn)', () => {
+    it.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['empty string', ''],
+      ['whitespace only', '   ']
+    ])('throws when the model is %s', (_label, value) => {
+      expect(() => normalizeModelToAgyLabel(value as string | undefined | null)).toThrow();
+      try {
+        normalizeModelToAgyLabel(value as string | undefined | null);
+      } catch (err) {
+        expect(err).toMatchObject({
+          name: 'LLMProviderError',
+          provider: 'google-gemini-cli',
+          code: 'CONFIGURATION_ERROR'
+        });
+      }
+    });
+
+    it('throws for an unknown/unmapped slug — never silently defaults', () => {
+      expect(() => normalizeModelToAgyLabel('not-a-real-model')).toThrow();
+      try {
+        normalizeModelToAgyLabel('not-a-real-model');
+      } catch (err) {
+        expect(err).toMatchObject({
+          name: 'LLMProviderError',
+          provider: 'google-gemini-cli',
+          code: 'CONFIGURATION_ERROR'
+        });
+        // The error names the supported models so the user can recover.
+        expect((err as Error).message).toContain('Gemini 3.5 Flash (Medium)');
+        expect((err as Error).message).toContain('Gemini 3.5 Flash (Low)');
+      }
+    });
+
+    it('rejects a legacy gemini slug that has no allowlist entry (e.g. a 2.5 spec)', () => {
+      // Guards against a future GoogleGeminiCliModels.ts spec being added without
+      // a matching allowlist entry — it must throw, not pass through.
+      expect(() => normalizeModelToAgyLabel('gemini-2.5-pro')).toThrow();
+    });
+  });
+
+  describe('live-fidelity anchor (auditor YELLOW carry-forward)', () => {
+    /**
+     * These two labels were live-verified against `agy models` (v1.0.10) on
+     * 2026-06-22: both appear VERBATIM in the real agy catalog. This anchor
+     * fails loudly if a future edit drifts the mapping target away from the
+     * real agy label — a mismatch would make `agy --model` fail open and
+     * silently run the wrong model.
+     *
+     * Live `agy models` output included, verbatim:
+     *   Gemini 3.5 Flash (Medium)
+     *   Gemini 3.5 Flash (Low)
+     */
+    it('pins the mapped labels to the verbatim live agy catalog strings', () => {
+      expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(normalizeModelToAgyLabel('gemini-3.1-flash-lite-preview')).toBe('Gemini 3.5 Flash (Low)');
+    });
+  });
+});

--- a/tests/unit/geminiCliModelNormalize.test.ts
+++ b/tests/unit/geminiCliModelNormalize.test.ts
@@ -10,7 +10,21 @@ import { normalizeModelToAgyLabel } from '../../src/services/llm/adapters/google
  * rejection behavior.
  */
 describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
-  describe('legacy slug → agy label mapping', () => {
+  describe('current catalog slug → agy label mapping (refreshed 5-entry catalog)', () => {
+    // Mirrors GoogleGeminiCliModels.ts + the SLUG_TO_AGY_LABEL current group;
+    // every shipped catalog slug must resolve to its verbatim agy label.
+    it.each([
+      ['gemini-3.5-flash-low', 'Gemini 3.5 Flash (Low)'],
+      ['gemini-3.5-flash-medium', 'Gemini 3.5 Flash (Medium)'],
+      ['gemini-3.5-flash-high', 'Gemini 3.5 Flash (High)'],
+      ['gemini-3.1-pro-low', 'Gemini 3.1 Pro (Low)'],
+      ['gemini-3.1-pro-high', 'Gemini 3.1 Pro (High)']
+    ])('maps %s to %s', (slug, label) => {
+      expect(normalizeModelToAgyLabel(slug)).toBe(label);
+    });
+  });
+
+  describe('legacy slug → agy label mapping (settings-compat aliases retained)', () => {
     it('maps gemini-3-flash-preview to its agy label', () => {
       expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
     });
@@ -28,6 +42,7 @@ describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
     it('returns a known agy label unchanged', () => {
       expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Medium)')).toBe('Gemini 3.5 Flash (Medium)');
       expect(normalizeModelToAgyLabel('Gemini 3.5 Flash (Low)')).toBe('Gemini 3.5 Flash (Low)');
+      expect(normalizeModelToAgyLabel('Gemini 3.1 Pro (High)')).toBe('Gemini 3.1 Pro (High)');
     });
   });
 
@@ -75,17 +90,28 @@ describe('normalizeModelToAgyLabel (fail-closed agy model allowlist)', () => {
 
   describe('live-fidelity anchor (auditor YELLOW carry-forward)', () => {
     /**
-     * These two labels were live-verified against `agy models` (v1.0.10) on
-     * 2026-06-22: both appear VERBATIM in the real agy catalog. This anchor
-     * fails loudly if a future edit drifts the mapping target away from the
-     * real agy label — a mismatch would make `agy --model` fail open and
-     * silently run the wrong model.
+     * These five labels were live-verified against `agy models` (v1.0.10) on
+     * 2026-06-22: each appears VERBATIM in the real agy catalog. This anchor
+     * fails loudly if a future edit drifts a mapping target away from the real
+     * agy label — a mismatch would make `agy --model` fail open and silently
+     * run the wrong model.
      *
-     * Live `agy models` output included, verbatim:
+     * Live `agy models` output included, verbatim (Gemini lines):
      *   Gemini 3.5 Flash (Medium)
+     *   Gemini 3.5 Flash (High)
      *   Gemini 3.5 Flash (Low)
+     *   Gemini 3.1 Pro (Low)
+     *   Gemini 3.1 Pro (High)
      */
-    it('pins the mapped labels to the verbatim live agy catalog strings', () => {
+    it('pins the current catalog slugs to their verbatim live agy catalog labels', () => {
+      expect(normalizeModelToAgyLabel('gemini-3.5-flash-low')).toBe('Gemini 3.5 Flash (Low)');
+      expect(normalizeModelToAgyLabel('gemini-3.5-flash-medium')).toBe('Gemini 3.5 Flash (Medium)');
+      expect(normalizeModelToAgyLabel('gemini-3.5-flash-high')).toBe('Gemini 3.5 Flash (High)');
+      expect(normalizeModelToAgyLabel('gemini-3.1-pro-low')).toBe('Gemini 3.1 Pro (Low)');
+      expect(normalizeModelToAgyLabel('gemini-3.1-pro-high')).toBe('Gemini 3.1 Pro (High)');
+    });
+
+    it('still resolves the retained legacy aliases (settings-compat)', () => {
       expect(normalizeModelToAgyLabel('gemini-3-flash-preview')).toBe('Gemini 3.5 Flash (Medium)');
       expect(normalizeModelToAgyLabel('gemini-3.1-flash-lite-preview')).toBe('Gemini 3.5 Flash (Low)');
     });


### PR DESCRIPTION
## Summary

Replaces the deprecated `gemini` CLI runtime with Google **Antigravity** (`agy`, v1.0.10) in the `google-gemini-cli` provider. Provider id `google-gemini-cli` is **preserved** for settings compatibility; only the runtime binary, output parsing, model normalization, invocation, and user-facing labels change.

Related to #271 (does not close it — see Verification below).

## Approach — Scenario A (zero-footprint, security-first)

- **Binary swap** `gemini` → `agy` (slice a)
- **Plain-text output** (slice b): `agy --print` emits plain text, not JSON. Deleted the `--output-format json` parse pipeline (~120 LoC) → `parseAgyOutput` = `stdout.trim()`; empty stdout → `PROVIDER_ERROR`; `supportsJSON:false`. No token-usage available (degrades gracefully).
- **Fail-closed model normalization** (slice c): `agy --model` fails *open* on an unknown slug (silently substitutes a default), so Nexus validates against a live-anchored allowlist and rejects unknown slugs with `CONFIGURATION_ERROR` *before* spawn. `gemini-3-flash-preview` → `Gemini 3.5 Flash (Medium)`, `gemini-3.1-flash-lite-preview` → `Gemini 3.5 Flash (Low)`.
- **Invocation + security** (slice d): `agy --print --model <label> --print-timeout 60s [--sandbox]`.
  - **No** `--dangerously-skip-permissions` — live-verified that without it, a built-in tool call hangs on an un-answerable headless permission prompt and is killed (fail-safe; tool never executes).
  - `--print-timeout 60s` (Go-duration string) is the **bounded security kill-switch** for that hang (this branch has no idle watchdog yet).
  - **Zero config write** — deleted the vestigial `buildGeminiCliSystemSettings` MCP/temp-settings block (agy ignores `GEMINI_CLI_SYSTEM_SETTINGS_PATH` and the prompt→text path never needed it). No `~/.gemini` writes.
  - `--sandbox` **platform-guarded to macOS** (verified Seatbelt, Docker-free); off-darwin falls back to the no-MCP + no-skip-perms floor.
  - **Env-strip** extended with `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` (agy fronts Claude/GPT too).
- **Auth probe hardening** (R7): tolerant presence-only check on `oauth_creds.json` — boolean only, token value never read/logged/returned.
- **UI relabel** (slice e): "Antigravity CLI / Google (Antigravity)". Provider id unchanged.

## Testing

- Full suite: **3717 passed / 21 skipped / 1 failed**. The single failure (`TaskBoardEditCoordinator.test.ts`, obsidian-mock `Modal` export gap) is **pre-existing and unrelated** — proven via stash-and-retest, zero agy references.
- Build (lint + tsc + esbuild + connector): **green**.
- **+16 net-new tests**: fail-closed normalize allowlist, a **live `agy models` anchor test** (pins the two label mappings so catalog drift fails at unit-test time), env-strip (Google + Anthropic + OpenAI), and a Scenario-A "no temp-settings file written" assertion.

## Verification — NOT yet manually tested

⚠️ **Implemented, pending manual Obsidian test.** Verified by unit tests + build + live `agy` smoke only. Before merge, a manual round-trip in Obsidian is needed (provider selection, a real completion via `agy`, auth flow). Issue #271 stays **open** until that manual verification passes.

### Manual-test residuals
- **Cross-platform `--sandbox`**: verified darwin-only; Linux/Windows need a per-platform live-verify before `--sandbox` is ever enabled off-darwin (guarded off there today).
- **Auth**: `agy` has **no** `auth` subcommand — first run is bare `agy` → browser Google sign-in (writes `~/.gemini/oauth_creds.json`).

## Notes
- `src/utils/connectorContent.ts` is intentionally **not** committed (generated artifact; regenerated locally/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)