### PR TITLE
Render the working ticker in-bubble so it stays attached

### DIFF
--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -531,14 +531,14 @@ export class ChatView extends ItemView {
       onLoadingStateChanged: (loading) => this.handleLoadingStateChanged(loading),
       onError: (message) => this.uiStateController.showError(message),
       onToolCallsDetected: (messageId, toolCalls) => {
-        this.workingIndicatorController.noteToolActivity();
+        this.workingIndicatorController.noteToolActivity(messageId);
         this.toolEventCoordinator.handleToolCallsDetected(
           messageId,
           toolCalls as unknown as DetectedToolCalls
         );
       },
       onToolExecutionStarted: (messageId, toolCall) => {
-        this.workingIndicatorController.noteToolActivity();
+        this.workingIndicatorController.noteToolActivity(messageId);
         this.toolEventCoordinator.handleToolExecutionStarted(messageId, toolCall);
       },
       onToolExecutionCompleted: (messageId, toolId, result, success, error) =>
@@ -626,8 +626,8 @@ export class ChatView extends ItemView {
     // Drives the "still working" gap ticker during the silent parts of a
     // streaming turn (e.g. while tools execute, which do not stream).
     this.workingIndicatorController = new WorkingIndicatorController({
-      show: () => this.messageDisplay.showWorkingIndicator(),
-      hide: () => this.messageDisplay.hideWorkingIndicator(),
+      show: (messageId) => this.messageDisplay.showWorkingIndicator(messageId),
+      hide: (messageId) => this.messageDisplay.hideWorkingIndicator(messageId),
     });
 
     this.toolStatusBar = new ToolStatusBar(
@@ -942,11 +942,10 @@ export class ChatView extends ItemView {
 
   private handleStreamingUpdate(messageId: string, content: string, isComplete: boolean, isIncremental?: boolean): void {
     if (isIncremental) {
-      // First/each streamed text token: stop the bubble's own pre-token loader
-      // (its DOM is wiped by the parser but its timers leak) and tell the gap
-      // ticker that text is flowing so it hides and re-arms its debounce.
-      this.messageDisplay.stopMessageLoader(messageId);
-      this.workingIndicatorController.noteText();
+      // A streamed text token arrived: tell the gap ticker text is flowing so it
+      // hides and re-arms its debounce (it reappears in-bubble once the stream
+      // goes quiet for a tool round-trip).
+      this.workingIndicatorController.noteText(messageId);
       this.streamingController.updateStreamingChunk(messageId, content);
     } else if (isComplete) {
       this.workingIndicatorController.end();

--- a/src/ui/chat/components/MessageBubble.ts
+++ b/src/ui/chat/components/MessageBubble.ts
@@ -27,6 +27,12 @@ export class MessageBubble extends Component {
   private loadingInterval: number | null = null;
   private copyFeedbackTimeout: number | null = null;
   private thinkingLoader: ThinkingLoader | null = null;
+  // The in-bubble "working" ticker (pre-text wait, tool-first turns, and the
+  // silent tool-execution gaps mid-stream). `workingTickerActive` is the intent
+  // flag that survives re-renders so a mid-stream reconcile re-applies the
+  // ticker instead of dropping it; `workingTickerEl` is its DOM wrapper.
+  private workingTickerActive = false;
+  private workingTickerEl: HTMLElement | null = null;
   private branchNavigatorBinder: MessageBubbleBranchNavigatorBinder;
   private imageRenderer: MessageBubbleImageRenderer;
   private textBubbleElement: HTMLElement | null = null;
@@ -82,12 +88,12 @@ export class MessageBubble extends Component {
         }
       }
 
-      const contentElement = this.textBubbleElement.querySelector('.message-content');
-      if (this.isHTMLElement(contentElement) && this.message.isLoading && !activeContent.trim()) {
-        this.appendLoadingIndicator(contentElement);
+      this.element = wrapper;
+
+      if (this.message.isLoading && !activeContent.trim()) {
+        this.ensureWorkingTicker();
       }
 
-      this.element = wrapper;
       return wrapper;
     }
 
@@ -104,15 +110,9 @@ export class MessageBubble extends Component {
 
     const bubble = messageContainer.createDiv('message-bubble');
 
-    // Loading state for empty assistant streaming — rendered inside the bubble
-    // ahead of content so the ThinkingLoader appears in place of the eventual
-    // text. No header / role-icon in the glass redesign.
-    if (this.message.role === 'assistant' && this.message.isLoading && !this.message.content.trim()) {
-      const loadingShell = bubble.createDiv('ai-loading-header');
-      this.startThinkingLoader(loadingShell);
-    }
-
-    // Message content
+    // Message content. The "working" ticker for empty assistant streaming is
+    // attached by createElement() via ensureWorkingTicker() so it sits inside
+    // this bubble's .message-content (kept attached even when there is no text).
     const content = bubble.createDiv('message-content');
     this.renderContent(content, messageContent).catch(error => {
       console.error('[MessageBubble] Error rendering initial content:', error);
@@ -324,17 +324,49 @@ export class MessageBubble extends Component {
       this.loadingInterval = null;
     }
 
-    if (this.element) {
-      const loadingElement = this.element.querySelector('.ai-loading-header');
-      if (loadingElement) {
-        loadingElement.remove();
-      }
-    }
+    // Terminal stop: clear the working ticker and its intent flag so it is not
+    // re-applied on subsequent re-renders.
+    this.removeWorkingTicker();
+  }
 
+  /**
+   * Show the in-bubble "working" ticker (idempotent). Lives inside the bubble's
+   * `.message-content` so it stays attached to the message — sitting after the
+   * streamed text during a tool gap, or filling an otherwise-empty bubble on a
+   * tool-first turn. Safe to call repeatedly; an already-mounted ticker keeps
+   * its word animation rather than restarting.
+   */
+  ensureWorkingTicker(): void {
+    this.workingTickerActive = true;
+    if (!this.element) return;
+    if (this.workingTickerEl && this.element.contains(this.workingTickerEl)) return;
+
+    const contentElement = this.element.querySelector('.message-content');
+    if (!this.isHTMLElement(contentElement)) return;
+
+    this.workingTickerEl = contentElement.createDiv('ai-loading-continuation');
+    this.startThinkingLoader(this.workingTickerEl);
+  }
+
+  /** Hide the in-bubble working ticker and clear its intent flag. */
+  removeWorkingTicker(): void {
+    this.workingTickerActive = false;
+    this.clearWorkingTickerEl();
+  }
+
+  /**
+   * Tear down the ticker DOM + timers WITHOUT clearing the intent flag, so a
+   * re-render can re-apply it (see updateWithNewMessage).
+   */
+  private clearWorkingTickerEl(): void {
     if (this.thinkingLoader) {
       this.thinkingLoader.stop();
       this.thinkingLoader.unload();
       this.thinkingLoader = null;
+    }
+    if (this.workingTickerEl) {
+      this.workingTickerEl.remove();
+      this.workingTickerEl = null;
     }
   }
 
@@ -365,7 +397,14 @@ export class MessageBubble extends Component {
   updateWithNewMessage(newMessage: ConversationMessage): void {
     const nextState = MessageBubbleStateResolver.resolve(newMessage);
 
-    this.stopLoadingAnimation();
+    // Clear the ticker DOM before re-render but PRESERVE the intent flag, so a
+    // mid-stream reconcile (e.g. LM Studio persisting a Responses API id during
+    // a tool gap) re-applies the ticker below instead of dropping it.
+    if (this.loadingInterval) {
+      window.clearInterval(this.loadingInterval);
+      this.loadingInterval = null;
+    }
+    this.clearWorkingTickerEl();
     this.message = newMessage;
 
     this.imageRenderer.clear();
@@ -398,8 +437,11 @@ export class MessageBubble extends Component {
       }
     }
 
-    if (newMessage.isLoading && newMessage.role === 'assistant') {
-      this.appendLoadingIndicator(contentElement);
+    // Re-apply the working ticker if the turn is still mid-flight: either the
+    // message is still loading (pre-text / tool-first) or the gap controller had
+    // it showing when this reconcile fired.
+    if (newMessage.role === 'assistant' && (newMessage.isLoading || this.workingTickerActive)) {
+      this.ensureWorkingTicker();
     }
   }
 
@@ -425,14 +467,6 @@ export class MessageBubble extends Component {
     } else {
       this.element = nextElement;
     }
-  }
-
-  /**
-   * Render the inline loading indicator used after the initial bubble is on screen.
-   */
-  private appendLoadingIndicator(contentElement: HTMLElement): void {
-    const loadingDiv = contentElement.createDiv('ai-loading-continuation');
-    this.startThinkingLoader(loadingDiv);
   }
 
   private startThinkingLoader(container: HTMLElement): void {

--- a/src/ui/chat/components/MessageDisplay.ts
+++ b/src/ui/chat/components/MessageDisplay.ts
@@ -6,7 +6,6 @@
 
 import { ConversationData, ConversationMessage } from '../../../types/chat/ChatTypes';
 import { MessageBubble } from './MessageBubble';
-import { ThinkingLoader } from './ThinkingLoader';
 import { BranchManager } from '../services/BranchManager';
 import { App, setIcon, ButtonComponent } from 'obsidian';
 
@@ -15,11 +14,6 @@ export class MessageDisplay {
   private currentConversationId: string | null = null;
   private messageBubbles: Map<string, MessageBubble> = new Map();
   private transientEventRow: HTMLElement | null = null;
-  // Gap ticker shown during the silent parts of a streaming turn (e.g. while
-  // tools execute). Lives outside the message bubbles so it survives both the
-  // streaming parser's container.empty() and incremental reconciliation.
-  private workingIndicatorRow: HTMLElement | null = null;
-  private workingIndicatorLoader: ThinkingLoader | null = null;
 
   constructor(
     private container: HTMLElement,
@@ -123,7 +117,6 @@ export class MessageDisplay {
     }
 
     this.ensureTransientEventRowPosition(messagesContainer as HTMLElement);
-    this.ensureWorkingIndicatorPosition(messagesContainer as HTMLElement);
   }
 
   /**
@@ -156,7 +149,6 @@ export class MessageDisplay {
     const bubble = this.createMessageBubble(message);
     this.container.querySelector('.messages-container')?.appendChild(bubble);
     this.ensureTransientEventRowPosition(this.container.querySelector('.messages-container'));
-    this.ensureWorkingIndicatorPosition(this.container.querySelector('.messages-container'));
     this.scrollToBottom();
   }
 
@@ -167,7 +159,6 @@ export class MessageDisplay {
     const bubble = this.createMessageBubble(message);
     this.container.querySelector('.messages-container')?.appendChild(bubble);
     this.ensureTransientEventRowPosition(this.container.querySelector('.messages-container'));
-    this.ensureWorkingIndicatorPosition(this.container.querySelector('.messages-container'));
     this.scrollToBottom();
   }
 
@@ -233,11 +224,6 @@ export class MessageDisplay {
     }
     this.messageBubbles.clear();
 
-    // Stop the gap ticker before container.empty() orphans its timers. A full
-    // render is a conversation switch / reload, so any prior turn's ticker is
-    // no longer relevant.
-    this.hideWorkingIndicator();
-
     this.container.empty();
     this.container.addClass('message-display');
 
@@ -301,63 +287,23 @@ export class MessageDisplay {
   }
 
   /**
-   * Show the "still working" gap ticker beneath the message list. Rendered as a
-   * non-bubble row so it survives incremental reconciliation (reconcile only
-   * touches messageBubbles) and the streaming parser's container.empty().
-   * Idempotent: re-showing keeps the existing ticker so its word animation does
-   * not restart on every gap.
+   * Show the "still working" ticker inside the given message's bubble. Rendered
+   * in-bubble (not a detached row) so it stays visually attached to the message
+   * — after the streamed text during a tool gap, or filling an otherwise-empty
+   * bubble on a tool-first turn. The bubble re-applies it across reconciliation.
    */
-  showWorkingIndicator(): void {
-    const messagesContainer = this.container.querySelector('.messages-container');
-    if (!messagesContainer) {
+  showWorkingIndicator(messageId: string): void {
+    const bubble = this.messageBubbles.get(messageId);
+    if (!bubble) {
       return;
     }
-
-    if (!this.workingIndicatorRow) {
-      const row = window.activeDocument.createElement('div');
-      row.className = 'message-working-row';
-      row.setAttribute('role', 'status');
-      row.setAttribute('aria-live', 'polite');
-      this.workingIndicatorRow = row;
-
-      this.workingIndicatorLoader = new ThinkingLoader();
-      this.workingIndicatorLoader.start(row);
-    }
-
-    this.ensureWorkingIndicatorPosition(messagesContainer as HTMLElement);
+    bubble.ensureWorkingTicker();
     this.scrollToBottom();
   }
 
-  /** Remove the gap ticker and stop its animation. */
-  hideWorkingIndicator(): void {
-    if (this.workingIndicatorLoader) {
-      this.workingIndicatorLoader.stop();
-      this.workingIndicatorLoader.unload();
-      this.workingIndicatorLoader = null;
-    }
-    if (this.workingIndicatorRow) {
-      this.workingIndicatorRow.remove();
-      this.workingIndicatorRow = null;
-    }
-  }
-
-  /**
-   * Stop a message bubble's own pre-first-token loader. Called when the first
-   * streamed text token arrives so the leaked ThinkingLoader intervals behind
-   * the bubble's loading indicator are cleared (the parser's container.empty()
-   * removes its DOM but not its timers).
-   */
-  stopMessageLoader(messageId: string): void {
-    this.messageBubbles.get(messageId)?.stopLoadingAnimation();
-  }
-
-  private ensureWorkingIndicatorPosition(messagesContainer: HTMLElement | null): void {
-    if (!messagesContainer || !this.workingIndicatorRow) {
-      return;
-    }
-    // Always re-append so the ticker stays at the very bottom, below any
-    // bubbles or tool-message bubbles created mid-turn.
-    messagesContainer.appendChild(this.workingIndicatorRow);
+  /** Remove the in-bubble working ticker for the given message. */
+  hideWorkingIndicator(messageId: string): void {
+    this.messageBubbles.get(messageId)?.removeWorkingTicker();
   }
 
   /**
@@ -603,7 +549,6 @@ export class MessageDisplay {
     }
     this.messageBubbles.clear();
     this.clearTransientEventRow();
-    this.hideWorkingIndicator();
     this.currentConversationId = null;
   }
 }

--- a/src/ui/chat/controllers/WorkingIndicatorController.ts
+++ b/src/ui/chat/controllers/WorkingIndicatorController.ts
@@ -13,33 +13,33 @@
  * turn, so the ticker visibly "stops once it starts generating" and never
  * returns while tools run.
  *
- * This controller owns a gap ticker that lives OUTSIDE the message bubble (so
- * it survives both the parser's `container.empty()` and bubble reconciliation,
- * including the mid-stream reconcile LM Studio triggers when it persists a
- * Responses API id) and shows it only when the assistant is mid-turn but text
- * is not actively flowing.
+ * This controller decides WHEN a "still working" ticker should be visible. The
+ * ticker itself is rendered in-bubble by MessageBubble (so it stays attached to
+ * the message and survives reconciliation); the controller only toggles it via
+ * the show/hide callbacks, passing the streaming message id.
  *
  * State machine (a single generation is active at a time)
  * -------------------------------------------------------
- * - begin():           a turn started. We stay idle — the in-bubble loader
+ * - begin():           a turn started. We stay idle — the bubble's own loader
  *                      already covers the pre-first-token wait (and any leading
  *                      tool calls before text), so we do nothing until text
- *                      actually starts to avoid showing two tickers at once.
- * - noteText():        a text chunk arrived. Hide the gap ticker (text is
- *                      visible) and arm a debounce; if no further text arrives
- *                      within GAP_DELAY_MS we treat the silence as a gap and
- *                      show the ticker. This is the provider-agnostic path that
- *                      works even when a provider emits no tool events (e.g.
- *                      some local models).
- * - noteToolActivity(): a tool was detected / started executing. If text has
+ *                      actually starts to avoid toggling a ticker the bubble is
+ *                      already showing.
+ * - noteText(id):      a text chunk arrived. Hide the ticker (text is visible)
+ *                      and arm a debounce; if no further text arrives within
+ *                      GAP_DELAY_MS we treat the silence as a gap and show the
+ *                      ticker. This is the provider-agnostic path that works
+ *                      even when a provider emits no tool events (some local
+ *                      models).
+ * - noteToolActivity(id): a tool was detected / started executing. If text has
  *                      already started, show the ticker immediately — more
  *                      responsive than waiting out the debounce. Ignored before
- *                      the first token (the in-bubble loader covers that).
+ *                      the first token (the bubble's loader covers that).
  * - end():             the turn finished / aborted / errored. Hide and disarm.
  */
 export interface WorkingIndicatorEvents {
-  show: () => void;
-  hide: () => void;
+  show: (messageId: string) => void;
+  hide: (messageId: string) => void;
 }
 
 export class WorkingIndicatorController {
@@ -52,6 +52,7 @@ export class WorkingIndicatorController {
   private active = false;
   private hasText = false;
   private shown = false;
+  private messageId: string | null = null;
   private gapTimer: number | null = null;
 
   constructor(private readonly events: WorkingIndicatorEvents) {}
@@ -60,21 +61,34 @@ export class WorkingIndicatorController {
   begin(): void {
     this.active = true;
     this.hasText = false;
+    this.messageId = null;
+    this.shown = false;
     this.clearGapTimer();
-    this.hideTicker();
   }
 
   /** A streamed text chunk arrived for the active turn. */
-  noteText(): void {
+  noteText(messageId: string): void {
     if (!this.active) return;
-    this.hasText = true;
-    this.hideTicker();
+    this.messageId = messageId;
+
+    if (!this.hasText) {
+      // First token: the bubble showed its own pre-text ticker (on isLoading).
+      // Force it down — even though the controller never "showed" it — so a
+      // mid-stream reconcile does not re-stamp the ticker over streaming text.
+      this.hasText = true;
+      this.shown = false;
+      this.events.hide(messageId);
+    } else {
+      this.hideTicker();
+    }
+
     this.armGapTimer();
   }
 
   /** A tool was detected or started executing for the active turn. */
-  noteToolActivity(): void {
+  noteToolActivity(messageId: string): void {
     if (!this.active || !this.hasText) return;
+    this.messageId = messageId;
     this.clearGapTimer();
     this.showTicker();
   }
@@ -85,6 +99,7 @@ export class WorkingIndicatorController {
     this.hasText = false;
     this.clearGapTimer();
     this.hideTicker();
+    this.messageId = null;
   }
 
   cleanup(): void {
@@ -109,14 +124,14 @@ export class WorkingIndicatorController {
   }
 
   private showTicker(): void {
-    if (this.shown) return;
+    if (this.shown || !this.messageId) return;
     this.shown = true;
-    this.events.show();
+    this.events.show(this.messageId);
   }
 
   private hideTicker(): void {
-    if (!this.shown) return;
+    if (!this.shown || !this.messageId) return;
     this.shown = false;
-    this.events.hide();
+    this.events.hide(this.messageId);
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -778,16 +778,6 @@ body.theme-light .message-content {
     font-weight: 600;
 }
 
-/* "Still working" gap ticker — shown beneath the message list during the
-   silent parts of a streaming turn (e.g. while tools execute, which do not
-   stream). Left-aligned to sit under the assistant's reply. Hosts a
-   ThinkingLoader (.thinking-loader). */
-.message-working-row {
-    display: flex;
-    justify-content: flex-start;
-    padding: 0.35rem 0.75rem 0.6rem;
-}
-
 /* Compaction divider — subtle centered rule with label, inserted
    after context compaction completes. Transparent background so the
    glass gradient shows through. */

--- a/tests/unit/WorkingIndicatorController.test.ts
+++ b/tests/unit/WorkingIndicatorController.test.ts
@@ -3,12 +3,13 @@
  *
  * Covers the gap-ticker state machine that shows a "still working" indicator
  * during the silent parts of a streaming turn (e.g. while tools execute):
- *   - begin() stays idle (the in-bubble loader covers the pre-first-token wait)
+ *   - begin() stays idle (the bubble's own loader covers the pre-first-token wait)
  *   - noteText() hides immediately, then the debounce reveals the ticker in a gap
  *   - a fresh text chunk re-arms the debounce (no flicker mid-stream)
  *   - noteToolActivity() shows immediately, but only after text has started
  *   - end() hides and disarms (no late show after the turn finishes)
  *   - show/hide events do not fire redundantly
+ *   - show/hide carry the streaming message id (so the right bubble is targeted)
  *
  * Constraints:
  *   - Node test env has no `window` — shim setTimeout/clearTimeout
@@ -25,6 +26,7 @@ if (typeof (global as any).window === 'undefined') {
 import { WorkingIndicatorController } from '../../src/ui/chat/controllers/WorkingIndicatorController';
 
 const GAP_DELAY_MS = 800;
+const MSG = 'ai-msg-1';
 
 describe('WorkingIndicatorController', () => {
   let show: jest.Mock;
@@ -47,7 +49,7 @@ describe('WorkingIndicatorController', () => {
     jest.useRealTimers();
   });
 
-  it('begin() stays idle — the in-bubble loader covers the initial wait', () => {
+  it('begin() stays idle — the bubble loader covers the initial wait', () => {
     controller.begin();
     jest.advanceTimersByTime(GAP_DELAY_MS * 2);
     expect(show).not.toHaveBeenCalled();
@@ -55,18 +57,19 @@ describe('WorkingIndicatorController', () => {
 
   it('shows the ticker after a gap once text has started', () => {
     controller.begin();
-    controller.noteText();
+    controller.noteText(MSG);
     expect(show).not.toHaveBeenCalled(); // text just arrived — not a gap yet
 
     jest.advanceTimersByTime(GAP_DELAY_MS);
     expect(show).toHaveBeenCalledTimes(1);
+    expect(show).toHaveBeenCalledWith(MSG);
   });
 
   it('re-arms the debounce on each text chunk (no mid-stream flicker)', () => {
     controller.begin();
-    controller.noteText();
+    controller.noteText(MSG);
     jest.advanceTimersByTime(GAP_DELAY_MS - 100);
-    controller.noteText(); // resets the timer before it could fire
+    controller.noteText(MSG); // resets the timer before it could fire
     jest.advanceTimersByTime(GAP_DELAY_MS - 100);
     expect(show).not.toHaveBeenCalled();
 
@@ -74,52 +77,64 @@ describe('WorkingIndicatorController', () => {
     expect(show).toHaveBeenCalledTimes(1);
   });
 
+  it('clears the bubble ticker on the first token (reconcile-safe handoff)', () => {
+    controller.begin();
+    controller.noteText(MSG); // first token forces the pre-text ticker down
+    expect(hide).toHaveBeenCalledWith(MSG);
+    expect(show).not.toHaveBeenCalled();
+  });
+
   it('hides immediately when text resumes after the ticker was shown', () => {
     controller.begin();
-    controller.noteText();
+    controller.noteText(MSG);
     jest.advanceTimersByTime(GAP_DELAY_MS);
     expect(show).toHaveBeenCalledTimes(1);
 
-    controller.noteText(); // continuation text arrived
-    expect(hide).toHaveBeenCalledTimes(1);
+    const hidesBefore = hide.mock.calls.length;
+    controller.noteText(MSG); // continuation text arrived
+    expect(hide.mock.calls.length).toBe(hidesBefore + 1);
+    expect(hide).toHaveBeenLastCalledWith(MSG);
   });
 
   it('noteToolActivity() shows immediately once text has started', () => {
     controller.begin();
-    controller.noteText();
-    controller.noteToolActivity();
+    controller.noteText(MSG);
+    controller.noteToolActivity(MSG);
     expect(show).toHaveBeenCalledTimes(1); // no need to wait out the debounce
+    expect(show).toHaveBeenCalledWith(MSG);
   });
 
   it('noteToolActivity() is ignored before any text (bubble loader covers it)', () => {
     controller.begin();
-    controller.noteToolActivity();
+    controller.noteToolActivity(MSG);
     expect(show).not.toHaveBeenCalled();
   });
 
   it('end() hides and disarms — no late show after the turn finishes', () => {
     controller.begin();
-    controller.noteText();
+    controller.noteText(MSG);
     controller.end();
     jest.advanceTimersByTime(GAP_DELAY_MS * 2);
     expect(show).not.toHaveBeenCalled();
   });
 
-  it('does not fire show/hide redundantly', () => {
+  it('does not restart the ticker when already shown, and end hides once', () => {
     controller.begin();
-    controller.noteText();
+    controller.noteText(MSG);
     jest.advanceTimersByTime(GAP_DELAY_MS);
-    controller.noteToolActivity(); // already shown
+    expect(show).toHaveBeenCalledTimes(1);
+    controller.noteToolActivity(MSG); // already shown — no second show
     expect(show).toHaveBeenCalledTimes(1);
 
+    const hidesBefore = hide.mock.calls.length;
     controller.end();
-    controller.end(); // already hidden
-    expect(hide).toHaveBeenCalledTimes(1);
+    controller.end(); // idempotent
+    expect(hide.mock.calls.length).toBe(hidesBefore + 1);
   });
 
   it('ignores stray signals when no turn is active', () => {
-    controller.noteText();
-    controller.noteToolActivity();
+    controller.noteText(MSG);
+    controller.noteToolActivity(MSG);
     jest.advanceTimersByTime(GAP_DELAY_MS * 2);
     expect(show).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
Follow-up to the gap-ticker (#279). That version rendered the "still working" ticker as a detached row below the message list, which looked awkward when the model goes straight to tool calling with no text — the assistant bubble is empty and the ticker floats below it (common on local models like Gemma, where the tool call arrives as raw tokens).

This moves the ticker **inside** the assistant bubble so it stays attached to the message.

## Changes
- **MessageBubble**: `ensureWorkingTicker()` / `removeWorkingTicker()` render the ticker inside the bubble's `.message-content` — after the streamed text during a tool gap, or filling an otherwise-empty bubble on a tool-first turn. A `workingTickerActive` intent flag makes it reconcile-safe: the bubble re-applies it on re-render while the turn is mid-flight, so the mid-stream reconcile LM Studio triggers when persisting a Responses API id no longer drops it.
- **WorkingIndicatorController**: now targets the streaming message by id (show/hide carry `messageId`) and clears the bubble's own pre-text loader on the first token, so a reconcile during text streaming can't re-stamp the ticker over the reply.
- **MessageDisplay**: `showWorkingIndicator(messageId)` / `hideWorkingIndicator(messageId)` delegate to the target bubble; removed the detached-row scaffolding.
- **styles.css**: removed the unused `.message-working-row` style.
- Tests updated for the message-id signatures and the first-token handoff.

## Behavior
- Tool-first / empty-text turn: ticker fills the bubble itself — attached, no floating-below-empty-bubble look.
- Text-then-tool gap: ticker sits under the streamed text in the same bubble.
- Cleared on the first text token and re-applied across reconciliation while the turn is live.

Build + lint + 33 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MB8WALG8GRrZHJSzdje2LG)_