### PR TITLE
Add GPT-5.6 model family

### DIFF
--- a/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexAdapter.ts
@@ -118,7 +118,7 @@ export class OpenAICodexAdapter extends BaseAdapter {
    */
   constructor(tokens: CodexOAuthTokens, onTokenRefresh?: TokenPersistCallback) {
     // Pass accessToken as apiKey for BaseAdapter compatibility; baseUrl is the Codex endpoint
-    super(tokens.accessToken, 'gpt-5.5', CODEX_API_ENDPOINT, false);
+    super(tokens.accessToken, 'gpt-5.6-sol', CODEX_API_ENDPOINT, false);
     this.tokens = { ...tokens };
     this.onTokenRefresh = onTokenRefresh;
     this.initializeCache();

--- a/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
+++ b/src/services/llm/adapters/openai-codex/OpenAICodexModels.ts
@@ -14,6 +14,54 @@ import { ModelSpec } from '../modelTypes';
 export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   {
     provider: 'openai-codex',
+    name: 'GPT-5.6 Sol',
+    apiName: 'gpt-5.6-sol',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai-codex',
+    name: 'GPT-5.6 Terra',
+    apiName: 'gpt-5.6-terra',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai-codex',
+    name: 'GPT-5.6 Luna',
+    apiName: 'gpt-5.6-luna',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai-codex',
     name: 'GPT-5.5',
     apiName: 'gpt-5.5',
     contextWindow: 400000,
@@ -142,4 +190,4 @@ export const OPENAI_CODEX_MODELS: ModelSpec[] = [
   }
 ];
 
-export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.5';
+export const OPENAI_CODEX_DEFAULT_MODEL = 'gpt-5.6-sol';

--- a/src/services/llm/adapters/openai/OpenAIAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAIAdapter.ts
@@ -140,7 +140,7 @@ export class OpenAIAdapter extends BaseAdapter {
   private deepResearch: DeepResearchHandler;
 
   constructor(apiKey: string) {
-    super(apiKey, 'gpt-5.5');
+    super(apiKey, 'gpt-5.6-sol');
     this.deepResearch = new DeepResearchHandler(this.apiKey, this.baseUrl);
     this.initializeCache();
   }

--- a/src/services/llm/adapters/openai/OpenAIModels.ts
+++ b/src/services/llm/adapters/openai/OpenAIModels.ts
@@ -1,6 +1,6 @@
 /**
  * OpenAI Model Specifications
- * Updated June 2026 — pruned the GPT-5 / GPT-5.1 generation (superseded by GPT-5.2+ and the 5.4/5.5 families)
+ * Updated July 2026 — added the GPT-5.6 Sol, Terra, and Luna family
  *
  * Pricing Notes:
  * - GPT-5 family supports 90% caching discount (cached tokens: $0.125/M vs $1.25/M fresh)
@@ -13,7 +13,57 @@
 import { ModelSpec } from '../modelTypes';
 
 export const OPENAI_MODELS: ModelSpec[] = [
-  // GPT-5.5 family (latest models)
+  // GPT-5.6 family (latest models)
+  {
+    provider: 'openai',
+    name: 'GPT-5.6 Sol',
+    apiName: 'gpt-5.6-sol',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai',
+    name: 'GPT-5.6 Terra',
+    apiName: 'gpt-5.6-terra',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 2.50,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openai',
+    name: 'GPT-5.6 Luna',
+    apiName: 'gpt-5.6-luna',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 1.00,
+    outputCostPerMillion: 6.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
+  // GPT-5.5 family
   {
     provider: 'openai',
     name: 'GPT-5.5',
@@ -185,4 +235,4 @@ export const OPENAI_MODELS: ModelSpec[] = [
   // These models use a different parameter structure and would need special handling
 ];
 
-export const OPENAI_DEFAULT_MODEL = 'gpt-5.5';
+export const OPENAI_DEFAULT_MODEL = 'gpt-5.6-sol';

--- a/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterAdapter.ts
@@ -158,7 +158,7 @@ export class OpenRouterAdapter extends BaseAdapter {
     apiKey: string,
     options?: { httpReferer?: string; xTitle?: string }
   ) {
-    super(apiKey, 'openai/gpt-5.5');
+    super(apiKey, 'openai/gpt-5.6-sol');
     this.httpReferer = options?.httpReferer?.trim() || 'https://synapticlabs.ai';
     this.xTitle = options?.xTitle?.trim() || BRAND_NAME;
     this.initializeCache();

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -1,7 +1,7 @@
 /**
  * OpenRouter Model Specifications
  * OpenRouter provides access to multiple providers through a unified API
- * Updated June 2026 — added GLM 5.2 + Kimi K2.7 Code; pruned superseded
+ * Updated July 2026 — added the GPT-5.6 family; pruned superseded
  * Claude 4.5 Opus/Sonnet, Gemini 2.5 / 3.0 Preview, and GPT-5 / GPT-5.1 entries
  */
 
@@ -428,6 +428,102 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'GPT-5.6 Luna',
+    apiName: 'openai/gpt-5.6-luna',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 1.00,
+    outputCostPerMillion: 6.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.6 Luna Pro',
+    apiName: 'openai/gpt-5.6-luna-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 1.00,
+    outputCostPerMillion: 6.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.6 Sol',
+    apiName: 'openai/gpt-5.6-sol',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.6 Sol Pro',
+    apiName: 'openai/gpt-5.6-sol-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 30.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.6 Terra',
+    apiName: 'openai/gpt-5.6-terra',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 2.50,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'GPT-5.6 Terra Pro',
+    apiName: 'openai/gpt-5.6-terra-pro',
+    contextWindow: 1050000,
+    maxTokens: 128000,
+    inputCostPerMillion: 2.50,
+    outputCostPerMillion: 15.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Kimi K2.7 Code',
     apiName: 'moonshotai/kimi-k2.7-code',
     contextWindow: 262144,
@@ -508,4 +604,4 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
 ];
 
-export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-5.5';
+export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-5.6-sol';

--- a/tests/debug/provider-model-live-smoke.test.ts
+++ b/tests/debug/provider-model-live-smoke.test.ts
@@ -7,14 +7,14 @@
  *   RUN_MODEL_SMOKE=1 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
  *
  * Run one provider/model:
- *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
- *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
- *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.5 npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai MODEL_SMOKE_MODEL=gpt-5.6-sol npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openrouter MODEL_SMOKE_MODEL=gpt-5.6-sol npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *   RUN_MODEL_SMOKE=1 MODEL_SMOKE_PROVIDER=openai-codex MODEL_SMOKE_MODEL=gpt-5.6-sol npx jest tests/debug/provider-model-live-smoke.test.ts --runInBand --no-coverage --verbose
  *
  * Provider-specific overrides when running all:
- *   OPENAI_SMOKE_MODEL=gpt-5.5
- *   OPENROUTER_SMOKE_MODEL=openai/gpt-5.5
- *   CODEX_SMOKE_MODEL=gpt-5.5
+ *   OPENAI_SMOKE_MODEL=gpt-5.6-sol
+ *   OPENROUTER_SMOKE_MODEL=openai/gpt-5.6-sol
+ *   CODEX_SMOKE_MODEL=gpt-5.6-sol
  */
 
 import * as fs from 'node:fs';

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -79,10 +79,63 @@ describe('ModelRegistry GPT-5.5 models', () => {
     expect(ModelRegistry.findModel('openai-codex', 'gpt-5.5-pro')).toBeUndefined();
   });
 
-  it('uses GPT-5.5 as the default for the updated OpenAI providers', () => {
-    expect(DEFAULT_MODELS.openai).toBe('gpt-5.5');
-    expect(DEFAULT_MODELS.openrouter).toBe('openai/gpt-5.5');
-    expect(DEFAULT_MODELS['openai-codex']).toBe('gpt-5.5');
+});
+
+describe('ModelRegistry GPT-5.6 models', () => {
+  const tiers = [
+    { suffix: 'sol', name: 'GPT-5.6 Sol', input: 5, output: 30 },
+    { suffix: 'terra', name: 'GPT-5.6 Terra', input: 2.5, output: 15 },
+    { suffix: 'luna', name: 'GPT-5.6 Luna', input: 1, output: 6 }
+  ];
+
+  it.each(tiers)('registers $name for OpenAI', ({ suffix, name, input, output }) => {
+    expect(ModelRegistry.findModel('openai', `gpt-5.6-${suffix}`)).toEqual(expect.objectContaining({
+      name,
+      contextWindow: 1050000,
+      maxTokens: 128000,
+      inputCostPerMillion: input,
+      outputCostPerMillion: output,
+      capabilities: expect.objectContaining({
+        supportsJSON: true,
+        supportsImages: true,
+        supportsFunctions: true,
+        supportsStreaming: true,
+        supportsThinking: true
+      })
+    }));
+  });
+
+  it.each(tiers)('registers $name for Codex', ({ suffix, name }) => {
+    expect(ModelRegistry.findModel('openai-codex', `gpt-5.6-${suffix}`)).toEqual(expect.objectContaining({
+      name,
+      contextWindow: 1050000,
+      maxTokens: 128000,
+      inputCostPerMillion: 0,
+      outputCostPerMillion: 0
+    }));
+  });
+
+  it.each(tiers)('registers $name and its Pro mode for OpenRouter', ({ suffix, name, input, output }) => {
+    expect(ModelRegistry.findModel('openrouter', `openai/gpt-5.6-${suffix}`)).toEqual(expect.objectContaining({
+      name,
+      contextWindow: 1050000,
+      maxTokens: 128000,
+      inputCostPerMillion: input,
+      outputCostPerMillion: output
+    }));
+    expect(ModelRegistry.findModel('openrouter', `openai/gpt-5.6-${suffix}-pro`)).toEqual(expect.objectContaining({
+      name: `${name} Pro`,
+      contextWindow: 1050000,
+      maxTokens: 128000,
+      inputCostPerMillion: input,
+      outputCostPerMillion: output
+    }));
+  });
+
+  it('uses GPT-5.6 Sol as the default for the updated OpenAI providers', () => {
+    expect(DEFAULT_MODELS.openai).toBe('gpt-5.6-sol');
+    expect(DEFAULT_MODELS.openrouter).toBe('openai/gpt-5.6-sol');
+    expect(DEFAULT_MODELS['openai-codex']).toBe('gpt-5.6-sol');
   });
 });
 

--- a/tests/unit/OpenAIAdapter.test.ts
+++ b/tests/unit/OpenAIAdapter.test.ts
@@ -59,7 +59,7 @@ describe('OpenAIAdapter', () => {
       const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
 
       expect(result.text).toBe('Hello world');
-      expect(result.model).toBe('gpt-5.5');
+      expect(result.model).toBe('gpt-5.6-sol');
       expect(result.provider).toBe('openai');
       expect(result.finishReason).toBe('stop');
       expect(result.usage).toEqual({ promptTokens: 10, completionTokens: 5, totalTokens: 15 });

--- a/tests/unit/OpenAICodexAdapter.test.ts
+++ b/tests/unit/OpenAICodexAdapter.test.ts
@@ -112,7 +112,7 @@ describe('OpenAICodexAdapter', () => {
 
     expect(request.headers.Authorization).toBe('Bearer test-access-token');
     expect(request.headers['ChatGPT-Account-Id']).toBe('acct-test-123');
-    expect(body.model).toBe('gpt-5.5');
+    expect(body.model).toBe('gpt-5.6-sol');
     expect(body.stream).toBe(true);
     expect(body.tool_choice).toBe('auto');
     expect(body.instructions).toContain('System message');

--- a/tests/unit/OpenRouterAdapter.test.ts
+++ b/tests/unit/OpenRouterAdapter.test.ts
@@ -52,7 +52,7 @@ describe('OpenRouterAdapter', () => {
       const result = await adapter.generateUncached('hi', { systemPrompt: 'Be brief' });
 
       expect(result.text).toBe('Routed');
-      expect(result.model).toBe('openai/gpt-5.5');
+      expect(result.model).toBe('openai/gpt-5.6-sol');
       expect(result.provider).toBe('openrouter');
       expect(result.finishReason).toBe('stop');
       expect(result.usage).toEqual({ promptTokens: 6, completionTokens: 2, totalTokens: 8 });


### PR DESCRIPTION
## What changed

- Add GPT-5.6 Sol, Terra, and Luna to the OpenAI and Codex OAuth model registries.
- Add the three GPT-5.6 tiers and their published Pro-mode aliases to OpenRouter.
- Make GPT-5.6 Sol the default for OpenAI, OpenRouter, and Codex OAuth.
- Update focused unit tests and reusable live-smoke examples.

## Why

OpenAI released the GPT-5.6 family across the API, Codex, and ChatGPT. Nexus needs current model metadata, pricing, capability flags, and provider defaults so the models are selectable without manual IDs.

## Validation

- `npx jest tests/unit/ModelRegistry.test.ts tests/unit/OpenAIAdapter.test.ts tests/unit/OpenRouterAdapter.test.ts tests/unit/OpenAICodexAdapter.test.ts --runInBand` — 56 tests passed.
- `npm run build` — ESLint, TypeScript, esbuild, connector compilation, and connector generation passed.
- Live smoke: OpenAI `gpt-5.6-sol` passed.
- Live smoke: OpenRouter `openai/gpt-5.6-sol` passed.
- Codex live smoke reached authentication but the locally stored OAuth refresh token had already been rotated; no model-rejection response was observed.