### PR TITLE
fix(security): confine vault writes — block path-traversal escape (Phase 1)

### DIFF
--- a/docs/plans/vault-path-confinement-plan.md
+++ b/docs/plans/vault-path-confinement-plan.md
@@ -1,0 +1,190 @@
+# Vault Path Confinement — Design Plan
+
+**Status:** Design (red-team confirmed the vuln; implementation pending)
+**Date:** 2026-07-18
+**Author:** red-team finding + design discussion (ProfSynapse + Claude)
+**Branch:** `fix/vault-path-confinement` (off `main`)
+**Severity:** High — arbitrary file write/mkdir outside the vault, reachable by any caller of `toolManager_useTools` (the local CLI **and** the existing Claude Desktop MCP connector).
+
+> **How it was found:** red-teaming the local CLI bridge (`docs/plans/local-cli-agent-bridge-plan.md`).
+> `nexus use "content write --path ../../../../../../tmp/x.md --content PWNED"` created a real file
+> in `/tmp`, and again in `~`. `storage createFolder --path ../../..` created a directory outside the
+> vault. The CLI only *surfaced* a pre-existing core bug — the same `useTools` entry point is what
+> Claude Desktop drives over MCP.
+
+## 1. The vulnerability
+
+`content write`, `storage createFolder` (and, by shared code path, `insert` / `replace` / `setProperty` /
+`storage move` / `copy` / `archive`) accept a caller-supplied `--path` and hand it, essentially raw, to
+the Obsidian vault API. On desktop, `vault.create()` / `vault.adapter.write()` resolve the path against the
+vault base directory with Node's `path.join`, which **follows `..`** and escapes the vault.
+
+| Op | Path goes to | `../…` behavior |
+|----|--------------|-----------------|
+| `content read`, `storage list` | `vault.getAbstractFileByPath()` → in-memory **index lookup** | not in index → `null` → "not found." Never touches disk. **Confined (by accident).** |
+| `content write`, `storage createFolder` | `vault.create()` / `adapter.write()` → desktop `FileSystemAdapter` → `path.join(vaultBase, p)` | Node resolves `..` → **writes outside the vault.** |
+
+Absolute paths (`/tmp/x.md`) are neutralized only incidentally — the leading `/` is stripped, making them
+vault-relative. `..` is never touched.
+
+## 2. Root cause (not "we forgot to check `..`")
+
+The traversal guard **already exists** and is correct:
+
+```ts
+// src/core/ObsidianPathManager.ts:51
+validatePath(path): PathValidationResult {
+  if (path.includes('..') || path.includes('~')) {              // line 56 — the guard
+    errors.push('Path traversal sequences are not allowed for security');
+  }
+  if (path.startsWith('/') || /^[A-Za-z]:/.test(path)) {        // absolute rejection
+    errors.push('Path should be relative to vault root, not absolute');
+  }
+  ...
+}
+
+// same class, line 43 — what the write path ACTUALLY calls:
+normalizePath(path): string { return normalizePath(path); }     // Obsidian's; does NOT collapse '..'
+```
+
+Every mutation (`VaultOperations.writeFile/ensureDirectory/moveFile`, and the tools that bypass even that)
+calls **`normalizePath()`**, never **`validatePath()`**. The guard sits one method away from the code it is
+meant to protect, permanently un-called on the dangerous path. `validatePath` is invoked only in a couple of
+batch spots (ObsidianPathManager.ts:361/381), never inline before a `vault.create`.
+
+The **7 copy-pasted leading-slash-only normalizers** are all symptoms of the same split — normalization got
+copied everywhere; validation didn't:
+
+```
+src/utils/pathUtils.ts:11                              (the "shared" one — also inert)
+src/core/ObsidianPathManager.ts:43                     (facade's normalize)
+src/agents/contentManager/tools/write.ts:139
+src/agents/contentManager/tools/insert.ts:61
+src/agents/contentManager/tools/replace.ts:235
+src/agents/contentManager/tools/setProperty.ts:121
+src/agents/contentManager/utils/ContentOperations.ts:15
+src/agents/storageManager/tools/baseDirectory.ts:29
+```
+
+> **This is the same disease as the pinned project learning** *"tool-schema `required`/`oneOf`/`enum` is NOT
+> runtime-validated — validation guards MUST live in the service/normalizer layer, not the schema."* A guard
+> that exists but is off the enforced path. A per-tool `reject('..')` bandaid would be the third instance of
+> the same mistake: an opt-in guard callers can skip.
+
+## 3. Design principle
+
+> **Make an unvalidated path un-writable by construction.** The only way to obtain a path the mutation layer
+> will accept is to pass through one function that *both* validates and normalizes. Confinement stops being a
+> check each caller may or may not run and becomes a property of the type system.
+
+This mirrors the fix the Skills App already shipped locally (`src/agents/apps/skills/services/skillPaths.ts`:
+`resolveVaultPath` / `assertInside` / `isSafePathSegment`) — generalize that idea to the whole plugin.
+
+### Trusted vs untrusted paths (the nuance that keeps this from breaking internals)
+
+Not every path is caller-supplied. Internal, trusted callers legitimately write to plugin-config locations
+that a strict untrusted check would (wrongly) reject or that simply must not be blocked:
+
+- Event store / cache / migration writing under `<configDir>/plugins/<id>/…` and `<rootPath>/data/…`
+- Hidden-file writes via `adapter.write` (`.obsidian/...`) — `VaultOperations.isHiddenPath` path
+
+So the confinement (`..`/`~`/absolute **rejection**) applies at the **untrusted tool boundary**
+(contentManager / storageManager / canvasManager tools that take an LLM/agent-supplied `--path`). Internal
+writes still route through the typed facade for canonicalization, but are constructed from code-controlled
+paths, not rejected. The branded type carries "this path was resolved"; the *rejection policy* lives in the
+resolver used at the untrusted boundary.
+
+## 4. The fix, in three phases
+
+Phase 1 closes the hole and is shippable on its own. Phases 2–3 make regression structurally impossible.
+
+### Phase 1 — Fused resolver + wire the untrusted write boundary (closes the hole)
+
+1. **New module `src/core/vaultPath.ts`** (or generalize `skillPaths.ts` up to core):
+   - `resolveVaultPath(raw: string): VaultPath` — the single chokepoint. Steps:
+     1. Reject non-string / empty.
+     2. Reject absolute (`startsWith('/')`, `^[A-Za-z]:`, `startsWith('\\')`).
+     3. Reject `~` as the first segment.
+     4. Normalize (Obsidian `normalizePath`), then **segment-based** traversal check: `split('/')` and
+        reject if any segment `=== '..'`. **Do NOT use `includes('..')`** — it false-positives on legit
+        names like `notes/a..b.md`. (Reject `.` segments too, except a bare `.` meaning root where the tool
+        already special-cases it.)
+     5. Return a **branded** `VaultPath` (`type VaultPath = string & { readonly __brand: 'VaultPath' }`)
+        constructable *only* here.
+   - `tryResolveVaultPath(raw): { ok: true; path: VaultPath } | { ok: false; error: string }` — non-throwing
+     variant so tools return the existing `{ success:false, error }` shape with a clean message.
+2. **Wire it at the untrusted boundary** — replace the leading-slash-only normalize in each write-side tool
+   with `tryResolveVaultPath` and early-return the error on failure:
+   - `contentManager/tools/write.ts`, `insert.ts`, `replace.ts`, `setProperty.ts`
+   - `contentManager/utils/ContentOperations.ts` (createContent/append/prepend/etc. — the shared write core)
+   - `storageManager/tools/createFolder.ts`, `move.ts`, `copy.ts`, `archive.ts` (validate **both** source and
+     target for move/copy)
+   - `canvasManager` write/update tools (same `--path` surface)
+3. **Tests** — `tests/core/vaultPath.test.ts` (resolver unit tests: `..` at every position, `~`, absolute,
+   backslash, mixed, false-positive names like `a..b.md` must PASS) + per-tool regression tests feeding `../`
+   and absolute paths and asserting a rejection result (not a thrown/escaped write).
+4. **Re-run the red-team probes** (§6) and confirm every write-escape is now blocked while normal
+   vault-relative writes still succeed.
+
+### Phase 2 — Type the boundary (make the mistake a compile error)
+
+1. Change `VaultOperations` mutators (`writeFile`, `ensureDirectory`, `moveFile`, `copyFile`, `deleteFile`,
+   `deleteFolder`, `batchWrite`) to accept **`VaultPath`**, not `string`.
+2. Callers construct a `VaultPath` at their trust boundary: untrusted tools via `resolveVaultPath` (rejecting
+   on bad input); internal callers via an explicit `vaultPathFromTrusted(codeControlledString)` constructor
+   that canonicalizes but does not reject (documented, greppable, code-supplied args only).
+3. **Delete** the 7 scattered normalizers and the inert `src/utils/pathUtils.normalizePath` (or reduce it to a
+   re-export of the resolver). Now a raw `string` literally cannot reach `vault.create` — picking the cheap
+   path is a type error.
+
+### Phase 3 — Arch guard (stop regression across the 35 call sites)
+
+1. **eslint `no-restricted-syntax`** (or a CI grep gate) forbidding direct
+   `vault.create` / `vault.modify` / `vault.createBinary` / `vault.createFolder` / `adapter.write` /
+   `adapter.writeBinary` outside `src/core/VaultOperations.ts`. ~35 files call these directly today
+   (inventory produced in Phase 0 recon); each must either route through `VaultOperations` or land on a
+   documented allowlist (event store / cache / migration internals).
+2. Config-level rule (matching the existing `no-nodejs-modules` / `no-deprecated` override style in
+   `eslint.config.mjs`) so the obsidian-releases bot's inline-disable rejection doesn't bite.
+
+## 5. Work breakdown (for parallel agents)
+
+| Track | Scope | Depends on | Conflicts with |
+|-------|-------|------------|----------------|
+| **A — Phase 1** | `vaultPath.ts` + wire content/storage/canvas write tools + unit/regression tests + red-team re-probe | — | owns the tool files |
+| **B — Phase 0 recon** | Authoritative inventory of all `vault.*`/`adapter.*` mutation call sites, classify **trusted-internal vs untrusted-boundary**, draft the Phase 3 eslint rule + allowlist (as a doc/patch, **not applied**) | — | read-only + doc; no code conflict with A |
+
+A is the critical path and self-contained. B is read-only prep that unblocks Phases 2–3; it must not edit the
+tool files A owns. Phase 2 (typed facade migration) follows A landing and consumes B's inventory — sequenced
+after review, not run concurrently on the same files.
+
+## 6. Red-team acceptance probes (must all be BLOCKED after Phase 1)
+
+Run against a live vault via the CLI (`nexus use "<cmd>" --vault code --memory .. --goal ..`); each must
+return a clean rejection and leave **no file on disk outside the vault**:
+
+- `content write --path ../../../../../../tmp/ESCAPE.md --content x`
+- `content write --path ../../../../../../../Users/<user>/ESCAPE.md --content x`
+- `storage createFolder --path ../../../../../../tmp/ESCAPE-dir`
+- `content insert` / `content replace` / `content setProperty` with a `../` path
+- `storage move --path notes/a.md --new-path ../../../../tmp/ESCAPE.md`
+
+Must still **SUCCEED** (no false positives):
+
+- `content write --path notes/a..b.md --content x` (legit name containing `..`)
+- `content write --path Nexus/data/legit.md --content x`
+- normal vault-relative reads/writes/lists as before
+
+## 7. Non-goals
+
+- Socket authentication / capability-scoping of the CLI (separate threat-model discussion; the socket is
+  already `0600` owner-only). This plan is strictly about vault-path confinement.
+- Sandboxing `data runPython` or the web tools' network reach.
+- Blocking writes into `.obsidian/` config from the untrusted boundary — worth considering as a follow-up
+  policy layer, but out of scope here (the traversal escape is the acute issue).
+
+## 8. Rollout
+
+Ship Phase 1 as the security fix (fast, closes the hole, fully tested + red-teamed). Land Phase 2 + the
+Phase 3 arch guard as a follow-up hardening PR once B's inventory is reviewed. Because the bug is reachable
+over the existing MCP connector, Phase 1 hardens Claude Desktop too, not just the new CLI.

--- a/src/agents/apps/elevenlabs/tools/musicGeneration.ts
+++ b/src/agents/apps/elevenlabs/tools/musicGeneration.ts
@@ -9,7 +9,8 @@ import { BaseTool } from '../../../baseTool';
 import { CommonParameters, CommonResult } from '../../../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { BaseAppAgent } from '../../BaseAppAgent';
-import { requestUrl, normalizePath, TFolder } from 'obsidian';
+import { requestUrl, TFolder } from 'obsidian';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 
@@ -107,7 +108,12 @@ export class MusicGenerationTool extends BaseTool<MusicGenerationParams, CommonR
           'Vault not available — cannot save audio file.');
       }
 
-      const outputPath = normalizePath(params.outputPath || `audio/music-${Date.now()}.mp3`);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolvedOutput = tryResolveVaultPath(params.outputPath || `audio/music-${Date.now()}.mp3`);
+      if (!resolvedOutput.ok) {
+        return this.prepareResult(false, undefined, resolvedOutput.error);
+      }
+      const outputPath = resolvedOutput.path;
 
       // Ensure parent directory exists
       const dir = outputPath.substring(0, outputPath.lastIndexOf('/'));

--- a/src/agents/apps/elevenlabs/tools/soundEffects.ts
+++ b/src/agents/apps/elevenlabs/tools/soundEffects.ts
@@ -9,7 +9,8 @@ import { BaseTool } from '../../../baseTool';
 import { CommonParameters, CommonResult } from '../../../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { BaseAppAgent } from '../../BaseAppAgent';
-import { requestUrl, normalizePath, TFolder } from 'obsidian';
+import { requestUrl, TFolder } from 'obsidian';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 
@@ -104,7 +105,12 @@ export class SoundEffectsTool extends BaseTool<SoundEffectsParams, CommonResult>
           'Vault not available — cannot save audio file.');
       }
 
-      const outputPath = normalizePath(params.outputPath || `audio/sfx-${Date.now()}.mp3`);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolvedOutput = tryResolveVaultPath(params.outputPath || `audio/sfx-${Date.now()}.mp3`);
+      if (!resolvedOutput.ok) {
+        return this.prepareResult(false, undefined, resolvedOutput.error);
+      }
+      const outputPath = resolvedOutput.path;
 
       // Ensure parent directory exists
       const dir = outputPath.substring(0, outputPath.lastIndexOf('/'));

--- a/src/agents/apps/elevenlabs/tools/textToSpeech.ts
+++ b/src/agents/apps/elevenlabs/tools/textToSpeech.ts
@@ -9,7 +9,8 @@ import { BaseTool } from '../../../baseTool';
 import { CommonParameters, CommonResult } from '../../../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
 import { BaseAppAgent } from '../../BaseAppAgent';
-import { requestUrl, normalizePath, TFolder } from 'obsidian';
+import { requestUrl, TFolder } from 'obsidian';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 import { labelNamed, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 
@@ -110,7 +111,12 @@ export class TextToSpeechTool extends BaseTool<TextToSpeechParams, CommonResult>
           'Vault not available — cannot save audio file.');
       }
 
-      const outputPath = normalizePath(params.outputPath || `audio/tts-${Date.now()}.mp3`);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolvedOutput = tryResolveVaultPath(params.outputPath || `audio/tts-${Date.now()}.mp3`);
+      if (!resolvedOutput.ok) {
+        return this.prepareResult(false, undefined, resolvedOutput.error);
+      }
+      const outputPath = resolvedOutput.path;
 
       // Ensure parent directory exists
       const dir = outputPath.substring(0, outputPath.lastIndexOf('/'));

--- a/src/agents/apps/webTools/utils/webViewer.ts
+++ b/src/agents/apps/webTools/utils/webViewer.ts
@@ -1,5 +1,6 @@
 import { App, normalizePath, TFile, TFolder, Vault, View, WorkspaceLeaf } from 'obsidian';
 import { sanitizeName } from '../../../../utils/pathUtils';
+import { resolveVaultPath } from '../../../../core/vaultPath';
 
 export type WebViewerOpenMode = 'tab' | 'split' | 'window' | 'current';
 
@@ -188,7 +189,9 @@ export function resolveUniqueMarkdownPath(vault: Vault, outputPath: string): str
 }
 
 export function resolveUniqueFilePath(vault: Vault, outputPath: string, extension: string): string {
-  const normalized = normalizePath(outputPath);
+  // Confine to the vault: reject traversal/absolute/home-expansion paths. Throws
+  // VaultPathError, which each capture tool's try/catch surfaces as a failure.
+  const normalized = resolveVaultPath(outputPath);
   const suffix = `.${extension}`;
   const withoutExtension = normalized.endsWith(suffix)
     ? normalized.slice(0, -suffix.length)

--- a/src/agents/canvasManager/utils/CanvasOperations.ts
+++ b/src/agents/canvasManager/utils/CanvasOperations.ts
@@ -1,5 +1,6 @@
 import { App, TFile, TFolder } from 'obsidian';
 import { CanvasData } from '../types';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 
 /**
  * Utility class for canvas file operations
@@ -20,6 +21,20 @@ export class CanvasOperations {
   }
 
   /**
+   * Resolve a caller-supplied canvas path for a WRITE operation, confining it to
+   * the vault (rejects traversal/absolute/home-expansion paths) and appending the
+   * `.canvas` extension. Throws on an out-of-vault path so a `..` can never reach
+   * `vault.create`/`vault.modify`.
+   */
+  private static resolveWritePath(path: string): string {
+    const result = tryResolveVaultPath(path);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return this.normalizePath(result.path);
+  }
+
+  /**
    * Read canvas data from a file
    */
   static async readCanvas(app: App, path: string): Promise<CanvasData> {
@@ -36,7 +51,8 @@ export class CanvasOperations {
    * Write canvas data to a NEW file (fails if exists)
    */
   static async writeCanvas(app: App, path: string, data: CanvasData): Promise<void> {
-    const normalizedPath = this.normalizePath(path);
+    // Confine to the vault: reject traversal/absolute/home-expansion paths.
+    const normalizedPath = this.resolveWritePath(path);
     const existingFile = app.vault.getAbstractFileByPath(normalizedPath);
 
     if (existingFile instanceof TFile) {
@@ -60,7 +76,8 @@ export class CanvasOperations {
    * Update an EXISTING canvas (fails if doesn't exist)
    */
   static async updateCanvas(app: App, path: string, data: CanvasData): Promise<void> {
-    const normalizedPath = this.normalizePath(path);
+    // Confine to the vault: reject traversal/absolute/home-expansion paths.
+    const normalizedPath = this.resolveWritePath(path);
     const file = app.vault.getAbstractFileByPath(normalizedPath);
 
     if (!file || !(file instanceof TFile)) {

--- a/src/agents/contentManager/tools/insert.ts
+++ b/src/agents/contentManager/tools/insert.ts
@@ -14,6 +14,7 @@ import { App, TFile } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { InsertParams, InsertResult } from '../types';
 import { createErrorMessage } from '../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 import { generateUnifiedDiff } from '../utils/unifiedDiff';
 import type { ToolStatusTense } from '../../interfaces/ITool';
 import { labelFileOp, verbs } from '../../utils/toolStatusLabels';
@@ -57,9 +58,12 @@ export class InsertTool extends BaseTool<InsertParams, InsertResult> {
     try {
       const { path, content, startLine } = params;
 
-      // Normalize path (remove leading slash)
-      const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-      const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolved = tryResolveVaultPath(path);
+      if (!resolved.ok) {
+        return this.prepareResult(false, undefined, resolved.error);
+      }
+      const file = this.app.vault.getAbstractFileByPath(resolved.path);
 
       if (!file) {
         return this.prepareResult(false, undefined,

--- a/src/agents/contentManager/tools/replace.ts
+++ b/src/agents/contentManager/tools/replace.ts
@@ -18,6 +18,7 @@ import { App, TFile } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { ReplaceParams, ReplaceResult } from '../types';
 import { createErrorMessage } from '../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 import { addRecommendations } from '../../../utils/recommendationUtils';
 import { NudgeHelpers } from '../../../utils/nudgeHelpers';
 import { generateUnifiedDiff } from '../utils/unifiedDiff';
@@ -232,8 +233,12 @@ export class ReplaceTool extends BaseTool<ReplaceParams, ReplaceResult> {
         );
       }
 
-      const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-      const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolved = tryResolveVaultPath(path);
+      if (!resolved.ok) {
+        return this.prepareResult(false, undefined, resolved.error);
+      }
+      const file = this.app.vault.getAbstractFileByPath(resolved.path);
 
       if (!file) {
         return this.prepareResult(false, undefined,

--- a/src/agents/contentManager/tools/setProperty.ts
+++ b/src/agents/contentManager/tools/setProperty.ts
@@ -2,6 +2,7 @@ import { App, TFile } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { SetPropertyParams, SetPropertyResult } from '../types';
 import { createErrorMessage } from '../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 import type { ToolStatusTense } from '../../interfaces/ITool';
 import { labelFileOp, verbs } from '../../utils/toolStatusLabels';
 
@@ -118,8 +119,12 @@ export class SetPropertyTool extends BaseTool<SetPropertyParams, SetPropertyResu
     try {
       const { path, property, value, mode = 'replace' } = params;
 
-      const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
-      const file = this.app.vault.getAbstractFileByPath(normalizedPath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolved = tryResolveVaultPath(path);
+      if (!resolved.ok) {
+        return this.prepareResult(false, undefined, resolved.error);
+      }
+      const file = this.app.vault.getAbstractFileByPath(resolved.path);
 
       if (!file) {
         return this.prepareResult(false, undefined,

--- a/src/agents/contentManager/tools/write.ts
+++ b/src/agents/contentManager/tools/write.ts
@@ -3,6 +3,7 @@ import { BaseTool } from '../../baseTool';
 import { WriteParams, WriteResult } from '../types';
 import { ContentOperations } from '../utils/ContentOperations';
 import { createErrorMessage } from '../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 import type { ToolStatusTense } from '../../interfaces/ITool';
 import { labelFileOp, verbs } from '../../utils/toolStatusLabels';
 
@@ -135,8 +136,12 @@ export class WriteTool extends BaseTool<WriteParams, WriteResult> {
         return this.prepareResult(false, undefined, frontmatterError);
       }
 
-      // Normalize path (remove leading slash)
-      const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolved = tryResolveVaultPath(path);
+      if (!resolved.ok) {
+        return this.prepareResult(false, undefined, resolved.error);
+      }
+      const normalizedPath = resolved.path;
       const existingFile = this.app.vault.getAbstractFileByPath(normalizedPath);
 
       if (existingFile) {

--- a/src/agents/contentManager/utils/ContentOperations.ts
+++ b/src/agents/contentManager/utils/ContentOperations.ts
@@ -1,18 +1,39 @@
 import { App, TFile } from 'obsidian';
 import { diff_match_patch } from 'diff-match-patch';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 
 /**
  * Utility class for content operations
  */
 export class ContentOperations {
   /**
-   * Normalize file path by removing any leading slash
+   * Normalize file path by removing any leading slash.
+   *
+   * Read-only helper: reads are confined by accident (a `..` path misses the
+   * in-memory index and returns "not found" without touching disk), so reads
+   * keep the lenient leading-slash strip. Write methods use
+   * {@link resolveWritePath}, which rejects traversal/absolute/home paths.
    * @param filePath Path to normalize
    * @returns Normalized path
    */
   private static normalizePath(filePath: string): string {
     // Remove leading slash if present
     return filePath.startsWith('/') ? filePath.slice(1) : filePath;
+  }
+
+  /**
+   * Resolve a caller-supplied path for a WRITE operation, confining it to the
+   * vault. Throws on traversal/absolute/home-expansion paths so a `..` can never
+   * reach `vault.create`/`vault.modify` and escape the vault base directory.
+   * @param filePath Caller-supplied path
+   * @returns Vault-relative normalized path
+   */
+  private static resolveWritePath(filePath: string): string {
+    const result = tryResolveVaultPath(filePath);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return result.path;
   }
 
   /**
@@ -112,8 +133,8 @@ export class ContentOperations {
    */
   static async createContent(app: App, filePath: string, content: string): Promise<TFile> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (file) {
@@ -148,8 +169,8 @@ export class ContentOperations {
     totalLength: number;
   }> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {
@@ -187,8 +208,8 @@ export class ContentOperations {
     totalLength: number;
   }> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {
@@ -231,8 +252,8 @@ export class ContentOperations {
     similarityThreshold = 0.95
   ): Promise<number> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {
@@ -305,8 +326,8 @@ export class ContentOperations {
     newContent: string
   ): Promise<number> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {
@@ -366,8 +387,8 @@ export class ContentOperations {
     similarityThreshold = 0.95
   ): Promise<number> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {
@@ -444,8 +465,8 @@ export class ContentOperations {
     wholeWord = false
   ): Promise<number> {
     try {
-      // Normalize path to remove any leading slash
-      const normalizedPath = this.normalizePath(filePath);
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const normalizedPath = this.resolveWritePath(filePath);
       const file = app.vault.getAbstractFileByPath(normalizedPath);
       
       if (!file) {

--- a/src/agents/ingestManager/tools/services/IngestionPipelineService.ts
+++ b/src/agents/ingestManager/tools/services/IngestionPipelineService.ts
@@ -10,6 +10,7 @@
  */
 
 import { Vault, TFile, normalizePath } from 'obsidian';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 import {
   IngestFileRequest,
   IngestToolResult,
@@ -52,7 +53,14 @@ export async function processFile(
   onProgress?: IngestProgressCallback
 ): Promise<IngestToolResult> {
   const startTime = Date.now();
-  const filePath = normalizePath(request.filePath);
+  // Confine the caller-supplied input path to the vault. The output note and any
+  // OCR asset folder are both derived from this path, so confining it here keeps
+  // every downstream write inside the vault.
+  const resolvedInput = tryResolveVaultPath(request.filePath);
+  if (!resolvedInput.ok) {
+    return { success: false, error: resolvedInput.error };
+  }
+  const filePath = resolvedInput.path;
   const warnings: string[] = [];
 
   // Validate file exists
@@ -121,7 +129,12 @@ export async function processFile(
 
   const outputPaths: string[] = [];
   for (const noteWrite of noteWrites) {
-    const normalizedOutput = normalizePath(noteWrite.outputPath);
+    // Defence in depth: confine the derived output note path to the vault.
+    const resolvedOutput = tryResolveVaultPath(noteWrite.outputPath);
+    if (!resolvedOutput.ok) {
+      return { success: false, error: resolvedOutput.error };
+    }
+    const normalizedOutput = resolvedOutput.path;
     const existingFile = deps.vault.getFileByPath(normalizedOutput);
 
     if (existingFile) {
@@ -237,7 +250,12 @@ async function saveOcrImages(
   sourceFilePath: string,
   vault: Vault
 ): Promise<SavedOcrImage[]> {
-  const assetFolder = buildAssetFolderPath(sourceFilePath);
+  // Defence in depth: confine the per-note OCR asset folder to the vault.
+  const assetFolderResult = tryResolveVaultPath(buildAssetFolderPath(sourceFilePath));
+  if (!assetFolderResult.ok) {
+    return [];
+  }
+  const assetFolder = assetFolderResult.path;
   await ensureFolder(vault, assetFolder);
 
   const saved: SavedOcrImage[] = [];

--- a/src/agents/memoryManager/tools/workspaces/createWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/createWorkspace.ts
@@ -17,6 +17,7 @@ import { createServiceIntegration } from '../../services/ValidationService';
 import type { IndividualWorkspace } from '../../../../types/storage/StorageTypes';
 import { addRecommendations } from '../../../../utils/recommendationUtils';
 import { NudgeHelpers } from '../../../../utils/nudgeHelpers';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 
 // Import types from existing workspace mode
 import { 
@@ -77,7 +78,19 @@ export class CreateWorkspaceTool extends BaseTool<CreateWorkspaceParameters, Cre
             if (!params.purpose) {
                 return this.prepareResult(false, undefined, 'Purpose is required. Describe what this workspace is used for.');
             }
-            
+
+            // Confine the workspace root to the vault (reject traversal/absolute
+            // paths). The root sentinels "/", "." and "" legitimately mean the
+            // vault root, so they are preserved as-is; everything else is confined.
+            const rootTrimmed = params.rootFolder.trim();
+            if (rootTrimmed !== '' && rootTrimmed !== '/' && rootTrimmed !== '.') {
+                const resolvedRoot = tryResolveVaultPath(params.rootFolder);
+                if (!resolvedRoot.ok) {
+                    return this.prepareResult(false, undefined, resolvedRoot.error);
+                }
+                params.rootFolder = resolvedRoot.path;
+            }
+
             // Ensure root folder exists
             try {
                 const folder = this.app.vault.getAbstractFileByPath(params.rootFolder);

--- a/src/agents/memoryManager/tools/workspaces/updateWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/updateWorkspace.ts
@@ -15,6 +15,7 @@ import { labelWithId, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { createServiceIntegration } from '../../services/ValidationService';
 import { createErrorMessage } from '../../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../../core/vaultPath';
 import { CommonResult, CommonParameters } from '../../../../types/mcp/AgentTypes';
 import type { IndividualWorkspace } from '../../../../types/storage/StorageTypes';
 import type { WorkspaceWorkflow } from '../../../../database/types/workspace/WorkspaceTypes';
@@ -121,6 +122,17 @@ export class UpdateWorkspaceTool extends BaseTool<UpdateWorkspaceParameters, Upd
                 workspaceCopy.description = params.description;
             }
             if (params.rootFolder !== undefined) {
+                // Confine the workspace root to the vault (reject traversal/absolute
+                // paths). The root sentinels "/", "." and "" legitimately mean the
+                // vault root, so they are preserved as-is; everything else is confined.
+                const rootTrimmed = params.rootFolder.trim();
+                if (rootTrimmed !== '' && rootTrimmed !== '/' && rootTrimmed !== '.') {
+                    const resolvedRoot = tryResolveVaultPath(params.rootFolder);
+                    if (!resolvedRoot.ok) {
+                        return this.prepareResult(false, undefined, resolvedRoot.error);
+                    }
+                    params.rootFolder = resolvedRoot.path;
+                }
                 // Ensure folder exists
                 try {
                     const folder = this.app.vault.getAbstractFileByPath(params.rootFolder);

--- a/src/agents/storageManager/tools/createFolder.ts
+++ b/src/agents/storageManager/tools/createFolder.ts
@@ -3,6 +3,7 @@ import { BaseTool } from '../../baseTool';
 import { CreateFolderParams, CreateFolderResult } from '../types';
 import { FileOperations } from '../utils/FileOperations';
 import { createErrorMessage } from '../../../utils/errorUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 import type { ToolStatusTense } from '../../interfaces/ITool';
 import { labelFileOp, verbs } from '../../utils/toolStatusLabels';
 
@@ -46,12 +47,19 @@ export class CreateFolderTool extends BaseTool<CreateFolderParams, CreateFolderR
         return this.prepareResult(false, undefined, 'Path is required');
       }
 
+      // Confine to the vault: reject traversal/absolute/home-expansion paths.
+      const resolved = tryResolveVaultPath(params.path);
+      if (!resolved.ok) {
+        return this.prepareResult(false, undefined, resolved.error);
+      }
+      const folderPath = resolved.path;
+
       if (typeof FileOperations?.createFolder === 'function') {
-        await FileOperations.createFolder(this.app, params.path);
+        await FileOperations.createFolder(this.app, folderPath);
       } else {
-        const existingFolder = this.app.vault.getAbstractFileByPath(params.path);
+        const existingFolder = this.app.vault.getAbstractFileByPath(folderPath);
         if (!existingFolder) {
-          await this.app.vault.createFolder(params.path);
+          await this.app.vault.createFolder(folderPath);
         }
       }
 

--- a/src/agents/storageManager/utils/FileOperations.ts
+++ b/src/agents/storageManager/utils/FileOperations.ts
@@ -1,10 +1,28 @@
 import { App, TFile, TFolder } from 'obsidian';
 import { smartNormalizePath, normalizePath } from '../../../utils/pathUtils';
+import { tryResolveVaultPath } from '../../../core/vaultPath';
 
 /**
  * Utility class for file operations
  */
 export class FileOperations {
+  /**
+   * Resolve a caller-supplied path for a WRITE operation, confining it to the
+   * vault. Throws on traversal/absolute/home-expansion paths so a `..` can never
+   * reach `vault.create`/`createFolder`/`renameFile` and escape the vault base
+   * directory. Trusted internal recursion (ensureFolder) builds paths from
+   * already-confined segments, so it is unaffected.
+   * @param path Caller-supplied path
+   * @returns Vault-relative normalized path
+   */
+  private static resolveWritePath(path: string): string {
+    const result = tryResolveVaultPath(path);
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    return result.path;
+  }
+
   /**
    * Create a note
    * @param app Obsidian app instance
@@ -20,8 +38,10 @@ export class FileOperations {
     content: string,
     overwrite = false
   ): Promise<{ file: TFile; existed: boolean }> {
+    // Confine to the vault before any normalization.
+    const safePath = FileOperations.resolveWritePath(path);
     // Apply smart normalization for note operations (includes .md extension handling)
-    const normalizedPath = smartNormalizePath(path, false, 'NOTE');
+    const normalizedPath = smartNormalizePath(safePath, false, 'NOTE');
     
     // Check if the file already exists
     const existingFile = app.vault.getAbstractFileByPath(normalizedPath);
@@ -58,8 +78,8 @@ export class FileOperations {
    * @throws Error if creation fails
    */
   static async createFolder(app: App, path: string): Promise<boolean> {
-    // Normalize path to remove any leading slash
-    const normalizedPath = normalizePath(path);
+    // Confine to the vault: reject traversal/absolute/home-expansion paths.
+    const normalizedPath = FileOperations.resolveWritePath(path);
     
     // Check if the folder already exists
     const existingFolder = app.vault.getAbstractFileByPath(normalizedPath);
@@ -110,8 +130,8 @@ export class FileOperations {
    * @throws Error if deletion fails
    */
   static async deleteNote(app: App, path: string): Promise<void> {
-    // Normalize path to remove any leading slash
-    const normalizedPath = normalizePath(path);
+    // Confine to the vault: reject traversal/absolute/home-expansion paths.
+    const normalizedPath = FileOperations.resolveWritePath(path);
     
     const file = app.vault.getAbstractFileByPath(normalizedPath);
     if (!file) {
@@ -134,8 +154,8 @@ export class FileOperations {
    * @throws Error if deletion fails
    */
   static async deleteFolder(app: App, path: string, recursive = false): Promise<void> {
-    // Normalize path to remove any leading slash
-    const normalizedPath = normalizePath(path);
+    // Confine to the vault: reject traversal/absolute/home-expansion paths.
+    const normalizedPath = FileOperations.resolveWritePath(path);
     
     const folder = app.vault.getAbstractFileByPath(normalizedPath);
     if (!folder) {
@@ -168,15 +188,15 @@ export class FileOperations {
     newPath: string,
     overwrite = false
   ): Promise<void> {
-    // Normalize paths to remove any leading slashes
-    const normalizedPath = normalizePath(path);
-    const normalizedNewPath = normalizePath(newPath);
-    
+    // Confine BOTH source and destination to the vault.
+    const normalizedPath = FileOperations.resolveWritePath(path);
+    const normalizedNewPath = FileOperations.resolveWritePath(newPath);
+
     const file = app.vault.getAbstractFileByPath(normalizedPath);
     if (!file) {
       throw new Error(`File not found: ${path}`);
     }
-    
+
     if (!(file instanceof TFile)) {
       throw new Error(`Path is not a file: ${path}`);
     }
@@ -215,10 +235,10 @@ export class FileOperations {
     newPath: string,
     overwrite = false
   ): Promise<void> {
-    // Normalize paths to remove any leading slashes
-    const normalizedPath = normalizePath(path);
-    const normalizedNewPath = normalizePath(newPath);
-    
+    // Confine BOTH source and destination to the vault.
+    const normalizedPath = FileOperations.resolveWritePath(path);
+    const normalizedNewPath = FileOperations.resolveWritePath(newPath);
+
     const folder = app.vault.getAbstractFileByPath(normalizedPath);
     if (!folder) {
       throw new Error(`Folder not found: ${path}`);
@@ -269,9 +289,9 @@ export class FileOperations {
     wasAutoIncremented: boolean;
     wasOverwritten: boolean;
   }> {
-    // Normalize paths to remove any leading slashes
-    const normalizedSourcePath = normalizePath(sourcePath);
-    const normalizedTargetPath = normalizePath(targetPath);
+    // Confine BOTH source and target to the vault.
+    const normalizedSourcePath = FileOperations.resolveWritePath(sourcePath);
+    const normalizedTargetPath = FileOperations.resolveWritePath(targetPath);
 
     // Check if source file exists
     const sourceFile = app.vault.getAbstractFileByPath(normalizedSourcePath);

--- a/src/core/vaultPath.ts
+++ b/src/core/vaultPath.ts
@@ -1,0 +1,172 @@
+/**
+ * vaultPath — the single containment boundary for caller-supplied vault paths.
+ *
+ * Location: src/core/vaultPath.ts
+ *
+ * ## Why this exists
+ *
+ * Obsidian's `normalizePath` collapses separators but does NOT resolve or strip
+ * `..` segments. On desktop, a `..`-bearing path handed to `vault.create()` /
+ * `adapter.write()` resolves against the vault base directory with Node's
+ * `path.join`, which follows `..` and escapes the vault entirely. A pre-existing
+ * traversal guard (`ObsidianPathManager.validatePath`) existed but was never
+ * called on the write path — every mutation used the inert leading-slash-only
+ * normalizer instead. See `docs/plans/vault-path-confinement-plan.md`.
+ *
+ * ## Design principle
+ *
+ * Make an unvalidated path un-writable by construction. The only way to obtain a
+ * {@link VaultPath} is to pass through this module. Untrusted, caller-supplied
+ * paths go through {@link resolveVaultPath} / {@link tryResolveVaultPath}, which
+ * REJECT traversal, absolute, and home-expansion paths. Trusted, code-controlled
+ * paths (event store, cache, migration internals) go through
+ * {@link vaultPathFromTrusted}, which canonicalizes but never rejects.
+ *
+ * ## Traversal check is SEGMENT-BASED, not substring-based
+ *
+ * We split on `/` and reject a segment equal to `..`. We deliberately do NOT use
+ * `includes('..')`, which would false-positive on legitimate names like
+ * `notes/a..b.md` or `foo..bar/x.md` — those MUST pass.
+ *
+ * ## Mobile-safe
+ *
+ * No Node built-ins, no heavy imports — only Obsidian's `normalizePath`. Safe to
+ * load during module init on Obsidian mobile.
+ */
+
+import { normalizePath } from 'obsidian';
+
+/**
+ * A vault-relative path that has been validated/canonicalized by this module.
+ * Branded so a raw `string` cannot be substituted for it in Phase 2 typing.
+ * Constructable ONLY via {@link resolveVaultPath}, {@link tryResolveVaultPath},
+ * or {@link vaultPathFromTrusted}.
+ */
+export type VaultPath = string & { readonly __brand: 'VaultPath' };
+
+/** Thrown by {@link resolveVaultPath} when a caller-supplied path is rejected. */
+export class VaultPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VaultPathError';
+  }
+}
+
+const brand = (path: string): VaultPath => path as VaultPath;
+
+/**
+ * True when the raw path is filesystem-absolute (and therefore not vault-relative):
+ * POSIX absolute (`/x`), Windows drive (`C:\x` / `C:/x`), or UNC / leading
+ * backslash (`\\server` / `\x`). Checked on the RAW input before `normalizePath`
+ * runs, because normalization strips the leading separator.
+ */
+function isAbsolute(raw: string): boolean {
+  return raw.startsWith('/') || /^[A-Za-z]:/.test(raw) || raw.startsWith('\\');
+}
+
+/**
+ * Non-throwing resolver for UNTRUSTED, caller-supplied paths. Returns a branded
+ * {@link VaultPath} on success or a clear, user-facing error message on failure.
+ *
+ * Rejection rules (in order):
+ *   1. Non-string or empty/whitespace-only input.
+ *   2. Absolute paths (POSIX, Windows drive, UNC / backslash).
+ *   3. A leading `~` (home directory expansion).
+ *   4. Any `..` path segment (directory traversal) — segment-based, so a name
+ *      like `a..b.md` is NOT affected.
+ *   5. Any `.` path segment (except a lone `.`/`` which means the vault root,
+ *      preserved so tools that special-case root keep working).
+ *
+ * The returned path is canonicalized (separators collapsed, empty segments and a
+ * trailing slash dropped). A lone `.`/`` resolves to `''` (vault root).
+ */
+export function tryResolveVaultPath(
+  raw: string
+): { ok: true; path: VaultPath } | { ok: false; error: string } {
+  if (typeof raw !== 'string') {
+    return { ok: false, error: 'Path must be a string.' };
+  }
+
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return { ok: false, error: 'Path cannot be empty.' };
+  }
+
+  if (isAbsolute(trimmed)) {
+    return { ok: false, error: 'Path must be relative to the vault, not absolute.' };
+  }
+
+  if (trimmed.startsWith('~')) {
+    return {
+      ok: false,
+      error: 'Path cannot start with "~". Home directory expansion is not allowed; use a vault-relative path.',
+    };
+  }
+
+  const normalized = normalizePath(trimmed);
+
+  // A lone '.' or '' means the vault root. Tools that accept a root target
+  // special-case this before calling here, but preserve it for safety.
+  if (normalized === '' || normalized === '.') {
+    return { ok: true, path: brand('') };
+  }
+
+  const out: string[] = [];
+  for (const segment of normalized.split('/')) {
+    if (segment === '') {
+      continue; // collapse leading/trailing/duplicate separators
+    }
+    if (segment === '..') {
+      return {
+        ok: false,
+        error: 'Path cannot contain ".." segments. Directory traversal outside the vault is not allowed.',
+      };
+    }
+    if (segment === '.') {
+      return { ok: false, error: 'Path cannot contain "." segments.' };
+    }
+    out.push(segment);
+  }
+
+  return { ok: true, path: brand(out.join('/')) };
+}
+
+/**
+ * Throwing resolver for UNTRUSTED, caller-supplied paths. Wraps
+ * {@link tryResolveVaultPath} and throws {@link VaultPathError} on rejection.
+ * Use at boundaries where a thrown error is caught and surfaced; prefer
+ * {@link tryResolveVaultPath} where the caller returns a `{ success, error }`
+ * result shape.
+ */
+export function resolveVaultPath(raw: string): VaultPath {
+  const result = tryResolveVaultPath(raw);
+  if (!result.ok) {
+    throw new VaultPathError(result.error);
+  }
+  return result.path;
+}
+
+/**
+ * Canonicalize a TRUSTED, code-controlled path into a {@link VaultPath} WITHOUT
+ * rejection. `.`/empty segments are dropped and `..` segments pop the prior
+ * segment (they can never climb above the root, so the result never begins with
+ * `..`). Introduced for Phase 2 typing of `VaultOperations` internals.
+ *
+ * ⚠️ Trusted callers ONLY — pass code-supplied paths (event store, cache,
+ * migration, hidden `.obsidian/...` writes), never raw LLM/agent input. Untrusted
+ * input must go through {@link tryResolveVaultPath} / {@link resolveVaultPath}.
+ */
+export function vaultPathFromTrusted(codeControlledPath: string): VaultPath {
+  const out: string[] = [];
+  for (const segment of normalizePath(codeControlledPath ?? '').split('/')) {
+    if (segment === '' || segment === '.') {
+      continue;
+    }
+    if (segment === '..') {
+      out.pop();
+      continue;
+    }
+    out.push(segment);
+  }
+  return brand(out.join('/'));
+}

--- a/src/core/vaultPath.ts
+++ b/src/core/vaultPath.ts
@@ -55,13 +55,19 @@ export class VaultPathError extends Error {
 const brand = (path: string): VaultPath => path as VaultPath;
 
 /**
- * True when the raw path is filesystem-absolute (and therefore not vault-relative):
- * POSIX absolute (`/x`), Windows drive (`C:\x` / `C:/x`), or UNC / leading
- * backslash (`\\server` / `\x`). Checked on the RAW input before `normalizePath`
- * runs, because normalization strips the leading separator.
+ * True when the raw path is filesystem-absolute in a way that is NOT vault-root
+ * relative: a Windows drive (`C:\x` / `C:/x`) or a UNC / leading backslash
+ * (`\\server` / `\x`). These are genuinely off-vault and rejected.
+ *
+ * A POSIX leading slash (`/notes/x.md`) is deliberately NOT treated as absolute:
+ * it is stripped and interpreted as vault-root-relative (the leading empty
+ * segment is dropped during the segment scan below), matching the long-standing
+ * lenient behavior and the File-Picker "strip leading slash" convention. This is
+ * safe because the real escape vector is `..`, which the segment scan still
+ * rejects (`/../x` → `..` segment → rejected).
  */
 function isAbsolute(raw: string): boolean {
-  return raw.startsWith('/') || /^[A-Za-z]:/.test(raw) || raw.startsWith('\\');
+  return /^[A-Za-z]:/.test(raw) || raw.startsWith('\\');
 }
 
 /**
@@ -70,7 +76,8 @@ function isAbsolute(raw: string): boolean {
  *
  * Rejection rules (in order):
  *   1. Non-string or empty/whitespace-only input.
- *   2. Absolute paths (POSIX, Windows drive, UNC / backslash).
+ *   2. Windows-drive / UNC / backslash-absolute paths. (A POSIX leading `/` is
+ *      NOT rejected — it is stripped to vault-root-relative; see {@link isAbsolute}.)
  *   3. A leading `~` (home directory expansion).
  *   4. Any `..` path segment (directory traversal) — segment-based, so a name
  *      like `a..b.md` is NOT affected.

--- a/tests/agents/canvasManager/canvasConfinement.test.ts
+++ b/tests/agents/canvasManager/canvasConfinement.test.ts
@@ -9,7 +9,9 @@ import { CanvasOperations } from '@/agents/canvasManager/utils/CanvasOperations'
 import { WriteCanvasTool } from '@/agents/canvasManager/tools/write';
 import { UpdateCanvasTool } from '@/agents/canvasManager/tools/update';
 
-const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+// Note: a POSIX leading slash (/tmp/ESCAPE) is intentionally NOT an escape — it
+// is stripped to a vault-relative path (backward-compat). The real vectors are ".." and "~".
+const ESCAPING = ['../../../../tmp/ESCAPE', '~/ESCAPE'];
 const emptyCanvas = { nodes: [], edges: [] };
 
 interface MockVault {

--- a/tests/agents/canvasManager/canvasConfinement.test.ts
+++ b/tests/agents/canvasManager/canvasConfinement.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Regression tests: the canvasManager write boundary confines caller paths to
+ * the vault. `../` and absolute paths must be rejected WITHOUT any vault write.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { TFile } from 'obsidian';
+import { CanvasOperations } from '@/agents/canvasManager/utils/CanvasOperations';
+import { WriteCanvasTool } from '@/agents/canvasManager/tools/write';
+import { UpdateCanvasTool } from '@/agents/canvasManager/tools/update';
+
+const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+const emptyCanvas = { nodes: [], edges: [] };
+
+interface MockVault {
+  create: jest.Mock;
+  modify: jest.Mock;
+  createFolder: jest.Mock;
+  read: jest.Mock;
+  getAbstractFileByPath: jest.Mock;
+}
+
+function makeApp(existing?: TFile): { app: any; vault: MockVault } {
+  const vault: MockVault = {
+    create: jest.fn().mockResolvedValue(new TFile()),
+    modify: jest.fn().mockResolvedValue(undefined),
+    createFolder: jest.fn().mockResolvedValue(undefined),
+    read: jest.fn().mockResolvedValue(JSON.stringify(emptyCanvas)),
+    getAbstractFileByPath: jest.fn().mockReturnValue(existing),
+  };
+  return { app: { vault }, vault };
+}
+
+describe('CanvasOperations.writeCanvas confinement', () => {
+  it.each(ESCAPING)('throws for escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    await expect(CanvasOperations.writeCanvas(app, path, emptyCanvas)).rejects.toThrow();
+    expect(vault.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a normal canvas (adds .canvas extension)', async () => {
+    const { app, vault } = makeApp();
+    await CanvasOperations.writeCanvas(app, 'diagrams/a', emptyCanvas);
+    expect(vault.create).toHaveBeenCalledWith('diagrams/a.canvas', expect.any(String));
+  });
+});
+
+describe('CanvasOperations.updateCanvas confinement', () => {
+  it.each(ESCAPING)('throws for escaping path %s with no modify', async (path) => {
+    const { app, vault } = makeApp();
+    await expect(CanvasOperations.updateCanvas(app, path, emptyCanvas)).rejects.toThrow();
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+});
+
+describe('WriteCanvasTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    const result = await new WriteCanvasTool(app).execute({ path, nodes: [], edges: [] } as any);
+    expect(result.success).toBe(false);
+    expect(vault.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a normal canvas', async () => {
+    const { app, vault } = makeApp();
+    const result = await new WriteCanvasTool(app).execute({ path: 'diagrams/a', nodes: [], edges: [] } as any);
+    expect(result.success).toBe(true);
+    expect(vault.create).toHaveBeenCalledWith('diagrams/a.canvas', expect.any(String));
+  });
+});
+
+describe('UpdateCanvasTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no modify', async (path) => {
+    const file = new TFile('a.canvas', 'diagrams/a.canvas');
+    const { app, vault } = makeApp(file);
+    const result = await new UpdateCanvasTool(app).execute({ path, nodes: [], edges: [] } as any);
+    expect(result.success).toBe(false);
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+});

--- a/tests/agents/contentManager/contentConfinement.test.ts
+++ b/tests/agents/contentManager/contentConfinement.test.ts
@@ -12,7 +12,8 @@ import { ReplaceTool } from '@/agents/contentManager/tools/replace';
 import { SetPropertyTool } from '@/agents/contentManager/tools/setProperty';
 import { ContentOperations } from '@/agents/contentManager/utils/ContentOperations';
 
-const ESCAPING = ['../../../../tmp/ESCAPE.md', '/tmp/ESCAPE.md', '~/ESCAPE.md', '..\\..\\ESCAPE.md'];
+// A POSIX leading slash (/tmp/ESCAPE.md) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE.md', '~/ESCAPE.md', '..\\..\\ESCAPE.md'];
 
 interface MockVault {
   create: jest.Mock;

--- a/tests/agents/contentManager/contentConfinement.test.ts
+++ b/tests/agents/contentManager/contentConfinement.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression tests: the contentManager write boundary confines caller paths to
+ * the vault. `../` and absolute paths must be rejected WITHOUT any vault write,
+ * while normal vault-relative writes still succeed.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { TFile } from 'obsidian';
+import { WriteTool } from '@/agents/contentManager/tools/write';
+import { InsertTool } from '@/agents/contentManager/tools/insert';
+import { ReplaceTool } from '@/agents/contentManager/tools/replace';
+import { SetPropertyTool } from '@/agents/contentManager/tools/setProperty';
+import { ContentOperations } from '@/agents/contentManager/utils/ContentOperations';
+
+const ESCAPING = ['../../../../tmp/ESCAPE.md', '/tmp/ESCAPE.md', '~/ESCAPE.md', '..\\..\\ESCAPE.md'];
+
+interface MockVault {
+  create: jest.Mock;
+  modify: jest.Mock;
+  createFolder: jest.Mock;
+  read: jest.Mock;
+  getAbstractFileByPath: jest.Mock;
+}
+
+function makeApp(existing?: TFile): { app: any; vault: MockVault; processFrontMatter: jest.Mock } {
+  const vault: MockVault = {
+    create: jest.fn().mockResolvedValue(existing ?? new TFile('a.md', 'notes/a.md')),
+    modify: jest.fn().mockResolvedValue(undefined),
+    createFolder: jest.fn().mockResolvedValue(undefined),
+    read: jest.fn().mockResolvedValue('line one\nline two\nline three'),
+    getAbstractFileByPath: jest.fn().mockReturnValue(existing),
+  };
+  const processFrontMatter = jest.fn(async (_file: unknown, mutate: (fm: Record<string, unknown>) => void) => {
+    mutate({});
+  });
+  const app = { vault, fileManager: { processFrontMatter } };
+  return { app, vault, processFrontMatter };
+}
+
+function assertNoWrites(vault: MockVault): void {
+  expect(vault.create).not.toHaveBeenCalled();
+  expect(vault.modify).not.toHaveBeenCalled();
+  expect(vault.createFolder).not.toHaveBeenCalled();
+}
+
+describe('WriteTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    const result = await new WriteTool(app).execute({ path, content: 'PWNED' } as any);
+    expect(result.success).toBe(false);
+    assertNoWrites(vault);
+  });
+
+  it('creates a normal vault-relative file', async () => {
+    const { app, vault } = makeApp();
+    const result = await new WriteTool(app).execute({ path: 'notes/a.md', content: 'hello' } as any);
+    expect(result.success).toBe(true);
+    expect(vault.create).toHaveBeenCalledWith('notes/a.md', 'hello');
+  });
+
+  it('still accepts a legit name containing ".."', async () => {
+    const { app, vault } = makeApp();
+    const result = await new WriteTool(app).execute({ path: 'notes/a..b.md', content: 'x' } as any);
+    expect(result.success).toBe(true);
+    expect(vault.create).toHaveBeenCalledWith('notes/a..b.md', 'x');
+  });
+});
+
+describe('ContentOperations.createContent confinement', () => {
+  it.each(ESCAPING)('throws for escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    await expect(ContentOperations.createContent(app, path, 'PWNED')).rejects.toThrow();
+    assertNoWrites(vault);
+  });
+
+  it('writes a normal path', async () => {
+    const { app, vault } = makeApp();
+    await ContentOperations.createContent(app, 'notes/a.md', 'hi');
+    expect(vault.create).toHaveBeenCalledWith('notes/a.md', 'hi');
+  });
+});
+
+describe('InsertTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    const result = await new InsertTool(app).execute({ path, content: 'x', startLine: 1 } as any);
+    expect(result.success).toBe(false);
+    assertNoWrites(vault);
+  });
+
+  it('inserts into a normal existing file', async () => {
+    const file = new TFile('a.md', 'notes/a.md');
+    const { app, vault } = makeApp(file);
+    const result = await new InsertTool(app).execute({ path: 'notes/a.md', content: 'x', startLine: 1 } as any);
+    expect(result.success).toBe(true);
+    expect(vault.modify).toHaveBeenCalled();
+  });
+});
+
+describe('ReplaceTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no write', async (path) => {
+    const { app, vault } = makeApp();
+    const result = await new ReplaceTool(app).execute({ path, start: 'line one', end: 'line three', content: '' } as any);
+    expect(result.success).toBe(false);
+    assertNoWrites(vault);
+  });
+
+  it('replaces a range in a normal existing file', async () => {
+    const file = new TFile('a.md', 'notes/a.md');
+    const { app, vault } = makeApp(file);
+    const result = await new ReplaceTool(app).execute({ path: 'notes/a.md', start: 'line one', end: 'line three', content: 'ONE' } as any);
+    expect(result.success).toBe(true);
+    expect(vault.modify).toHaveBeenCalled();
+  });
+});
+
+describe('SetPropertyTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no frontmatter write', async (path) => {
+    const { app, processFrontMatter } = makeApp();
+    const result = await new SetPropertyTool(app).execute({ path, property: 'tags', value: 'x' } as any);
+    expect(result.success).toBe(false);
+    expect(processFrontMatter).not.toHaveBeenCalled();
+  });
+
+  it('sets a property on a normal existing file', async () => {
+    const file = new TFile('a.md', 'notes/a.md');
+    const { app, processFrontMatter } = makeApp(file);
+    const result = await new SetPropertyTool(app).execute({ path: 'notes/a.md', property: 'tags', value: 'x' } as any);
+    expect(result.success).toBe(true);
+    expect(processFrontMatter).toHaveBeenCalled();
+  });
+});

--- a/tests/agents/elevenlabs/elevenlabsConfinement.test.ts
+++ b/tests/agents/elevenlabs/elevenlabsConfinement.test.ts
@@ -8,7 +8,8 @@
 import { __setRequestUrlMock } from 'obsidian';
 import { TextToSpeechTool } from '@/agents/apps/elevenlabs/tools/textToSpeech';
 
-const ESCAPING = ['../../../../tmp/ESCAPE.mp3', '/tmp/ESCAPE.mp3', '~/ESCAPE.mp3'];
+// A POSIX leading slash (/tmp/ESCAPE.mp3) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE.mp3', '~/ESCAPE.mp3'];
 
 function makeAgent(): { agent: any; createBinary: jest.Mock } {
   const createBinary = jest.fn().mockResolvedValue(undefined);

--- a/tests/agents/elevenlabs/elevenlabsConfinement.test.ts
+++ b/tests/agents/elevenlabs/elevenlabsConfinement.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression test: the ElevenLabs textToSpeech tool confines the caller-supplied
+ * `outputPath` to the vault. An escaping path must be rejected WITHOUT writing the
+ * audio binary. (soundEffects / musicGeneration share the identical guard.)
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { __setRequestUrlMock } from 'obsidian';
+import { TextToSpeechTool } from '@/agents/apps/elevenlabs/tools/textToSpeech';
+
+const ESCAPING = ['../../../../tmp/ESCAPE.mp3', '/tmp/ESCAPE.mp3', '~/ESCAPE.mp3'];
+
+function makeAgent(): { agent: any; createBinary: jest.Mock } {
+  const createBinary = jest.fn().mockResolvedValue(undefined);
+  const vault = {
+    getAbstractFileByPath: jest.fn().mockReturnValue(null),
+    createFolder: jest.fn().mockResolvedValue(undefined),
+    createBinary,
+  };
+  const agent = {
+    hasRequiredCredentials: () => true,
+    getMissingCredentials: () => [],
+    getCredential: () => 'api-key',
+    getDefaultModelId: () => 'eleven_multilingual_v2',
+    getVault: () => vault,
+  };
+  return { agent, createBinary };
+}
+
+beforeEach(() => {
+  __setRequestUrlMock(async () => ({
+    status: 200,
+    arrayBuffer: new ArrayBuffer(8),
+    text: '',
+    headers: {},
+    json: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any);
+});
+
+describe('TextToSpeechTool outputPath confinement', () => {
+  it.each(ESCAPING)('rejects escaping outputPath %s with no binary write', async (outputPath) => {
+    const { agent, createBinary } = makeAgent();
+    const result = await new TextToSpeechTool(agent).execute({ prompt: 'hello', outputPath } as any);
+    expect(result.success).toBe(false);
+    expect(createBinary).not.toHaveBeenCalled();
+  });
+
+  it('writes audio to a normal vault path', async () => {
+    const { agent, createBinary } = makeAgent();
+    const result = await new TextToSpeechTool(agent).execute({ prompt: 'hello', outputPath: 'audio/out.mp3' } as any);
+    expect(result.success).toBe(true);
+    expect(createBinary).toHaveBeenCalledWith('audio/out.mp3', expect.anything());
+  });
+});

--- a/tests/agents/ingestManager/ingestConfinement.test.ts
+++ b/tests/agents/ingestManager/ingestConfinement.test.ts
@@ -8,7 +8,8 @@
 
 import { processFile } from '@/agents/ingestManager/tools/services/IngestionPipelineService';
 
-const ESCAPING = ['../../../../tmp/ESCAPE.pdf', '/tmp/ESCAPE.pdf', '~/ESCAPE.pdf'];
+// A POSIX leading slash (/tmp/ESCAPE.pdf) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE.pdf', '~/ESCAPE.pdf'];
 
 function makeDeps(): { deps: any; vault: any } {
   const vault = {

--- a/tests/agents/ingestManager/ingestConfinement.test.ts
+++ b/tests/agents/ingestManager/ingestConfinement.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Regression test: the ingestion pipeline confines the caller-supplied input
+ * path to the vault. `buildOutputPath` derives the output note (and OCR asset
+ * folder) directly from `request.filePath`, so an escaping input must be rejected
+ * before any write.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { processFile } from '@/agents/ingestManager/tools/services/IngestionPipelineService';
+
+const ESCAPING = ['../../../../tmp/ESCAPE.pdf', '/tmp/ESCAPE.pdf', '~/ESCAPE.pdf'];
+
+function makeDeps(): { deps: any; vault: any } {
+  const vault = {
+    getFileByPath: jest.fn().mockReturnValue(null),
+    getFolderByPath: jest.fn().mockReturnValue(null),
+    readBinary: jest.fn(),
+    create: jest.fn(),
+    modify: jest.fn(),
+    createBinary: jest.fn(),
+    createFolder: jest.fn(),
+  };
+  const deps = { vault, ocrDeps: {}, transcriptionService: {} };
+  return { deps, vault };
+}
+
+describe('processFile input-path confinement', () => {
+  it.each(ESCAPING)('rejects escaping filePath %s with no write', async (filePath) => {
+    const { deps, vault } = makeDeps();
+    const result = await processFile({ filePath }, deps);
+    expect(result.success).toBe(false);
+    expect(vault.create).not.toHaveBeenCalled();
+    expect(vault.createBinary).not.toHaveBeenCalled();
+    expect(vault.createFolder).not.toHaveBeenCalled();
+    // The rejection is the confinement error, not a downstream "file not found".
+    expect(result.error).toMatch(/\.\.|absolute|~/);
+  });
+
+  it('a normal (non-existent) path passes confinement and fails only on file lookup', async () => {
+    const { deps } = makeDeps();
+    const result = await processFile({ filePath: 'inbox/report.pdf' }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/not found/i);
+  });
+});

--- a/tests/agents/memoryManager/workspaceConfinement.test.ts
+++ b/tests/agents/memoryManager/workspaceConfinement.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Regression tests: the memoryManager workspace tools confine the caller-supplied
+ * `rootFolder` to the vault. An escaping rootFolder must be rejected WITHOUT a
+ * vault createFolder or a workspace persist.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+const mockCreateWorkspace = jest.fn().mockResolvedValue({ id: 'ws-1', name: 'ws' });
+const mockUpdateWorkspace = jest.fn().mockResolvedValue(undefined);
+const mockGetByNameOrId = jest.fn();
+
+jest.mock('@/agents/memoryManager/services/ValidationService', () => ({
+  createServiceIntegration: () => ({
+    getWorkspaceService: async () => ({
+      success: true,
+      service: {
+        getWorkspaceByNameOrId: mockGetByNameOrId,
+        createWorkspace: mockCreateWorkspace,
+        updateWorkspace: mockUpdateWorkspace,
+      },
+    }),
+  }),
+}));
+
+import { CreateWorkspaceTool } from '@/agents/memoryManager/tools/workspaces/createWorkspace';
+import { UpdateWorkspaceTool } from '@/agents/memoryManager/tools/workspaces/updateWorkspace';
+
+const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+
+function makeAgent(): { agent: any; createFolder: jest.Mock } {
+  const createFolder = jest.fn().mockResolvedValue(undefined);
+  const app = { vault: { getAbstractFileByPath: jest.fn().mockReturnValue(null), createFolder } };
+  return { agent: { getApp: () => app }, createFolder };
+}
+
+beforeEach(() => {
+  mockCreateWorkspace.mockClear();
+  mockUpdateWorkspace.mockClear();
+  mockGetByNameOrId.mockReset();
+});
+
+describe('CreateWorkspaceTool rootFolder confinement', () => {
+  it.each(ESCAPING)('rejects escaping rootFolder %s with no createFolder/persist', async (rootFolder) => {
+    mockGetByNameOrId.mockResolvedValue(null);
+    const { agent, createFolder } = makeAgent();
+    const result = await new CreateWorkspaceTool(agent).execute({
+      name: 'ws', description: 'd', purpose: 'p', rootFolder,
+    } as any);
+    expect(result.success).toBe(false);
+    expect(createFolder).not.toHaveBeenCalled();
+    expect(mockCreateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('creates a workspace with a normal rootFolder', async () => {
+    mockGetByNameOrId.mockResolvedValue(null);
+    const { agent } = makeAgent();
+    const result = await new CreateWorkspaceTool(agent).execute({
+      name: 'ws', description: 'd', purpose: 'p', rootFolder: 'projects/ws',
+    } as any);
+    expect(result.success).toBe(true);
+    expect(mockCreateWorkspace).toHaveBeenCalledWith(expect.objectContaining({ rootFolder: 'projects/ws' }));
+  });
+
+  it('accepts the "/" root sentinel (vault root) without rejecting it as absolute', async () => {
+    mockGetByNameOrId.mockResolvedValue(null);
+    const { agent } = makeAgent();
+    const result = await new CreateWorkspaceTool(agent).execute({
+      name: 'ws', description: 'd', purpose: 'p', rootFolder: '/',
+    } as any);
+    expect(result.success).toBe(true);
+    expect(mockCreateWorkspace).toHaveBeenCalledWith(expect.objectContaining({ rootFolder: '/' }));
+  });
+});
+
+describe('UpdateWorkspaceTool rootFolder confinement', () => {
+  it.each(ESCAPING)('rejects escaping rootFolder %s with no createFolder/persist', async (rootFolder) => {
+    mockGetByNameOrId.mockResolvedValue({ id: 'ws-1', name: 'ws', context: {} });
+    const { agent, createFolder } = makeAgent();
+    const result = await new UpdateWorkspaceTool(agent).execute({ id: 'ws', rootFolder } as any);
+    expect(result.success).toBe(false);
+    expect(createFolder).not.toHaveBeenCalled();
+    expect(mockUpdateWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('updates a workspace with a normal rootFolder', async () => {
+    mockGetByNameOrId.mockResolvedValue({ id: 'ws-1', name: 'ws', context: {} });
+    const { agent } = makeAgent();
+    const result = await new UpdateWorkspaceTool(agent).execute({ id: 'ws', rootFolder: 'projects/ws' } as any);
+    expect(result.success).toBe(true);
+    expect(mockUpdateWorkspace).toHaveBeenCalledWith('ws-1', expect.objectContaining({ rootFolder: 'projects/ws' }));
+  });
+});

--- a/tests/agents/memoryManager/workspaceConfinement.test.ts
+++ b/tests/agents/memoryManager/workspaceConfinement.test.ts
@@ -25,7 +25,8 @@ jest.mock('@/agents/memoryManager/services/ValidationService', () => ({
 import { CreateWorkspaceTool } from '@/agents/memoryManager/tools/workspaces/createWorkspace';
 import { UpdateWorkspaceTool } from '@/agents/memoryManager/tools/workspaces/updateWorkspace';
 
-const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+// A POSIX leading slash (/tmp/ESCAPE) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE', '~/ESCAPE'];
 
 function makeAgent(): { agent: any; createFolder: jest.Mock } {
   const createFolder = jest.fn().mockResolvedValue(undefined);

--- a/tests/agents/storageManager/storageConfinement.test.ts
+++ b/tests/agents/storageManager/storageConfinement.test.ts
@@ -11,7 +11,8 @@ import { FileOperations } from '@/agents/storageManager/utils/FileOperations';
 import { CreateFolderTool } from '@/agents/storageManager/tools/createFolder';
 import { MoveTool } from '@/agents/storageManager/tools/move';
 
-const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE', '..\\..\\ESCAPE'];
+// A POSIX leading slash (/tmp/ESCAPE) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE', '~/ESCAPE', '..\\..\\ESCAPE'];
 
 interface MockVault {
   create: jest.Mock;
@@ -74,7 +75,7 @@ describe('FileOperations.duplicateNote confinement (source AND target)', () => {
     const source = new TFile('a.md', 'notes/a.md');
     const { app, vault } = makeApp({ 'notes/a.md': source });
     await expect(
-      FileOperations.duplicateNote(app, 'notes/a.md', '/tmp/ESCAPE.md', false, false)
+      FileOperations.duplicateNote(app, 'notes/a.md', '../../../../tmp/ESCAPE.md', false, false)
     ).rejects.toThrow();
     expect(vault.create).not.toHaveBeenCalled();
   });

--- a/tests/agents/storageManager/storageConfinement.test.ts
+++ b/tests/agents/storageManager/storageConfinement.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression tests: the storageManager write boundary confines caller paths to
+ * the vault. `../` and absolute paths must be rejected WITHOUT any vault mutation
+ * (create/createFolder/rename), while normal operations still succeed. Move/copy
+ * validate BOTH source and target.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { TFile } from 'obsidian';
+import { FileOperations } from '@/agents/storageManager/utils/FileOperations';
+import { CreateFolderTool } from '@/agents/storageManager/tools/createFolder';
+import { MoveTool } from '@/agents/storageManager/tools/move';
+
+const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE', '..\\..\\ESCAPE'];
+
+interface MockVault {
+  create: jest.Mock;
+  createFolder: jest.Mock;
+  getAbstractFileByPath: jest.Mock;
+  read: jest.Mock;
+}
+
+function makeApp(files: Record<string, TFile> = {}): { app: any; vault: MockVault; renameFile: jest.Mock; trashFile: jest.Mock } {
+  const vault: MockVault = {
+    create: jest.fn().mockResolvedValue(new TFile()),
+    createFolder: jest.fn().mockResolvedValue(undefined),
+    getAbstractFileByPath: jest.fn((p: string) => files[p] ?? null),
+    read: jest.fn().mockResolvedValue('body'),
+  };
+  const renameFile = jest.fn().mockResolvedValue(undefined);
+  const trashFile = jest.fn().mockResolvedValue(undefined);
+  const app = { vault, fileManager: { renameFile, trashFile } };
+  return { app, vault, renameFile, trashFile };
+}
+
+describe('FileOperations.createFolder confinement', () => {
+  it.each(ESCAPING)('throws for escaping path %s with no createFolder', async (path) => {
+    const { app, vault } = makeApp();
+    await expect(FileOperations.createFolder(app, path)).rejects.toThrow();
+    expect(vault.createFolder).not.toHaveBeenCalled();
+  });
+
+  it('creates a normal folder', async () => {
+    const { app, vault } = makeApp();
+    await FileOperations.createFolder(app, 'projects/2024');
+    expect(vault.createFolder).toHaveBeenCalledWith('projects/2024');
+  });
+});
+
+describe('FileOperations.moveNote confinement (source AND target)', () => {
+  it('rejects an escaping TARGET with a valid source and never renames', async () => {
+    const source = new TFile('a.md', 'notes/a.md');
+    const { app, renameFile } = makeApp({ 'notes/a.md': source });
+    await expect(FileOperations.moveNote(app, 'notes/a.md', '../../../../tmp/ESCAPE.md')).rejects.toThrow();
+    expect(renameFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects an escaping SOURCE and never renames', async () => {
+    const { app, renameFile } = makeApp();
+    await expect(FileOperations.moveNote(app, '../../../../tmp/ESCAPE.md', 'notes/b.md')).rejects.toThrow();
+    expect(renameFile).not.toHaveBeenCalled();
+  });
+
+  it('moves a normal file', async () => {
+    const source = new TFile('a.md', 'notes/a.md');
+    const { app, renameFile } = makeApp({ 'notes/a.md': source });
+    await FileOperations.moveNote(app, 'notes/a.md', 'archive/a.md');
+    expect(renameFile).toHaveBeenCalledWith(source, 'archive/a.md');
+  });
+});
+
+describe('FileOperations.duplicateNote confinement (source AND target)', () => {
+  it('rejects an escaping TARGET and never creates', async () => {
+    const source = new TFile('a.md', 'notes/a.md');
+    const { app, vault } = makeApp({ 'notes/a.md': source });
+    await expect(
+      FileOperations.duplicateNote(app, 'notes/a.md', '/tmp/ESCAPE.md', false, false)
+    ).rejects.toThrow();
+    expect(vault.create).not.toHaveBeenCalled();
+  });
+});
+
+describe('CreateFolderTool confinement', () => {
+  it.each(ESCAPING)('rejects escaping path %s with no createFolder', async (path) => {
+    const { app, vault } = makeApp();
+    const result = await new CreateFolderTool(app).execute({ path } as any);
+    expect(result.success).toBe(false);
+    expect(vault.createFolder).not.toHaveBeenCalled();
+  });
+
+  it('creates a normal folder', async () => {
+    const { app, vault } = makeApp();
+    const result = await new CreateFolderTool(app).execute({ path: 'projects/new' } as any);
+    expect(result.success).toBe(true);
+    expect(vault.createFolder).toHaveBeenCalledWith('projects/new');
+  });
+});
+
+describe('MoveTool confinement', () => {
+  it('rejects an escaping TARGET (valid source) and never renames', async () => {
+    const source = new TFile('a.md', 'notes/a.md');
+    const { app, renameFile } = makeApp({ 'notes/a.md': source });
+    const result = await new MoveTool(app).execute({ path: 'notes/a.md', newPath: '../../../../tmp/ESCAPE.md' } as any);
+    expect(result.success).toBe(false);
+    expect(renameFile).not.toHaveBeenCalled();
+  });
+
+  it('moves a normal file', async () => {
+    const source = new TFile('a.md', 'notes/a.md');
+    const { app, renameFile } = makeApp({ 'notes/a.md': source });
+    const result = await new MoveTool(app).execute({ path: 'notes/a.md', newPath: 'archive/a.md' } as any);
+    expect(result.success).toBe(true);
+    expect(renameFile).toHaveBeenCalledWith(source, 'archive/a.md');
+  });
+});

--- a/tests/agents/webTools/webToolsConfinement.test.ts
+++ b/tests/agents/webTools/webToolsConfinement.test.ts
@@ -7,7 +7,8 @@
 
 import { resolveUniqueFilePath, resolveUniqueMarkdownPath } from '@/agents/apps/webTools/utils/webViewer';
 
-const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+// A POSIX leading slash (/tmp/ESCAPE) is stripped to vault-relative (backward-compat), not an escape.
+const ESCAPING = ['../../../../tmp/ESCAPE', '~/ESCAPE'];
 
 function makeVault(): any {
   return { getAbstractFileByPath: jest.fn().mockReturnValue(null) };

--- a/tests/agents/webTools/webToolsConfinement.test.ts
+++ b/tests/agents/webTools/webToolsConfinement.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Regression tests: the webTools capture boundary confines the caller-supplied
+ * outputPath to the vault. `resolveUniqueFilePath` is the shared chokepoint for
+ * capturePagePdf / capturePagePng / captureToMarkdown.
+ * See docs/plans/vault-path-confinement-plan.md.
+ */
+
+import { resolveUniqueFilePath, resolveUniqueMarkdownPath } from '@/agents/apps/webTools/utils/webViewer';
+
+const ESCAPING = ['../../../../tmp/ESCAPE', '/tmp/ESCAPE', '~/ESCAPE'];
+
+function makeVault(): any {
+  return { getAbstractFileByPath: jest.fn().mockReturnValue(null) };
+}
+
+describe('resolveUniqueFilePath confinement', () => {
+  it.each(ESCAPING)('throws for escaping outputPath %s', (outputPath) => {
+    expect(() => resolveUniqueFilePath(makeVault(), outputPath, 'pdf')).toThrow();
+  });
+
+  it('returns a confined path for a normal outputPath', () => {
+    expect(resolveUniqueFilePath(makeVault(), 'captures/page', 'pdf')).toBe('captures/page.pdf');
+  });
+
+  it('markdown variant is also confined', () => {
+    expect(() => resolveUniqueMarkdownPath(makeVault(), '../../ESCAPE')).toThrow();
+    expect(resolveUniqueMarkdownPath(makeVault(), 'captures/page')).toBe('captures/page.md');
+  });
+});

--- a/tests/core/vaultPath.test.ts
+++ b/tests/core/vaultPath.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the vault-path confinement resolver.
+ * See src/core/vaultPath.ts and docs/plans/vault-path-confinement-plan.md.
+ */
+
+import {
+  tryResolveVaultPath,
+  resolveVaultPath,
+  vaultPathFromTrusted,
+  VaultPathError,
+} from '@/core/vaultPath';
+
+describe('vaultPath resolver — rejects escaping paths', () => {
+  const escaping: Array<[string, string]> = [
+    ['.. alone', '..'],
+    ['../ at start', '../secrets.md'],
+    ['../../ climb', '../../etc/passwd'],
+    ['.. in the middle', 'notes/../../tmp/x.md'],
+    ['.. at the end', 'notes/..'],
+    ['deep traversal', 'a/b/c/../../../../../tmp/x.md'],
+    ['leading ~', '~/escape.md'],
+    ['bare ~', '~'],
+    ['~user home', '~alice/notes.md'],
+    ['POSIX absolute', '/tmp/ESCAPE.md'],
+    ['POSIX absolute to home', '/Users/someone/ESCAPE.md'],
+    ['Windows drive backslash', 'C:\\Windows\\x.md'],
+    ['Windows drive forward slash', 'C:/Windows/x.md'],
+    ['UNC path', '\\\\server\\share\\x.md'],
+    ['leading backslash', '\\x.md'],
+    ['backslash traversal', 'a\\..\\..\\b.md'],
+    ['dot segment in middle', 'notes/./secret.md'],
+  ];
+
+  it.each(escaping)('rejects %s (%s)', (_label, input) => {
+    const result = tryResolveVaultPath(input);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(typeof result.error).toBe('string');
+      expect(result.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('rejects non-string and empty/whitespace input', () => {
+    // @ts-expect-error — exercising the runtime guard for non-string input
+    expect(tryResolveVaultPath(null).ok).toBe(false);
+    // @ts-expect-error — exercising the runtime guard for non-string input
+    expect(tryResolveVaultPath(42).ok).toBe(false);
+    expect(tryResolveVaultPath('').ok).toBe(false);
+    expect(tryResolveVaultPath('   ').ok).toBe(false);
+  });
+
+  it('gives a traversal-specific error for ".." and an absolute error for "/x"', () => {
+    const trav = tryResolveVaultPath('../x.md');
+    const abs = tryResolveVaultPath('/x.md');
+    expect(trav.ok).toBe(false);
+    expect(abs.ok).toBe(false);
+    if (!trav.ok) expect(trav.error).toMatch(/\.\./);
+    if (!abs.ok) expect(abs.error).toMatch(/absolute/i);
+  });
+});
+
+describe('vaultPath resolver — accepts legitimate vault paths (no false positives)', () => {
+  const valid: Array<[string, string]> = [
+    ['simple note', 'notes/a.md', 'notes/a.md'],
+    ['name containing double dots', 'notes/a..b.md', 'notes/a..b.md'],
+    ['dotted filename', 'a.b.md', 'a.b.md'],
+    ['folder with double dots', 'foo..bar/x.md', 'foo..bar/x.md'],
+    ['nested Nexus data', 'Nexus/data/x.md', 'Nexus/data/x.md'],
+    ['deep nesting', 'a/b/c/d/e.md', 'a/b/c/d/e.md'],
+    ['collapses duplicate slashes', 'a//b.md', 'a/b.md'],
+    ['strips trailing slash', 'folder/', 'folder'],
+    ['double dots as whole name', '..foo.md', '..foo.md'],
+    ['trailing double-dot name', 'a/b..', 'a/b..'],
+  ];
+
+  it.each(valid)('accepts %s and canonicalizes to %s', (_label, input, expected) => {
+    const result = tryResolveVaultPath(input);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(String(result.path)).toBe(expected);
+    }
+  });
+
+  it('treats a lone "." as the vault root', () => {
+    const result = tryResolveVaultPath('.');
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(String(result.path)).toBe('');
+  });
+});
+
+describe('resolveVaultPath (throwing variant)', () => {
+  it('throws VaultPathError on traversal', () => {
+    expect(() => resolveVaultPath('../x.md')).toThrow(VaultPathError);
+  });
+
+  it('returns the confined path for a valid input', () => {
+    expect(String(resolveVaultPath('notes/a..b.md'))).toBe('notes/a..b.md');
+  });
+});
+
+describe('vaultPathFromTrusted (canonicalize-only, no rejection)', () => {
+  it('folds away "." and empty segments', () => {
+    expect(String(vaultPathFromTrusted('a/./b//c'))).toBe('a/b/c');
+  });
+
+  it('pops ".." segments and never begins with ".."', () => {
+    expect(String(vaultPathFromTrusted('a/b/../c'))).toBe('a/c');
+    expect(String(vaultPathFromTrusted('../../a'))).toBe('a');
+    expect(String(vaultPathFromTrusted('..'))).toBe('');
+  });
+
+  it('handles empty / nullish input without throwing', () => {
+    expect(String(vaultPathFromTrusted(''))).toBe('');
+    // @ts-expect-error — defensive nullish handling
+    expect(String(vaultPathFromTrusted(undefined))).toBe('');
+  });
+});

--- a/tests/core/vaultPath.test.ts
+++ b/tests/core/vaultPath.test.ts
@@ -21,8 +21,6 @@ describe('vaultPath resolver — rejects escaping paths', () => {
     ['leading ~', '~/escape.md'],
     ['bare ~', '~'],
     ['~user home', '~alice/notes.md'],
-    ['POSIX absolute', '/tmp/ESCAPE.md'],
-    ['POSIX absolute to home', '/Users/someone/ESCAPE.md'],
     ['Windows drive backslash', 'C:\\Windows\\x.md'],
     ['Windows drive forward slash', 'C:/Windows/x.md'],
     ['UNC path', '\\\\server\\share\\x.md'],
@@ -49,13 +47,23 @@ describe('vaultPath resolver — rejects escaping paths', () => {
     expect(tryResolveVaultPath('   ').ok).toBe(false);
   });
 
-  it('gives a traversal-specific error for ".." and an absolute error for "/x"', () => {
+  it('gives a traversal-specific error for ".." but a Windows-drive error for "C:\\x"', () => {
     const trav = tryResolveVaultPath('../x.md');
-    const abs = tryResolveVaultPath('/x.md');
+    const drive = tryResolveVaultPath('C:\\x.md');
     expect(trav.ok).toBe(false);
-    expect(abs.ok).toBe(false);
+    expect(drive.ok).toBe(false);
     if (!trav.ok) expect(trav.error).toMatch(/\.\./);
-    if (!abs.ok) expect(abs.error).toMatch(/absolute/i);
+    if (!drive.ok) expect(drive.error).toMatch(/absolute/i);
+  });
+
+  it('strips a POSIX leading slash to a vault-relative path (backward-compat, still confined)', () => {
+    // Leading "/" never escaped the vault (it resolves inside it); preserve the
+    // long-standing lenient behavior. The real escape vector ".." stays rejected.
+    expect(tryResolveVaultPath('/notes/x.md')).toEqual({ ok: true, path: 'notes/x.md' });
+    expect(tryResolveVaultPath('/tmp/ESCAPE.md')).toEqual({ ok: true, path: 'tmp/ESCAPE.md' });
+    expect(tryResolveVaultPath('/Users/someone/x.md')).toEqual({ ok: true, path: 'Users/someone/x.md' });
+    // ...but a leading slash followed by traversal is still rejected.
+    expect(tryResolveVaultPath('/../escape.md').ok).toBe(false);
   });
 });
 

--- a/tests/unit/ReplaceTool.test.ts
+++ b/tests/unit/ReplaceTool.test.ts
@@ -823,12 +823,12 @@ describe('ReplaceTool (pattern anchors)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Adversarial: leading-slash (absolute) path is now REJECTED
-  //   Vault-path confinement (docs/plans/vault-path-confinement-plan.md) rejects
-  //   absolute paths at the untrusted tool boundary instead of silently stripping
-  //   the leading '/'. The tool must return a rejection and never touch the vault.
+  // Adversarial: leading-slash path is normalized
+  //   replace.ts strips a leading '/' before resolving the path; confirm this
+  //   doesn't accidentally produce a "File not found" when callers send
+  //   absolute-style paths.
   // ---------------------------------------------------------------------------
-  it('adversarial: leading-slash (absolute) path is rejected without a write', async () => {
+  it('adversarial: leading-slash path is normalized and resolves to the file', async () => {
     mockFileContent = 'alpha\nbeta\ngamma';
     const result = await tool.execute({
       ...baseParams,
@@ -838,9 +838,11 @@ describe('ReplaceTool (pattern anchors)', () => {
       content: 'B',
     });
 
-    expect(result.success).toBe(false);
-    expect(mockFileContent).toBe('alpha\nbeta\ngamma'); // unchanged
-    expect(app.vault.modify).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('test/note.md');
+    expect(mockFileContent).toBe('alpha\nB\ngamma');
+    expect(app.vault.modify).toHaveBeenCalledTimes(1);
+    expect(app.vault.modify).toHaveBeenCalledWith(mockFile, 'alpha\nB\ngamma');
   });
 
   // ---------------------------------------------------------------------------

--- a/tests/unit/ReplaceTool.test.ts
+++ b/tests/unit/ReplaceTool.test.ts
@@ -823,12 +823,12 @@ describe('ReplaceTool (pattern anchors)', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Adversarial: leading-slash path is normalized
-  //   replace.ts strips a leading '/' before resolving the path; confirm this
-  //   doesn't accidentally produce a "File not found" when callers send
-  //   absolute-style paths.
+  // Adversarial: leading-slash (absolute) path is now REJECTED
+  //   Vault-path confinement (docs/plans/vault-path-confinement-plan.md) rejects
+  //   absolute paths at the untrusted tool boundary instead of silently stripping
+  //   the leading '/'. The tool must return a rejection and never touch the vault.
   // ---------------------------------------------------------------------------
-  it('adversarial: leading-slash path is normalized and resolves to the file', async () => {
+  it('adversarial: leading-slash (absolute) path is rejected without a write', async () => {
     mockFileContent = 'alpha\nbeta\ngamma';
     const result = await tool.execute({
       ...baseParams,
@@ -838,11 +838,9 @@ describe('ReplaceTool (pattern anchors)', () => {
       content: 'B',
     });
 
-    expect(result.success).toBe(true);
-    expect(app.vault.getAbstractFileByPath).toHaveBeenCalledWith('test/note.md');
-    expect(mockFileContent).toBe('alpha\nB\ngamma');
-    expect(app.vault.modify).toHaveBeenCalledTimes(1);
-    expect(app.vault.modify).toHaveBeenCalledWith(mockFile, 'alpha\nB\ngamma');
+    expect(result.success).toBe(false);
+    expect(mockFileContent).toBe('alpha\nbeta\ngamma'); // unchanged
+    expect(app.vault.modify).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes an **arbitrary file write / mkdir outside the vault** reachable by any caller of `toolManager_useTools` — both the new local CLI and the **existing Claude Desktop MCP connector**. A caller-supplied `--path` (or `outputPath`/`rootFolder`) with `..` segments escaped the vault:

```
content write --path ../../../../tmp/x.md --content PWNED   → wrote a real file to /tmp
storage createFolder --path ../../..                        → made a dir outside the vault
```

Found while red-teaming the local CLI bridge; the CLI only *surfaced* a pre-existing core bug.

## Root cause

Not a missing check — the traversal guard **existed** (`ObsidianPathManager.validatePath` rejects `..`/`~`/absolute) but was **never called on the write path**. Every mutation used an inert leading-slash-only normalizer that doesn't collapse `..`. Validation and normalization were two separate methods; the write path only ran the one that doesn't protect anything. (Reads looked safe only by accident — they go through the in-memory index, which returns null for out-of-vault paths.)

Full analysis: `docs/plans/vault-path-confinement-plan.md`.

## The fix (Phase 1 of 3)

New `src/core/vaultPath.ts` — a single containment boundary:
- **branded `VaultPath`**, constructable only through this module
- `resolveVaultPath` / `tryResolveVaultPath` (untrusted): reject non-string/empty, Windows-drive/UNC/backslash absolute, leading `~`, and any `..`/`.` **path segment**. The traversal check is **segment-based**, so legit names like `notes/a..b.md` still pass.
- `vaultPathFromTrusted` (canonicalize-only) — introduced for Phase 2 internals
- mobile-safe (only imports Obsidian `normalizePath`)

Wired at **every untrusted write boundary** (per a full call-site recon): content (`write`/`insert`/`replace`/`setProperty` + `ContentOperations`), storage (`FileOperations` create/delete/move/copy — both source and target — + `createFolder`), canvas, memory-manager workspace `rootFolder`, elevenlabs `outputPath`, webTools `resolveUniqueFilePath`, and ingest (input + derived output/OCR).

**Leading-slash behavior (deliberate):** a POSIX `/notes/x.md` is *stripped* to vault-relative (it never escaped), preserving backward-compat and the repo's File-Picker convention. Only the real vectors (`..`, `~`, `C:\`, `\\`) are rejected.

## Scope / non-goals

- `VaultOperations` signatures are unchanged here (**Phase 2** types them to `VaultPath`).
- No eslint arch-guard yet (**Phase 3** — draft + allowlist already prepared).
- ~22 already-guarded sites (composer/runPython/video/audio/readAloud/ImageFileManager use `isValidPath`) are over-rejecting-but-secure today; migrating them to the shared resolver is Phase 2.

## Verification

- Full `npm run build` green (lint + TS6 + esbuild + connector)
- Full suite **3934 passed / 21 skipped / 0 failed** (+~130 new tests: resolver + per-boundary confinement, each asserting rejection **and** that the vault mutation API is never called)
- **Live-verified in Obsidian**: the exact escapes above are now rejected with no file on disk; normal and leading-slash writes still succeed in-vault

## Note on merge order

This is independent of the local CLI feature PR (no file overlap) but should land **first** — it hardens the existing MCP connector and the CLI both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01436Lor1dV4kevTHyCtjk6B