### PR TITLE
feat(getstarted): provider-picker for nexus CLI (Claude Code, Cursor, Codex)

### DIFF
--- a/src/services/cli/LocalCliInstaller.ts
+++ b/src/services/cli/LocalCliInstaller.ts
@@ -26,10 +26,17 @@ type PathModule = typeof import('node:path');
 const AGENTS_BEGIN = '<!-- BEGIN nexus-cli (managed by Nexus plugin) -->';
 const AGENTS_END = '<!-- END nexus-cli -->';
 
+/** The agent providers the CLI can wire into. */
+export type CliProviderId = 'claudeCode' | 'cursor' | 'codex';
+
 export interface DetectedAgents {
     claudeCode: boolean;
     codex: boolean;
+    cursor: boolean;
 }
+
+/** Which providers to wire the CLI skill/pointer into (defaults to whatever is detected). */
+export type CliInstallTargets = Record<CliProviderId, boolean>;
 
 export interface CliInstallPaths {
     dataDir: string;
@@ -40,6 +47,7 @@ export interface CliInstallPaths {
     binDir: string;
     binPath: string;
     claudeSkillLink: string;
+    cursorSkillLink: string;
     codexAgentsPath: string;
 }
 
@@ -49,6 +57,7 @@ export interface CliInstallStatus {
     onPath: boolean;
     stale: boolean;
     skillLinked: boolean;
+    cursorLinked: boolean;
     codexLinked: boolean;
     detected: DetectedAgents;
     paths: CliInstallPaths;
@@ -87,6 +96,7 @@ export class LocalCliInstaller {
             binDir,
             binPath: path.join(binDir, Platform.isWin ? 'nexus.cmd' : 'nexus'),
             claudeSkillLink: path.join(home, '.claude', 'skills', 'nexus'),
+            cursorSkillLink: path.join(home, '.cursor', 'skills', 'nexus'),
             codexAgentsPath: path.join(home, '.codex', 'AGENTS.md'),
         };
     }
@@ -98,15 +108,21 @@ export class LocalCliInstaller {
         return {
             claudeCode: fs.existsSync(path.join(home, '.claude')),
             codex: fs.existsSync(path.join(home, '.codex')),
+            cursor: fs.existsSync(path.join(home, '.cursor')),
         };
+    }
+
+    /** The skill-symlink location for a skill-based provider (Claude Code, Cursor). */
+    private skillLinkFor(id: 'claudeCode' | 'cursor', paths: CliInstallPaths): string {
+        return id === 'cursor' ? paths.cursorSkillLink : paths.claudeSkillLink;
     }
 
     status(): CliInstallStatus {
         if (!this.isSupported()) {
             return {
                 supported: false, installed: false, onPath: false, stale: false,
-                skillLinked: false, codexLinked: false,
-                detected: { claudeCode: false, codex: false },
+                skillLinked: false, cursorLinked: false, codexLinked: false,
+                detected: { claudeCode: false, codex: false, cursor: false },
                 paths: {} as CliInstallPaths,
             };
         }
@@ -128,34 +144,48 @@ export class LocalCliInstaller {
             onPath: this.pointsTo(paths.binPath, paths.cliJsPath),
             stale,
             skillLinked: this.pointsTo(paths.claudeSkillLink, paths.skillDir),
+            cursorLinked: this.pointsTo(paths.cursorSkillLink, paths.skillDir),
             codexLinked: this.hasCodexBlock(paths.codexAgentsPath),
             detected: this.detectAgents(),
             paths,
         };
     }
 
+    /** Default install targets: wire whatever is detected on the machine. */
+    private defaultTargets(): CliInstallTargets {
+        const d = this.detectAgents();
+        return { claudeCode: d.claudeCode, codex: d.codex, cursor: d.cursor };
+    }
+
     /** Human-readable list of exactly what enable() will create, for disclosure before acting. */
-    describePlan(): string[] {
+    describePlan(targets?: Partial<CliInstallTargets>): string[] {
         if (!this.isSupported()) return ['Local CLI install requires desktop.'];
         const paths = this.getPaths();
-        const detected = this.detectAgents();
+        const t = { ...this.defaultTargets(), ...targets };
         const lines = [
             `CLI binary: ${paths.cliJsPath}`,
             `On PATH:    ${paths.binPath} → nexus-cli.js`,
         ];
-        if (detected.claudeCode) lines.push(`Claude Code skill: ${paths.claudeSkillLink} → ${paths.skillDir}`);
-        if (detected.codex) lines.push(`Codex pointer: appended to ${paths.codexAgentsPath}`);
-        if (!detected.claudeCode && !detected.codex) {
-            lines.push('No Claude Code (~/.claude) or Codex (~/.codex) detected — only the CLI will be installed.');
+        if (t.claudeCode) lines.push(`Claude Code skill: ${paths.claudeSkillLink} → ${paths.skillDir}`);
+        if (t.cursor) lines.push(`Cursor skill: ${paths.cursorSkillLink} → ${paths.skillDir}`);
+        if (t.codex) lines.push(`Codex pointer: appended to ${paths.codexAgentsPath}`);
+        if (!t.claudeCode && !t.cursor && !t.codex) {
+            lines.push('No agent provider selected — only the nexus command will be installed.');
         }
         return lines;
     }
 
-    enable(): CliInstallResult {
+    /**
+     * Install the `nexus` command and wire it into the selected agent providers.
+     * `targets` defaults to whatever is detected on the machine; pass an explicit
+     * selection (from the Get Started picker) to override per provider.
+     */
+    enable(targets?: Partial<CliInstallTargets>): CliInstallResult {
         if (!this.isSupported()) throw new Error('Local CLI install is desktop-only.');
         const fs = this.fs();
         const paths = this.getPaths();
         const detected = this.detectAgents();
+        const t = { ...this.defaultTargets(), ...targets };
         const created: string[] = [];
         const warnings: string[] = [];
 
@@ -186,24 +216,66 @@ export class LocalCliInstaller {
             }
         }
 
-        // 4. Claude Code skill
-        if (detected.claudeCode) {
-            fs.mkdirSync(this.path().dirname(paths.claudeSkillLink), { recursive: true });
-            if (Platform.isWin) {
-                this.copyDir(paths.skillDir, paths.claudeSkillLink);
-                created.push(paths.claudeSkillLink);
-            } else if (this.linkReplace(paths.claudeSkillLink, paths.skillDir, warnings)) {
-                created.push(paths.claudeSkillLink);
-            }
-        }
+        // 4. Skill-based providers (Claude Code, Cursor) — same skills mechanism,
+        //    just different link locations. Both read the same skill dir.
+        if (t.claudeCode) this.wireSkillLink(paths.claudeSkillLink, paths, created, warnings);
+        if (t.cursor) this.wireSkillLink(paths.cursorSkillLink, paths, created, warnings);
 
-        // 5. Codex pointer
-        if (detected.codex) {
+        // 5. Codex pointer (AGENTS.md block).
+        if (t.codex) {
             this.writeCodexBlock(paths.codexAgentsPath);
             created.push(paths.codexAgentsPath);
         }
 
         return { created, warnings, detected };
+    }
+
+    /**
+     * Wire or unwire the CLI into a single provider after the CLI is installed
+     * (from the Get Started provider checkboxes). No-op with a warning if the CLI
+     * binary isn't installed yet.
+     */
+    setProvider(id: CliProviderId, enabled: boolean): CliInstallResult {
+        if (!this.isSupported()) throw new Error('Local CLI install is desktop-only.');
+        const fs = this.fs();
+        const paths = this.getPaths();
+        const created: string[] = [];
+        const warnings: string[] = [];
+        if (!fs.existsSync(paths.cliJsPath)) {
+            warnings.push('Install the CLI first, then choose providers.');
+            return { created, warnings, detected: this.detectAgents() };
+        }
+        if (id === 'codex') {
+            if (enabled) { this.writeCodexBlock(paths.codexAgentsPath); created.push(paths.codexAgentsPath); }
+            else this.removeCodexBlock(paths.codexAgentsPath);
+        } else {
+            const link = this.skillLinkFor(id, paths);
+            if (enabled) this.wireSkillLink(link, paths, created, warnings);
+            else this.unwireSkillLink(link, created, warnings);
+        }
+        return { created, warnings, detected: this.detectAgents() };
+    }
+
+    /** Create the skill symlink (or copy on Windows) at `link` → skillDir. */
+    private wireSkillLink(link: string, paths: CliInstallPaths, created: string[], warnings: string[]): void {
+        this.fs().mkdirSync(this.path().dirname(link), { recursive: true });
+        if (Platform.isWin) {
+            this.copyDir(paths.skillDir, link);
+            created.push(link);
+        } else if (this.linkReplace(link, paths.skillDir, warnings)) {
+            created.push(link);
+        }
+    }
+
+    /** Remove a skill link we own (symlink, or copied dir on Windows). */
+    private unwireSkillLink(link: string, created: string[], warnings: string[]): void {
+        const fs = this.fs();
+        try {
+            if (this.pointsTo(link, this.getPaths().skillDir) || this.isOurSymlink(link) || (Platform.isWin && fs.existsSync(link))) {
+                fs.rmSync(link, { recursive: true, force: true });
+                created.push(link);
+            }
+        } catch (e) { warnings.push(`Could not remove ${link}: ${(e as Error).message}`); }
     }
 
     uninstall(): CliInstallResult {
@@ -217,6 +289,7 @@ export class LocalCliInstaller {
         for (const [link, target] of [
             [paths.binPath, paths.cliJsPath] as const,
             [paths.claudeSkillLink, paths.skillDir] as const,
+            [paths.cursorSkillLink, paths.skillDir] as const,
         ]) {
             if (this.pointsTo(link, target) || this.isOurSymlink(link)) {
                 try { fs.rmSync(link, { recursive: true, force: true }); created.push(link); }
@@ -225,7 +298,7 @@ export class LocalCliInstaller {
         }
         // Windows shim / copied skill are real files — remove by path if present.
         if (Platform.isWin) {
-            for (const p of [paths.binPath, paths.claudeSkillLink]) {
+            for (const p of [paths.binPath, paths.claudeSkillLink, paths.cursorSkillLink]) {
                 try { if (fs.existsSync(p)) { fs.rmSync(p, { recursive: true, force: true }); created.push(p); } } catch { /* ignore */ }
             }
         }

--- a/src/settings/tabs/GetStartedTab.ts
+++ b/src/settings/tabs/GetStartedTab.ts
@@ -15,7 +15,7 @@ import { getPrimaryServerKey } from '../../constants/branding';
 import { ConfigStatus, getClaudeDesktopConfigPath, getConfigStatus } from '../getStartedStatus';
 import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
 import { CONNECTOR_JS_CONTENT } from '../../utils/connectorContent';
-import { LocalCliInstaller } from '../../services/cli/LocalCliInstaller';
+import { LocalCliInstaller, CliProviderId, CliInstallTargets } from '../../services/cli/LocalCliInstaller';
 import {
     appendCodexMcpTomlSnippet,
     buildCodexMcpTomlSnippet,
@@ -648,10 +648,54 @@ export class GetStartedTab {
         row.createSpan({ text: statusText, cls: 'nexus-mcp-status' });
 
         const actions = row.createDiv('nexus-mcp-actions');
+
+        // Provider picker — which agents to wire the nexus CLI into. Claude Code and
+        // Cursor use the same skills mechanism (a symlink into their skills dir);
+        // Codex gets an AGENTS.md pointer block.
+        const providers: Array<{ id: CliProviderId; label: string; hint: string }> = [
+            { id: 'claudeCode', label: 'Claude Code', hint: '~/.claude/skills' },
+            { id: 'cursor', label: 'Cursor', hint: '~/.cursor/skills' },
+            { id: 'codex', label: 'Codex', hint: '~/.codex/AGENTS.md' },
+        ];
+        const isLinked = (id: CliProviderId): boolean =>
+            id === 'claudeCode' ? status.skillLinked
+                : id === 'cursor' ? status.cursorLinked
+                    : status.codexLinked;
+
+        const picker = block.createDiv('nexus-cli-providers');
+        picker.createEl('p', {
+            text: status.installed
+                ? 'Wire the nexus CLI into these agents — toggle any time:'
+                : 'Choose which agents to wire the nexus CLI into:',
+            cls: 'setting-item-description'
+        });
+        const checkboxes = new Map<CliProviderId, HTMLInputElement>();
+        for (const prov of providers) {
+            const detectedHere = status.detected[prov.id];
+            const rowEl = picker.createDiv('nexus-cli-provider-row');
+            const cb = rowEl.createEl('input', { attr: { type: 'checkbox' } });
+            cb.checked = status.installed ? isLinked(prov.id) : detectedHere;
+            const label = rowEl.createEl('label');
+            label.createSpan({ text: prov.label });
+            label.createSpan({
+                text: detectedHere ? ` — ${prov.hint}` : ` — ${prov.hint} (not detected)`,
+                cls: 'nexus-cli-provider-hint'
+            });
+            checkboxes.set(prov.id, cb);
+            if (status.installed && component) {
+                // Post-install: each toggle wires/unwires that provider immediately.
+                component.registerDomEvent(cb, 'change', () => this.setCliProvider(installer, prov.id, prov.label, cb.checked));
+            }
+        }
+
         if (!status.installed) {
             const enableBtn = actions.createEl('button', { text: 'Install CLI', cls: 'mod-cta' });
             if (component) {
-                component.registerDomEvent(enableBtn, 'click', () => this.enableLocalCli(installer));
+                component.registerDomEvent(enableBtn, 'click', () => {
+                    const targets: Partial<CliInstallTargets> = {};
+                    for (const [id, cb] of checkboxes) targets[id] = cb.checked;
+                    this.enableLocalCli(installer, targets);
+                });
             }
         } else {
             const revealBtn = actions.createEl('button', { text: this.getRevealButtonText() });
@@ -663,17 +707,6 @@ export class GetStartedTab {
                 component.registerDomEvent(uninstallBtn, 'click', () => this.uninstallLocalCli(installer));
             }
         }
-
-        const detected = status.detected;
-        const detectedNames: string[] = [];
-        if (detected.claudeCode) detectedNames.push('Claude Code');
-        if (detected.codex) detectedNames.push('Codex');
-        block.createEl('p', {
-            text: detectedNames.length
-                ? `Detected on this machine: ${detectedNames.join(', ')}. The skill and pointer are wired up automatically.`
-                : 'No Claude Code (~/.claude) or Codex (~/.codex) detected — only the nexus command will be installed.',
-            cls: 'setting-item-description'
-        });
 
         const details = block.createEl('details', { cls: 'nexus-manual-details' });
         details.createEl('summary', { text: status.installed ? 'What’s installed' : 'What this installs' });
@@ -687,9 +720,9 @@ export class GetStartedTab {
         });
     }
 
-    private enableLocalCli(installer: LocalCliInstaller): void {
+    private enableLocalCli(installer: LocalCliInstaller, targets?: Partial<CliInstallTargets>): void {
         try {
-            const result = installer.enable();
+            const result = installer.enable(targets);
             const warn = result.warnings.length
                 ? ` (${result.warnings.length} note${result.warnings.length === 1 ? '' : 's'})`
                 : '';
@@ -699,6 +732,18 @@ export class GetStartedTab {
         } catch (error) {
             console.error('[GetStartedTab] Error installing local CLI:', error);
             new Notice(`Failed to install local CLI: ${(error as Error).message}`);
+        }
+    }
+
+    private setCliProvider(installer: LocalCliInstaller, id: CliProviderId, label: string, enabled: boolean): void {
+        try {
+            const result = installer.setProvider(id, enabled);
+            for (const w of result.warnings) console.warn('[GetStartedTab] Local CLI:', w);
+            new Notice(enabled ? `Wired nexus into ${label}.` : `Removed nexus from ${label}.`);
+            this.render();
+        } catch (error) {
+            console.error('[GetStartedTab] Error updating CLI provider:', error);
+            new Notice(`Failed to update ${label}: ${(error as Error).message}`);
         }
     }
 

--- a/src/settings/tabs/GetStartedTab.ts
+++ b/src/settings/tabs/GetStartedTab.ts
@@ -169,11 +169,11 @@ export class GetStartedTab {
             component.registerDomEvent(chatPath, 'click', chatClickHandler);
         }
 
-        // Path 2: MCP Integration
+        // Path 2: External agents (MCP clients + CLI coding agents)
         const mcpPath = paths.createDiv('nexus-setup-path');
         mcpPath.createDiv('nexus-setup-path-icon').setText('🔗');
-        mcpPath.createDiv('nexus-setup-path-title').setText('MCP integration');
-        mcpPath.createDiv('nexus-setup-path-desc').setText('Connect Claude Desktop, LM Studio, etc.');
+        mcpPath.createDiv('nexus-setup-path-title').setText('External agents');
+        mcpPath.createDiv('nexus-setup-path-desc').setText('Connect Claude Desktop, Codex, Cursor, and more');
         const mcpClickHandler = () => {
             this.currentView = 'mcp-setup';
             this.render();
@@ -242,7 +242,7 @@ export class GetStartedTab {
     }
 
     /**
-     * Render MCP Integration setup view
+     * Render External agents setup view (MCP clients + CLI coding agents)
      */
     private renderMCPSetup(): void {
         new BackButton(
@@ -255,12 +255,12 @@ export class GetStartedTab {
             this.services.component
         );
 
-        this.container.createEl('h3', { text: 'MCP integration setup' });
+        this.container.createEl('h3', { text: 'External agent setup' });
 
-        // MCP setup requires Node.js modules (path, fs, child_process) — desktop only
+        // Setup requires Node.js modules (path, fs, child_process) — desktop only
         if (!Platform.isDesktop) {
             this.container.createEl('p', {
-                text: 'MCP integration requires a desktop environment.',
+                text: 'External agent setup requires a desktop environment.',
                 cls: 'setting-item-description'
             });
             return;

--- a/styles.css
+++ b/styles.css
@@ -4776,6 +4776,36 @@ body.is-mobile .message-action-btn.message-branch-next {
     color: var(--text-success);
 }
 
+.nexus-cli-providers {
+    margin-top: 10px;
+    padding: 10px 16px;
+    background: var(--background-secondary);
+    border-radius: 8px;
+}
+
+.nexus-cli-provider-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+}
+
+.nexus-cli-provider-row input[type="checkbox"] {
+    margin: 0;
+}
+
+.nexus-cli-provider-row label {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+    cursor: pointer;
+}
+
+.nexus-cli-provider-hint {
+    color: var(--text-muted);
+    font-size: var(--font-smaller);
+}
+
 .nexus-mcp-actions {
     display: flex;
     gap: 8px;

--- a/tests/services/cli/LocalCliInstaller.test.ts
+++ b/tests/services/cli/LocalCliInstaller.test.ts
@@ -35,8 +35,9 @@ describe('LocalCliInstaller', () => {
 
     beforeEach(() => {
         TEST_HOME = realFs.mkdtempSync(realPath.join(realOs.tmpdir(), 'nexus-cli-test-'));
-        // Simulate both agents being installed so detection fires.
+        // Simulate all three agents being installed so detection fires.
         realFs.mkdirSync(realPath.join(TEST_HOME, '.claude'), { recursive: true });
+        realFs.mkdirSync(realPath.join(TEST_HOME, '.cursor'), { recursive: true });
         realFs.mkdirSync(realPath.join(TEST_HOME, '.codex'), { recursive: true });
         installer = new LocalCliInstaller();
     });
@@ -45,7 +46,7 @@ describe('LocalCliInstaller', () => {
         realFs.rmSync(TEST_HOME, { recursive: true, force: true });
     });
 
-    it('enable() writes the CLI, skill, PATH symlink, Claude skill link, and Codex block', () => {
+    it('enable() writes the CLI, skill, PATH symlink, Claude + Cursor skill links, and Codex block', () => {
         const result = installer.enable();
         const p = installer.getPaths();
 
@@ -54,9 +55,11 @@ describe('LocalCliInstaller', () => {
         expect(realFs.lstatSync(p.binPath).isSymbolicLink()).toBe(true);
         expect(realFs.realpathSync(p.binPath)).toBe(realFs.realpathSync(p.cliJsPath));
         expect(realFs.lstatSync(p.claudeSkillLink).isSymbolicLink()).toBe(true);
+        expect(realFs.lstatSync(p.cursorSkillLink).isSymbolicLink()).toBe(true);
+        expect(realFs.realpathSync(p.cursorSkillLink)).toBe(realFs.realpathSync(p.skillDir));
         expect(realFs.readFileSync(p.codexAgentsPath, 'utf-8')).toContain('Nexus vault access');
         expect(result.created).toContain(p.cliJsPath);
-        expect(result.detected).toEqual({ claudeCode: true, codex: true });
+        expect(result.detected).toEqual({ claudeCode: true, cursor: true, codex: true });
     });
 
     it('status() reflects an installed, on-PATH, linked state', () => {
@@ -66,7 +69,32 @@ describe('LocalCliInstaller', () => {
         expect(s.onPath).toBe(true);
         expect(s.stale).toBe(false);
         expect(s.skillLinked).toBe(true);
+        expect(s.cursorLinked).toBe(true);
         expect(s.codexLinked).toBe(true);
+    });
+
+    it('enable(targets) wires only the selected providers', () => {
+        installer.enable({ claudeCode: true, cursor: false, codex: false });
+        const s = installer.status();
+        expect(s.installed).toBe(true);
+        expect(s.skillLinked).toBe(true);
+        expect(s.cursorLinked).toBe(false);
+        expect(s.codexLinked).toBe(false);
+    });
+
+    it('setProvider() wires and unwires a single provider without touching the others', () => {
+        installer.enable({ claudeCode: true, cursor: false, codex: false });
+        expect(installer.status().cursorLinked).toBe(false);
+
+        installer.setProvider('cursor', true);
+        let s = installer.status();
+        expect(s.cursorLinked).toBe(true);
+        expect(s.skillLinked).toBe(true);
+
+        installer.setProvider('cursor', false);
+        s = installer.status();
+        expect(s.cursorLinked).toBe(false);
+        expect(s.skillLinked).toBe(true);
     });
 
     it('reconcile() refreshes a stale on-disk CLI copy', () => {
@@ -103,6 +131,7 @@ describe('LocalCliInstaller', () => {
         expect(realFs.existsSync(p.dataDir)).toBe(false);
         expect(realFs.existsSync(p.binPath)).toBe(false);
         expect(realFs.existsSync(p.claudeSkillLink)).toBe(false);
+        expect(realFs.existsSync(p.cursorSkillLink)).toBe(false);
 
         const codex = realFs.readFileSync(p.codexAgentsPath, 'utf-8');
         expect(codex).toContain('Keep this line.');


### PR DESCRIPTION
## What

Replaces the single Install/Uninstall button in **Get Started → local nexus CLI** with a per-provider **checkbox picker**, so users pick which coding agents to wire the CLI into instead of it always going to whatever's auto-detected.

## Why

The previous flow auto-wired every detected agent with no choice. Users asked to "click which providers they want to add it to." Scope for now: **Claude Code, Cursor, Codex** (more later).

## How

- **Pre-install:** one checkbox per provider, pre-checked by auto-detection (`~/.claude`, `~/.cursor`, `~/.codex`). Install wires only the selected targets via `enable(targets)`.
- **Post-install:** each checkbox reflects live link state and toggles that provider on the spot via `setProvider(id, enabled)` — no full reinstall. Reveal + global Uninstall unchanged.
- **Cursor is now a first-class target.** It uses the *same* Agent Skills mechanism as Claude Code (a symlink into `~/.cursor/skills/nexus`), verified against Cursor's official docs (2.4+ Agent Skills). Codex keeps its `~/.codex/AGENTS.md` pointer block.

### Installer changes (`LocalCliInstaller`)
- `CliProviderId` / `CliInstallTargets` types; target-aware `enable(targets?)`.
- New `setProvider(id, enabled)` + `wireSkillLink()` / `unwireSkillLink()` helpers.
- Cursor detection, `cursorLinked` status, uninstall cleanup for the cursor link.

## Tests
- `LocalCliInstaller.test.ts`: cursor link on `enable()`, targeted `enable({...})`, `setProvider` wire/unwire round-trip, cursor cleanup on uninstall.
- Full suite green (3956 pass / 0 fail / 21 skipped); build + lint clean.

## Manual test
Open **Settings → Get Started → local nexus CLI**, toggle providers before install, install, then flip individual checkboxes and confirm the symlinks/AGENTS.md block appear/disappear under `~/.claude`, `~/.cursor`, `~/.codex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01436Lor1dV4kevTHyCtjk6B