### PR TITLE
fix(lint): unblock 5.15.0 release — drop inline eslint-disable in vaultPath

### DIFF
--- a/src/core/vaultPath.ts
+++ b/src/core/vaultPath.ts
@@ -55,6 +55,18 @@ export class VaultPathError extends Error {
 const brand = (path: string): VaultPath => path as VaultPath;
 
 /**
+ * True if the string contains any C0 control character (U+0000–U+001F, incl. NUL).
+ * Codepoint scan rather than a control-char regex literal, which the store-scanner
+ * lint rejects.
+ */
+function hasControlCharacter(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) < 0x20) return true;
+  }
+  return false;
+}
+
+/**
  * Windows reserved device names. A file named after any of these (with or without
  * an extension, in any folder) maps to a device, not a file — writes silently
  * vanish (data loss) or block on a device (hang). Matched case-insensitively
@@ -143,8 +155,7 @@ export function tryResolveVaultPath(
 
   // Control characters (incl. NUL) are never legitimate in a vault path and can
   // defeat downstream string handling; Obsidian's normalizePath does not strip them.
-  // eslint-disable-next-line no-control-regex
-  if (/[\x00-\x1f]/.test(trimmed)) {
+  if (hasControlCharacter(trimmed)) {
     return { ok: false, error: 'Path cannot contain control characters.' };
   }
 


### PR DESCRIPTION
The 5.15.0 release workflow failed at the `npm run build` lint step: CI's eslint (via `eslint-plugin-obsidianmd`, the store scanner) rejects undescribed inline disable directives, flagging the `// eslint-disable-next-line no-control-regex` I added for the control-char guard in `src/core/vaultPath.ts`. Local `npm run lint` didn't catch it (older plugin version in local `node_modules`).

Fix: replace the control-char **regex literal** with a **codepoint scan** (`charCodeAt(i) < 0x20`), removing the disable entirely. Identical behavior, no new deps.

- Build + lint clean locally; `vaultPath` tests 62/0.
- No version change — off the merged 5.15.0 commit; the `5.15.0` tag will be re-pointed at this after merge (the prior tag never produced a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TML4ntSuzSk8EAen9qBDuk