### PR TITLE
Fix CLI Node discovery on macOS

### DIFF
--- a/src/services/cli/LocalCliInstaller.ts
+++ b/src/services/cli/LocalCliInstaller.ts
@@ -18,6 +18,7 @@
  */
 import { Platform } from 'obsidian';
 import { desktopRequire } from '../../utils/desktopRequire';
+import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
 import { NEXUS_CLI_JS, NEXUS_SKILL_MD, NEXUS_AGENTS_MD, NEXUS_PLAYBOOKS } from '../../utils/cliAssets';
 
 type FsModule = typeof import('node:fs');
@@ -582,7 +583,13 @@ export class LocalCliInstaller {
 
     private nodeRuntimeReady(): boolean {
         try {
-            const result = this.childProcess().spawnSync('node', ['--version'], {
+            // Obsidian launched from Finder/the Start menu often has a stale or
+            // minimal PATH, especially when Node is managed by nvm/fnm/asdf.
+            // Use the same desktop discovery as the rest of Nexus so a runtime
+            // visible in the user's login shell is not incorrectly rejected.
+            const nodePath = resolveDesktopBinaryPath('node');
+            if (!nodePath) return false;
+            const result = this.childProcess().spawnSync(nodePath, ['--version'], {
                 encoding: 'utf-8',
                 timeout: 5_000,
                 windowsHide: true,

--- a/tests/services/cli/LocalCliInstaller.test.ts
+++ b/tests/services/cli/LocalCliInstaller.test.ts
@@ -13,6 +13,8 @@ let TEST_HOME = '';
 const ORIGINAL_LOCALAPPDATA = process.env.LOCALAPPDATA;
 const ORIGINAL_PATH = process.env.PATH;
 const mockSpawnSync = jest.fn();
+const DEFAULT_NODE_PATH = '/resolved/bin/node';
+const mockResolveDesktopBinaryPath = jest.fn(() => DEFAULT_NODE_PATH);
 
 interface MockSpawnResult {
     status: number;
@@ -26,7 +28,7 @@ const nodeOk: MockSpawnResult = { status: 0, stdout: 'v20.19.0\n', stderr: '' };
 function mockNodeAndPowerShell(...powerShellResults: MockSpawnResult[]): void {
     let powerShellIndex = 0;
     mockSpawnSync.mockImplementation((command: string) => {
-        if (command === 'node') return nodeOk;
+        if (command === DEFAULT_NODE_PATH) return nodeOk;
         return powerShellResults[powerShellIndex++] ?? { status: 0, stdout: 'PRESENT\n', stderr: '' };
     });
 }
@@ -54,6 +56,10 @@ jest.mock('../../../src/utils/desktopRequire', () => ({
     },
 }));
 
+jest.mock('../../../src/utils/binaryDiscovery', () => ({
+    resolveDesktopBinaryPath: mockResolveDesktopBinaryPath,
+}));
+
 import { LocalCliInstaller } from '../../../src/services/cli/LocalCliInstaller';
 import { NEXUS_CLI_JS } from '../../../src/utils/cliAssets';
 
@@ -75,6 +81,8 @@ describe('LocalCliInstaller', () => {
         if (ORIGINAL_PATH === undefined) delete process.env.PATH;
         else process.env.PATH = ORIGINAL_PATH;
         mockSpawnSync.mockReset();
+        mockResolveDesktopBinaryPath.mockReset();
+        mockResolveDesktopBinaryPath.mockReturnValue(DEFAULT_NODE_PATH);
         mockNodeAndPowerShell();
         TEST_HOME = realFs.mkdtempSync(realPath.join(realOs.tmpdir(), 'nexus-cli-test-'));
         // Simulate all three agents being installed so detection fires.
@@ -117,6 +125,29 @@ describe('LocalCliInstaller', () => {
         expect(s.skillLinked).toBe(true);
         expect(s.cursorLinked).toBe(true);
         expect(s.codexLinked).toBe(true);
+    });
+
+    posixIt('accepts Node.js 24 discovered outside Obsidian\'s inherited PATH', () => {
+        const discoveredNode = realPath.join(TEST_HOME, '.nvm', 'versions', 'node', 'v24.4.0', 'bin', 'node');
+        mockResolveDesktopBinaryPath.mockReturnValue(discoveredNode);
+        mockSpawnSync.mockImplementation((command: string) => {
+            if (command === discoveredNode) {
+                return { status: 0, stdout: 'v24.4.0\n', stderr: '' };
+            }
+            return { status: 1, stdout: '', stderr: 'not found' };
+        });
+
+        expect(() => installer.enable({ claudeCode: false, cursor: false, codex: false })).not.toThrow();
+        expect(mockSpawnSync).toHaveBeenCalledWith(
+            discoveredNode,
+            ['--version'],
+            expect.objectContaining({ encoding: 'utf-8' })
+        );
+        expect(mockSpawnSync).not.toHaveBeenCalledWith(
+            'node',
+            ['--version'],
+            expect.anything()
+        );
     });
 
     posixIt('enable(targets) wires only the selected providers', () => {

--- a/tests/unit/binaryDiscovery.test.ts
+++ b/tests/unit/binaryDiscovery.test.ts
@@ -15,6 +15,7 @@ jest.mock('fs', () => ({
 describe('resolveDesktopBinaryPath', () => {
   const originalAppData = process.env.APPDATA;
   const execSyncMock = childProcess.execSync as jest.Mock;
+  const execFileSyncMock = childProcess.execFileSync as jest.Mock;
   const existsSyncMock = nodeFs.existsSync as jest.Mock;
 
   beforeEach(() => {
@@ -59,6 +60,23 @@ describe('resolveDesktopBinaryPath', () => {
 
     expect(resolveDesktopBinaryPath('claude')?.replace(/\//g, '\\')).toBe(
       'C:\\Users\\test\\AppData\\Roaming\\npm\\claude.cmd'
+    );
+  });
+
+  it('finds Node from the macOS login shell when the app PATH is stale', () => {
+    Platform.isWin = false;
+    const nodePath = '/Users/test/.nvm/versions/node/v24.4.0/bin/node';
+    execSyncMock.mockImplementation(() => {
+      throw new Error('node is not on the app PATH');
+    });
+    execFileSyncMock.mockReturnValue(`${nodePath}\n` as never);
+    existsSyncMock.mockImplementation((path) => String(path) === nodePath);
+
+    expect(resolveDesktopBinaryPath('node')).toBe(nodePath);
+    expect(execFileSyncMock).toHaveBeenCalledWith(
+      process.env.SHELL || '/bin/zsh',
+      ['-lc', "command -v 'node'"],
+      expect.objectContaining({ encoding: 'utf8' })
     );
   });
 });


### PR DESCRIPTION
## Summary

- resolve the Node.js executable with the shared desktop binary discovery before probing its version
- support macOS GUI launches whose inherited PATH does not include nvm, fnm, or asdf
- add regression coverage for Node.js 24 and login-shell discovery

## Root cause

The local CLI installer invoked bare `node --version` using Obsidian's inherited environment. On macOS, an app launched from Finder or the Dock often cannot see shell-managed Node installations, so a valid Node 24 runtime was misreported as failing the Node 18 requirement.

## Validation

- relevant Jest suites: 15 tests passed
- ESLint passed
- `tsc --noEmit --skipLibCheck` passed