### PR TITLE
feat: add Realtime 2.1, Kimi K3, and Voxtral transcription

### DIFF
--- a/src/services/llm/TranscriptionService.ts
+++ b/src/services/llm/TranscriptionService.ts
@@ -4,6 +4,7 @@ import { GroqTranscriptionAdapter } from './adapters/groq/GroqTranscriptionAdapt
 import { MistralTranscriptionAdapter } from './adapters/mistral/MistralTranscriptionAdapter';
 import { DeepgramTranscriptionAdapter } from './adapters/deepgram/DeepgramTranscriptionAdapter';
 import { AssemblyAITranscriptionAdapter } from './adapters/assemblyai/AssemblyAITranscriptionAdapter';
+import { OpenRouterTranscriptionAdapter } from './adapters/openrouter/OpenRouterTranscriptionAdapter';
 import type { BaseTranscriptionAdapter } from './adapters/BaseTranscriptionAdapter';
 import {
   getTranscriptionModel,
@@ -100,6 +101,15 @@ export class TranscriptionService {
     if (assemblyAIConfig?.enabled && assemblyAIConfig.apiKey) {
       this.adapters.set('assemblyai', new AssemblyAITranscriptionAdapter({
         apiKey: assemblyAIConfig.apiKey
+      }));
+    }
+
+    const openRouterConfig = this.llmSettings.providers?.openrouter;
+    if (openRouterConfig?.enabled && openRouterConfig.apiKey) {
+      this.adapters.set('openrouter', new OpenRouterTranscriptionAdapter({
+        apiKey: openRouterConfig.apiKey,
+        httpReferer: openRouterConfig.httpReferer,
+        xTitle: openRouterConfig.xTitle
       }));
     }
 

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -1,7 +1,7 @@
 /**
  * OpenRouter Model Specifications
  * OpenRouter provides access to multiple providers through a unified API
- * Updated July 2026 — added the GPT-5.6 family; pruned superseded
+ * Updated July 2026 — added the GPT-5.6 family and Kimi K3; pruned superseded
  * Claude 4.5 Opus/Sonnet, Gemini 2.5 / 3.0 Preview, and GPT-5 / GPT-5.1 entries
  */
 
@@ -530,6 +530,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     maxTokens: 16384,
     inputCostPerMillion: 0.74,
     outputCostPerMillion: 3.50,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
+    name: 'Kimi K3',
+    apiName: 'moonshotai/kimi-k3',
+    contextWindow: 1048576,
+    maxTokens: 131072,
+    inputCostPerMillion: 3.00,
+    outputCostPerMillion: 15.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter.ts
@@ -1,0 +1,74 @@
+import { requestUrl } from 'obsidian';
+import { BRAND_NAME } from '../../../../constants/branding';
+import { BaseTranscriptionAdapter } from '../BaseTranscriptionAdapter';
+import type {
+  AudioChunk,
+  TranscriptionProvider,
+  TranscriptionRequest,
+  TranscriptionSegment
+} from '../../types/VoiceTypes';
+import { parseWhisperResponse } from '../../utils/WhisperResponseParser';
+
+export class OpenRouterTranscriptionAdapter extends BaseTranscriptionAdapter {
+  readonly provider: TranscriptionProvider = 'openrouter';
+  private readonly endpoint = 'https://openrouter.ai/api/v1/audio/transcriptions';
+
+  async transcribeChunk(
+    chunk: AudioChunk,
+    request: TranscriptionRequest & { provider: TranscriptionProvider; model: string }
+  ): Promise<TranscriptionSegment[]> {
+    const response = await requestUrl({
+      url: this.endpoint,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.config.apiKey}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': this.config.httpReferer?.trim() || 'https://synapticlabs.ai',
+        'X-Title': this.config.xTitle?.trim() || BRAND_NAME
+      },
+      body: JSON.stringify({
+        model: request.model,
+        input_audio: {
+          data: arrayBufferToBase64(chunk.data),
+          format: mimeToOpenRouterFormat(chunk.mimeType)
+        }
+      })
+    });
+
+    if (response.status !== 200) {
+      throw new Error(`OpenRouter transcription failed: HTTP ${response.status}`);
+    }
+
+    return parseWhisperResponse(response.json as unknown, chunk.durationSeconds);
+  }
+}
+
+function mimeToOpenRouterFormat(mimeType: string): string {
+  const formats: Record<string, string> = {
+    'audio/wav': 'wav',
+    'audio/mpeg': 'mp3',
+    'audio/mp4': 'm4a',
+    'audio/aac': 'aac',
+    'audio/ogg': 'ogg',
+    'audio/opus': 'ogg',
+    'audio/flac': 'flac',
+    'audio/webm': 'webm'
+  };
+  const format = formats[mimeType];
+  if (!format) {
+    throw new Error(`OpenRouter transcription does not support audio format "${mimeType}".`);
+  }
+  return format;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...Array.from(bytes.subarray(index, index + chunkSize)));
+  }
+
+  return btoa(binary);
+}

--- a/src/services/llm/types/RealtimeVoiceTypes.ts
+++ b/src/services/llm/types/RealtimeVoiceTypes.ts
@@ -110,6 +110,28 @@ const GOOGLE_REALTIME_VOICES: RealtimeVoiceDeclaration[] = [
 const REALTIME_VOICE_MODELS: RealtimeVoiceModelDeclaration[] = [
   {
     provider: 'openai',
+    id: 'gpt-realtime-2.1',
+    name: 'GPT Realtime 2.1',
+    transport: 'webrtc',
+    defaultVoice: 'marin',
+    voices: OPENAI_REALTIME_VOICES,
+    supportsTools: true,
+    supportsTranscripts: true,
+    maxSessionMinutes: 60
+  },
+  {
+    provider: 'openai',
+    id: 'gpt-realtime-2.1-mini',
+    name: 'GPT Realtime 2.1 mini',
+    transport: 'webrtc',
+    defaultVoice: 'marin',
+    voices: OPENAI_REALTIME_VOICES,
+    supportsTools: true,
+    supportsTranscripts: true,
+    maxSessionMinutes: 60
+  },
+  {
+    provider: 'openai',
     id: 'gpt-realtime-2',
     name: 'GPT Realtime 2',
     transport: 'webrtc',

--- a/src/services/llm/types/VoiceTypes.ts
+++ b/src/services/llm/types/VoiceTypes.ts
@@ -7,7 +7,7 @@
 
 import type { LLMProviderSettings } from '../../../types/llm/ProviderTypes';
 
-export type TranscriptionProvider = 'openai' | 'groq' | 'mistral' | 'deepgram' | 'assemblyai';
+export type TranscriptionProvider = 'openai' | 'groq' | 'mistral' | 'deepgram' | 'assemblyai' | 'openrouter';
 
 export type TranscriptionExecution =
   | 'speech-api-segmented'
@@ -107,6 +107,15 @@ const TRANSCRIPTION_MODELS: TranscriptionModelDeclaration[] = [
     supportsWordTimestamps: true,
     supportsSpeakerLabels: true,
     supportsPrompt: true
+  },
+  {
+    provider: 'openrouter',
+    id: 'mistralai/voxtral-mini-transcribe',
+    name: 'Voxtral Mini Transcribe via OpenRouter',
+    execution: 'speech-api-segmented',
+    supportsWordTimestamps: false,
+    supportsSpeakerLabels: false,
+    supportsPrompt: false
   },
   {
     provider: 'deepgram',

--- a/tests/integration/transcription-live.test.ts
+++ b/tests/integration/transcription-live.test.ts
@@ -9,6 +9,7 @@
  *   DEEPGRAM_API_KEY=...
  *   ASSEMBLYAI_API_KEY=...
  *   MISTRAL_API_KEY=...
+ *   OPENROUTER_API_KEY=...
  *
  * Run:
  *   npx jest tests/integration/transcription-live.test.ts --no-coverage --verbose
@@ -21,6 +22,7 @@ import { GroqTranscriptionAdapter } from '../../src/services/llm/adapters/groq/G
 import { DeepgramTranscriptionAdapter } from '../../src/services/llm/adapters/deepgram/DeepgramTranscriptionAdapter';
 import { AssemblyAITranscriptionAdapter } from '../../src/services/llm/adapters/assemblyai/AssemblyAITranscriptionAdapter';
 import { MistralTranscriptionAdapter } from '../../src/services/llm/adapters/mistral/MistralTranscriptionAdapter';
+import { OpenRouterTranscriptionAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter';
 import type { AudioChunk, TranscriptionRequest, TranscriptionProvider, TranscriptionSegment } from '../../src/services/llm/types/VoiceTypes';
 
 // Wire requestUrl to real HTTP via fetch
@@ -131,6 +133,7 @@ const groqKey = process.env.GROQ_API_KEY;
 const deepgramKey = process.env.DEEPGRAM_API_KEY;
 const assemblyaiKey = process.env.ASSEMBLYAI_API_KEY;
 const mistralKey = process.env.MISTRAL_API_KEY;
+const openrouterKey = process.env.OPENROUTER_API_KEY;
 
 // --- Speech-API providers (Whisper format) ---
 
@@ -170,6 +173,19 @@ describe('Live Transcription: Mistral', () => {
   }, 30_000);
 });
 
+describe('Live Transcription: OpenRouter', () => {
+  const runTest = openrouterKey && LIVE_TRANSCRIPTION_ENABLED ? it : it.skip;
+
+  runTest('transcribes with Voxtral Mini Transcribe', async () => {
+    const adapter = new OpenRouterTranscriptionAdapter({ apiKey: openrouterKey! });
+    const segments = await adapter.transcribeChunk(
+      testChunk,
+      makeRequest('openrouter', 'mistralai/voxtral-mini-transcribe')
+    );
+    validateSegments(segments, 'OpenRouter/mistralai/voxtral-mini-transcribe');
+  }, 30_000);
+});
+
 // --- Deepgram (raw binary body) ---
 
 describe('Live Transcription: Deepgram', () => {
@@ -206,6 +222,7 @@ const configuredProviders = [
   mistralKey && 'mistral',
   deepgramKey && 'deepgram',
   assemblyaiKey && 'assemblyai',
+  openrouterKey && 'openrouter',
 ].filter(Boolean) as string[];
 
 describe('Provider summary', () => {
@@ -219,13 +236,13 @@ describe('Provider summary', () => {
         'afconvert -f WAVE -d LEI16 /tmp/test-transcription.aiff /tmp/test-transcription.wav'
       );
     }
-    console.log(`\nConfigured providers (${configuredProviders.length}/5): ${configuredProviders.join(', ')}`);
-    const missing = ['openai', 'groq', 'mistral', 'deepgram', 'assemblyai']
+    console.log(`\nConfigured providers (${configuredProviders.length}/6): ${configuredProviders.join(', ')}`);
+    const missing = ['openai', 'groq', 'mistral', 'deepgram', 'assemblyai', 'openrouter']
       .filter(p => !configuredProviders.includes(p));
     if (missing.length > 0) {
       console.log(`Skipped (no API key): ${missing.join(', ')}`);
     }
     // All providers accounted for (configured + skipped = total)
-    expect(configuredProviders.length + missing.length).toBe(5);
+    expect(configuredProviders.length + missing.length).toBe(6);
   });
 });

--- a/tests/unit/LLMTranscriptionService.test.ts
+++ b/tests/unit/LLMTranscriptionService.test.ts
@@ -24,10 +24,12 @@ jest.mock('../../src/services/llm/adapters/groq/GroqTranscriptionAdapter');
 jest.mock('../../src/services/llm/adapters/mistral/MistralTranscriptionAdapter');
 jest.mock('../../src/services/llm/adapters/deepgram/DeepgramTranscriptionAdapter');
 jest.mock('../../src/services/llm/adapters/assemblyai/AssemblyAITranscriptionAdapter');
+jest.mock('../../src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter');
 
 import { TranscriptionService } from '../../src/services/llm/TranscriptionService';
 import { chunkAudio } from '../../src/services/llm/utils/AudioChunkingService';
 import { OpenAITranscriptionAdapter } from '../../src/services/llm/adapters/openai/OpenAITranscriptionAdapter';
+import { OpenRouterTranscriptionAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter';
 import { DEFAULT_LLM_PROVIDER_SETTINGS, type LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
 import type { AudioChunk } from '../../src/services/llm/types/VoiceTypes';
 
@@ -93,6 +95,27 @@ describe('TranscriptionService (class-based)', () => {
       const service = new TranscriptionService(makeSettings());
       // OpenAI adapter should have been constructed
       expect(OpenAITranscriptionAdapter).toHaveBeenCalledWith({ apiKey: 'sk-test' });
+    });
+
+    it('initializes OpenRouter transcription with attribution headers', () => {
+      new TranscriptionService(makeSettings({
+        providers: {
+          ...DEFAULT_LLM_PROVIDER_SETTINGS.providers,
+          openai: { apiKey: '', enabled: false },
+          openrouter: {
+            apiKey: 'or-test',
+            enabled: true,
+            httpReferer: 'https://example.com',
+            xTitle: 'Nexus test'
+          }
+        }
+      }));
+
+      expect(OpenRouterTranscriptionAdapter).toHaveBeenCalledWith({
+        apiKey: 'or-test',
+        httpReferer: 'https://example.com',
+        xTitle: 'Nexus test'
+      });
     });
 
     it('does not initialize adapters for disabled providers', () => {

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -160,3 +160,22 @@ describe('ModelRegistry Gemini 3.5 Flash models', () => {
     }));
   });
 });
+
+describe('ModelRegistry Kimi K3 model', () => {
+  it('registers Kimi K3 for OpenRouter with current pricing and capabilities', () => {
+    expect(ModelRegistry.findModel('openrouter', 'moonshotai/kimi-k3')).toEqual(expect.objectContaining({
+      name: 'Kimi K3',
+      contextWindow: 1048576,
+      maxTokens: 131072,
+      inputCostPerMillion: 3,
+      outputCostPerMillion: 15,
+      capabilities: expect.objectContaining({
+        supportsJSON: true,
+        supportsImages: true,
+        supportsFunctions: true,
+        supportsStreaming: true,
+        supportsThinking: true
+      })
+    }));
+  });
+});

--- a/tests/unit/OpenRouterTranscriptionAdapter.test.ts
+++ b/tests/unit/OpenRouterTranscriptionAdapter.test.ts
@@ -1,0 +1,92 @@
+import { __setRequestUrlMock } from 'obsidian';
+import { OpenRouterTranscriptionAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter';
+import type {
+  AudioChunk,
+  TranscriptionProvider,
+  TranscriptionRequest
+} from '../../src/services/llm/types/VoiceTypes';
+
+function makeChunk(overrides: Partial<AudioChunk> = {}): AudioChunk {
+  return {
+    data: new Uint8Array([1, 2, 3]).buffer,
+    mimeType: 'audio/wav',
+    startSeconds: 0,
+    durationSeconds: 30,
+    ...overrides
+  };
+}
+
+function makeRequest(
+  overrides: Partial<TranscriptionRequest & { provider: TranscriptionProvider; model: string }> = {}
+): TranscriptionRequest & { provider: TranscriptionProvider; model: string } {
+  return {
+    audioData: new ArrayBuffer(3),
+    mimeType: 'audio/wav',
+    fileName: 'test.wav',
+    provider: 'openrouter',
+    model: 'mistralai/voxtral-mini-transcribe',
+    ...overrides
+  };
+}
+
+describe('OpenRouterTranscriptionAdapter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends base64 audio to the OpenRouter transcription endpoint', async () => {
+    let capturedRequest: { url?: string; headers?: Record<string, string>; body?: string | ArrayBuffer } = {};
+    __setRequestUrlMock(async request => {
+      capturedRequest = request;
+      return {
+        status: 200,
+        json: { text: 'Hello from Voxtral.' }
+      };
+    });
+
+    const adapter = new OpenRouterTranscriptionAdapter({
+      apiKey: 'or-test-key',
+      httpReferer: 'https://example.com',
+      xTitle: 'Nexus test'
+    });
+    const result = await adapter.transcribeChunk(makeChunk(), makeRequest());
+
+    expect(capturedRequest.url).toBe('https://openrouter.ai/api/v1/audio/transcriptions');
+    expect(capturedRequest.headers).toEqual(expect.objectContaining({
+      Authorization: 'Bearer or-test-key',
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://example.com',
+      'X-Title': 'Nexus test'
+    }));
+    expect(JSON.parse(capturedRequest.body as string)).toEqual({
+      model: 'mistralai/voxtral-mini-transcribe',
+      input_audio: {
+        data: 'AQID',
+        format: 'wav'
+      }
+    });
+    expect(result).toEqual([{
+      startSeconds: 0,
+      endSeconds: 30,
+      text: 'Hello from Voxtral.',
+      words: undefined
+    }]);
+  });
+
+  it('rejects audio formats OpenRouter does not document', async () => {
+    const adapter = new OpenRouterTranscriptionAdapter({ apiKey: 'or-test-key' });
+
+    await expect(adapter.transcribeChunk(
+      makeChunk({ mimeType: 'audio/x-ms-wma' }),
+      makeRequest({ mimeType: 'audio/x-ms-wma', fileName: 'test.wma' })
+    )).rejects.toThrow('does not support audio format');
+  });
+
+  it('throws a provider-specific error for non-200 responses', async () => {
+    __setRequestUrlMock(async () => ({ status: 429, json: {} }));
+    const adapter = new OpenRouterTranscriptionAdapter({ apiKey: 'or-test-key' });
+
+    await expect(adapter.transcribeChunk(makeChunk(), makeRequest()))
+      .rejects.toThrow('OpenRouter transcription failed: HTTP 429');
+  });
+});

--- a/tests/unit/VoiceAudioCapabilityTypes.test.ts
+++ b/tests/unit/VoiceAudioCapabilityTypes.test.ts
@@ -192,7 +192,11 @@ describe('SpeechTypes', () => {
 
 describe('RealtimeVoiceTypes', () => {
   it('declares realtime models separately from speech models', () => {
-    expect(getRealtimeVoiceModelsForProvider('openai').map(model => model.id)).toContain('gpt-realtime-2');
+    expect(getRealtimeVoiceModelsForProvider('openai').map(model => model.id)).toEqual(expect.arrayContaining([
+      'gpt-realtime-2.1',
+      'gpt-realtime-2.1-mini',
+      'gpt-realtime-2'
+    ]));
     expect(getRealtimeVoiceModelsForProvider('openrouter')).toEqual([]);
   });
 
@@ -218,7 +222,7 @@ describe('RealtimeVoiceTypes', () => {
 
     expect(selection).toEqual(expect.objectContaining({
       provider: 'openai',
-      model: 'gpt-realtime-2',
+      model: 'gpt-realtime-2.1',
       source: 'auto',
       status: 'resolved'
     }));

--- a/tests/unit/VoiceTypes.test.ts
+++ b/tests/unit/VoiceTypes.test.ts
@@ -39,7 +39,7 @@ describe('VoiceTypes', () => {
     });
 
     it.each([
-      'openai', 'groq', 'mistral', 'deepgram', 'assemblyai'
+      'openai', 'groq', 'mistral', 'deepgram', 'assemblyai', 'openrouter'
     ] as TranscriptionProvider[])('returns at least one model for %s', (provider) => {
       const models = getTranscriptionModelsForProvider(provider);
       expect(models.length).toBeGreaterThanOrEqual(1);
@@ -78,14 +78,15 @@ describe('VoiceTypes', () => {
   // ── getTranscriptionProviders ───────────────────────────────────────
 
   describe('getTranscriptionProviders', () => {
-    it('returns all 5 providers', () => {
+    it('returns all 6 providers', () => {
       const providers = getTranscriptionProviders();
       expect(providers).toContain('openai');
       expect(providers).toContain('groq');
       expect(providers).toContain('mistral');
       expect(providers).toContain('deepgram');
       expect(providers).toContain('assemblyai');
-      expect(providers).toHaveLength(5);
+      expect(providers).toContain('openrouter');
+      expect(providers).toHaveLength(6);
     });
 
     it('returns no duplicates', () => {


### PR DESCRIPTION
## What changed

- add OpenAI `gpt-realtime-2.1` and `gpt-realtime-2.1-mini` to live voice, preferring 2.1 for automatic selection while retaining legacy models
- add OpenRouter `moonshotai/kimi-k3` with current context, pricing, and capability metadata
- add functional OpenRouter transcription via `mistralai/voxtral-mini-transcribe` and `/api/v1/audio/transcriptions`
- extend unit and live integration coverage for the new catalogs and adapter

## Why

The upstream models were released but were not yet available in Nexus. OpenRouter realtime models are intentionally not added because OpenRouter does not expose those IDs; Voxtral is wired through its supported STT endpoint instead.

## Validation

- 115 focused unit tests passed
- production build, ESLint, and TypeScript checks passed
- live OpenRouter Kimi K3 smoke test passed
- live Voxtral transcription passed and matched all 7 expected fixture words
