### PR TITLE
fix: add shell-safe CLI content transport

### DIFF
--- a/cli/agents-snippet.md
+++ b/cli/agents-snippet.md
@@ -12,6 +12,9 @@ offline and instant, so read it before your first command instead of guessing.
   Drill down: `nexus tools storage list` = one tool's full arg schema.
 - **Execute:** `nexus use --memory "<what you're doing>" --goal "<objective>" -- <agent command --flags>`.
   `--memory`/`--goal` are **required** on every `use`.
+- **Multiline content:** keep Markdown/YAML and embedded quotes out of shell
+  argv. After `--`, use `--content-stdin` with piped input or
+  `--content-file <local-path>` instead of `--content`.
 - **Task recipes:** `nexus playbook <name>` emits a ready-to-run recipe plus your
   workspaces and preloaded tools in one call (`nexus playbook` lists them).
 - Search/list results are **locations, not contents** — follow a hit with

--- a/cli/commandLine.ts
+++ b/cli/commandLine.ts
@@ -5,6 +5,11 @@ export interface PartitionedUseArgv {
     toolArgv: string[] | null;
 }
 
+export interface ToolContentReaders {
+    readStdin: () => string;
+    readFile: (path: string) => string;
+}
+
 /**
  * Split `nexus use [context] -- [tool argv]` before generic flag parsing.
  * The delimiter is meaningful only for `use`; other verbs retain their
@@ -39,6 +44,54 @@ export function serializeToolArgv(toolArgv: string[]): string {
         throw new Error('Structured `use` needs an agent and command after `--`.');
     }
     return toolArgv.map(quoteToolToken).join(' ');
+}
+
+/**
+ * Replace CLI-only content transport flags with the normal tool `--content`
+ * flag. This keeps large/multiline payloads out of shell argv, where Windows
+ * `.cmd` wrappers and nested quote parsing can otherwise alter them.
+ */
+export function hydrateToolContentArgv(toolArgv: string[], readers: ToolContentReaders): string[] {
+    const stdinIndexes: number[] = [];
+    const fileIndexes: number[] = [];
+    const contentIndexes: number[] = [];
+
+    toolArgv.forEach((token, index) => {
+        if (token === '--content-stdin') stdinIndexes.push(index);
+        if (token === '--content-file') fileIndexes.push(index);
+        if (token === '--content') contentIndexes.push(index);
+    });
+
+    const transportCount = stdinIndexes.length + fileIndexes.length;
+    if (transportCount === 0) return toolArgv;
+    if (transportCount > 1) {
+        throw new Error('Use exactly one of --content-stdin or --content-file.');
+    }
+    if (contentIndexes.length > 0) {
+        throw new Error('Do not combine --content with --content-stdin or --content-file.');
+    }
+
+    if (stdinIndexes.length === 1) {
+        const index = stdinIndexes[0];
+        return [
+            ...toolArgv.slice(0, index),
+            '--content',
+            readers.readStdin(),
+            ...toolArgv.slice(index + 1),
+        ];
+    }
+
+    const index = fileIndexes[0];
+    const path = toolArgv[index + 1];
+    if (path === undefined || path.startsWith('--')) {
+        throw new Error('--content-file requires a local file path.');
+    }
+    return [
+        ...toolArgv.slice(0, index),
+        '--content',
+        readers.readFile(path),
+        ...toolArgv.slice(index + 2),
+    ];
 }
 
 /** Resolve either canonical structured argv or the legacy one-string form. */

--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -15,7 +15,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { McpLineClient, McpToolResult } from './mcpLineClient';
 import { playbooksDir, parseFrontmatter, listPlaybooks } from './playbooks';
-import { partitionUseArgv, resolveUseCommand } from './commandLine';
+import { hydrateToolContentArgv, partitionUseArgv, resolveUseCommand } from './commandLine';
 import {
     listVaultSockets,
     NAME_PREFIX,
@@ -156,12 +156,20 @@ CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
   --json                  print the raw JSON result
   --dry-run               print the reconstructed request; do not connect or execute
 
+CONTENT INPUT (CLI-only flags after the \`--\` delimiter)
+  --content-stdin         read the tool's --content value from standard input
+  --content-file <path>   read the tool's --content value from a local file
+                          (use one transport flag; do not also pass --content)
+
 CLI SYNTAX
   • Canonical form: context flags first, then \`--\`, then one tool command as normal
     shell arguments. Commands are kebab-case (content set-property, memory load-workspace).
     Multiword values need only one shell quote layer: --workspace "NeuroAI Mapping".
   • The legacy one-string form remains supported. On Windows PowerShell, nested double
     quotes can be consumed before Node receives them; prefer the canonical \`--\` form.
+  • For multiline Markdown or text containing embedded quotes, keep the payload out of
+    shell argv: \`Get-Content -Raw note.md | nexus use ... -- content write --path X.md --content-stdin\`,
+    or pass \`--content-file note.md\`.
   • Paths are vault-relative. "..", "~", absolute paths are rejected; a leading "/" is
     stripped. You cannot read or write outside the vault.
   • Arrays: --tags "[work, urgent]". Wikilinks keep brackets: --links "[[[A]], [[B]]]".
@@ -340,7 +348,18 @@ async function main(): Promise<number> {
     if (cmd === 'use') {
         let command: string;
         try {
-            command = resolveUseCommand(positionals, toolArgv);
+            const hydratedToolArgv = toolArgv === null
+                ? null
+                : hydrateToolContentArgv(toolArgv, {
+                    readStdin: () => {
+                        if (process.stdin.isTTY) {
+                            throw new Error('--content-stdin requires piped or redirected standard input.');
+                        }
+                        return readFileSync(0, 'utf8');
+                    },
+                    readFile: (path) => readFileSync(path, 'utf8'),
+                });
+            command = resolveUseCommand(positionals, hydratedToolArgv);
         } catch (error) {
             process.stderr.write(`Error: ${(error as Error).message}\n`);
             return 2;

--- a/guide/nexus-cli.md
+++ b/guide/nexus-cli.md
@@ -70,6 +70,25 @@ with a structured-form example instead of executing a truncated request.
 Use `--dry-run` before the delimiter to print the reconstructed request without
 opening a vault connection or executing a tool.
 
+### Multiline content
+
+On Windows, a `.cmd` wrapper cannot reliably forward a multiline argument
+through `%*`. Embedded quote layers can also be altered before Node receives
+them. For Markdown, YAML frontmatter, wikilinks, or other large text, keep the
+content out of shell arguments with either CLI-only transport flag:
+
+```powershell
+Get-Content -Raw .\note.md |
+  nexus use --memory "importing a note" --goal "write the note" -- content write --path Notes/Imported.md --content-stdin
+
+nexus use --memory "importing a note" --goal "write the note" -- content write --path Notes/Imported.md --content-file ".\note.md"
+```
+
+Both flags must appear after the `--` delimiter. They are converted to the
+tool's normal `--content` value inside the CLI. Use only one, and do not combine
+either with `--content`. `--content-file` reads a local filesystem path; the
+destination passed to the Nexus tool remains vault-relative.
+
 ## Choosing a vault
 
 The vault name lives in the socket name, so selection happens at call time:
@@ -108,3 +127,5 @@ The vault name lives in the socket name, so selection happens at call time:
   `--goal`.
 - **PowerShell split a legacy command** — move context flags before `--` and
   pass the tool normally after it; do not nest a quoted command string.
+- **Multiline content is truncated or split** — pipe it with
+  `--content-stdin` or pass its local path with `--content-file`.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -5,11 +5,8 @@ description: >-
   tasks, memory/workspaces, saved prompts) from the shell via the `nexus` CLI —
   no MCP connection needed. Use whenever the user refers to their vault, notes,
   daily notes, second brain, or Obsidian, or asks you to find/read/change
-  something stored there.
-when_to_use: >-
-  The task involves the user's Obsidian vault or notes and the `nexus` command
-  is on PATH. Not for editing files in the current code repo — use normal file
-  tools for those.
+  something stored there and the `nexus` command is on PATH. Do not use it to
+  edit files in the current code repository; use normal file tools for those.
 ---
 
 # Nexus vault CLI
@@ -56,6 +53,16 @@ nexus use --memory "<what you're doing>" --goal "<objective>" -- \
 The `--` delimiter is canonical: context belongs before it; the tool command
 belongs after it. This avoids nested command-string quoting, especially in
 Windows PowerShell. The legacy one-string form remains supported.
+
+For multiline Markdown or content containing embedded quotes, keep the body
+out of shell argv. Pipe it with `--content-stdin` or pass a local path with
+`--content-file`; put either flag after the `--` delimiter and do not also pass
+`--content`:
+
+```powershell
+Get-Content -Raw .\note.md |
+    nexus use --memory "importing note" --goal "write note" -- content write --path Notes/Imported.md --content-stdin
+```
 
 Everything else — the flag table, per-tool schemas, syntax rules, the live
 per-vault catalog (including any enabled app agents) — comes from `nexus --help`,

--- a/skill/playbooks/_preamble.md
+++ b/skill/playbooks/_preamble.md
@@ -24,3 +24,7 @@ so you can go straight to `nexus use` without a separate `nexus tools` call.
 Paths are vault-relative and confined — no `..`, `~`, or absolute escapes. **All
 flags are kebab-case** — camelCase (e.g. `--activeTask`) is rejected as an unknown
 flag; use `--active-task`.
+
+For multiline Markdown/YAML or embedded quotes, keep content out of shell argv:
+after `--`, pipe with `--content-stdin` or pass `--content-file <local-path>`
+instead of `--content`.

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,7 +7,7 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "2441e94c26231d02";
+export const NEXUS_CLI_ASSETS_HASH = "ff4ecbd3b850b8a8";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
@@ -186,6 +186,44 @@ function serializeToolArgv(toolArgv) {
   }
   return toolArgv.map(quoteToolToken).join(" ");
 }
+function hydrateToolContentArgv(toolArgv, readers) {
+  const stdinIndexes = [];
+  const fileIndexes = [];
+  const contentIndexes = [];
+  toolArgv.forEach((token, index2) => {
+    if (token === "--content-stdin") stdinIndexes.push(index2);
+    if (token === "--content-file") fileIndexes.push(index2);
+    if (token === "--content") contentIndexes.push(index2);
+  });
+  const transportCount = stdinIndexes.length + fileIndexes.length;
+  if (transportCount === 0) return toolArgv;
+  if (transportCount > 1) {
+    throw new Error("Use exactly one of --content-stdin or --content-file.");
+  }
+  if (contentIndexes.length > 0) {
+    throw new Error("Do not combine --content with --content-stdin or --content-file.");
+  }
+  if (stdinIndexes.length === 1) {
+    const index2 = stdinIndexes[0];
+    return [
+      ...toolArgv.slice(0, index2),
+      "--content",
+      readers.readStdin(),
+      ...toolArgv.slice(index2 + 1)
+    ];
+  }
+  const index = fileIndexes[0];
+  const path = toolArgv[index + 1];
+  if (path === void 0 || path.startsWith("--")) {
+    throw new Error("--content-file requires a local file path.");
+  }
+  return [
+    ...toolArgv.slice(0, index),
+    "--content",
+    readers.readFile(path),
+    ...toolArgv.slice(index + 2)
+  ];
+}
 function resolveUseCommand(positionals, toolArgv) {
   if (toolArgv !== null) {
     if (positionals.length !== 1 || positionals[0] !== "use") {
@@ -362,12 +400,20 @@ CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` 
   --json                  print the raw JSON result
   --dry-run               print the reconstructed request; do not connect or execute
 
+CONTENT INPUT (CLI-only flags after the \\\`--\\\` delimiter)
+  --content-stdin         read the tool's --content value from standard input
+  --content-file <path>   read the tool's --content value from a local file
+                          (use one transport flag; do not also pass --content)
+
 CLI SYNTAX
   \\u2022 Canonical form: context flags first, then \\\`--\\\`, then one tool command as normal
     shell arguments. Commands are kebab-case (content set-property, memory load-workspace).
     Multiword values need only one shell quote layer: --workspace "NeuroAI Mapping".
   \\u2022 The legacy one-string form remains supported. On Windows PowerShell, nested double
     quotes can be consumed before Node receives them; prefer the canonical \\\`--\\\` form.
+  \\u2022 For multiline Markdown or text containing embedded quotes, keep the payload out of
+    shell argv: \\\`Get-Content -Raw note.md | nexus use ... -- content write --path X.md --content-stdin\\\`,
+    or pass \\\`--content-file note.md\\\`.
   \\u2022 Paths are vault-relative. "..", "~", absolute paths are rejected; a leading "/" is
     stripped. You cannot read or write outside the vault.
   \\u2022 Arrays: --tags "[work, urgent]". Wikilinks keep brackets: --links "[[[A]], [[B]]]".
@@ -536,7 +582,16 @@ Once a vault is open, preload them with:
   if (cmd === "use") {
     let command;
     try {
-      command = resolveUseCommand(positionals, toolArgv);
+      const hydratedToolArgv = toolArgv === null ? null : hydrateToolContentArgv(toolArgv, {
+        readStdin: () => {
+          if (process.stdin.isTTY) {
+            throw new Error("--content-stdin requires piped or redirected standard input.");
+          }
+          return (0, import_node_fs3.readFileSync)(0, "utf8");
+        },
+        readFile: (path) => (0, import_node_fs3.readFileSync)(path, "utf8")
+      });
+      command = resolveUseCommand(positionals, hydratedToolArgv);
     } catch (error) {
       process.stderr.write(\`Error: \${error.message}
 \`);
@@ -585,11 +640,8 @@ description: >-
   tasks, memory/workspaces, saved prompts) from the shell via the \`nexus\` CLI —
   no MCP connection needed. Use whenever the user refers to their vault, notes,
   daily notes, second brain, or Obsidian, or asks you to find/read/change
-  something stored there.
-when_to_use: >-
-  The task involves the user's Obsidian vault or notes and the \`nexus\` command
-  is on PATH. Not for editing files in the current code repo — use normal file
-  tools for those.
+  something stored there and the \`nexus\` command is on PATH. Do not use it to
+  edit files in the current code repository; use normal file tools for those.
 ---
 
 # Nexus vault CLI
@@ -637,6 +689,16 @@ The \`--\` delimiter is canonical: context belongs before it; the tool command
 belongs after it. This avoids nested command-string quoting, especially in
 Windows PowerShell. The legacy one-string form remains supported.
 
+For multiline Markdown or content containing embedded quotes, keep the body
+out of shell argv. Pipe it with \`--content-stdin\` or pass a local path with
+\`--content-file\`; put either flag after the \`--\` delimiter and do not also pass
+\`--content\`:
+
+\`\`\`powershell
+Get-Content -Raw .\\note.md |
+    nexus use --memory "importing note" --goal "write note" -- content write --path Notes/Imported.md --content-stdin
+\`\`\`
+
 Everything else — the flag table, per-tool schemas, syntax rules, the live
 per-vault catalog (including any enabled app agents) — comes from \`nexus --help\`,
 \`nexus tools <tool>\`, and \`nexus playbook <name>\`. Prefer those over guessing;
@@ -658,6 +720,9 @@ offline and instant, so read it before your first command instead of guessing.
   Drill down: \`nexus tools storage list\` = one tool's full arg schema.
 - **Execute:** \`nexus use --memory "<what you're doing>" --goal "<objective>" -- <agent command --flags>\`.
   \`--memory\`/\`--goal\` are **required** on every \`use\`.
+- **Multiline content:** keep Markdown/YAML and embedded quotes out of shell
+  argv. After \`--\`, use \`--content-stdin\` with piped input or
+  \`--content-file <local-path>\` instead of \`--content\`.
 - **Task recipes:** \`nexus playbook <name>\` emits a ready-to-run recipe plus your
   workspaces and preloaded tools in one call (\`nexus playbook\` lists them).
 - Search/list results are **locations, not contents** — follow a hit with
@@ -699,6 +764,10 @@ so you can go straight to \`nexus use\` without a separate \`nexus tools\` call.
 Paths are vault-relative and confined — no \`..\`, \`~\`, or absolute escapes. **All
 flags are kebab-case** — camelCase (e.g. \`--activeTask\`) is rejected as an unknown
 flag; use \`--active-task\`.
+
+For multiline Markdown/YAML or embedded quotes, keep content out of shell argv:
+after \`--\`, pipe with \`--content-stdin\` or pass \`--content-file <local-path>\`
+instead of \`--content\`.
 `,
     "organize.md": `---
 name: organize

--- a/tests/unit/ToolManagerCliSyntax.test.ts
+++ b/tests/unit/ToolManagerCliSyntax.test.ts
@@ -20,6 +20,7 @@ import * as path from 'node:path';
 import { createHeadlessAgentStack, HeadlessAgentStackResult } from '../eval/headless/HeadlessAgentStack';
 import { TestVaultManager } from '../eval/headless/TestVaultManager';
 import { ToolCliNormalizer, parseCliForDisplay, splitTopLevelSegments, tokenizeWithMeta } from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import { serializeToolArgv } from '../../cli/commandLine';
 import type { IAgent } from '../../src/agents/interfaces/IAgent';
 import type { ITool } from '../../src/agents/interfaces/ITool';
 
@@ -1242,6 +1243,28 @@ describe('parser characterization — CLI migration audit', () => {
     });
     expect(calls).toHaveLength(1);
     expect(calls[0].params.content).toBe('alpha, beta, gamma');
+  });
+
+  it('E.1b: shell-preserved YAML quotes and wikilinks survive downstream parsing', () => {
+    const markdown = [
+      '---',
+      'owner: "[[Stakeholders/Ashlea Burke]]"',
+      'reviewers: ["[[People/Joseph Rosenbaum]]", "[[People/Ada Lovelace]]"]',
+      '---',
+      '',
+      '# Project update',
+    ].join('\n');
+    const tool = serializeToolArgv([
+      'content', 'write', '--path', 'Projects/Update.md', '--content', markdown,
+    ]);
+
+    const calls = makeNormalizer().normalizeExecutionCalls({ tool });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].params).toEqual({
+      path: 'Projects/Update.md',
+      content: markdown,
+    });
   });
 
   it('E.2: comma inside JSON array-flag value does not split segments', () => {

--- a/tests/unit/nexusCliCommandLine.test.ts
+++ b/tests/unit/nexusCliCommandLine.test.ts
@@ -1,4 +1,5 @@
 import {
+    hydrateToolContentArgv,
     partitionUseArgv,
     resolveUseCommand,
     serializeToolArgv,
@@ -39,6 +40,65 @@ describe('Nexus CLI structured use argv', () => {
 
         const command = serializeToolArgv(argv);
         expect(tokenizeWithMeta(command).map((token) => token.value)).toEqual(argv);
+    });
+
+    it('round-trips multiline Markdown with YAML quotes, spaces, and wikilinks', () => {
+        const markdown = [
+            '---',
+            'owner: "[[Stakeholders/Ashlea Burke]]"',
+            'reviewers: ["[[People/Joseph Rosenbaum]]", "[[People/Ada Lovelace]]"]',
+            '---',
+            '',
+            '# Project update',
+            'A multiline body with "embedded quotes" and spaces.',
+        ].join('\n');
+        const argv = ['content', 'write', '--path', 'Projects/Update.md', '--content', markdown];
+
+        const command = serializeToolArgv(argv);
+
+        expect(tokenizeWithMeta(command).map((token) => token.value)).toEqual(argv);
+    });
+
+    it('hydrates multiline content from stdin without putting it in shell argv', () => {
+        const markdown = '---\nowner: "[[Stakeholders/Ashlea Burke]]"\n---\nBody';
+        const argv = hydrateToolContentArgv(
+            ['content', 'write', '--path', 'Projects/Update.md', '--content-stdin'],
+            { readStdin: () => markdown, readFile: () => '' }
+        );
+
+        expect(argv).toEqual([
+            'content', 'write', '--path', 'Projects/Update.md', '--content', markdown,
+        ]);
+        expect(tokenizeWithMeta(serializeToolArgv(argv)).map((token) => token.value)).toEqual(argv);
+    });
+
+    it('hydrates multiline content from a local file path containing spaces', () => {
+        const markdown = '# Imported note\n\nContent with "quotes".';
+        const readFile = jest.fn(() => markdown);
+
+        const argv = hydrateToolContentArgv(
+            ['content', 'write', '--content-file', 'C:\\Temp Files\\note.md', '--path', 'Imported.md'],
+            { readStdin: () => '', readFile }
+        );
+
+        expect(readFile).toHaveBeenCalledWith('C:\\Temp Files\\note.md');
+        expect(argv).toEqual([
+            'content', 'write', '--content', markdown, '--path', 'Imported.md',
+        ]);
+    });
+
+    it('rejects ambiguous or incomplete content transports', () => {
+        const readers = { readStdin: () => 'stdin', readFile: () => 'file' };
+
+        expect(() => hydrateToolContentArgv([
+            'content', 'write', '--content', 'inline', '--content-stdin',
+        ], readers)).toThrow(/Do not combine --content/);
+        expect(() => hydrateToolContentArgv([
+            'content', 'write', '--content-stdin', '--content-file', 'note.md',
+        ], readers)).toThrow(/exactly one/);
+        expect(() => hydrateToolContentArgv([
+            'content', 'write', '--content-file', '--path', 'Note.md',
+        ], readers)).toThrow(/requires a local file path/);
     });
 
     it('reconstructs the reported multiword workspace command', () => {


### PR DESCRIPTION
## Summary

- add CLI-only `--content-stdin` and `--content-file` transports for tool `--content` values
- document the safe multiline workflow in CLI help, the Nexus guide, agent skill guidance, Codex pointer text, and playbook preamble
- add regressions for multiline Markdown, YAML double quotes, spaces, commas, and wikilinks
- remove the unsupported `when_to_use` key from Nexus skill frontmatter and preserve its guidance in the description

## Why

The Windows `nexus.cmd` wrapper forwards arguments through `%*`, which cannot reliably preserve multiline PowerShell arguments. Large Markdown payloads also had to survive nested shell quoting before reaching the existing CLI serializer and downstream tool parser. Reading content from stdin or a local file keeps the payload out of shell argv and avoids both failure modes.

The current structured argv serializer already preserves embedded double quotes once Node receives the complete argument; the new regression tests pin that behavior through downstream `ToolCliNormalizer` parsing.

## Impact

Agents and users can now write multiline Markdown/YAML safely with either:

```powershell
Get-Content -Raw .\note.md |
  nexus use --memory "importing note" --goal "write note" -- content write --path Notes/Imported.md --content-stdin
```

or `--content-file .\note.md` after the `--` delimiter.

## Validation

- `npm run build`
- 200 focused Jest tests passed; 11 platform-inapplicable tests skipped
- Nexus skill `quick_validate.py` passed
- live `nexus.cmd` write/read/archive round trip against the Plugin Tester vault
- live `--content-file` copy matched the source SHA-256 exactly
- `git diff --check`
