### PR TITLE
Show available vaults in Nexus CLI help

### DIFF
--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -23,6 +23,7 @@ import {
     UNIX_SUFFIX,
     WIN_PIPE_DIR,
     VaultSocket,
+    formatAvailableVaults,
     isOwnUnixSocket,
 } from './vaultDiscovery';
 
@@ -125,6 +126,15 @@ function buildUsage(): string {
         playbookLines = '    (run `nexus playbook` to list)';
     }
 
+    // Help remains useful without a running vault, but when discovery is available it
+    // should answer the immediate follow-up question: which value can I pass to --vault?
+    let availableVaultLines: string;
+    try {
+        availableVaultLines = formatAvailableVaults(listVaultSockets());
+    } catch (error) {
+        availableVaultLines = `  (could not enumerate: ${(error as Error).message})`;
+    }
+
     return `nexus — drive a running Nexus (Obsidian) vault from the shell (no MCP config)
 
 Two verbs: DISCOVER what you can do, then EXECUTE. Discovery returns schemas, never
@@ -143,6 +153,9 @@ COMMANDS
   nexus vaults                       List open Nexus vaults (live sockets)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
+
+AVAILABLE VAULTS  (live; refreshed whenever help runs)
+${availableVaultLines}
 
 CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
          --workspace/--session/--vault and fills memory/goal for you)

--- a/cli/vaultDiscovery.ts
+++ b/cli/vaultDiscovery.ts
@@ -19,6 +19,18 @@ export interface VaultSocket {
     path: string;
 }
 
+/** Format live endpoints for the dynamic section in `nexus --help`. */
+export function formatAvailableVaults(sockets: readonly VaultSocket[]): string {
+    if (sockets.length === 0) {
+        return '  (none detected — open Obsidian with Nexus enabled)';
+    }
+
+    const nameWidth = Math.max(...sockets.map((socket) => socket.name.length));
+    return sockets
+        .map((socket) => `  ${socket.name.padEnd(nameWidth)}  ${socket.path}`)
+        .join('\n');
+}
+
 const WINDOWS_PIPE_LIST_SCRIPT = "Get-ChildItem -LiteralPath '\\\\.\\pipe\\' -Name";
 const SAFE_PIPE_NAME = /^nexus_mcp_[a-z0-9_-]+$/;
 

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,7 +7,7 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "2441e94c26231d02";
+export const NEXUS_CLI_ASSETS_HASH = "62f92ad70ecbb4f2";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
@@ -211,6 +211,13 @@ var NAME_PREFIX = "nexus_mcp_";
 var UNIX_SOCK_DIR = "/tmp";
 var UNIX_SUFFIX = ".sock";
 var WIN_PIPE_DIR = "\\\\\\\\.\\\\pipe\\\\";
+function formatAvailableVaults(sockets) {
+  if (sockets.length === 0) {
+    return "  (none detected \\u2014 open Obsidian with Nexus enabled)";
+  }
+  const nameWidth = Math.max(...sockets.map((socket) => socket.name.length));
+  return sockets.map((socket) => \`  \${socket.name.padEnd(nameWidth)}  \${socket.path}\`).join("\\n");
+}
 var WINDOWS_PIPE_LIST_SCRIPT = "Get-ChildItem -LiteralPath '\\\\\\\\.\\\\pipe\\\\' -Name";
 var SAFE_PIPE_NAME = /^nexus_mcp_[a-z0-9_-]+$/;
 function parseWindowsPipeListing(output) {
@@ -331,6 +338,12 @@ function buildUsage() {
   } catch {
     playbookLines = "    (run \`nexus playbook\` to list)";
   }
+  let availableVaultLines;
+  try {
+    availableVaultLines = formatAvailableVaults(listVaultSockets());
+  } catch (error) {
+    availableVaultLines = \`  (could not enumerate: \${error.message})\`;
+  }
   return \`nexus \\u2014 drive a running Nexus (Obsidian) vault from the shell (no MCP config)
 
 Two verbs: DISCOVER what you can do, then EXECUTE. Discovery returns schemas, never
@@ -349,6 +362,9 @@ COMMANDS
   nexus vaults                       List open Nexus vaults (live sockets)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
+
+AVAILABLE VAULTS  (live; refreshed whenever help runs)
+\${availableVaultLines}
 
 CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` reads only
          --workspace/--session/--vault and fills memory/goal for you)

--- a/tests/unit/nexusVaultDiscovery.test.ts
+++ b/tests/unit/nexusVaultDiscovery.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { listVaultSockets, parseWindowsPipeListing } from '../../cli/vaultDiscovery';
+import { formatAvailableVaults, listVaultSockets, parseWindowsPipeListing } from '../../cli/vaultDiscovery';
 
 jest.mock('node:child_process', () => ({
     spawnSync: jest.fn(),
@@ -88,5 +88,23 @@ describe('Windows Nexus vault discovery', () => {
         expect(() => listVaultSockets('win32')).toThrow(
             'Could not enumerate Windows named pipes: access denied. Pass --vault <name> or set NEXUS_VAULT as a fallback.'
         );
+    });
+});
+
+describe('Nexus vault help formatting', () => {
+    it('shows a useful empty state when no vaults are open', () => {
+        expect(formatAvailableVaults([])).toBe(
+            '  (none detected — open Obsidian with Nexus enabled)'
+        );
+    });
+
+    it('shows every available vault with aligned paths', () => {
+        expect(formatAvailableVaults([
+            { name: 'notes', path: '/tmp/nexus_mcp_notes.sock' },
+            { name: 'research-vault', path: '/tmp/nexus_mcp_research-vault.sock' },
+        ])).toBe([
+            '  notes           /tmp/nexus_mcp_notes.sock',
+            '  research-vault  /tmp/nexus_mcp_research-vault.sock',
+        ].join('\n'));
     });
 });


### PR DESCRIPTION
## What changed

- Add a live **Available vaults** section to `nexus --help` and `nexus help`
- Show aligned vault names and socket paths using the existing local vault discovery
- Show a useful empty or enumeration-error state without making help fail
- Rebuild the embedded CLI installer asset

## Why

Users currently need to run a separate `nexus vaults` command before choosing a `--vault` value. Including live vault discovery in the authoritative help manual makes that context immediately visible.

## Validation

- `npm test -- --runInBand tests/unit/nexusVaultDiscovery.test.ts` — 6 tests passed
- `npm run build:cli` — CLI TypeScript check and bundle generation passed
- `node nexus-cli.js --help` — verified against three live local vaults
- `git diff --check` — passed

A broader installer test run passed 21/22 tests; the remaining environment-sensitive Windows PATH namesake assertion is unrelated to this change.
