### PR TITLE
Fix voice input transcription chunking

### DIFF
--- a/src/ui/chat/controllers/ChatVoiceInputController.ts
+++ b/src/ui/chat/controllers/ChatVoiceInputController.ts
@@ -32,14 +32,13 @@ export class ChatVoiceInputController {
   private stream: MediaStream | null = null;
   private activeMimeType: string | null = null;
   private activeSettings: LLMProviderSettings | null = null;
-  private queuedBlobs: Blob[] = [];
-  private transcriptChunks: string[] = [];
-  private processingQueue = false;
+  private recordedBlobs: Blob[] = [];
+  private finalizingRecording = false;
   private recorderStopped = false;
   private finalizePromise: Promise<string> | null = null;
   private resolveFinalize: ((value: string) => void) | null = null;
   private rejectFinalize: ((error: Error) => void) | null = null;
-  private firstChunkError: Error | null = null;
+  private recordingError: Error | null = null;
 
   constructor(
     private readonly app: App | undefined,
@@ -115,8 +114,9 @@ export class ChatVoiceInputController {
       this.recorder = new MediaRecorder(this.stream, { mimeType });
       this.recorder.ondataavailable = (event: BlobEvent) => {
         if (event.data.size > 0) {
-          this.queuedBlobs.push(event.data);
-          void this.processQueuedChunks();
+          // Timeslice blobs are not guaranteed to be independently playable.
+          // Preserve their order and transcribe the complete recording on stop.
+          this.recordedBlobs.push(event.data);
         }
       };
       this.recorder.onstop = () => {
@@ -125,7 +125,7 @@ export class ChatVoiceInputController {
         this.tryFinalize();
       };
       this.recorder.onerror = () => {
-        this.firstChunkError = this.firstChunkError ?? new Error('Audio recording failed.');
+        this.recordingError = this.recordingError ?? new Error('Audio recording failed.');
         this.recorderStopped = true;
         this.stopStreamTracks();
         this.tryFinalize();
@@ -161,8 +161,8 @@ export class ChatVoiceInputController {
       if (normalizedTranscript.length > 0) {
         this.callbacks.onTranscriptReady(normalizedTranscript);
       }
-      if (this.firstChunkError && normalizedTranscript.length > 0) {
-        this.callbacks.onError('Voice input kept a partial transcript after one chunk failed.');
+      if (this.recordingError && normalizedTranscript.length > 0) {
+        this.callbacks.onError('Voice input kept a partial transcript after recording ended unexpectedly.');
       }
     } catch (error) {
       this.callbacks.onError(
@@ -195,34 +195,38 @@ export class ChatVoiceInputController {
     this.setState('idle');
   }
 
-  private async processQueuedChunks(): Promise<void> {
-    if (this.processingQueue) {
+  private tryFinalize(): void {
+    if (!this.recorderStopped || this.finalizingRecording) {
       return;
     }
 
-    this.processingQueue = true;
+    this.finalizingRecording = true;
+    const combinedBlob = new Blob(this.recordedBlobs, {
+      type: this.activeMimeType ?? 'audio/webm'
+    });
 
+    void this.transcribeCombinedRecording(combinedBlob);
+  }
+
+  private async transcribeCombinedRecording(blob: Blob): Promise<void> {
     try {
-      while (this.queuedBlobs.length > 0) {
-        const blob = this.queuedBlobs.shift();
-        if (!blob) {
-          continue;
-        }
-
-        try {
-          const text = await this.transcribeBlob(blob);
-          if (text.length > 0) {
-            this.transcriptChunks.push(text);
-          }
-        } catch (error) {
-          this.firstChunkError = this.firstChunkError ?? (
-            error instanceof Error ? error : new Error('Voice input transcription failed.')
-          );
-        }
+      const transcript = blob.size > 0 ? await this.transcribeBlob(blob) : '';
+      if (transcript.length > 0) {
+        this.resolveFinalize?.(transcript);
+      } else if (this.recordingError) {
+        this.rejectFinalize?.(this.recordingError);
+      } else {
+        this.resolveFinalize?.('');
       }
+    } catch (error) {
+      this.rejectFinalize?.(
+        error instanceof Error ? error : new Error('Voice input transcription failed.')
+      );
     } finally {
-      this.processingQueue = false;
-      this.tryFinalize();
+      this.finalizingRecording = false;
+      this.resolveFinalize = null;
+      this.rejectFinalize = null;
+      this.finalizePromise = null;
     }
   }
 
@@ -244,37 +248,16 @@ export class ChatVoiceInputController {
     return result.text.replace(/\s+/g, ' ').trim();
   }
 
-  private tryFinalize(): void {
-    if (!this.recorderStopped || this.processingQueue || this.queuedBlobs.length > 0) {
-      return;
-    }
-
-    const transcript = this.transcriptChunks.join(' ').replace(/\s+/g, ' ').trim();
-
-    if (transcript.length > 0) {
-      this.resolveFinalize?.(transcript);
-    } else if (this.firstChunkError) {
-      this.rejectFinalize?.(this.firstChunkError);
-    } else {
-      this.resolveFinalize?.('');
-    }
-
-    this.resolveFinalize = null;
-    this.rejectFinalize = null;
-    this.finalizePromise = null;
-  }
-
   private stopStreamTracks(): void {
     this.stream?.getTracks().forEach(track => track.stop());
     this.stream = null;
   }
 
   private resetSessionState(): void {
-    this.queuedBlobs = [];
-    this.transcriptChunks = [];
-    this.processingQueue = false;
+    this.recordedBlobs = [];
+    this.finalizingRecording = false;
     this.recorderStopped = false;
-    this.firstChunkError = null;
+    this.recordingError = null;
   }
 
   private setState(state: ChatVoiceInputState): void {

--- a/tests/unit/ChatVoiceInputController.test.ts
+++ b/tests/unit/ChatVoiceInputController.test.ts
@@ -15,8 +15,10 @@ jest.mock('../../src/services/llm/TranscriptionService', () => ({
 
 class MockMediaRecorder {
   static isTypeSupported = jest.fn(() => true);
+  static latestInstance: MockMediaRecorder | null = null;
 
   state: 'inactive' | 'recording' = 'inactive';
+  finalData = 'voice';
   ondataavailable: ((event: BlobEvent) => void) | null = null;
   onstop: (() => void) | null = null;
   onerror: (() => void) | null = null;
@@ -24,7 +26,9 @@ class MockMediaRecorder {
   constructor(
     public readonly _stream: MediaStream,
     public readonly _options: { mimeType: string }
-  ) {}
+  ) {
+    MockMediaRecorder.latestInstance = this;
+  }
 
   start(): void {
     this.state = 'recording';
@@ -32,10 +36,14 @@ class MockMediaRecorder {
 
   stop(): void {
     this.state = 'inactive';
-    this.ondataavailable?.({
-      data: new Blob(['voice'], { type: 'audio/webm' })
-    } as BlobEvent);
+    this.emitData(this.finalData);
     this.onstop?.();
+  }
+
+  emitData(data: string): void {
+    this.ondataavailable?.({
+      data: new Blob([data], { type: 'audio/webm' })
+    } as BlobEvent);
   }
 }
 
@@ -48,6 +56,7 @@ describe('ChatVoiceInputController', () => {
     mockedGetNexusPlugin.mockReset();
     mockedCreateOrReuse.mockReset();
     mediaTrackStop.mockReset();
+    MockMediaRecorder.latestInstance = null;
 
     Object.defineProperty(global, 'MediaRecorder', {
       writable: true,
@@ -91,7 +100,7 @@ describe('ChatVoiceInputController', () => {
     expect(controller.isAvailable()).toBe(true);
   });
 
-  it('records, transcribes queued chunks, and returns the transcript when stopped', async () => {
+  it('records, transcribes the recording, and returns the transcript when stopped', async () => {
     const onStateChange = jest.fn();
     const onTranscriptReady = jest.fn();
     const onError = jest.fn();
@@ -134,6 +143,55 @@ describe('ChatVoiceInputController', () => {
     expect(onStateChange).toHaveBeenLastCalledWith('idle');
     expect(onError).not.toHaveBeenCalled();
     expect(mediaTrackStop).toHaveBeenCalled();
+  });
+
+  it('combines periodic and final recorder slices before transcribing', async () => {
+    const onTranscriptReady = jest.fn();
+    const transcribe = jest.fn().mockImplementation(async request => {
+      const audioText = new TextDecoder().decode(new Uint8Array(request.audioData));
+      return {
+        provider: 'openai',
+        model: 'whisper-1',
+        text: audioText === 'update me on what is happening with Alex'
+          ? 'update me on what is happening with Alex'
+          : '',
+        segments: []
+      };
+    });
+
+    mockedGetNexusPlugin.mockReturnValue({
+      settings: {
+        settings: {
+          llmProviders: { providers: {} } as never
+        }
+      }
+    } as App);
+    mockedCreateOrReuse.mockReturnValue({
+      getAvailableProviders: () => [
+        {
+          provider: 'openai',
+          available: true,
+          models: [{ id: 'whisper-1' }]
+        }
+      ],
+      transcribe
+    } as never);
+
+    const controller = new ChatVoiceInputController({} as App, {
+      onStateChange: jest.fn(),
+      onTranscriptReady,
+      onError: jest.fn()
+    });
+
+    await controller.startRecording();
+    MockMediaRecorder.latestInstance?.emitData('update me on what is happening with ');
+    if (MockMediaRecorder.latestInstance) {
+      MockMediaRecorder.latestInstance.finalData = 'Alex';
+    }
+    await controller.stopRecording();
+
+    expect(transcribe).toHaveBeenCalledTimes(1);
+    expect(onTranscriptReady).toHaveBeenCalledWith('update me on what is happening with Alex');
   });
 
   it('prefers resolved chat transcription settings when provided', () => {


### PR DESCRIPTION
## What changed

- collect MediaRecorder timeslice blobs in order
- combine the complete recording before transcription
- add a regression test that splits a phrase immediately before the final word

## Why

MediaRecorder does not guarantee that individual timeslice blobs are independently playable. Transcribing each 2.5-second slice separately could drop a short trailing slice, causing the end of dictated messages to disappear.

## Impact

Chat voice input now sends one valid, complete recording for transcription, preserving trailing words such as “Alex” in the reported reproduction.

## Validation

- focused ChatVoiceInputController tests: 4 passed
- production build, TypeScript checks, and lint: passed
- full test suite: 4,050 passed; 1 unrelated existing Windows LocalCliInstaller PATH-precedence test failed
