### PR TITLE
Add OpenAI gpt-transcribe, gpt-live-transcribe, and diarization

### DIFF
--- a/src/services/llm/adapters/openai/OpenAITranscriptionAdapter.ts
+++ b/src/services/llm/adapters/openai/OpenAITranscriptionAdapter.ts
@@ -9,6 +9,27 @@ import type {
 import { buildMultipartFormData } from '../../utils/MultipartFormDataBuilder';
 import { parseWhisperResponse } from '../../utils/WhisperResponseParser';
 
+/**
+ * Response format per model. OpenAI's transcription models no longer share one
+ * contract:
+ *
+ * - `whisper-1` is the only model that still accepts `verbose_json`, and the
+ *   only one that returns word timestamps.
+ * - `gpt-4o-transcribe-diarize` speaks `diarized_json`: segments with speaker
+ *   labels and timing, but no word-level detail.
+ * - The `gpt-transcribe` generation returns plain JSON with no timing at all,
+ *   and rejects `verbose_json` outright rather than degrading to it.
+ */
+type OpenAITranscriptionResponseFormat = 'verbose_json' | 'diarized_json' | 'json';
+
+const RESPONSE_FORMAT_BY_MODEL: Record<string, OpenAITranscriptionResponseFormat> = {
+  'whisper-1': 'verbose_json',
+  'gpt-4o-transcribe-diarize': 'diarized_json'
+};
+
+/** Diarization models reject `prompt` with a 400 rather than ignoring it. */
+const MODELS_REJECTING_PROMPT = new Set(['gpt-4o-transcribe-diarize']);
+
 export class OpenAITranscriptionAdapter extends BaseTranscriptionAdapter {
   readonly provider: TranscriptionProvider = 'openai';
   private readonly endpoint = 'https://api.openai.com/v1/audio/transcriptions';
@@ -17,6 +38,8 @@ export class OpenAITranscriptionAdapter extends BaseTranscriptionAdapter {
     chunk: AudioChunk,
     request: TranscriptionRequest & { provider: TranscriptionProvider; model: string }
   ): Promise<TranscriptionSegment[]> {
+    const responseFormat = RESPONSE_FORMAT_BY_MODEL[request.model] ?? 'json';
+
     const fields = [
       {
         name: 'file',
@@ -27,14 +50,17 @@ export class OpenAITranscriptionAdapter extends BaseTranscriptionAdapter {
       { name: 'model', value: request.model }
     ];
 
-    if (request.prompt?.trim()) {
+    if (request.prompt?.trim() && !MODELS_REJECTING_PROMPT.has(request.model)) {
       fields.push({ name: 'prompt', value: request.prompt.trim() });
     }
 
-    fields.push({ name: 'response_format', value: 'verbose_json' });
-    fields.push({ name: 'timestamp_granularities[]', value: 'segment' });
-    if (request.requestWordTimestamps === true) {
-      fields.push({ name: 'timestamp_granularities[]', value: 'word' });
+    fields.push({ name: 'response_format', value: responseFormat });
+
+    if (responseFormat === 'verbose_json') {
+      fields.push({ name: 'timestamp_granularities[]', value: 'segment' });
+      if (request.requestWordTimestamps === true) {
+        fields.push({ name: 'timestamp_granularities[]', value: 'word' });
+      }
     }
 
     const { body, contentType } = buildMultipartFormData(fields);
@@ -52,7 +78,9 @@ export class OpenAITranscriptionAdapter extends BaseTranscriptionAdapter {
       throw new Error(`OpenAI transcription failed: HTTP ${response.status}`);
     }
 
-    return parseWhisperResponse(response.json as unknown, chunk.durationSeconds);
+    return parseWhisperResponse(response.json as unknown, chunk.durationSeconds, {
+      extractSpeakers: responseFormat === 'diarized_json'
+    });
   }
 }
 

--- a/src/services/llm/types/RealtimeVoiceTypes.ts
+++ b/src/services/llm/types/RealtimeVoiceTypes.ts
@@ -171,6 +171,15 @@ const REALTIME_VOICE_MODELS: RealtimeVoiceModelDeclaration[] = [
     supportsTranscripts: true
   },
   {
+    provider: 'openai',
+    id: 'gpt-live-transcribe',
+    name: 'GPT Live Transcribe',
+    transport: 'websocket',
+    execution: 'transcription-pipeline',
+    supportsTools: true,
+    supportsTranscripts: true
+  },
+  {
     provider: 'assemblyai',
     id: 'universal-3-5-pro',
     name: 'Universal 3.5 Pro Realtime',

--- a/src/services/llm/types/VoiceTypes.ts
+++ b/src/services/llm/types/VoiceTypes.ts
@@ -76,12 +76,31 @@ export interface AudioChunk {
 
 const TRANSCRIPTION_MODELS: TranscriptionModelDeclaration[] = [
   {
+    // Kept first so it stays the OpenAI default: it is the only OpenAI model
+    // that still returns word timestamps, which ingestion asks for.
     provider: 'openai',
     id: 'whisper-1',
     name: 'Whisper 1',
     execution: 'speech-api-segmented',
     supportsWordTimestamps: true,
     supportsPrompt: true
+  },
+  {
+    provider: 'openai',
+    id: 'gpt-transcribe',
+    name: 'GPT Transcribe',
+    execution: 'speech-api-segmented',
+    supportsWordTimestamps: false,
+    supportsPrompt: true
+  },
+  {
+    provider: 'openai',
+    id: 'gpt-4o-transcribe-diarize',
+    name: 'GPT-4o Transcribe Diarize',
+    execution: 'speech-api-segmented',
+    supportsWordTimestamps: false,
+    supportsSpeakerLabels: true,
+    supportsPrompt: false
   },
   {
     provider: 'groq',

--- a/src/services/realtimeVoice/OpenAILiveTranscribeSession.ts
+++ b/src/services/realtimeVoice/OpenAILiveTranscribeSession.ts
@@ -1,17 +1,21 @@
 import { requestUrl } from 'obsidian';
 import type {
   RealtimeVoiceSession,
-  ResolvedAssemblyAIRealtimeVoiceSessionRequest,
+  ResolvedOpenAIRealtimeVoiceSessionRequest,
 } from './RealtimeVoiceSessionTypes';
-import { encodeFloatPcm16 } from './pcmAudio';
+import { computeRms, encodeBase64, encodeFloatPcm16 } from './pcmAudio';
 
-interface AssemblyAIStreamingMessage {
+interface RealtimeTranscriptionEvent {
   type?: unknown;
-  turn_order?: unknown;
+  delta?: unknown;
   transcript?: unknown;
-  end_of_turn?: unknown;
-  error?: unknown;
-  message?: unknown;
+  error?: {
+    message?: unknown;
+  };
+}
+
+interface ClientSecretResponse {
+  value?: unknown;
 }
 
 interface LegacyAudioProcessEvent extends Event {
@@ -28,13 +32,25 @@ type LegacyCreateScriptProcessor = (
   numberOfOutputChannels: number
 ) => LegacyScriptProcessorNode;
 
-const SAMPLE_RATE = 16000;
-/** AssemblyAI rejects an agent_context longer than this. */
-const MAX_AGENT_CONTEXT_CHARS = 1750;
-const TOKEN_ENDPOINT = 'https://streaming.assemblyai.com/v3/token?expires_in_seconds=60';
-const STREAMING_ENDPOINT = 'wss://streaming.assemblyai.com/v3/ws';
+const SAMPLE_RATE = 24000;
+const CLIENT_SECRET_ENDPOINT = 'https://api.openai.com/v1/realtime/client_secrets';
+const REALTIME_ENDPOINT = 'wss://api.openai.com/v1/realtime?intent=transcription';
 
-export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
+/**
+ * gpt-live-transcribe rejects server-side turn detection, so the client decides
+ * when a turn ends. These drive a simple energy gate: speech starts once the
+ * signal clears the threshold, and the turn is committed after a stretch of
+ * quiet. The minimum guards against committing a buffer the API considers too
+ * short to transcribe.
+ */
+const SPEECH_RMS_THRESHOLD = 0.012;
+const SILENCE_MS_BEFORE_COMMIT = 800;
+const MIN_COMMIT_MS = 150;
+
+/** The session prompt doubles as spoken-reply context, same role as AssemblyAI's agent_context. */
+const MAX_PROMPT_CHARS = 2000;
+
+export class OpenAILiveTranscribeSession implements RealtimeVoiceSession {
   readonly mode = 'composed' as const;
 
   private websocket: WebSocket | null = null;
@@ -43,32 +59,33 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
   private captureSource: MediaStreamAudioSourceNode | null = null;
   private captureProcessor: LegacyScriptProcessorNode | null = null;
   private captureSink: GainNode | null = null;
-  private closeTimer: number | null = null;
   private stopped = false;
   private connected = false;
   private currentState: 'connecting' | 'listening' | 'user-speaking' | null = null;
-  private finalizedTurns = new Set<string>();
+  private agentContext = '';
 
-  constructor(private readonly request: ResolvedAssemblyAIRealtimeVoiceSessionRequest) {}
+  private speaking = false;
+  private silenceMs = 0;
+  private bufferedMs = 0;
+
+  constructor(private readonly request: ResolvedOpenAIRealtimeVoiceSessionRequest) {}
 
   async start(): Promise<void> {
     this.assertRuntimeSupport();
     this.stopped = false;
     this.connected = false;
-    this.finalizedTurns.clear();
+    this.resetTurnState();
     this.emitStateChange('connecting');
 
-    const token = await this.createTemporaryToken();
+    const clientSecret = await this.createClientSecret();
     if (this.stopped) {
       return;
     }
 
-    const query = new URLSearchParams({
-      sample_rate: String(SAMPLE_RATE),
-      speech_model: this.request.model,
-      token,
-    });
-    const websocket = new WebSocket(`${STREAMING_ENDPOINT}?${query.toString()}`);
+    const websocket = new WebSocket(REALTIME_ENDPOINT, [
+      'realtime',
+      `openai-insecure-api-key.${clientSecret}`,
+    ]);
     this.websocket = websocket;
 
     return new Promise<void>((resolve, reject) => {
@@ -83,16 +100,8 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
         reject(error instanceof Error ? error : new Error(String(error)));
       };
 
-      const resolveOnce = (): void => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        resolve();
-      };
-
       websocket.onerror = () => {
-        rejectOnce(new Error('AssemblyAI realtime WebSocket failed. Check the API key and network connection.'));
+        rejectOnce(new Error('OpenAI realtime transcription WebSocket failed. Check the API key and network connection.'));
       };
 
       websocket.onclose = (event) => {
@@ -102,8 +111,8 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
 
         const reason = event.reason?.trim();
         const message = reason
-          ? `AssemblyAI realtime connection closed: ${reason}`
-          : `AssemblyAI realtime connection closed (code ${event.code}).`;
+          ? `OpenAI realtime transcription connection closed: ${reason}`
+          : `OpenAI realtime transcription connection closed (code ${event.code}).`;
         if (!settled) {
           rejectOnce(new Error(message));
           return;
@@ -111,11 +120,16 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
         this.request.callbacks.onError(message);
       };
 
+      websocket.onopen = () => {
+        this.sendSessionUpdate();
+      };
+
       websocket.onmessage = (event) => {
         void this.handleServerMessage(event.data)
           .then(() => {
-            if (this.connected) {
-              resolveOnce();
+            if (this.connected && !settled) {
+              settled = true;
+              resolve();
             }
           })
           .catch((error) => {
@@ -124,7 +138,7 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
               return;
             }
             this.request.callbacks.onError(
-              error instanceof Error ? error.message : 'AssemblyAI realtime session failed.',
+              error instanceof Error ? error.message : 'OpenAI realtime transcription failed.',
               error
             );
           });
@@ -136,13 +150,8 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
     this.stopped = true;
     this.connected = false;
     this.currentState = null;
-    this.finalizedTurns.clear();
+    this.resetTurnState();
     this.stopAudioCapture();
-
-    if (this.closeTimer !== null) {
-      window.clearTimeout(this.closeTimer);
-      this.closeTimer = null;
-    }
 
     const websocket = this.websocket;
     this.websocket = null;
@@ -150,51 +159,80 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
       return;
     }
 
-    if (websocket.readyState === WebSocket.OPEN) {
-      websocket.send(JSON.stringify({ type: 'Terminate' }));
-      this.closeTimer = window.setTimeout(() => {
-        this.closeTimer = null;
-        websocket.close();
-      }, 250);
-      return;
-    }
-
-    if (websocket.readyState === WebSocket.CONNECTING) {
+    if (websocket.readyState === WebSocket.OPEN || websocket.readyState === WebSocket.CONNECTING) {
       websocket.close();
     }
   }
 
   updateAgentContext(text: string): void {
-    const context = normalizeText(text).slice(0, MAX_AGENT_CONTEXT_CHARS);
-    if (!context || !this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+    const context = normalizeText(text).slice(0, MAX_PROMPT_CHARS);
+    if (!context) {
+      return;
+    }
+
+    this.agentContext = context;
+    this.sendSessionUpdate();
+  }
+
+  private sendSessionUpdate(): void {
+    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
       return;
     }
 
     this.websocket.send(JSON.stringify({
-      type: 'UpdateConfiguration',
-      agent_context: context,
+      type: 'session.update',
+      session: {
+        type: 'transcription',
+        audio: {
+          input: {
+            format: { type: 'audio/pcm', rate: SAMPLE_RATE },
+            transcription: {
+              model: this.request.model,
+              ...(this.buildPrompt() ? { prompt: this.buildPrompt() } : {}),
+            },
+          },
+        },
+      },
     }));
   }
 
-  private async createTemporaryToken(): Promise<string> {
+  private buildPrompt(): string {
+    return this.agentContext || normalizeText(this.request.instructions ?? '').slice(0, MAX_PROMPT_CHARS);
+  }
+
+  private async createClientSecret(): Promise<string> {
     const response = await requestUrl({
-      url: TOKEN_ENDPOINT,
-      method: 'GET',
+      url: CLIENT_SECRET_ENDPOINT,
+      method: 'POST',
       headers: {
-        Authorization: this.request.apiKey,
+        Authorization: `Bearer ${this.request.apiKey}`,
+        'Content-Type': 'application/json',
       },
+      body: JSON.stringify({
+        session: {
+          type: 'transcription',
+          audio: {
+            input: {
+              format: { type: 'audio/pcm', rate: SAMPLE_RATE },
+              transcription: { model: this.request.model },
+            },
+          },
+        },
+      }),
     });
 
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`AssemblyAI realtime token request failed: HTTP ${response.status}.`);
+      throw new Error(
+        `OpenAI realtime transcription token request failed: HTTP ${response.status}: ${response.text || 'Unknown error'}`
+      );
     }
 
-    const body = response.json as { token?: unknown };
-    if (typeof body.token !== 'string' || !body.token.trim()) {
-      throw new Error('AssemblyAI realtime token response did not include a usable token.');
+    const body = response.json as ClientSecretResponse;
+    if (typeof body.value !== 'string' || !body.value.trim()) {
+      throw new Error('OpenAI realtime transcription token response did not include a usable token.');
     }
 
-    return body.token.trim();
+    return body.value.trim();
   }
 
   private async handleServerMessage(rawData: unknown): Promise<void> {
@@ -207,42 +245,37 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
       return;
     }
 
-    const message = JSON.parse(messageText) as AssemblyAIStreamingMessage;
+    const message = JSON.parse(messageText) as RealtimeTranscriptionEvent;
     const type = typeof message.type === 'string' ? message.type : '';
 
-    if (type === 'Begin') {
+    if (type === 'session.created') {
       await this.startAudioCapture();
       this.connected = true;
       this.emitStateChange('listening');
       return;
     }
 
-    if (type === 'SpeechStarted') {
-      this.request.callbacks.onSpeechStarted?.();
-      this.emitStateChange('user-speaking');
-      return;
-    }
-
-    if (type === 'Turn') {
-      const transcript = normalizeText(message.transcript);
-      if (transcript) {
+    if (type === 'conversation.item.input_audio_transcription.delta') {
+      if (normalizeText(message.delta)) {
         this.emitStateChange('user-speaking');
       }
-
-      if (message.end_of_turn === true && transcript) {
-        const turnKey = getTurnKey(message, transcript);
-        if (!this.finalizedTurns.has(turnKey)) {
-          this.finalizedTurns.add(turnKey);
-          this.request.callbacks.onUserTranscript?.(transcript);
-        }
-        this.emitStateChange('listening');
-      }
       return;
     }
 
-    if (type === 'Error') {
-      const detail = normalizeText(message.error) || normalizeText(message.message);
-      throw new Error(detail ? `AssemblyAI realtime error: ${detail}` : 'AssemblyAI realtime session reported an error.');
+    if (type === 'conversation.item.input_audio_transcription.completed') {
+      const transcript = normalizeText(message.transcript);
+      if (transcript) {
+        this.request.callbacks.onUserTranscript?.(transcript);
+      }
+      this.emitStateChange('listening');
+      return;
+    }
+
+    if (type === 'error') {
+      const detail = normalizeText(message.error?.message);
+      throw new Error(
+        detail ? `OpenAI realtime transcription error: ${detail}` : 'OpenAI realtime transcription reported an error.'
+      );
     }
   }
 
@@ -278,19 +311,66 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
       }
 
       const inputBuffer = event.inputBuffer;
-      const pcm = encodeFloatPcm16(
-        inputBuffer.getChannelData(0),
-        inputBuffer.sampleRate,
-        SAMPLE_RATE
-      );
-      if (pcm.byteLength > 0) {
-        this.websocket.send(pcm);
+      const samples = inputBuffer.getChannelData(0);
+      const pcm = encodeFloatPcm16(samples, inputBuffer.sampleRate, SAMPLE_RATE);
+      if (pcm.byteLength === 0) {
+        return;
       }
+
+      this.websocket.send(JSON.stringify({
+        type: 'input_audio_buffer.append',
+        audio: encodeBase64(pcm),
+      }));
+
+      const chunkMs = (samples.length / inputBuffer.sampleRate) * 1000;
+      this.bufferedMs += chunkMs;
+      this.trackTurn(computeRms(samples), chunkMs);
     };
 
     this.captureSource = source;
     this.captureProcessor = processor;
     this.captureSink = sink;
+  }
+
+  /**
+   * Energy-gated turn detection. The model does its own transcription but will
+   * not tell us when the speaker stopped, so a turn is committed once speech has
+   * been followed by a long enough stretch of quiet.
+   */
+  private trackTurn(rms: number, chunkMs: number): void {
+    if (rms >= SPEECH_RMS_THRESHOLD) {
+      if (!this.speaking) {
+        this.speaking = true;
+        this.request.callbacks.onSpeechStarted?.();
+        this.emitStateChange('user-speaking');
+      }
+      this.silenceMs = 0;
+      return;
+    }
+
+    if (!this.speaking) {
+      return;
+    }
+
+    this.silenceMs += chunkMs;
+    if (this.silenceMs >= SILENCE_MS_BEFORE_COMMIT && this.bufferedMs >= MIN_COMMIT_MS) {
+      this.commitTurn();
+    }
+  }
+
+  private commitTurn(): void {
+    if (!this.websocket || this.websocket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.websocket.send(JSON.stringify({ type: 'input_audio_buffer.commit' }));
+    this.resetTurnState();
+  }
+
+  private resetTurnState(): void {
+    this.speaking = false;
+    this.silenceMs = 0;
+    this.bufferedMs = 0;
   }
 
   private stopAudioCapture(): void {
@@ -343,13 +423,6 @@ export class AssemblyAIRealtimeVoiceSession implements RealtimeVoiceSession {
 
 function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : '';
-}
-
-function getTurnKey(message: AssemblyAIStreamingMessage, transcript: string): string {
-  if (typeof message.turn_order === 'number' || typeof message.turn_order === 'string') {
-    return String(message.turn_order);
-  }
-  return transcript;
 }
 
 async function coerceMessageText(data: unknown): Promise<string | null> {

--- a/src/services/realtimeVoice/RealtimeVoiceService.ts
+++ b/src/services/realtimeVoice/RealtimeVoiceService.ts
@@ -7,6 +7,7 @@ import {
 import { OpenAIRealtimeVoiceSession } from './OpenAIRealtimeVoiceSession';
 import { GoogleRealtimeVoiceSession } from './GoogleRealtimeVoiceSession';
 import { AssemblyAIRealtimeVoiceSession } from './AssemblyAIRealtimeVoiceSession';
+import { OpenAILiveTranscribeSession } from './OpenAILiveTranscribeSession';
 import type {
   RealtimeVoiceAvailability,
   RealtimeVoiceSession,
@@ -35,8 +36,20 @@ export class RealtimeVoiceService {
     if (resolved.provider === 'assemblyai') {
       return new AssemblyAIRealtimeVoiceSession(resolved);
     }
+    if (this.isTranscriptionPipeline(resolved.provider, resolved.model)) {
+      return new OpenAILiveTranscribeSession(resolved);
+    }
 
     return new OpenAIRealtimeVoiceSession(resolved);
+  }
+
+  /**
+   * Pipeline models transcribe only; the reply comes from Nexus chat and the
+   * speech model. OpenAI ships both shapes, so the model decides which session
+   * class and which transport requirements apply.
+   */
+  private isTranscriptionPipeline(provider: string, model: string): boolean {
+    return getRealtimeVoiceModel(provider, model)?.execution === 'transcription-pipeline';
   }
 
   private resolveRequest(
@@ -96,10 +109,12 @@ export class RealtimeVoiceService {
     }
 
     const declaration = getRealtimeVoiceModel(selection.provider, selection.model);
+    // Pipeline models have no voice of their own — the speech model supplies it.
+    const fallbackVoice = declaration?.execution === 'transcription-pipeline' ? '' : 'marin';
     return {
       provider: selection.provider,
       model: selection.model,
-      voice: selection.voice || declaration?.defaultVoice || (selection.provider === 'assemblyai' ? '' : 'marin'),
+      voice: selection.voice || declaration?.defaultVoice || fallbackVoice,
     };
   }
 
@@ -149,6 +164,18 @@ export class RealtimeVoiceService {
 
     if (!this.getOpenAIApiKey()) {
       return { available: false, reason: 'OpenAI is not enabled and configured for live voice.' };
+    }
+
+    if (this.isTranscriptionPipeline(selection.provider, selection.model)) {
+      if (typeof WebSocket === 'undefined') {
+        return { available: false, reason: 'WebSocket is not available in this Obsidian environment.' };
+      }
+
+      if (typeof AudioContext === 'undefined') {
+        return { available: false, reason: 'AudioContext is not available in this Obsidian environment.' };
+      }
+
+      return { available: true };
     }
 
     if (typeof RTCPeerConnection === 'undefined') {

--- a/src/services/realtimeVoice/pcmAudio.ts
+++ b/src/services/realtimeVoice/pcmAudio.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared PCM helpers for realtime transcription sessions.
+ *
+ * Both the AssemblyAI and OpenAI live-transcribe sessions capture microphone
+ * audio through a ScriptProcessor and ship little-endian 16-bit PCM upstream,
+ * just at different sample rates.
+ */
+
+/** Downmix a Float32 buffer to little-endian PCM16 at the target sample rate. */
+export function encodeFloatPcm16(
+  samples: Float32Array,
+  inputRate: number,
+  targetRate: number
+): ArrayBuffer {
+  const resampled = inputRate === targetRate
+    ? samples
+    : resampleLinear(samples, inputRate, targetRate);
+  const bytes = new ArrayBuffer(resampled.length * 2);
+  const view = new DataView(bytes);
+
+  for (let index = 0; index < resampled.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, resampled[index]));
+    const value = sample < 0 ? Math.round(sample * 0x8000) : Math.round(sample * 0x7fff);
+    view.setInt16(index * 2, value, true);
+  }
+
+  return bytes;
+}
+
+/** Linear-interpolation resample. Good enough for speech at these rates. */
+export function resampleLinear(
+  samples: Float32Array,
+  inputRate: number,
+  targetRate: number
+): Float32Array {
+  if (samples.length === 0) {
+    return new Float32Array();
+  }
+
+  const targetLength = Math.max(1, Math.round(samples.length * targetRate / inputRate));
+  const result = new Float32Array(targetLength);
+  const scale = inputRate / targetRate;
+  for (let index = 0; index < targetLength; index += 1) {
+    const position = index * scale;
+    const left = Math.floor(position);
+    const right = Math.min(left + 1, samples.length - 1);
+    const weight = position - left;
+    result[index] = samples[left] + (samples[right] - samples[left]) * weight;
+  }
+  return result;
+}
+
+/** Root-mean-square amplitude, used as a cheap voice-activity signal. */
+export function computeRms(samples: Float32Array): number {
+  if (samples.length === 0) {
+    return 0;
+  }
+
+  let sum = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    sum += samples[index] * samples[index];
+  }
+  return Math.sqrt(sum / samples.length);
+}
+
+/** Base64-encode PCM bytes without relying on Node's Buffer. */
+export function encodeBase64(bytes: ArrayBuffer): string {
+  const view = new Uint8Array(bytes);
+  let binary = '';
+  for (let index = 0; index < view.length; index += 1) {
+    binary += String.fromCharCode(view[index]);
+  }
+  return btoa(binary);
+}

--- a/tests/unit/LLMTranscriptionService.test.ts
+++ b/tests/unit/LLMTranscriptionService.test.ts
@@ -31,7 +31,10 @@ import { chunkAudio } from '../../src/services/llm/utils/AudioChunkingService';
 import { OpenAITranscriptionAdapter } from '../../src/services/llm/adapters/openai/OpenAITranscriptionAdapter';
 import { OpenRouterTranscriptionAdapter } from '../../src/services/llm/adapters/openrouter/OpenRouterTranscriptionAdapter';
 import { DEFAULT_LLM_PROVIDER_SETTINGS, type LLMProviderSettings } from '../../src/types/llm/ProviderTypes';
-import type { AudioChunk } from '../../src/services/llm/types/VoiceTypes';
+import {
+  getTranscriptionModelsForProvider,
+  type AudioChunk
+} from '../../src/services/llm/types/VoiceTypes';
 
 const chunkAudioMock = chunkAudio as jest.MockedFunction<typeof chunkAudio>;
 
@@ -361,7 +364,9 @@ describe('TranscriptionService (class-based)', () => {
     it('returns all models when none are disabled', () => {
       const service = new TranscriptionService(makeSettings());
       const models = service.getModelsForProvider('openai');
-      expect(models).toHaveLength(1);
+      expect(models.map(m => m.id)).toEqual(
+        getTranscriptionModelsForProvider('openai').map(m => m.id)
+      );
       expect(models[0].id).toBe('whisper-1');
     });
 

--- a/tests/unit/OpenAILiveTranscribeSession.test.ts
+++ b/tests/unit/OpenAILiveTranscribeSession.test.ts
@@ -1,0 +1,134 @@
+import { __setRequestUrlMock } from 'obsidian';
+import { OpenAILiveTranscribeSession } from '../../src/services/realtimeVoice/OpenAILiveTranscribeSession';
+import type { ResolvedOpenAIRealtimeVoiceSessionRequest } from '../../src/services/realtimeVoice/RealtimeVoiceSessionTypes';
+
+type TestableSession = OpenAILiveTranscribeSession & {
+  createClientSecret: () => Promise<string>;
+  handleServerMessage: (rawData: unknown) => Promise<void>;
+  trackTurn: (rms: number, chunkMs: number) => void;
+  websocket: { readyState: number; send: jest.Mock } | null;
+  connected: boolean;
+  bufferedMs: number;
+};
+
+describe('OpenAILiveTranscribeSession', () => {
+  function createSession(
+    callbacks: Partial<ResolvedOpenAIRealtimeVoiceSessionRequest['callbacks']> = {}
+  ): TestableSession {
+    return new OpenAILiveTranscribeSession({
+      provider: 'openai',
+      model: 'gpt-live-transcribe',
+      voice: '',
+      apiKey: 'sk-test-key',
+      callbacks: {
+        onStateChange: jest.fn(),
+        onError: jest.fn(),
+        onSpeechStarted: jest.fn(),
+        onUserTranscript: jest.fn(),
+        ...callbacks,
+      },
+    }) as TestableSession;
+  }
+
+  function attachSocket(session: TestableSession): jest.Mock {
+    const send = jest.fn();
+    session.websocket = { readyState: WebSocket.OPEN, send };
+    return send;
+  }
+
+  it('mints an ephemeral transcription-session token rather than using the raw key', async () => {
+    const requests: Array<{ url?: string; body?: string; headers?: Record<string, string> }> = [];
+    __setRequestUrlMock(async request => {
+      requests.push(request);
+      return { status: 200, json: { value: 'ek_test_token' } };
+    });
+
+    const token = await createSession().createClientSecret();
+
+    expect(token).toBe('ek_test_token');
+    expect(requests[0]?.url).toBe('https://api.openai.com/v1/realtime/client_secrets');
+    expect(requests[0]?.headers?.Authorization).toBe('Bearer sk-test-key');
+
+    const body = JSON.parse(requests[0]?.body ?? '{}');
+    expect(body.session.type).toBe('transcription');
+    expect(body.session.audio.input.transcription.model).toBe('gpt-live-transcribe');
+    // The model rejects turn_detection outright, so it must never be sent.
+    expect(body.session.audio.input).not.toHaveProperty('turn_detection');
+  });
+
+  it('commits a turn after speech is followed by enough silence', () => {
+    const onSpeechStarted = jest.fn();
+    const session = createSession({ onSpeechStarted });
+    const send = attachSocket(session);
+    session.bufferedMs = 1000;
+
+    session.trackTurn(0.4, 100);
+    expect(onSpeechStarted).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+
+    session.trackTurn(0.0001, 400);
+    expect(send).not.toHaveBeenCalled();
+
+    session.trackTurn(0.0001, 500);
+    expect(JSON.parse(send.mock.calls[0][0]).type).toBe('input_audio_buffer.commit');
+  });
+
+  it('never commits when the mic only ever picked up silence', () => {
+    const onSpeechStarted = jest.fn();
+    const session = createSession({ onSpeechStarted });
+    const send = attachSocket(session);
+    session.bufferedMs = 5000;
+
+    for (let i = 0; i < 50; i += 1) {
+      session.trackTurn(0.0001, 100);
+    }
+
+    expect(send).not.toHaveBeenCalled();
+    expect(onSpeechStarted).not.toHaveBeenCalled();
+  });
+
+  it('does not commit a buffer too short for the API to transcribe', () => {
+    const session = createSession();
+    const send = attachSocket(session);
+    session.bufferedMs = 20;
+
+    session.trackTurn(0.4, 10);
+    session.trackTurn(0.0001, 2000);
+
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('emits the finalized transcript and returns to listening', async () => {
+    const onUserTranscript = jest.fn();
+    const onStateChange = jest.fn();
+    const session = createSession({ onUserTranscript, onStateChange });
+
+    await session.handleServerMessage(JSON.stringify({
+      type: 'conversation.item.input_audio_transcription.completed',
+      transcript: '  Hello  Nexus.  ',
+    }));
+
+    expect(onUserTranscript).toHaveBeenCalledWith('Hello Nexus.');
+    expect(onStateChange).toHaveBeenLastCalledWith('listening');
+  });
+
+  it('surfaces server error events', async () => {
+    const session = createSession();
+
+    await expect(session.handleServerMessage(JSON.stringify({
+      type: 'error',
+      error: { message: 'Something broke' },
+    }))).rejects.toThrow('Something broke');
+  });
+
+  it('carries the spoken reply into the session prompt as transcription context', () => {
+    const session = createSession();
+    const send = attachSocket(session);
+
+    session.updateAgentContext('The ticket number is AC-42.');
+
+    const payload = JSON.parse(send.mock.calls[0][0]);
+    expect(payload.type).toBe('session.update');
+    expect(payload.session.audio.input.transcription.prompt).toBe('The ticket number is AC-42.');
+  });
+});

--- a/tests/unit/OpenAITranscriptionAdapter.test.ts
+++ b/tests/unit/OpenAITranscriptionAdapter.test.ts
@@ -119,6 +119,49 @@ describe('OpenAITranscriptionAdapter', () => {
       );
     });
 
+    it('asks gpt-transcribe for plain json, never verbose_json or timestamps', async () => {
+      await adapter.transcribeChunk(makeChunk(), makeRequest({ model: 'gpt-transcribe' }));
+
+      const fields = buildMultipartMock.mock.calls[0][0];
+      expect(fields).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'model', value: 'gpt-transcribe' }),
+          expect.objectContaining({ name: 'response_format', value: 'json' })
+        ])
+      );
+      expect(fields.some(f => f.name === 'timestamp_granularities[]')).toBe(false);
+    });
+
+    it('does not request word timestamps from gpt-transcribe even when asked', async () => {
+      await adapter.transcribeChunk(
+        makeChunk(),
+        makeRequest({ model: 'gpt-transcribe', requestWordTimestamps: true })
+      );
+
+      const fields = buildMultipartMock.mock.calls[0][0];
+      expect(fields.some(f => f.name === 'timestamp_granularities[]')).toBe(false);
+    });
+
+    it('asks the diarization model for diarized_json', async () => {
+      await adapter.transcribeChunk(makeChunk(), makeRequest({ model: 'gpt-4o-transcribe-diarize' }));
+
+      expect(buildMultipartMock).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'response_format', value: 'diarized_json' })
+        ])
+      );
+    });
+
+    it('omits prompt for the diarization model, which rejects it outright', async () => {
+      await adapter.transcribeChunk(
+        makeChunk(),
+        makeRequest({ model: 'gpt-4o-transcribe-diarize', prompt: 'A support call.' })
+      );
+
+      const fields = buildMultipartMock.mock.calls[0][0];
+      expect(fields.some(f => f.name === 'prompt')).toBe(false);
+    });
+
     it('includes prompt when provided', async () => {
       await adapter.transcribeChunk(
         makeChunk(),
@@ -230,6 +273,52 @@ describe('OpenAITranscriptionAdapter', () => {
         text: 'Full transcript',
         words: undefined
       }]);
+    });
+
+    it('spans the whole chunk for a gpt-transcribe response, which carries no timing', async () => {
+      __setRequestUrlMock(async () => ({
+        status: 200,
+        json: {
+          text: 'Nexus transcription smoke test.',
+          languages: [{ code: 'en' }],
+          usage: { type: 'duration', seconds: 7 }
+        }
+      }));
+
+      const result = await adapter.transcribeChunk(
+        makeChunk({ durationSeconds: 45 }),
+        makeRequest({ model: 'gpt-transcribe' })
+      );
+
+      expect(result).toEqual([{
+        startSeconds: 0,
+        endSeconds: 45,
+        text: 'Nexus transcription smoke test.',
+        words: undefined
+      }]);
+    });
+
+    it('keeps speaker labels from a diarized_json response', async () => {
+      __setRequestUrlMock(async () => ({
+        status: 200,
+        json: {
+          text: 'Hello there. Hi back.',
+          segments: [
+            { type: 'transcript.text.segment', text: ' Hello there.', speaker: 'A', start: 0, end: 2.5 },
+            { type: 'transcript.text.segment', text: ' Hi back.', speaker: 'B', start: 3.3, end: 5.1 }
+          ]
+        }
+      }));
+
+      const result = await adapter.transcribeChunk(
+        makeChunk(),
+        makeRequest({ model: 'gpt-4o-transcribe-diarize' })
+      );
+
+      expect(result).toEqual([
+        expect.objectContaining({ text: 'Hello there.', speaker: 'A', startSeconds: 0, endSeconds: 2.5 }),
+        expect.objectContaining({ text: 'Hi back.', speaker: 'B', startSeconds: 3.3, endSeconds: 5.1 })
+      ]);
     });
 
     it('uses chunk duration when response has no duration', async () => {

--- a/tests/unit/VoiceTypes.test.ts
+++ b/tests/unit/VoiceTypes.test.ts
@@ -21,11 +21,27 @@ describe('VoiceTypes', () => {
   // ── getTranscriptionModelsForProvider ────────────────────────────────
 
   describe('getTranscriptionModelsForProvider', () => {
-    it('returns OpenAI models', () => {
+    it('returns OpenAI models, with whisper-1 first so the default keeps word timestamps', () => {
       const models = getTranscriptionModelsForProvider('openai');
-      expect(models).toHaveLength(1);
-      expect(models[0].id).toBe('whisper-1');
+      expect(models.map(m => m.id)).toEqual([
+        'whisper-1',
+        'gpt-transcribe',
+        'gpt-4o-transcribe-diarize'
+      ]);
+      expect(models[0].supportsWordTimestamps).toBe(true);
       expect(models.every(m => m.provider === 'openai')).toBe(true);
+    });
+
+    it('declares the newer OpenAI models honestly: no word timestamps, speakers only on diarize', () => {
+      expect(getTranscriptionModel('openai', 'gpt-transcribe')).toEqual(expect.objectContaining({
+        supportsWordTimestamps: false,
+        supportsPrompt: true
+      }));
+      expect(getTranscriptionModel('openai', 'gpt-4o-transcribe-diarize')).toEqual(expect.objectContaining({
+        supportsWordTimestamps: false,
+        supportsSpeakerLabels: true,
+        supportsPrompt: false
+      }));
     });
 
     it('returns Groq models', () => {


### PR DESCRIPTION
Stacked on #301 — review/merge that first. The live-transcribe session depends on the composed voice pipeline #301 introduces.

OpenAI shipped two transcription models in late July 2026. Nexus was still on `whisper-1` alone — the `gpt-4o-transcribe` generation had never been picked up either. This adds three models.

## Why it wasn't just a catalog addition

The adapter hardcoded `response_format=verbose_json` for every model, and the newer models reject that rather than degrading:

```
response_format 'verbose_json' is not compatible with model 'gpt-4o-transcribe-api-ev3'. Use 'json' or 'text' instead.
```

(The published speech-to-text table says otherwise — this is from the live API.) Response format is now chosen per model.

## Models

| Model | Format | Timing | Notes |
|---|---|---|---|
| `whisper-1` | `verbose_json` | segments + words | unchanged |
| `gpt-transcribe` | `json` | none | cheaper + more accurate on real-world audio; a chunk-spanning segment is synthesized |
| `gpt-4o-transcribe-diarize` | `diarized_json` | segments + speakers | first OpenAI model here that can label speakers |

**`whisper-1` stays first in the catalog, and therefore stays the OpenAI default.** It is the only OpenAI model that still returns word timestamps, and ingestion asks for them (`IngestionPipelineService.ts:432`) with `TranscriptionService` gating on `declaration.supportsWordTimestamps`. Promoting `gpt-transcribe` would have silently dropped word-level data from every ingest.

`gpt-4o-transcribe-diarize` also rejects `prompt` with a 400 (`Prompt is not supported for diarization models`) instead of ignoring it, so prompt is suppressed for that model and the declaration says `supportsPrompt: false`.

## Live voice

`gpt-live-transcribe` joins live voice as an OpenAI transcription pipeline, alongside the AssemblyAI one from #301.

The notable difference: the model refuses server-side turn detection (`Turn detection is not supported for this transcription model`), so the client owns turn boundaries. `OpenAILiveTranscribeSession` runs an energy gate — speech starts above an RMS threshold, the turn commits after a stretch of quiet — with a minimum buffer so it never commits audio too short to transcribe, and it never commits a turn that was silence throughout. Speech onset also drives barge-in.

The assistant's spoken reply is fed back as the session transcription `prompt`, the same role `agent_context` plays for AssemblyAI.

Session transport now follows the model's **execution mode** rather than the provider, since OpenAI ships both a WebRTC native agent and a WebSocket pipeline — availability checks `WebSocket`/`AudioContext` for pipeline models and `RTCPeerConnection` for native ones. PCM encode/resample helpers moved to a shared `pcmAudio.ts` now that two sessions need them.

Protocol verified end-to-end against the live API, not docs: ephemeral token from `/v1/realtime/client_secrets` with `session.type='transcription'`, WebSocket to `/v1/realtime?intent=transcription` with the `openai-insecure-api-key.<ephemeral>` subprotocol, base64 PCM16 at 24 kHz via `input_audio_buffer.append`, transcripts on `conversation.item.input_audio_transcription.delta`/`.completed`.

## Verification

- `npx tsc --noEmit`, `npm run lint`, `npm run build` — all clean
- Full suite: 4056 pass, 22 skipped, 1 fail — `LocalCliInstaller on Windows reports a namesake command that appears earlier on PATH`, which fails identically on `origin/main` and is untouched here
- New: 7 tests for the live session (token minting asserts `turn_detection` is never sent; commit-after-silence, never-commit-on-silence, minimum-buffer, prompt carry-through), 6 for the adapter's per-model request shape and parsing
- Two hardcoded model-count assertions were replaced with catalog-derived ones so the next model addition doesn't break them

Not yet exercised in Obsidian — the live session needs a manual mic test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)