### PR TITLE
fix(providers): Nexus brand for OpenRouter OAuth key label + fix dropped pre-auth params

### DIFF
--- a/src/settings/tabs/ProvidersTab.ts
+++ b/src/settings/tabs/ProvidersTab.ts
@@ -25,6 +25,7 @@ import type { OAuthModalConfig, SecondaryOAuthProviderConfig } from '../../compo
 import { OAuthService } from '../../services/oauth/OAuthService';
 import { ClaudeCodeAuthService } from '../../services/external/ClaudeCodeAuthService';
 import { GeminiCliAuthService } from '../../services/external/GeminiCliAuthService';
+import { BRAND_NAME } from '../../constants/branding';
 
 /**
  * Provider display configuration
@@ -218,13 +219,13 @@ export class ProvidersTab {
                 providerLabel: 'OpenRouter',
                 preAuthFields: [
                     {
-                        key: 'key_name',
+                        key: 'key_label',
                         label: 'Key label',
-                        defaultValue: 'Claudesidian MCP',
+                        defaultValue: BRAND_NAME,
                         required: false,
                     },
                     {
-                        key: 'limit',
+                        key: 'credit_limit',
                         label: 'Credit limit (optional)',
                         placeholder: 'Leave blank for unlimited',
                         required: false,


### PR DESCRIPTION
## What

The OpenRouter OAuth "Key label" field defaulted to the hardcoded legacy string `'Claudesidian MCP'`. It now uses `BRAND_NAME` from `src/constants/branding.ts` (`'Nexus'`) so it tracks the brand constant instead of drifting again.

## Also fixed (pre-existing, same code block)

While tracing the string I found the pre-auth field keys never matched what the provider reads:

- `OAuthModals` passes each `preAuthField`'s `key` through verbatim as the authorization query param.
- `OpenRouterOAuthProvider.buildAuthUrl` (`src/services/oauth/providers/OpenRouterOAuthProvider.ts:58-63`) reads `key_label` and `credit_limit`.
- The UI was emitting `key_name` and `limit`.

Both params were silently dropped, so the key label never reached OpenRouter **and** the credit limit the user typed was ignored. Renaming the field keys to match the provider contract is required for the label default above to have any visible effect — changing the default alone would not have changed what appears in the OpenRouter dashboard.

## Verification

- `tsc --noEmit` clean
- `eslint` clean on the touched file

⚠️ Static verification only — not yet exercised against a live OpenRouter OAuth connect. Worth confirming the key lands in the OpenRouter dashboard named "Nexus" with the credit limit applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MpVQ8Whwg5iJ7opuQRCv9g
