### PR TITLE
Fix task metadata merge semantics

### DIFF
--- a/src/agents/taskManager/services/TaskService.ts
+++ b/src/agents/taskManager/services/TaskService.ts
@@ -28,10 +28,16 @@ import {
   LinkedNoteInput
 } from '../types';
 import type { IProjectRepository, ProjectMetadata } from '../../../database/repositories/interfaces/IProjectRepository';
-import type { ITaskRepository, TaskMetadata, NoteLink } from '../../../database/repositories/interfaces/ITaskRepository';
+import type {
+  ITaskRepository,
+  TaskMetadata,
+  NoteLink,
+  UpdateTaskData as RepositoryUpdateTaskData
+} from '../../../database/repositories/interfaces/ITaskRepository';
 import { PaginatedResult } from '../../../types/pagination/PaginationTypes';
 import { logger } from '../../../utils/logger';
 import { formatTaskRef, taskRefToIdPrefix } from '../utils/taskRefs';
+import { isMetadataUpdateTriviallyEmpty } from '../../../database/repositories/metadataUpdate';
 
 /**
  * Page size used when draining a paginated repository query to build a
@@ -209,6 +215,14 @@ export class TaskService {
       throw new Error(`Project "${projectId}" not found`);
     }
 
+    const metadataTriviallyEmpty = isMetadataUpdateTriviallyEmpty(data);
+    const hasOrdinaryUpdate = data.name !== undefined
+      || data.description !== undefined
+      || data.status !== undefined;
+    if (!hasOrdinaryUpdate && metadataTriviallyEmpty) {
+      return;
+    }
+
     // If renaming, check for duplicate
     if (data.name && data.name !== project.name) {
       const existing = await this.projectRepo.getByName(project.workspaceId, data.name);
@@ -217,10 +231,7 @@ export class TaskService {
       }
     }
 
-    await this.projectRepo.update(projectId, {
-      ...data,
-      updated: Date.now()
-    });
+    await this.projectRepo.update(projectId, data);
 
     this.notifyTaskBoard({
       workspaceId: project.workspaceId,
@@ -239,8 +250,7 @@ export class TaskService {
     }
 
     await this.projectRepo.update(projectId, {
-      status: 'archived',
-      updated: Date.now()
+      status: 'archived'
     });
 
     this.notifyTaskBoard({
@@ -399,10 +409,9 @@ export class TaskService {
     }
     taskId = task.id;
 
-    const updateData: Partial<Omit<TaskMetadata, 'completedAt'>> & { updated: number; completedAt?: number | null } = {
-      ...data,
-      updated: Date.now()
-    };
+    const metadataTriviallyEmpty = isMetadataUpdateTriviallyEmpty(data);
+
+    const updateData: RepositoryUpdateTaskData = { ...data };
 
     // Invariant: completedAt exists iff the (post-update) status is 'done'.
     // Use null (not undefined) to clear — undefined is dropped by the repository's
@@ -414,6 +423,17 @@ export class TaskService {
     } else if (effectiveStatus !== 'done' && task.completedAt != null) {
       // Re-opened, or a non-done task carrying a stale timestamp — clear it.
       updateData.completedAt = null;
+    }
+
+    const hasOrdinaryUpdate = data.title !== undefined
+      || data.description !== undefined
+      || data.status !== undefined
+      || data.priority !== undefined
+      || data.dueDate !== undefined
+      || data.assignee !== undefined
+      || data.tags !== undefined;
+    if (!hasOrdinaryUpdate && updateData.completedAt === undefined && metadataTriviallyEmpty) {
+      return;
     }
 
     await this.taskRepo.update(taskId, updateData);
@@ -436,7 +456,7 @@ export class TaskService {
     }
     taskId = task.id;
 
-    const updateData: Partial<TaskMetadata> & { updated: number } = { updated: Date.now() };
+    const updateData: RepositoryUpdateTaskData = {};
 
     if (target.projectId && target.projectId !== task.projectId) {
       const newProject = await this.projectRepo.getById(target.projectId);

--- a/src/agents/taskManager/tools/projects/updateProject.ts
+++ b/src/agents/taskManager/tools/projects/updateProject.ts
@@ -34,7 +34,9 @@ export class UpdateProjectTool extends BaseTool<UpdateProjectParameters, UpdateP
         name: params.name,
         description: params.description,
         status: params.status,
-        metadata: params.metadata
+        metadata: params.metadata,
+        metadataMode: params.metadataMode,
+        removeMetadataKeys: params.removeMetadataKeys
       });
 
       return { success: true };
@@ -51,7 +53,9 @@ export class UpdateProjectTool extends BaseTool<UpdateProjectParameters, UpdateP
         name: { type: 'string', description: 'New project name' },
         description: { type: 'string', description: 'New project description' },
         status: { type: 'string', enum: ['active', 'completed', 'archived'], description: 'New project status' },
-        metadata: { type: 'object', description: 'Custom metadata to merge', additionalProperties: true }
+        metadata: { type: 'object', description: 'Custom metadata. Shallow-merged by default: supplied top-level keys overwrite matching keys and all other stored keys survive. Nested objects are replaced whole. Use metadataMode "replace" with {} to clear all metadata.', additionalProperties: true },
+        metadataMode: { type: 'string', enum: ['merge', 'replace'], description: 'How to apply metadata. "merge" is the default. "replace" stores exactly the supplied metadata object and requires metadata; it cannot be combined with removeMetadataKeys.' },
+        removeMetadataKeys: { type: 'array', items: { type: 'string' }, description: 'Top-level metadata keys to delete after applying a merge patch. Merge mode only.' }
       },
       required: ['projectId']
     });

--- a/src/agents/taskManager/tools/tasks/updateTask.ts
+++ b/src/agents/taskManager/tools/tasks/updateTask.ts
@@ -31,10 +31,19 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
         return this.prepareResult(false, undefined, 'taskId is required');
       }
 
+      const hasMetadataRequest = params.metadata !== undefined
+        || params.metadataMode !== undefined
+        || params.removeMetadataKeys !== undefined;
+
       // Update task fields
-      const hasFieldUpdates = params.title || params.description !== undefined ||
-        params.status || params.priority || params.dueDate !== undefined ||
-        params.assignee !== undefined || params.tags || params.metadata;
+      const hasFieldUpdates = params.title !== undefined
+        || params.description !== undefined
+        || params.status !== undefined
+        || params.priority !== undefined
+        || params.dueDate !== undefined
+        || params.assignee !== undefined
+        || params.tags !== undefined
+        || hasMetadataRequest;
 
       if (hasFieldUpdates) {
         await this.taskService.updateTask(params.taskId, {
@@ -45,7 +54,9 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
           dueDate: params.dueDate,
           assignee: params.assignee,
           tags: params.tags,
-          metadata: params.metadata
+          metadata: params.metadata,
+          metadataMode: params.metadataMode,
+          removeMetadataKeys: params.removeMetadataKeys
         });
       }
 
@@ -110,7 +121,9 @@ export class UpdateTaskTool extends BaseTool<UpdateTaskParameters, UpdateTaskRes
           }
         },
         removeNoteLinks: { type: 'array', items: { type: 'string' }, description: 'Vault note paths to unlink from this task' },
-        metadata: { type: 'object', description: 'Custom metadata to merge (keys are merged, not replaced)', additionalProperties: true }
+        metadata: { type: 'object', description: 'Custom metadata. Shallow-merged by default: supplied top-level keys overwrite matching keys and all other stored keys survive. Nested objects are replaced whole. Use metadataMode "replace" with {} to clear all metadata.', additionalProperties: true },
+        metadataMode: { type: 'string', enum: ['merge', 'replace'], description: 'How to apply metadata. "merge" is the default. "replace" stores exactly the supplied metadata object and requires metadata; it cannot be combined with removeMetadataKeys.' },
+        removeMetadataKeys: { type: 'array', items: { type: 'string' }, description: 'Top-level metadata keys to delete after applying a merge patch. Merge mode only.' }
       },
       required: ['taskId']
     });

--- a/src/agents/taskManager/types.ts
+++ b/src/agents/taskManager/types.ts
@@ -9,6 +9,7 @@ import { CommonParameters, CommonResult } from '../../types';
 import type { TaskStatus, TaskPriority, LinkType } from '../../database/repositories/interfaces/ITaskRepository';
 import type { TaskMetadata } from '../../database/repositories/interfaces/ITaskRepository';
 import type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
+import type { MetadataUpdateMode } from '../../database/repositories/metadataUpdate';
 
 // ────────────────────────────────────────────────────────────────
 // Re-exported Entity Types (canonical source: repository interfaces)
@@ -16,6 +17,7 @@ import type { ProjectMetadata } from '../../database/repositories/interfaces/IPr
 
 export type { ProjectMetadata } from '../../database/repositories/interfaces/IProjectRepository';
 export type { TaskMetadata } from '../../database/repositories/interfaces/ITaskRepository';
+export type { MetadataUpdateMode } from '../../database/repositories/metadataUpdate';
 
 // Re-export enum-like unions from repository interfaces as canonical source
 export type { TaskStatus, TaskPriority, LinkType } from '../../database/repositories/interfaces/ITaskRepository';
@@ -101,6 +103,8 @@ export interface UpdateProjectData {
   description?: string;
   status?: ProjectStatus;
   metadata?: Record<string, unknown>;
+  metadataMode?: MetadataUpdateMode;
+  removeMetadataKeys?: string[];
 }
 
 export interface CreateTaskData {
@@ -125,6 +129,8 @@ export interface UpdateTaskData {
   assignee?: string;
   tags?: string[];
   metadata?: Record<string, unknown>;
+  metadataMode?: MetadataUpdateMode;
+  removeMetadataKeys?: string[];
 }
 
 // ────────────────────────────────────────────────────────────────
@@ -199,6 +205,8 @@ export interface UpdateProjectParameters extends CommonParameters {
   description?: string;
   status?: ProjectStatus;
   metadata?: Record<string, unknown>;
+  metadataMode?: MetadataUpdateMode;
+  removeMetadataKeys?: string[];
 }
 
 export interface ArchiveProjectParameters extends CommonParameters {
@@ -246,6 +254,8 @@ export interface UpdateTaskParameters extends CommonParameters {
   addNoteLinks?: Array<{ notePath: string; linkType?: LinkType }>;
   removeNoteLinks?: string[];
   metadata?: Record<string, unknown>;
+  metadataMode?: MetadataUpdateMode;
+  removeMetadataKeys?: string[];
 }
 
 export interface MoveTaskParameters extends CommonParameters {

--- a/src/database/repositories/ProjectRepository.ts
+++ b/src/database/repositories/ProjectRepository.ts
@@ -32,6 +32,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { parseJsonColumn } from '../utils/jsonColumn';
+import { resolveMetadataUpdate } from './metadataUpdate';
 
 interface ProjectRow extends DatabaseRow {
   id: string;
@@ -144,8 +145,6 @@ export class ProjectRepository
   }
 
   async update(id: string, data: UpdateProjectData): Promise<void> {
-    const now = Date.now();
-
     try {
       // Look up the project to get workspaceId for JSONL path
       const existing = await this.getById(id);
@@ -153,13 +152,26 @@ export class ProjectRepository
         throw new Error(`Project not found: ${id}`);
       }
 
+      const hasFieldUpdate = data.name !== undefined
+        || data.description !== undefined
+        || data.status !== undefined;
+      let wrote = false;
+
       await this.transaction(async () => {
+        const resolvedMetadata = await this.resolveMetadataInTransaction(id, data);
+        if (!hasFieldUpdate && resolvedMetadata === undefined) {
+          return;
+        }
+
+        wrote = true;
+        const now = Date.now();
+
         // 1. Write event to JSONL
         const eventData: Record<string, unknown> = { updated: now };
         if (data.name !== undefined) eventData.name = data.name;
         if (data.description !== undefined) eventData.description = data.description;
         if (data.status !== undefined) eventData.status = data.status;
-        if (data.metadata !== undefined) eventData.metadataJson = JSON.stringify(data.metadata);
+        if (resolvedMetadata !== undefined) eventData.metadataJson = JSON.stringify(resolvedMetadata);
 
         await this.writeEvent<ProjectUpdatedEvent>(
           this.jsonlPath(existing.workspaceId),
@@ -186,9 +198,9 @@ export class ProjectRepository
           setClauses.push('status = ?');
           params.push(data.status);
         }
-        if (data.metadata !== undefined) {
+        if (resolvedMetadata !== undefined) {
           setClauses.push('metadataJson = ?');
-          params.push(JSON.stringify(data.metadata));
+          params.push(JSON.stringify(resolvedMetadata));
         }
 
         params.push(id);
@@ -198,6 +210,10 @@ export class ProjectRepository
           params
         );
       });
+
+      if (!wrote) {
+        return;
+      }
 
       // 3. Invalidate cache
       const statusChanged = data.status !== undefined && data.status !== existing.status;
@@ -306,6 +322,37 @@ export class ProjectRepository
   // ============================================================================
   // Protected Methods
   // ============================================================================
+
+  private async resolveMetadataInTransaction(
+    id: string,
+    data: UpdateProjectData
+  ): Promise<Record<string, unknown> | undefined> {
+    const hasMetadataOperation = data.metadata !== undefined
+      || data.metadataMode !== undefined
+      || data.removeMetadataKeys !== undefined;
+    if (!hasMetadataOperation) {
+      return undefined;
+    }
+
+    let current: Record<string, unknown> | undefined;
+    if (data.metadataMode !== 'replace') {
+      const row = await this.sqliteCache.queryOne<{ metadataJson?: string | null }>(
+        'SELECT metadataJson FROM projects WHERE id = ?',
+        [id]
+      );
+      current = parseJsonColumn<Record<string, unknown>>(
+        row?.metadataJson,
+        `ProjectRepository.metadata#${id}`
+      );
+    }
+
+    return resolveMetadataUpdate({
+      current,
+      metadata: data.metadata,
+      metadataMode: data.metadataMode,
+      removeMetadataKeys: data.removeMetadataKeys
+    });
+  }
 
   protected rowToEntity(row: DatabaseRow): ProjectMetadata {
     const projectRow = row as ProjectRow;

--- a/src/database/repositories/TaskRepository.ts
+++ b/src/database/repositories/TaskRepository.ts
@@ -43,6 +43,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { parseJsonColumn } from '../utils/jsonColumn';
+import { resolveMetadataUpdate } from './metadataUpdate';
 
 interface TaskRow extends DatabaseRow {
   id: string;
@@ -180,15 +181,33 @@ export class TaskRepository
   }
 
   async update(id: string, data: UpdateTaskData): Promise<void> {
-    const now = Date.now();
-
     try {
       const existing = await this.getById(id);
       if (!existing) {
         throw new Error(`Task not found: ${id}`);
       }
 
+      const hasFieldUpdate = data.title !== undefined
+        || data.description !== undefined
+        || data.status !== undefined
+        || data.priority !== undefined
+        || data.dueDate !== undefined
+        || data.assignee !== undefined
+        || data.tags !== undefined
+        || data.projectId !== undefined
+        || data.parentTaskId !== undefined
+        || data.completedAt !== undefined;
+      let wrote = false;
+
       await this.transaction(async () => {
+        const resolvedMetadata = await this.resolveMetadataInTransaction(id, data);
+        if (!hasFieldUpdate && resolvedMetadata === undefined) {
+          return;
+        }
+
+        wrote = true;
+        const now = Date.now();
+
         // 1. Build event data
         const eventData: Record<string, unknown> = { updated: now };
         if (data.title !== undefined) eventData.title = data.title;
@@ -201,7 +220,7 @@ export class TaskRepository
         if (data.projectId !== undefined) eventData.projectId = data.projectId;
         if (data.parentTaskId !== undefined) eventData.parentTaskId = data.parentTaskId;
         if (data.completedAt !== undefined) eventData.completedAt = data.completedAt;
-        if (data.metadata !== undefined) eventData.metadataJson = JSON.stringify(data.metadata);
+        if (resolvedMetadata !== undefined) eventData.metadataJson = JSON.stringify(resolvedMetadata);
 
         await this.writeEvent<TaskUpdatedEvent>(
           this.jsonlPath(existing.workspaceId),
@@ -226,7 +245,7 @@ export class TaskRepository
         if (data.projectId !== undefined) { setClauses.push('projectId = ?'); params.push(data.projectId); }
         if (data.parentTaskId !== undefined) { setClauses.push('parentTaskId = ?'); params.push(data.parentTaskId); }
         if (data.completedAt !== undefined) { setClauses.push('completedAt = ?'); params.push(data.completedAt); }
-        if (data.metadata !== undefined) { setClauses.push('metadataJson = ?'); params.push(JSON.stringify(data.metadata)); }
+        if (resolvedMetadata !== undefined) { setClauses.push('metadataJson = ?'); params.push(JSON.stringify(resolvedMetadata)); }
 
         params.push(id);
 
@@ -235,6 +254,10 @@ export class TaskRepository
           params
         );
       });
+
+      if (!wrote) {
+        return;
+      }
 
       // 3. Invalidate cache
       const statusChanged = data.status !== undefined && data.status !== existing.status;
@@ -613,6 +636,37 @@ export class TaskRepository
   // ============================================================================
   // Protected Methods
   // ============================================================================
+
+  private async resolveMetadataInTransaction(
+    id: string,
+    data: UpdateTaskData
+  ): Promise<Record<string, unknown> | undefined> {
+    const hasMetadataOperation = data.metadata !== undefined
+      || data.metadataMode !== undefined
+      || data.removeMetadataKeys !== undefined;
+    if (!hasMetadataOperation) {
+      return undefined;
+    }
+
+    let current: Record<string, unknown> | undefined;
+    if (data.metadataMode !== 'replace') {
+      const row = await this.sqliteCache.queryOne<{ metadataJson?: string | null }>(
+        'SELECT metadataJson FROM tasks WHERE id = ?',
+        [id]
+      );
+      current = parseJsonColumn<Record<string, unknown>>(
+        row?.metadataJson,
+        `TaskRepository.metadata#${id}`
+      );
+    }
+
+    return resolveMetadataUpdate({
+      current,
+      metadata: data.metadata,
+      metadataMode: data.metadataMode,
+      removeMetadataKeys: data.removeMetadataKeys
+    });
+  }
 
   protected rowToEntity(row: DatabaseRow): TaskMetadata {
     const taskRow = row as TaskRow;

--- a/src/database/repositories/interfaces/IProjectRepository.ts
+++ b/src/database/repositories/interfaces/IProjectRepository.ts
@@ -13,6 +13,7 @@
 
 import { IRepository } from './IRepository';
 import { PaginatedResult, PaginationParams } from '../../../types/pagination/PaginationTypes';
+import type { MetadataUpdateMode } from '../metadataUpdate';
 
 /**
  * Project metadata as stored in SQLite
@@ -46,12 +47,16 @@ export interface UpdateProjectData {
   description?: string;
   status?: 'active' | 'completed' | 'archived';
   metadata?: Record<string, unknown>;
+  /** Defaults to a shallow key merge. */
+  metadataMode?: MetadataUpdateMode;
+  /** Keys to remove after applying a merge patch. */
+  removeMetadataKeys?: string[];
 }
 
 /**
  * Project repository interface
  */
-export interface IProjectRepository extends IRepository<ProjectMetadata> {
+export interface IProjectRepository extends IRepository<ProjectMetadata, CreateProjectData, UpdateProjectData> {
   /**
    * Get projects for a workspace with optional pagination
    */

--- a/src/database/repositories/interfaces/ITaskRepository.ts
+++ b/src/database/repositories/interfaces/ITaskRepository.ts
@@ -13,6 +13,7 @@
 
 import { IRepository } from './IRepository';
 import { PaginatedResult, PaginationParams } from '../../../types/pagination/PaginationTypes';
+import type { MetadataUpdateMode } from '../metadataUpdate';
 
 /**
  * Task status values. Note: 'blocked' is derived, not stored.
@@ -82,6 +83,10 @@ export interface UpdateTaskData {
   /** number = completion timestamp; null = explicitly clear a stale timestamp; undefined = no change. */
   completedAt?: number | null;
   metadata?: Record<string, unknown>;
+  /** Defaults to a shallow key merge. */
+  metadataMode?: MetadataUpdateMode;
+  /** Keys to remove after applying a merge patch. */
+  removeMetadataKeys?: string[];
 }
 
 /**

--- a/src/database/repositories/metadataUpdate.ts
+++ b/src/database/repositories/metadataUpdate.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure metadata-update semantics shared by task and project repositories.
+ * Repositories resolve the operation against SQLite inside their transaction,
+ * then persist the complete resulting object to both SQLite and JSONL.
+ */
+
+export type MetadataUpdateMode = 'merge' | 'replace';
+
+export interface MetadataUpdateOperation {
+  current?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+  metadataMode?: MetadataUpdateMode;
+  removeMetadataKeys?: string[];
+}
+
+interface NormalizedMetadataUpdate {
+  current: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+  mode: MetadataUpdateMode;
+  removals: string[];
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Reflect.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function copyDefinedEntries(source: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(source).filter(([, value]) => value !== undefined)
+  );
+}
+
+function normalizeMetadataUpdate(operation: MetadataUpdateOperation): NormalizedMetadataUpdate {
+  const { current, metadata, metadataMode, removeMetadataKeys } = operation;
+
+  if (metadataMode !== undefined && metadataMode !== 'merge' && metadataMode !== 'replace') {
+    throw new Error('metadataMode must be either "merge" or "replace"');
+  }
+  if (metadata !== undefined && !isPlainObject(metadata)) {
+    throw new Error('metadata must be an object');
+  }
+  if (current !== undefined && !isPlainObject(current)) {
+    throw new Error('Stored metadata must be an object');
+  }
+  if (removeMetadataKeys !== undefined && !Array.isArray(removeMetadataKeys)) {
+    throw new Error('removeMetadataKeys must be an array of non-empty strings');
+  }
+
+  const removals: string[] = [];
+  for (const key of removeMetadataKeys ?? []) {
+    if (typeof key !== 'string' || key.trim().length === 0) {
+      throw new Error('removeMetadataKeys must be an array of non-empty strings');
+    }
+    if (!removals.includes(key)) {
+      removals.push(key);
+    }
+  }
+
+  const mode = metadataMode ?? 'merge';
+  if (mode === 'replace') {
+    if (metadata === undefined) {
+      throw new Error('metadataMode "replace" requires an explicit metadata object');
+    }
+    if (removals.length > 0) {
+      throw new Error('removeMetadataKeys cannot be combined with metadataMode "replace"');
+    }
+  }
+
+  return {
+    current: current ?? {},
+    metadata: copyDefinedEntries(metadata ?? {}),
+    mode,
+    removals
+  };
+}
+
+/**
+ * Detect no-ops that do not depend on the current stored value. This is safe at
+ * the service layer and ensures malformed inputs are validated before an early
+ * return. Current-value-dependent no-ops remain the repository's responsibility.
+ */
+export function isMetadataUpdateTriviallyEmpty(operation: MetadataUpdateOperation): boolean {
+  const normalized = normalizeMetadataUpdate(operation);
+  return normalized.mode === 'merge'
+    && Object.keys(normalized.metadata).length === 0
+    && normalized.removals.length === 0;
+}
+
+/**
+ * Resolve a shallow merge, explicit replacement, or merge-mode removals.
+ * Returns undefined when the metadata operation makes no effective change.
+ */
+export function resolveMetadataUpdate(
+  operation: MetadataUpdateOperation
+): Record<string, unknown> | undefined {
+  const normalized = normalizeMetadataUpdate(operation);
+
+  if (normalized.mode === 'replace') {
+    return normalized.metadata;
+  }
+
+  const patchKeys = Object.keys(normalized.metadata);
+  const effectiveRemovals = normalized.removals.filter(key =>
+    Object.prototype.hasOwnProperty.call(normalized.current, key)
+    || Object.prototype.hasOwnProperty.call(normalized.metadata, key)
+  );
+
+  if (patchKeys.length === 0 && effectiveRemovals.length === 0) {
+    return undefined;
+  }
+
+  const merged = { ...normalized.current, ...normalized.metadata };
+  for (const key of effectiveRemovals) {
+    delete merged[key];
+  }
+  return merged;
+}

--- a/src/database/storage/SQLiteCacheManager.ts
+++ b/src/database/storage/SQLiteCacheManager.ts
@@ -502,7 +502,9 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
 
   /**
    * Execute a function within a transaction
-   * Handles concurrent access via lock and nested transactions via depth tracking
+   * Serializes concurrent access through SQLiteTransactionCoordinator.
+   * Nested calls are not supported; callers should keep one transaction boundary
+   * around the complete operation instead of opening a transaction from inside one.
    */
   async transaction<T>(fn: () => Promise<T>): Promise<T> {
     return this.transactionCoordinator.run(

--- a/src/database/storage/SQLiteTransactionCoordinator.ts
+++ b/src/database/storage/SQLiteTransactionCoordinator.ts
@@ -1,5 +1,4 @@
 export class SQLiteTransactionCoordinator {
-  private transactionDepth = 0;
   private transactionLock: Promise<void> = Promise.resolve();
 
   async run<T>(
@@ -8,10 +7,6 @@ export class SQLiteTransactionCoordinator {
     rollbackTransaction: () => Promise<void>,
     fn: () => Promise<T>
   ): Promise<T> {
-    if (this.transactionDepth > 0) {
-      return fn();
-    }
-
     let releaseLock: (() => void) | undefined;
     const previousLock = this.transactionLock;
     this.transactionLock = new Promise<void>(resolve => {
@@ -20,8 +15,6 @@ export class SQLiteTransactionCoordinator {
 
     try {
       await previousLock;
-
-      this.transactionDepth++;
       await beginTransaction();
 
       try {
@@ -31,8 +24,6 @@ export class SQLiteTransactionCoordinator {
       } catch (error) {
         await rollbackTransaction();
         throw error;
-      } finally {
-        this.transactionDepth--;
       }
     } finally {
       releaseLock?.();

--- a/tests/unit/MetadataUpdate.test.ts
+++ b/tests/unit/MetadataUpdate.test.ts
@@ -1,0 +1,99 @@
+import {
+  isMetadataUpdateTriviallyEmpty,
+  resolveMetadataUpdate
+} from '../../src/database/repositories/metadataUpdate';
+
+describe('metadata updates', () => {
+  it('shallow-merges by default and preserves unrelated keys', () => {
+    expect(resolveMetadataUpdate({
+      current: { keep: true, nested: { a: 1, b: 2 } },
+      metadata: { nested: { b: 3 }, added: 1 }
+    })).toEqual({ keep: true, nested: { b: 3 }, added: 1 });
+  });
+
+  it('preserves falsy and null patch values', () => {
+    expect(resolveMetadataUpdate({
+      current: { flag: true, count: 1, label: 'x', value: 'x' },
+      metadata: { flag: false, count: 0, label: '', value: null }
+    })).toEqual({ flag: false, count: 0, label: '', value: null });
+  });
+
+  it('ignores undefined patch values', () => {
+    expect(resolveMetadataUpdate({
+      current: { keep: true },
+      metadata: { keep: undefined, added: 1 }
+    })).toEqual({ keep: true, added: 1 });
+  });
+
+  it('replaces the complete object in replace mode', () => {
+    expect(resolveMetadataUpdate({
+      current: { old: true },
+      metadata: { replacement: true },
+      metadataMode: 'replace'
+    })).toEqual({ replacement: true });
+  });
+
+  it('clears metadata with replace and an empty object', () => {
+    expect(resolveMetadataUpdate({
+      current: { old: true },
+      metadata: {},
+      metadataMode: 'replace'
+    })).toEqual({});
+  });
+
+  it('applies removals after the merge patch', () => {
+    expect(resolveMetadataUpdate({
+      current: { keep: true, stale: 1 },
+      metadata: { added: 2 },
+      removeMetadataKeys: ['stale']
+    })).toEqual({ keep: true, added: 2 });
+  });
+
+  it('returns undefined for empty or ineffective merge operations', () => {
+    expect(resolveMetadataUpdate({ current: { keep: true }, metadata: {} })).toBeUndefined();
+    expect(resolveMetadataUpdate({ current: { keep: true }, removeMetadataKeys: ['missing'] })).toBeUndefined();
+  });
+
+  it('rejects replace without metadata', () => {
+    expect(() => resolveMetadataUpdate({ metadataMode: 'replace' })).toThrow(/requires.*metadata/);
+  });
+
+  it('rejects replace combined with removals', () => {
+    expect(() => resolveMetadataUpdate({
+      metadataMode: 'replace',
+      metadata: {},
+      removeMetadataKeys: ['old']
+    })).toThrow(/removeMetadataKeys/);
+  });
+
+  it('rejects invalid runtime metadata shapes', () => {
+    expect(() => isMetadataUpdateTriviallyEmpty({
+      metadata: [] as unknown as Record<string, unknown>
+    })).toThrow(/metadata must be an object/);
+    expect(() => isMetadataUpdateTriviallyEmpty({
+      metadata: null as unknown as Record<string, unknown>
+    })).toThrow(/metadata must be an object/);
+  });
+
+  it('rejects invalid modes before no-op detection', () => {
+    expect(() => isMetadataUpdateTriviallyEmpty({
+      metadataMode: 'invalid' as 'merge'
+    })).toThrow(/metadataMode/);
+  });
+
+  it('rejects invalid removal lists before no-op detection', () => {
+    expect(() => isMetadataUpdateTriviallyEmpty({
+      removeMetadataKeys: 'key' as unknown as string[]
+    })).toThrow(/removeMetadataKeys/);
+    expect(() => isMetadataUpdateTriviallyEmpty({
+      removeMetadataKeys: [' ']
+    })).toThrow(/removeMetadataKeys/);
+  });
+
+  it('recognizes only validated, current-independent no-ops', () => {
+    expect(isMetadataUpdateTriviallyEmpty({ metadata: {} })).toBe(true);
+    expect(isMetadataUpdateTriviallyEmpty({ metadataMode: 'merge', removeMetadataKeys: [] })).toBe(true);
+    expect(isMetadataUpdateTriviallyEmpty({ removeMetadataKeys: ['possibly-present'] })).toBe(false);
+    expect(isMetadataUpdateTriviallyEmpty({ metadataMode: 'replace', metadata: {} })).toBe(false);
+  });
+});

--- a/tests/unit/ProjectRepository.test.ts
+++ b/tests/unit/ProjectRepository.test.ts
@@ -272,6 +272,76 @@ describe('ProjectRepository', () => {
       expect(sql).not.toContain('name = ?');
     });
 
+    it('shallow-merges metadata and writes the complete snapshot to both stores', async () => {
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+        id: 'proj-1',
+        workspaceId: 'ws-1',
+        name: 'Original',
+        description: null,
+        status: 'active',
+        created: 1000,
+        updated: 1000,
+        metadataJson: JSON.stringify({ keep: true, nested: { old: true } })
+      });
+
+      await repo.update('proj-1', { metadata: { nested: { next: true }, added: 1 } });
+
+      const event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({
+        keep: true,
+        nested: { next: true },
+        added: 1
+      });
+
+      const [sql, params] = (deps.sqliteCache.run as jest.Mock).mock.calls[0];
+      const metadataIndex = (sql as string).split(' WHERE ')[0].split(', ').indexOf('metadataJson = ?');
+      expect(JSON.parse(params[metadataIndex])).toEqual({
+        keep: true,
+        nested: { next: true },
+        added: 1
+      });
+      expect(deps.sqliteCache.queryOne).toHaveBeenCalledWith(
+        'SELECT metadataJson FROM projects WHERE id = ?',
+        ['proj-1']
+      );
+    });
+
+    it('supports replacement and removals', async () => {
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+        id: 'proj-1', workspaceId: 'ws-1', name: 'Original', description: null,
+        status: 'active', created: 1000, updated: 1000,
+        metadataJson: JSON.stringify({ keep: true, stale: true })
+      });
+
+      await repo.update('proj-1', { removeMetadataKeys: ['stale'] });
+      let event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({ keep: true });
+
+      jest.clearAllMocks();
+      (deps.queryCache.cachedQuery as jest.Mock).mockImplementation(
+        (_key: string, fn: () => Promise<unknown>) => fn()
+      );
+      (deps.sqliteCache.transaction as jest.Mock).mockImplementation(
+        (fn: () => Promise<unknown>) => fn()
+      );
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+        id: 'proj-1', workspaceId: 'ws-1', name: 'Original', description: null,
+        status: 'active', created: 1000, updated: 1000, metadataJson: null
+      });
+      await repo.update('proj-1', { metadataMode: 'replace', metadata: {} });
+      event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({});
+    });
+
+    it('writes nothing for an ineffective metadata-only update', async () => {
+      await repo.update('proj-1', { metadata: {} });
+
+      expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+      expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+      expect(deps.queryCache.invalidateById).not.toHaveBeenCalled();
+      expect(deps.queryCache.invalidateByType).not.toHaveBeenCalled();
+    });
+
     it('should invalidate cache by ID for non-status updates', async () => {
       await repo.update('proj-1', { name: 'X' });
       expect(deps.queryCache.invalidateById).toHaveBeenCalledWith('project', 'proj-1');

--- a/tests/unit/SQLiteCacheManager.test.ts
+++ b/tests/unit/SQLiteCacheManager.test.ts
@@ -123,18 +123,49 @@ describe('SQLiteCacheManager', () => {
       expect(manager.rollback).not.toHaveBeenCalled();
     });
 
-    it('does not open a nested SQL transaction', async () => {
+    it('serializes a transaction that starts after the first body has entered', async () => {
       const manager = createManager();
+      const firstGate = createDeferred<void>();
+      const firstStarted = createDeferred<void>();
+      const order: string[] = [];
 
-      await manager.transaction(async () => {
-        await manager.transaction(async () => {
-          return 'nested';
-        });
-        return 'outer';
+      manager.beginTransaction.mockImplementation(async () => {
+        order.push('begin');
+      });
+      manager.commit.mockImplementation(async () => {
+        order.push('commit');
       });
 
-      expect(manager.beginTransaction).toHaveBeenCalledTimes(1);
-      expect(manager.commit).toHaveBeenCalledTimes(1);
+      const first = manager.transaction(async () => {
+        order.push('first-start');
+        firstStarted.resolve();
+        await firstGate.promise;
+        order.push('first-end');
+      });
+
+      await firstStarted.promise;
+
+      const second = manager.transaction(async () => {
+        order.push('second-start');
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(order).toEqual(['begin', 'first-start']);
+
+      firstGate.resolve();
+      await Promise.all([first, second]);
+
+      expect(order).toEqual([
+        'begin',
+        'first-start',
+        'first-end',
+        'commit',
+        'begin',
+        'second-start',
+        'commit'
+      ]);
+      expect(manager.beginTransaction).toHaveBeenCalledTimes(2);
+      expect(manager.commit).toHaveBeenCalledTimes(2);
       expect(manager.rollback).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/SQLiteTransactionCoordinator.test.ts
+++ b/tests/unit/SQLiteTransactionCoordinator.test.ts
@@ -74,29 +74,67 @@ describe('SQLiteTransactionCoordinator', () => {
     expect(rollbackTransaction).not.toHaveBeenCalled();
   });
 
-  it('does not open nested SQL transactions', async () => {
+  it('serializes a transaction that starts after the first body has entered', async () => {
     const coordinator = new SQLiteTransactionCoordinator();
+    const firstGate = createDeferred<void>();
+    const firstStarted = createDeferred<void>();
     const beginTransaction = jest.fn().mockResolvedValue(undefined);
     const commitTransaction = jest.fn().mockResolvedValue(undefined);
     const rollbackTransaction = jest.fn().mockResolvedValue(undefined);
+    const order: string[] = [];
 
-    await coordinator.run(
-      beginTransaction,
-      commitTransaction,
+    const first = coordinator.run(
+      async () => {
+        order.push('first-begin');
+        await beginTransaction();
+      },
+      async () => {
+        order.push('first-commit');
+        await commitTransaction();
+      },
       rollbackTransaction,
       async () => {
-        await coordinator.run(
-          beginTransaction,
-          commitTransaction,
-          rollbackTransaction,
-          async () => 'nested'
-        );
-        return 'outer';
+        order.push('first-start');
+        firstStarted.resolve();
+        await firstGate.promise;
+        order.push('first-end');
       }
     );
 
-    expect(beginTransaction).toHaveBeenCalledTimes(1);
-    expect(commitTransaction).toHaveBeenCalledTimes(1);
+    await firstStarted.promise;
+
+    const second = coordinator.run(
+      async () => {
+        order.push('second-begin');
+        await beginTransaction();
+      },
+      async () => {
+        order.push('second-commit');
+        await commitTransaction();
+      },
+      rollbackTransaction,
+      async () => {
+        order.push('second-start');
+      }
+    );
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(order).toEqual(['first-begin', 'first-start']);
+
+    firstGate.resolve();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual([
+      'first-begin',
+      'first-start',
+      'first-end',
+      'first-commit',
+      'second-begin',
+      'second-start',
+      'second-commit'
+    ]);
+    expect(beginTransaction).toHaveBeenCalledTimes(2);
+    expect(commitTransaction).toHaveBeenCalledTimes(2);
     expect(rollbackTransaction).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/TaskManagerTools.test.ts
+++ b/tests/unit/TaskManagerTools.test.ts
@@ -268,6 +268,28 @@ describe('TaskManager Tools', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Not found');
     });
+
+    it('forwards metadata mode and removals and documents them in the schema', async () => {
+      mockService.updateProject.mockResolvedValue();
+
+      await tool.execute({
+        ...baseParams,
+        projectId: 'proj-1',
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      });
+
+      expect(mockService.updateProject).toHaveBeenCalledWith('proj-1', expect.objectContaining({
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      }));
+      const properties = tool.getParameterSchema().properties as Record<string, Record<string, unknown>>;
+      expect(properties.metadataMode.enum).toEqual(['merge', 'replace']);
+      expect(properties.removeMetadataKeys.type).toBe('array');
+      expect(properties.metadata.description).toMatch(/Shallow-merged/);
+    });
   });
 
   // ============================================================================
@@ -567,6 +589,24 @@ describe('TaskManager Tools', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('cycle');
+    });
+
+    it('forwards metadata-only operations and documents them in the schema', async () => {
+      mockService.updateTask.mockResolvedValue();
+
+      await tool.execute({
+        ...baseParams,
+        taskId: 'task-1',
+        removeMetadataKeys: ['stale']
+      });
+
+      expect(mockService.updateTask).toHaveBeenCalledWith('task-1', expect.objectContaining({
+        removeMetadataKeys: ['stale']
+      }));
+      const properties = tool.getParameterSchema().properties as Record<string, Record<string, unknown>>;
+      expect(properties.metadataMode.enum).toEqual(['merge', 'replace']);
+      expect(properties.removeMetadataKeys.type).toBe('array');
+      expect(properties.metadata.description).toMatch(/Shallow-merged/);
     });
   });
 

--- a/tests/unit/TaskRepository.test.ts
+++ b/tests/unit/TaskRepository.test.ts
@@ -304,6 +304,81 @@ describe('TaskRepository', () => {
       expect(sqlCall[0]).not.toContain('status = ?');
     });
 
+    it('shallow-merges metadata and writes the complete snapshot to both stores', async () => {
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        metadataJson: JSON.stringify({ keep: true, nested: { old: true } })
+      });
+
+      await repo.update('task-1', { metadata: { nested: { next: true }, added: 1 } });
+
+      const event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({
+        keep: true,
+        nested: { next: true },
+        added: 1
+      });
+
+      const [sql, params] = (deps.sqliteCache.run as jest.Mock).mock.calls[0];
+      const metadataIndex = (sql as string).split(' WHERE ')[0].split(', ').indexOf('metadataJson = ?');
+      expect(JSON.parse(params[metadataIndex])).toEqual({
+        keep: true,
+        nested: { next: true },
+        added: 1
+      });
+      expect(deps.sqliteCache.queryOne).toHaveBeenCalledWith(
+        'SELECT metadataJson FROM tasks WHERE id = ?',
+        ['task-1']
+      );
+    });
+
+    it('supports explicit replacement, clearing, and key removal', async () => {
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({
+        ...sampleRow,
+        metadataJson: JSON.stringify({ keep: true, stale: true })
+      });
+
+      await repo.update('task-1', { removeMetadataKeys: ['stale'] });
+      let event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({ keep: true });
+
+      jest.clearAllMocks();
+      (deps.queryCache.cachedQuery as jest.Mock).mockImplementation(
+        (_key: string, fn: () => Promise<unknown>) => fn()
+      );
+      (deps.sqliteCache.transaction as jest.Mock).mockImplementation(
+        (fn: () => Promise<unknown>) => fn()
+      );
+      (deps.sqliteCache.queryOne as jest.Mock).mockResolvedValue({ ...sampleRow });
+      await repo.update('task-1', { metadataMode: 'replace', metadata: {} });
+      event = (deps.jsonlWriter.appendEvent as jest.Mock).mock.calls[0][1];
+      expect(JSON.parse(event.data.metadataJson)).toEqual({});
+      expect(deps.sqliteCache.queryOne).not.toHaveBeenCalledWith(
+        'SELECT metadataJson FROM tasks WHERE id = ?',
+        expect.anything()
+      );
+    });
+
+    it('writes nothing for an ineffective metadata-only update', async () => {
+      await repo.update('task-1', { metadata: {} });
+
+      expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+      expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+      expect(deps.queryCache.invalidateById).not.toHaveBeenCalled();
+      expect(deps.queryCache.invalidateByType).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid metadata operations before either store is written', async () => {
+      await expect(repo.update('task-1', {
+        metadataMode: 'replace',
+        metadata: {},
+        removeMetadataKeys: ['stale']
+      })).rejects.toThrow(/removeMetadataKeys/);
+
+      expect(deps.jsonlWriter.appendEvent).not.toHaveBeenCalled();
+      expect(deps.sqliteCache.run).not.toHaveBeenCalled();
+    });
+
     it('should handle completedAt update', async () => {
       await repo.update('task-1', { completedAt: 5000 });
 

--- a/tests/unit/TaskService.test.ts
+++ b/tests/unit/TaskService.test.ts
@@ -265,6 +265,44 @@ describe('TaskService', () => {
 
       expect(projectRepo.getByName).not.toHaveBeenCalled();
     });
+
+    it('forwards metadata operations without precomputing the merge', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject({ metadata: { keep: true } }));
+
+      await service.updateProject('proj-1', {
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      });
+
+      expect(projectRepo.update).toHaveBeenCalledWith('proj-1', expect.objectContaining({
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      }));
+    });
+
+    it('validates malformed metadata before treating an update as a no-op', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+
+      await expect(service.updateProject('proj-1', {
+        metadata: [] as unknown as Record<string, unknown>
+      })).rejects.toThrow(/metadata must be an object/);
+      await expect(service.updateProject('proj-1', {
+        metadataMode: 'invalid' as 'merge'
+      })).rejects.toThrow(/metadataMode/);
+
+      expect(projectRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('does not persist or notify for an empty metadata-only merge', async () => {
+      projectRepo.getById.mockResolvedValue(createMockProject());
+
+      await service.updateProject('proj-1', { metadata: {} });
+
+      expect(projectRepo.update).not.toHaveBeenCalled();
+      expect(taskBoardNotifier.notify).not.toHaveBeenCalled();
+    });
   });
 
   describe('archiveProject', () => {
@@ -853,6 +891,44 @@ describe('TaskService', () => {
         status: 'done',
         completedAt: expect.any(Number)
       }));
+    });
+
+    it('forwards metadata operations without precomputing the merge', async () => {
+      taskRepo.getById.mockResolvedValue(createMockTask({ metadata: { keep: true } }));
+
+      await service.updateTask('task-1', {
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      });
+
+      expect(taskRepo.update).toHaveBeenCalledWith('task-1', expect.objectContaining({
+        metadata: { added: true },
+        metadataMode: 'merge',
+        removeMetadataKeys: ['stale']
+      }));
+    });
+
+    it('validates malformed metadata before treating an update as a no-op', async () => {
+      taskRepo.getById.mockResolvedValue(createMockTask());
+
+      await expect(service.updateTask('task-1', {
+        metadata: [] as unknown as Record<string, unknown>
+      })).rejects.toThrow(/metadata must be an object/);
+      await expect(service.updateTask('task-1', {
+        removeMetadataKeys: 'stale' as unknown as string[]
+      })).rejects.toThrow(/removeMetadataKeys/);
+
+      expect(taskRepo.update).not.toHaveBeenCalled();
+    });
+
+    it('does not persist or notify for an empty metadata-only merge', async () => {
+      taskRepo.getById.mockResolvedValue(createMockTask());
+
+      await service.updateTask('task-1', { metadata: {} });
+
+      expect(taskRepo.update).not.toHaveBeenCalled();
+      expect(taskBoardNotifier.notify).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- make task and project metadata updates shallow-merge by default, matching the documented tool contract
- add explicit `metadataMode: "replace"` and `removeMetadataKeys` operations
- validate runtime metadata operations before no-op handling
- persist complete resolved metadata snapshots to both JSONL and SQLite
- serialize transactions that arrive after another transaction has started

## Root cause

The update tools documented key merging, but both repositories serialized the incoming partial metadata object as the complete stored value. Omitted keys were silently dropped. The transaction coordinator also treated concurrent calls that arrived after transaction start as nested, bypassing its queue.

## Validation

- 275 focused tests passed
- 4,089 tests across 331 suites passed when excluding two unrelated baseline failures
- the two excluded failures reproduce on unchanged `main`: Windows PATH detection and sandbox-blocked OAuth callback listener ports
- ESLint passed
- TypeScript checks passed
- production plugin, CLI, and connector build steps passed
- `git diff --check` passed

Closes #305
