### PR TITLE
Fix load-state returning stale tags

### DIFF
--- a/src/agents/memoryManager/tools/states/loadState.ts
+++ b/src/agents/memoryManager/tools/states/loadState.ts
@@ -44,6 +44,7 @@ interface LoadedStateContext {
 interface LoadedStateResult {
     loadedState: WorkspaceState;
     relatedTraces: WorkspaceMemoryTrace[];
+    currentTags?: string[];
 }
 
 interface RestoredStateResult {
@@ -208,7 +209,9 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
                 success: true,
                 data: {
                     loadedState,
-                    relatedTraces: relatedTraces || []
+                    relatedTraces: relatedTraces || [],
+                    // getState returns the stored snapshot and drops mutable top-level metadata.
+                    currentTags: matchingState.tags
                 }
             };
 
@@ -309,7 +312,7 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
             activeFiles: stateContext.activeFiles || [],
             nextSteps: stateContext.nextSteps || [],
             description: loadedState.description,
-            tags: loadedState.state?.metadata?.tags || []
+            tags: stateData.currentTags ?? loadedState.state?.metadata?.tags ?? []
         };
 
         return this.prepareResult(

--- a/tests/unit/LoadStateTool.test.ts
+++ b/tests/unit/LoadStateTool.test.ts
@@ -26,12 +26,13 @@ describe('LoadStateTool', () => {
     return new LoadStateTool(agent);
   }
 
-  it('resolves workspace names before loading states', async () => {
+  it('resolves workspace names and prefers current tags over stale snapshot tags', async () => {
     const matchingState = {
       id: 'state-1',
       name: 'Checkpoint',
       sessionId: 'session-1',
-      workspaceId: 'workspace-uuid'
+      workspaceId: 'workspace-uuid',
+      tags: ['current']
     };
     const loadedState = {
       id: 'state-1',
@@ -48,7 +49,7 @@ describe('LoadStateTool', () => {
       },
       state: {
         metadata: {
-          tags: ['test']
+          tags: ['stale']
         }
       }
     };
@@ -98,8 +99,67 @@ describe('LoadStateTool', () => {
       activeFiles: ['note.md'],
       nextSteps: ['Continue testing'],
       description: 'Checkpoint description',
-      tags: ['test']
+      tags: ['current']
     });
+  });
+
+  it('keeps an empty current tag list instead of restoring stale snapshot tags', async () => {
+    const memoryService = {
+      getStates: jest.fn().mockResolvedValue({
+        items: [{
+          id: 'state-1',
+          name: 'Checkpoint',
+          sessionId: 'session-1',
+          workspaceId: 'workspace-uuid',
+          tags: []
+        }],
+        page: 0,
+        pageSize: 100,
+        totalItems: 1,
+        totalPages: 1,
+        hasNextPage: false,
+        hasPreviousPage: false
+      }),
+      getState: jest.fn().mockResolvedValue({
+        id: 'state-1',
+        name: 'Checkpoint',
+        sessionId: 'session-1',
+        workspaceId: 'workspace-uuid',
+        created: Date.now(),
+        context: {
+          conversationContext: 'Conversation context',
+          activeTask: 'Active task',
+          activeFiles: [],
+          nextSteps: []
+        },
+        state: { metadata: { tags: ['stale'] } }
+      }),
+      getMemoryTraces: jest.fn().mockResolvedValue({ items: [] })
+    };
+    const workspaceService = {
+      getWorkspaceByNameOrId: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      }),
+      getWorkspace: jest.fn().mockResolvedValue({
+        id: 'workspace-uuid',
+        name: 'Workspace Name'
+      })
+    };
+    const tool = createTool(memoryService, workspaceService);
+
+    const result = await tool.execute({
+      context: {
+        workspaceId: 'Workspace Name',
+        sessionId: 'session-1',
+        memory: 'Testing cleared state tags.',
+        goal: 'Verify cleared tags remain empty.'
+      },
+      name: 'Checkpoint'
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({ tags: [] });
   });
 
   it('returns a clear error when the scoped workspace name cannot be resolved', async () => {


### PR DESCRIPTION
## Summary

- carry current top-level state tags through the `loadState` read path
- prefer current tags over the immutable snapshot metadata
- preserve an explicitly cleared tag list (`[]`)
- add regression coverage for stale and cleared snapshot tags

## Root cause

`updateState` updates the top-level state metadata without rewriting the stored snapshot. `MemoryService.getState` returns only that snapshot, so `loadState` discarded the current tags even though its preceding `getStates` lookup already had the correct value.

## Validation

- 40 relevant tests passed
- TypeScript check passed
- ESLint passed for the changed implementation
- Full Jest suite: 4,094 passed; one unrelated Windows PATH-ordering test failed identically on untouched `main`

Closes #306
