### PR TITLE
Ground CLI agents in the real workspace list, and stop surfaces asserting more than they know

### DIFF
--- a/src/agents/memoryManager/services/WorkspaceMatcher.ts
+++ b/src/agents/memoryManager/services/WorkspaceMatcher.ts
@@ -9,7 +9,7 @@
  * returns nothing on a cold cache, so tool-facing search scores locally over
  * the lightweight workspace index instead.
  *
- * Used by: SearchWorkspacesTool
+ * Used by: SearchWorkspacesTool, LoadWorkspaceTool (miss recovery)
  */
 
 import { WorkspaceMetadata } from '../../../types/storage/StorageTypes';
@@ -168,4 +168,95 @@ export function matchWorkspaces(
 
   const limit = options?.limit;
   return typeof limit === 'number' && limit > 0 ? matches.slice(0, limit) : matches;
+}
+
+/**
+ * Minimum score a lone match must reach before it is auto-resolved on behalf of
+ * the caller.
+ *
+ * Deliberately low, because the invented names this recovers from are usually
+ * LONGER than the real one ("Research Notes" for "Research"), and scoreWorkspace
+ * charges for query tokens the target lacks — that pair scores 0.125, not 0.8.
+ * At 0.1 the floor means "at least ~40% of the query's tokens appear in the
+ * name"; the real guard against a wild match is the name/id requirement in
+ * resolveWorkspaceIdentifier, not this number.
+ */
+export const AUTO_RESOLVE_MIN_SCORE = 0.1;
+
+/** Candidates surfaced when a miss cannot be auto-resolved. */
+export const MAX_SUGGESTED_CANDIDATES = 5;
+
+/**
+ * Words agents append to an invented workspace name that carry no signal here —
+ * everything in this list is a workspace, so "Research Workspace" and
+ * "Research" are the same request. Left out of matchWorkspaces on purpose: this
+ * only applies to recovering a failed lookup, not to what the user typed into
+ * an explicit search.
+ */
+const FILLER_TOKENS = new Set(['workspace', 'workspaces']);
+
+/**
+ * Drop filler words from a failed identifier. Returns the original when
+ * stripping would leave nothing to match on (a workspace really named
+ * "Workspace").
+ */
+function stripFillerTokens(identifier: string): string {
+  const kept = identifier
+    .trim()
+    .split(/\s+/)
+    .filter(word => !FILLER_TOKENS.has(word.toLowerCase().replace(/[^a-z0-9]/gi, '')));
+
+  return kept.length > 0 ? kept.join(' ') : identifier;
+}
+
+export type WorkspaceResolution =
+  /** Exactly one confident match — safe to load without asking. */
+  | { kind: 'auto'; match: WorkspaceMatch }
+  /** Something matched, but not confidently enough to pick for the caller. */
+  | { kind: 'candidates'; candidates: WorkspaceMatch[] }
+  /** Nothing matched at all. */
+  | { kind: 'none' };
+
+/**
+ * Decide what to do with a workspace identifier that failed exact lookup.
+ *
+ * Exact name/id lookup happens upstream (WorkspaceService.getWorkspaceByNameOrId),
+ * so this only ever sees genuine misses — typically a name an agent invented
+ * from the user's phrasing instead of one it actually saw. Rather than dead-end
+ * the call (which is what makes agents retry-loop on guessed names), it either
+ * resolves the obvious single candidate or hands back a ranked shortlist.
+ *
+ * Auto-resolution requires a single match that hit on name or id, matching the
+ * `searchWorkspaces --load` contract's strictness. Two plausible workspaces is
+ * a decision for the caller, not a coin flip; and a workspace that matched only
+ * because a query word brushed its description or folder path is not evidence
+ * the caller meant it.
+ *
+ * @param workspaces Lightweight workspace index rows
+ * @param identifier The identifier that failed exact lookup
+ * @param options includeArchived (default false)
+ */
+export function resolveWorkspaceIdentifier(
+  workspaces: WorkspaceMetadata[],
+  identifier: string,
+  options?: { includeArchived?: boolean }
+): WorkspaceResolution {
+  const matches = matchWorkspaces(workspaces, stripFillerTokens(identifier), {
+    includeArchived: options?.includeArchived ?? false
+  });
+
+  if (matches.length === 0) {
+    return { kind: 'none' };
+  }
+
+  const only = matches.length === 1 ? matches[0] : null;
+  const matchedIdentity = only
+    ? only.matchedOn.includes('name') || only.matchedOn.includes('id')
+    : false;
+
+  if (only && matchedIdentity && only.score >= AUTO_RESOLVE_MIN_SCORE) {
+    return { kind: 'auto', match: only };
+  }
+
+  return { kind: 'candidates', candidates: matches.slice(0, MAX_SUGGESTED_CANDIDATES) };
 }

--- a/src/agents/memoryManager/services/WorkspaceMatcher.ts
+++ b/src/agents/memoryManager/services/WorkspaceMatcher.ts
@@ -226,11 +226,12 @@ export type WorkspaceResolution =
  * the call (which is what makes agents retry-loop on guessed names), it either
  * resolves the obvious single candidate or hands back a ranked shortlist.
  *
- * Auto-resolution requires a single match that hit on name or id, matching the
- * `searchWorkspaces --load` contract's strictness. Two plausible workspaces is
- * a decision for the caller, not a coin flip; and a workspace that matched only
- * because a query word brushed its description or folder path is not evidence
- * the caller meant it.
+ * Auto-resolution requires exactly one match that hit on name or id, matching
+ * the `searchWorkspaces --load` contract's strictness. Two plausible workspaces
+ * is a decision for the caller, not a coin flip; and a workspace that matched
+ * only because a query word brushed its description or folder path is neither
+ * evidence the caller meant it NOR grounds to block a clear name match. Such
+ * rows still appear in the shortlist when nothing wins on identity.
  *
  * @param workspaces Lightweight workspace index rows
  * @param identifier The identifier that failed exact lookup
@@ -249,12 +250,19 @@ export function resolveWorkspaceIdentifier(
     return { kind: 'none' };
   }
 
-  const only = matches.length === 1 ? matches[0] : null;
-  const matchedIdentity = only
-    ? only.matchedOn.includes('name') || only.matchedOn.includes('id')
-    : false;
+  // Count rivals by the same standard used to qualify a winner: a hit on name
+  // or id. Counting every match instead let a single noise row veto an obvious
+  // resolution — "Blog Testing" matched "Blog Testing Workspace" at 0.8 on the
+  // name, but also brushed an unrelated workspace whose DESCRIPTION ended
+  // "...handle testing" for 0.075, and that was enough to force a shortlist.
+  // Description- and folder-only hits are already declared insufficient to pick
+  // a workspace; they should not be strong enough to block one either.
+  const identityMatches = matches.filter(
+    match => match.matchedOn.includes('name') || match.matchedOn.includes('id')
+  );
+  const only = identityMatches.length === 1 ? identityMatches[0] : null;
 
-  if (only && matchedIdentity && only.score >= AUTO_RESOLVE_MIN_SCORE) {
+  if (only && only.score >= AUTO_RESOLVE_MIN_SCORE) {
     return { kind: 'auto', match: only };
   }
 

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -153,7 +153,11 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
       if (!workspace) {
         const recovered = await this.recoverFromMiss(workspaceService, params);
         if (!recovered.workspace) {
-          console.error('[LoadWorkspaceMode] Workspace not found:', params.workspace);
+          // Log the reason the CALLER was given, not a fixed "not found".
+          // A miss during the post-load cache rebuild is a different problem
+          // from a workspace that genuinely does not exist, and a console that
+          // reports both identically sends debugging down the wrong path.
+          console.error('[LoadWorkspaceMode] Could not resolve workspace:', recovered.report.note);
           return this.createErrorResult(recovered.report.note, params, recovered.report);
         }
         workspace = recovered.workspace;

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -19,7 +19,8 @@ import { labelWithId, verbs } from '../../../utils/toolStatusLabels';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import {
   LoadWorkspaceParameters,
-  LoadWorkspaceResult
+  LoadWorkspaceResult,
+  WorkspaceResolutionReport
 } from '../../../../database/types/workspace/ParameterTypes';
 import { ProjectWorkspace, WorkspaceWorkflow } from '../../../../database/types/workspace/WorkspaceTypes';
 import { IndividualWorkspace } from '../../../../types/storage/StorageTypes';
@@ -32,7 +33,13 @@ import { WorkspaceDataFetcher } from '../../services/WorkspaceDataFetcher';
 import { WorkspacePromptResolver } from '../../services/WorkspacePromptResolver';
 import { WorkspaceContextBuilder } from '../../services/WorkspaceContextBuilder';
 import { WorkspaceFileCollector } from '../../services/WorkspaceFileCollector';
+import { resolveWorkspaceIdentifier } from '../../services/WorkspaceMatcher';
 import type { WorkspaceTaskSummary } from '../../../taskManager/types';
+import type { WorkspaceMetadata } from '../../../../types/storage/StorageTypes';
+import type { WorkspaceService } from '../../../../services/WorkspaceService';
+
+/** Workspace names listed back to the caller when nothing matched at all. */
+const MAX_LISTED_WORKSPACES = 25;
 
 /**
  * Mode to load and restore a workspace by ID
@@ -61,8 +68,8 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
     super(
       'loadWorkspace',
       'Load Workspace',
-      'Load a workspace by ID and restore context and state',
-      '2.0.0'
+      'Load a workspace by name or ID and restore its context and state. Pass a name you have actually seen (getTools workspace list, search-workspaces, list-workspaces) — never one inferred from the user\'s wording.',
+      '2.1.0'
     );
     this.agent = agent;
 
@@ -138,10 +145,21 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
         );
       }
 
+      // Exact lookup missed. Rather than dead-ending (which is what sends
+      // agents into retry loops on invented names), fall back to fuzzy
+      // resolution: load the obvious single candidate, or hand back a ranked
+      // shortlist so the next call is guaranteed to be a real workspace.
+      let resolution: WorkspaceResolutionReport | undefined;
       if (!workspace) {
-        console.error('[LoadWorkspaceMode] Workspace not found:', params.workspace);
-        return this.createErrorResult(`Workspace '${params.workspace}' not found (searched by both name and ID)`, params);
+        const recovered = await this.recoverFromMiss(workspaceService, params);
+        if (!recovered.workspace) {
+          console.error('[LoadWorkspaceMode] Workspace not found:', params.workspace);
+          return this.createErrorResult(recovered.report.note, params, recovered.report);
+        }
+        workspace = recovered.workspace;
+        resolution = recovered.report;
       }
+
       const projectWorkspace = workspace as ProjectWorkspace;
 
       // Update last accessed timestamp (use actual workspace ID, not the identifier)
@@ -255,7 +273,8 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
             hasPreviousPage: statesResult.hasPreviousPage
           }
         },
-        workspaceContext
+        workspaceContext,
+        ...(resolution ? { resolution } : {})
       };
 
       // Add navigation fallback message if workspace path building failed
@@ -284,13 +303,135 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
   }
 
   /**
+   * Turn a failed exact lookup into either a resolved workspace or an
+   * actionable shortlist.
+   *
+   * Every branch returns something the caller can act on immediately — a
+   * loaded workspace, ranked candidates with the exact retry command, or the
+   * full inventory when nothing matched. The one thing it never returns is a
+   * bare "not found", which is the response agents respond to by guessing
+   * again.
+   */
+  private async recoverFromMiss(
+    workspaceService: WorkspaceService,
+    params: LoadWorkspaceParameters
+  ): Promise<{ workspace: IndividualWorkspace | null; report: WorkspaceResolutionReport }> {
+    const requested = params.workspace;
+
+    let workspaces: WorkspaceMetadata[] = [];
+    try {
+      workspaces = await workspaceService.listWorkspaces();
+    } catch (listError) {
+      console.error('[LoadWorkspaceMode] Failed to list workspaces for miss recovery:', listError);
+      return {
+        workspace: null,
+        report: {
+          requested,
+          autoResolved: false,
+          note: `Workspace '${requested}' not found (searched by both name and ID), and the workspace list could not be read to suggest alternatives. Retry with: memory list-workspaces`
+        }
+      };
+    }
+
+    const active = workspaces.filter(workspace => !workspace.isArchived);
+    const resolution = resolveWorkspaceIdentifier(workspaces, requested);
+
+    if (resolution.kind === 'auto') {
+      const target = resolution.match.workspace;
+      const loaded = await workspaceService.getWorkspace(target.id);
+
+      if (loaded) {
+        return {
+          workspace: loaded,
+          report: {
+            requested,
+            autoResolved: true,
+            resolvedTo: { id: target.id, name: target.name },
+            note: `No workspace is named '${requested}'. '${target.name}' was the only close match, so it was loaded instead. Use the name '${target.name}' (or id ${target.id}) from here on.`
+          }
+        };
+      }
+
+      // Index row without a loadable record — treat it as a candidate rather
+      // than silently reporting nothing matched.
+      return {
+        workspace: null,
+        report: {
+          requested,
+          autoResolved: false,
+          candidates: [this.toCandidate(resolution.match.workspace, resolution.match.score)],
+          note: `Workspace '${requested}' not found. Closest match '${target.name}' could not be loaded. Retry with: memory load-workspace --workspace ${target.id}`
+        }
+      };
+    }
+
+    if (resolution.kind === 'candidates') {
+      const candidates = resolution.candidates.map(match =>
+        this.toCandidate(match.workspace, match.score)
+      );
+      return {
+        workspace: null,
+        report: {
+          requested,
+          autoResolved: false,
+          candidates,
+          note: `No workspace is named '${requested}'. ${candidates.length} workspace${candidates.length === 1 ? '' : 's'} partially matched — pick one instead of guessing again: ${candidates.map(candidate => `"${candidate.name}"`).join(', ')}. Load with: memory load-workspace --workspace ${candidates[0].name}`
+        }
+      };
+    }
+
+    const names = active.slice(0, MAX_LISTED_WORKSPACES).map(workspace => workspace.name);
+
+    if (names.length === 0) {
+      return {
+        workspace: null,
+        report: {
+          requested,
+          autoResolved: false,
+          availableWorkspaces: [],
+          note: `Workspace '${requested}' not found, and no workspaces exist yet. Create one with: memory create-workspace --name "<name>" --rootFolder "<folder>"`
+        }
+      };
+    }
+
+    const truncated = active.length > names.length ? ` (${active.length} total)` : '';
+    return {
+      workspace: null,
+      report: {
+        requested,
+        autoResolved: false,
+        availableWorkspaces: names,
+        note: `Workspace '${requested}' does not exist and nothing resembles it. These are the workspaces that actually exist${truncated}: ${names.map(name => `"${name}"`).join(', ')}. Load one of these by name — do not invent another: memory load-workspace --workspace "${names[0]}"`
+      }
+    };
+  }
+
+  private toCandidate(
+    workspace: WorkspaceMetadata,
+    score: number
+  ): NonNullable<WorkspaceResolutionReport['candidates']>[number] {
+    return {
+      id: workspace.id,
+      name: workspace.name,
+      ...(workspace.description ? { description: workspace.description } : {}),
+      rootFolder: workspace.rootFolder || '',
+      score: Number(score.toFixed(3))
+    };
+  }
+
+  /**
    * Create an error result with default data structure
    * Follows DRY principle by consolidating error result creation
    */
-  protected createErrorResult(errorMessage: string, params: LoadWorkspaceParameters): LoadWorkspaceResult {
+  protected createErrorResult(
+    errorMessage: string,
+    params: LoadWorkspaceParameters,
+    resolution?: WorkspaceResolutionReport
+  ): LoadWorkspaceResult {
     return {
       success: false,
       error: errorMessage,
+      ...(resolution ? { resolution } : {}),
       data: {
         context: {
           name: 'Unknown',
@@ -325,7 +466,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
       properties: {
         workspace: {
           type: 'string',
-          description: 'Workspace name or ID to load (REQUIRED). Accepts either the workspace name or the unique workspace ID. Using the name returned by create-workspace is fine; you do not need to call list-workspaces just to find the UUID.'
+          description: 'Workspace name or ID to load (REQUIRED). Use a name you have actually seen — from the workspace list in getTools, from search-workspaces/list-workspaces, or from the create-workspace you just made. Do NOT infer a name from how the user phrased the request; "load my research workspace" does not mean a workspace named "Research" exists. If you do not have a confirmed name, run "memory search-workspaces --query <fragment> --load" first: it auto-loads on a single match and lists candidates otherwise. A near-miss here is recovered (single close match auto-loads, otherwise candidates are returned) — but recovery costs a round trip that discovery would have saved.'
         },
         limit: {
           type: 'number',
@@ -566,6 +707,45 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
               description: 'Full path from root workspace'
             }
           }
+        },
+        resolution: {
+          type: 'object',
+          description: 'Present only when the requested name/ID was not an exact match. Read "note" and follow it — either a near-miss was resolved for you (use resolvedTo.name from now on) or the workspaces that actually exist are listed here. Never retry with another guessed name.',
+          properties: {
+            requested: { type: 'string', description: 'The identifier that was asked for' },
+            autoResolved: { type: 'boolean', description: 'True when a single close match was loaded in place of the requested name' },
+            resolvedTo: {
+              type: 'object',
+              description: 'The workspace actually loaded (present when autoResolved is true)',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' }
+              },
+              required: ['id', 'name']
+            },
+            candidates: {
+              type: 'array',
+              description: 'Ranked partial matches to choose between when nothing was auto-resolved',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  name: { type: 'string' },
+                  description: { type: 'string' },
+                  rootFolder: { type: 'string' },
+                  score: { type: 'number', description: 'Relevance score (higher is better)' }
+                },
+                required: ['id', 'name', 'rootFolder', 'score']
+              }
+            },
+            availableWorkspaces: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Names of every existing workspace, listed when nothing resembled the request'
+            },
+            note: { type: 'string', description: 'What happened and the exact next command to run' }
+          },
+          required: ['requested', 'autoResolved', 'note']
         }
       },
       required: ['success']

--- a/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
+++ b/src/agents/memoryManager/tools/workspaces/loadWorkspace.ts
@@ -375,7 +375,7 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
           requested,
           autoResolved: false,
           candidates,
-          note: `No workspace is named '${requested}'. ${candidates.length} workspace${candidates.length === 1 ? '' : 's'} partially matched — pick one instead of guessing again: ${candidates.map(candidate => `"${candidate.name}"`).join(', ')}. Load with: memory load-workspace --workspace ${candidates[0].name}`
+          note: `No workspace is named '${requested}'. ${candidates.length} workspace${candidates.length === 1 ? '' : 's'} partially matched — pick one instead of guessing again: ${candidates.map(candidate => `"${candidate.name}"`).join(', ')}. Load with: memory load-workspace --workspace "${candidates[0].name}"`
         }
       };
     }
@@ -395,13 +395,23 @@ export class LoadWorkspaceTool extends BaseTool<LoadWorkspaceParameters, LoadWor
     }
 
     const truncated = active.length > names.length ? ` (${active.length} total)` : '';
+    const quoted = names.map(name => `"${name}"`).join(', ');
+
+    // Only assert that the list is exhaustive when the cache says it is.
+    // Immediately after a reload the rebuild is still replaying and this list
+    // is partial — claiming "nothing resembles it" then tells the agent a real
+    // workspace does not exist, which is the failure this tool exists to stop.
+    const note = workspaceService.isListComplete()
+      ? `Workspace '${requested}' does not exist and nothing resembles it. These are the workspaces that actually exist${truncated}: ${quoted}. Load one of these by name — do not invent another: memory load-workspace --workspace "${names[0]}"`
+      : `Workspace '${requested}' was not found, but the workspace cache is still rebuilding, so this list is INCOMPLETE — do not conclude the workspace is missing. Known so far${truncated}: ${quoted}. Retry in a few seconds with: memory load-workspace --workspace "${requested}"`;
+
     return {
       workspace: null,
       report: {
         requested,
         autoResolved: false,
         availableWorkspaces: names,
-        note: `Workspace '${requested}' does not exist and nothing resembles it. These are the workspaces that actually exist${truncated}: ${names.map(name => `"${name}"`).join(', ')}. Load one of these by name — do not invent another: memory load-workspace --workspace "${names[0]}"`
+        note
       }
     };
   }

--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -371,9 +371,19 @@ export class ToolBatchExecutionService {
 
         const { data, ...extra } = toolResultPayload;
 
+        const hasExtra = Object.keys(extra).length > 0;
+
         if (data !== undefined && data !== null) {
-          result.data = data;
-        } else if (Object.keys(extra).length > 0) {
+          // Keep sibling fields instead of dropping them. A tool that returns
+          // `data` PLUS a top-level field used to lose the latter silently —
+          // which is how loadWorkspace's `resolution` note vanished, leaving
+          // an auto-resolved near-miss looking like a plain successful load
+          // and the caller never learning a different workspace was opened.
+          // `data` is spread last so no existing key can change value.
+          result.data = hasExtra && typeof data === 'object' && !Array.isArray(data)
+            ? { ...extra, ...(data as Record<string, unknown>) }
+            : data;
+        } else if (hasExtra) {
           result.data = extra;
         }
       }

--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -7,6 +7,16 @@ import { getNexusPlugin } from '../../../utils/pluginLocator';
 import { WorkspaceService } from '../../../services/WorkspaceService';
 import { matchWorkspaces } from '../../memoryManager/services/WorkspaceMatcher';
 
+/**
+ * The slice of NexusPlugin this service needs. Declared structurally to avoid
+ * importing the plugin class (circular) — but unlike an inline cast it names
+ * members that actually exist on the class.
+ */
+interface NexusPluginLike {
+  services?: { workspaceService?: WorkspaceService };
+  getService?<T>(name: string, timeoutMs?: number): Promise<T | null>;
+}
+
 export interface ToolManagerWorkspaceInfo {
   name: string;
   description?: string;
@@ -245,12 +255,18 @@ export class ToolBatchExecutionService {
     }
 
     try {
-      const plugin = getNexusPlugin(this.app);
+      const plugin = getNexusPlugin(this.app) as NexusPluginLike | null;
       if (!plugin) {
         return null;
       }
 
-      const workspaceService = (plugin as { workspaceService?: WorkspaceService }).workspaceService;
+      // NexusPlugin exposes services via the `services` getter and `getService()`
+      // — there is no top-level `plugin.workspaceService`. Reading one silently
+      // yielded undefined here, so this whole validation branch never fired.
+      const workspaceService =
+        plugin.services?.workspaceService
+        ?? (await plugin.getService?.<WorkspaceService>('workspaceService'))
+        ?? null;
       if (!workspaceService) {
         return null;
       }

--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -5,6 +5,7 @@ import { NormalizedUseToolParams, ToolCallParams, ToolCallResult, ToolContext, U
 import { getErrorMessage } from '../../../utils/errorUtils';
 import { getNexusPlugin } from '../../../utils/pluginLocator';
 import { WorkspaceService } from '../../../services/WorkspaceService';
+import { matchWorkspaces } from '../../memoryManager/services/WorkspaceMatcher';
 
 export interface ToolManagerWorkspaceInfo {
   name: string;
@@ -260,10 +261,21 @@ export class ToolBatchExecutionService {
         return null;
       }
 
-      const availableNames = this.knownWorkspaces.length > 0
-        ? this.knownWorkspaces.map(workspace => `"${workspace.name}"`).join(', ')
+      // Name the alternatives off the LIVE list, not `knownWorkspaces` — that
+      // snapshot is taken at boot and is empty whenever SQLite was not ready
+      // then, which produced "Available: (none created yet)" on vaults that
+      // had workspaces all along.
+      const active = workspaces.filter(workspace => !workspace.isArchived);
+      const availableNames = active.length > 0
+        ? active.map(workspace => `"${workspace.name}"`).join(', ')
         : '(none created yet)';
-      return `Invalid workspace "${workspaceId}". Available: "default" (global), ${availableNames}`;
+
+      // A wrong workspaceId is usually a near-miss on a real name, so point at
+      // the closest one instead of leaving the caller to guess again.
+      const closest = matchWorkspaces(active, workspaceId, { limit: 1 })[0];
+      const didYouMean = closest ? ` Closest match: "${closest.workspace.name}".` : '';
+
+      return `Invalid workspace "${workspaceId}".${didYouMean} Use one of these exact values — do not infer a workspace name from the user's wording. Available: "default" (global), ${availableNames}`;
     } catch {
       return null;
     }

--- a/src/agents/toolManager/toolManager.ts
+++ b/src/agents/toolManager/toolManager.ts
@@ -25,6 +25,16 @@ export interface SchemaData {
 }
 
 /**
+ * Reads the current workspace names on demand.
+ *
+ * SchemaData is a boot-time snapshot, and it is empty whenever SQLite was not
+ * yet query-ready at agent registration. An agent that sees no workspaces at
+ * discovery has nothing to pick from and invents a name instead, so getTools
+ * resolves the list live at call time rather than trusting the snapshot.
+ */
+export type WorkspaceNameProvider = () => Promise<{ name: string; description?: string }[]>;
+
+/**
  * Configuration for ToolManager agent
  */
 export const ToolManagerConfig = {
@@ -51,8 +61,14 @@ export class ToolManagerAgent extends BaseAgent {
    * @param app Obsidian app instance
    * @param agentRegistry Map of all registered agents (excluding toolManager itself)
    * @param schemaData Dynamic data for tool descriptions (workspaces, custom agents, vault structure)
+   * @param workspaceProvider Live workspace-name lookup used by getTools when the snapshot is stale or empty
    */
-  constructor(app: App, agentRegistry: Map<string, IAgent>, schemaData?: SchemaData) {
+  constructor(
+    app: App,
+    agentRegistry: Map<string, IAgent>,
+    schemaData?: SchemaData,
+    workspaceProvider?: WorkspaceNameProvider
+  ) {
     super(
       ToolManagerConfig.name,
       ToolManagerConfig.description,
@@ -68,7 +84,7 @@ export class ToolManagerAgent extends BaseAgent {
     this.toolCliNormalizer = new ToolCliNormalizer(agentRegistry);
 
     // Register the two tools with schema data
-    this.getToolsTool = new GetToolsTool(agentRegistry, data);
+    this.getToolsTool = new GetToolsTool(agentRegistry, data, workspaceProvider);
     this.useToolTool = new UseToolTool(this.toolBatchExecutionService, this.toolCliNormalizer);
     this.registerTool(this.getToolsTool);
     this.registerTool(this.useToolTool);

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -85,7 +85,17 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
     }
 
     lines.push('');
-    lines.push(`Existing workspaces (exact names — never invent one): [default${schemaData.workspaces.length > 0 ? `,${schemaData.workspaces.map(w => w.name).join(',')}` : ''}]`);
+    // Only claim to enumerate workspaces when we actually have them. This
+    // description is built from a boot snapshot that is routinely empty (the
+    // storage adapter is created seconds after agents register), and the old
+    // unconditional "[default]" asserted that default was the ONLY workspace —
+    // a confident falsehood on every vault that had others. That is what sent
+    // agents off inventing a name from the user's phrasing.
+    if (schemaData.workspaces.length > 0) {
+      lines.push(`Existing workspaces (exact names — never invent one): [default,${schemaData.workspaces.map(w => w.name).join(',')}]`);
+    } else {
+      lines.push('Existing workspaces: not listed here. The getTools RESULT carries the live list — read "workspaces" there and pass one of those exact names. Never infer a workspace name from the user\'s wording.');
+    }
 
     if (schemaData.vaultRoot.length > 0) {
       const folders = schemaData.vaultRoot.slice(0, 5);
@@ -119,10 +129,31 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
       const workspaces = await this.workspaceProvider();
       const names = workspaces.map(workspace => workspace.name).filter(Boolean);
       this.workspaceCache = { names, fetchedAt: now };
+
+      // Heal the boot snapshot. The description is what MCP clients read from
+      // tools/list, and it cannot be re-fetched on demand — so the first live
+      // lookup writes the real names back into it. Every later tools/list (a
+      // fresh CLI invocation, a reconnecting client) then sees the truth
+      // instead of the empty boot-time list.
+      if (names.length > 0 && !this.sameNames(snapshot, names)) {
+        this.schemaData = {
+          ...this.schemaData,
+          workspaces: workspaces.map(workspace => ({
+            name: workspace.name,
+            description: workspace.description
+          }))
+        };
+        this.description = this.buildDescription(this.schemaData);
+      }
+
       return names;
     } catch {
       return snapshot;
     }
+  }
+
+  private sameNames(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((name, index) => name === b[index]);
   }
 
   async execute(params: GetToolsParams): Promise<GetToolsResult> {

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -1,11 +1,20 @@
 import { ITool } from '../../interfaces/ITool';
 import { IAgent } from '../../interfaces/IAgent';
 import { getErrorMessage } from '../../../utils/errorUtils';
-import { SchemaData } from '../toolManager';
+import { SchemaData, WorkspaceNameProvider } from '../toolManager';
 import { GetToolsParams, GetToolsResult } from '../types';
 import { ToolCliNormalizer } from '../services/ToolCliNormalizer';
 
 const INTERNAL_ONLY_TOOLS = new Set<string>([]);
+
+/** Cap on workspace names echoed back per discovery call. */
+const MAX_LISTED_WORKSPACES = 40;
+
+/**
+ * How long a live workspace lookup is reused. Discovery is often several calls
+ * in a row; the list does not change between them.
+ */
+const WORKSPACE_CACHE_TTL_MS = 5000;
 
 export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
   slug: string;
@@ -16,14 +25,21 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
   private agentRegistry: Map<string, IAgent>;
   private cliNormalizer: ToolCliNormalizer;
   private schemaData: SchemaData;
+  private workspaceProvider?: WorkspaceNameProvider;
+  private workspaceCache: { names: string[]; fetchedAt: number } | null = null;
 
-  constructor(agentRegistry: Map<string, IAgent>, schemaData: SchemaData) {
+  constructor(
+    agentRegistry: Map<string, IAgent>,
+    schemaData: SchemaData,
+    workspaceProvider?: WorkspaceNameProvider
+  ) {
     this.slug = 'getTools';
     this.name = 'Get Tools';
     this.version = '1.0.0';
     this.agentRegistry = agentRegistry;
     this.cliNormalizer = new ToolCliNormalizer(agentRegistry);
     this.schemaData = schemaData;
+    this.workspaceProvider = workspaceProvider;
     this.description = this.buildDescription(schemaData);
   }
 
@@ -69,7 +85,7 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
     }
 
     lines.push('');
-    lines.push(`Workspaces: [default${schemaData.workspaces.length > 0 ? `,${schemaData.workspaces.map(w => w.name).join(',')}` : ''}]`);
+    lines.push(`Existing workspaces (exact names — never invent one): [default${schemaData.workspaces.length > 0 ? `,${schemaData.workspaces.map(w => w.name).join(',')}` : ''}]`);
 
     if (schemaData.vaultRoot.length > 0) {
       const folders = schemaData.vaultRoot.slice(0, 5);
@@ -80,7 +96,35 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
     return lines.join('\n');
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await -- implements ITool.execute() async interface
+  /**
+   * Current workspace names, live where possible.
+   *
+   * Falls back to the boot snapshot when no provider is wired or the lookup
+   * fails — a stale list still beats no list, since an empty one is what makes
+   * agents guess names.
+   */
+  private async getWorkspaceNames(): Promise<string[]> {
+    const snapshot = this.schemaData.workspaces.map(workspace => workspace.name);
+
+    if (!this.workspaceProvider) {
+      return snapshot;
+    }
+
+    const now = Date.now();
+    if (this.workspaceCache && now - this.workspaceCache.fetchedAt < WORKSPACE_CACHE_TTL_MS) {
+      return this.workspaceCache.names;
+    }
+
+    try {
+      const workspaces = await this.workspaceProvider();
+      const names = workspaces.map(workspace => workspace.name).filter(Boolean);
+      this.workspaceCache = { names, fetchedAt: now };
+      return names;
+    } catch {
+      return snapshot;
+    }
+  }
+
   async execute(params: GetToolsParams): Promise<GetToolsResult> {
     try {
       const requests = this.cliNormalizer.normalizeDiscoveryRequests(params);
@@ -124,11 +168,25 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
         }
       }
 
+      // The live workspace list rides along on every discovery call. Workspace
+      // names are the one argument agents habitually invent (they read one out
+      // of the user's phrasing), and discovery is the last step before they
+      // commit to one — so the real names have to be in front of them here,
+      // not just in a description built at boot when the list may still have
+      // been empty.
+      const workspaceNames = await this.getWorkspaceNames();
+      const listedWorkspaces = ['default', ...workspaceNames.slice(0, MAX_LISTED_WORKSPACES)];
+      const workspacesTruncated = workspaceNames.length > MAX_LISTED_WORKSPACES;
+
       return {
         success: true,
         ...(notFound.length > 0 ? { error: `Some items not found: ${notFound.join(', ')}` } : {}),
         data: {
           tools: resultSchemas,
+          workspaces: listedWorkspaces,
+          workspacesNote: workspacesTruncated
+            ? `These are the only workspaces that exist (first ${MAX_LISTED_WORKSPACES} of ${workspaceNames.length}; use "memory search-workspaces" for the rest). Pass one of these exact names — do not infer a workspace name from the user's wording.`
+            : 'These are the only workspaces that exist. Pass one of these exact names — do not infer a workspace name from the user\'s wording.',
           ...(returnedCompact
             ? { note: 'Compact list (command + description). For a tool\'s full arguments and examples, call getTools with a specific "agent tool" selector (e.g. "storage move") before using it.' }
             : {})
@@ -219,6 +277,12 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
                 required: ['agent', 'tool', 'description', 'command']
               }
             },
+            workspaces: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Every workspace that currently exists. These are the only valid values for a workspace name or workspaceId — pass one verbatim, never a name inferred from the user\'s wording.'
+            },
+            workspacesNote: { type: 'string' },
             note: { type: 'string' }
           }
         }

--- a/src/agents/toolManager/types.ts
+++ b/src/agents/toolManager/types.ts
@@ -68,6 +68,11 @@ export interface GetToolsResult extends CommonResult {
   error?: string;
   data?: {
     tools: CliToolSchema[];
+    // Live list of every workspace that exists ("default" first). Echoed on every
+    // discovery call so the model picks a real workspace instead of inventing one
+    // from the user's phrasing.
+    workspaces?: string[];
+    workspacesNote?: string;
     // Present when `tools` are compact (broad discovery) — tells the model how to get
     // full arguments for a specific tool before calling it.
     note?: string;

--- a/src/database/types/workspace/ParameterTypes.ts
+++ b/src/database/types/workspace/ParameterTypes.ts
@@ -134,6 +134,40 @@ export interface LoadWorkspaceResult extends CommonResult {
       hasPreviousPage: boolean;
     };
   };
+  /**
+   * Present only when the requested identifier did not match a workspace
+   * exactly. Either reports the near-miss that was resolved and loaded, or
+   * carries the shortlist to pick from so the caller never has to guess again.
+   */
+  resolution?: WorkspaceResolutionReport;
+}
+
+/**
+ * Miss-recovery report attached to loadWorkspace when the requested workspace
+ * name or ID was not an exact match.
+ */
+export interface WorkspaceResolutionReport {
+  /** The identifier the caller asked for. */
+  requested: string;
+  /** Whether a near-miss was confidently resolved and loaded anyway. */
+  autoResolved: boolean;
+  /** The workspace actually loaded, when autoResolved is true. */
+  resolvedTo?: {
+    id: string;
+    name: string;
+  };
+  /** Ranked alternatives when nothing was auto-resolved. */
+  candidates?: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    rootFolder: string;
+    score: number;
+  }>;
+  /** Every workspace available, listed when nothing matched at all. */
+  availableWorkspaces?: string[];
+  /** Human/agent-readable explanation plus the exact next command to run. */
+  note: string;
 }
 
 /**

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -18,6 +18,7 @@ import { convertWorkspaceMetadata } from './helpers/WorkspaceTypeConverters';
 import { normalizeWorkspaceData, normalizeWorkspaceContext } from './helpers/WorkspaceNormalizer';
 import { WorkspaceSessionService } from './workspace/WorkspaceSessionService';
 import { WorkspaceStateService } from './workspace/WorkspaceStateService';
+import { withTimeout } from '../utils/withTimeout';
 import {
   SystemGuidesWorkspaceProvider,
   type SystemGuidesWorkspaceSummary,
@@ -27,6 +28,13 @@ import {
 // Export constant for backward compatibility
 export const GLOBAL_WORKSPACE_ID = 'default';
 const DEFAULT_WORKSPACE_NAME = 'Default Workspace';
+
+/**
+ * Ceiling on waiting for the query cache to finish replaying. Long enough to
+ * cover a normal post-load rebuild, short enough that a stalled one fails the
+ * operation instead of wedging it.
+ */
+const QUERY_READY_WAIT_MS = 5000;
 
 interface WorkspaceServiceOptions {
   vaultOperations?: VaultOperations;
@@ -114,6 +122,24 @@ export class WorkspaceService {
     return adapter.isQueryReady?.() ?? adapter.isReady();
   }
 
+  /**
+   * Block until the query cache has finished replaying, bounded so a stalled
+   * rebuild cannot hang a write path. Returns whether it actually settled.
+   */
+  private async waitForQueryReady(): Promise<boolean> {
+    const adapter = this.getReadyAdapter();
+    if (!adapter) {
+      return false;
+    }
+    if (adapter.isQueryReady?.()) {
+      return true;
+    }
+    if (typeof adapter.waitForQueryReady !== 'function') {
+      return adapter.isReady();
+    }
+    return withTimeout(adapter.waitForQueryReady(), QUERY_READY_WAIT_MS, false);
+  }
+
   private isWorkspaceNameUniqueConstraint(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
     return message.includes('UNIQUE constraint failed: workspaces.name');
@@ -122,6 +148,15 @@ export class WorkspaceService {
   private async reuseExistingWorkspaceAfterUniqueError(
     data: Partial<IndividualWorkspace>
   ): Promise<IndividualWorkspace | null> {
+    // The constraint is proof that a row with this name already exists, so a
+    // null lookup here means our view is stale — not that the workspace is
+    // absent. Both lookups below already returned null moments ago (that is
+    // how we reached the INSERT at all), so repeating them against a cache
+    // that is still replaying JSONL fails precisely when this recovery is
+    // needed: observed live as "Failed to persist session" on the first CLI
+    // call after every reload. Let the rebuild settle before looking again.
+    await this.waitForQueryReady();
+
     const existingById = data.id ? await this.getWorkspace(data.id) : null;
     if (existingById) {
       return existingById;

--- a/src/services/WorkspaceService.ts
+++ b/src/services/WorkspaceService.ts
@@ -96,6 +96,24 @@ export class WorkspaceService {
     return resolveAdapter(this.storageAdapterOrGetter);
   }
 
+  /**
+   * Whether listWorkspaces() results can honestly be described as COMPLETE.
+   *
+   * False during the post-load rebuild, when the SQLite cache is still
+   * replaying JSONL and list queries return a partial set (measured live at 1
+   * of 12 workspaces seconds after a reload). Any caller about to tell an
+   * agent "these are the only workspaces that exist" must check this first —
+   * that claim is what stops agents inventing names, so it must never be made
+   * about a partial list.
+   */
+  isListComplete(): boolean {
+    const adapter = this.getReadyAdapter();
+    if (!adapter) {
+      return false;
+    }
+    return adapter.isQueryReady?.() ?? adapter.isReady();
+  }
+
   private isWorkspaceNameUniqueConstraint(error: unknown): boolean {
     const message = error instanceof Error ? error.message : String(error);
     return message.includes('UNIQUE constraint failed: workspaces.name');

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -532,6 +532,16 @@ export class AgentInitializationService {
         return [];
       }
 
+      // Only report a list we can claim is COMPLETE. For a few seconds after
+      // load the SQLite cache is still replaying JSONL, and listWorkspaces()
+      // happily returns the partial set — measured live at 1 of 12. Callers
+      // present this list as "these are the only workspaces that exist", so a
+      // partial answer is worse than none: it is the same confident falsehood
+      // that made agents invent names, just with different wording.
+      if (!(await this.waitForQueryReady())) {
+        return [];
+      }
+
       const workspaces = await withTimeout(
         workspaceService.listWorkspaces(),
         LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS,
@@ -547,6 +557,29 @@ export class AgentInitializationService {
       logger.systemWarn(`Live workspace lookup failed: ${getErrorMessage(error)}`);
       return [];
     }
+  }
+
+  /**
+   * True once the SQLite cache has finished replaying JSONL and its queries
+   * return the complete set. Bounded so a slow rebuild degrades discovery to
+   * "no list" rather than hanging it.
+   */
+  private async waitForQueryReady(): Promise<boolean> {
+    const adapter = this.serviceManager?.getServiceIfReady<IStorageAdapter>('hybridStorageAdapter');
+    if (!adapter) {
+      return false;
+    }
+
+    if (adapter.isQueryReady?.()) {
+      return true;
+    }
+
+    if (typeof adapter.waitForQueryReady !== 'function') {
+      // No readiness signal to consult — fall back to the coarse ready flag.
+      return adapter.isReady();
+    }
+
+    return withTimeout(adapter.waitForQueryReady(), LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS, false);
   }
 
   /**

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -416,8 +416,16 @@ export class AgentInitializationService {
     // Build schema data for dynamic tool descriptions
     const schemaData = await this.buildSchemaData();
 
-    // Create ToolManagerAgent with the full agent registry and schema data
-    const toolManagerAgent = new ToolManagerAgent(this.app, agentRegistry, schemaData);
+    // Create ToolManagerAgent with the full agent registry and schema data.
+    // The workspace provider is passed separately: schemaData is a snapshot
+    // taken here, and it is empty whenever SQLite was not query-ready yet, so
+    // getTools re-reads the list at call time instead.
+    const toolManagerAgent = new ToolManagerAgent(
+      this.app,
+      agentRegistry,
+      schemaData,
+      () => this.listWorkspaceSummaries()
+    );
 
     this.agentManager.registerAgent(toolManagerAgent);
     logger.systemLog(`ToolManager agent initialized successfully with ${agentRegistry.size} agents`);
@@ -437,6 +445,43 @@ export class AgentInitializationService {
       return storageAdapter.isReady();
     }
     return false;
+  }
+
+  /**
+   * List the current workspaces for tool discovery.
+   *
+   * Non-blocking by design: WorkspaceService.listWorkspaces() blocks on
+   * ensureInitialized(), so this returns empty rather than stalling when
+   * SQLite is not query-ready. Callers re-invoke it later — at boot the list
+   * is often empty, and a permanently empty list is what leaves agents with no
+   * real workspace name to pick.
+   */
+  private async listWorkspaceSummaries(): Promise<{ name: string; description?: string }[]> {
+    try {
+      let workspaceService: WorkspaceService | null = null;
+
+      if (this.serviceManager) {
+        workspaceService = this.serviceManager.getServiceIfReady<WorkspaceService>('workspaceService');
+      } else if (hasTypedServices(this.plugin)) {
+        workspaceService = this.plugin.services.workspaceService ?? null;
+      }
+
+      // CRITICAL: Check if SQLite is ready BEFORE calling any service methods
+      if (!workspaceService || !this.isSQLiteReady()) {
+        return [];
+      }
+
+      const workspaces = await workspaceService.listWorkspaces();
+      return workspaces
+        .filter(workspace => !workspace.isArchived)
+        .map(workspace => ({
+          name: workspace.name,
+          description: workspace.description
+        }));
+    } catch {
+      logger.systemWarn('Failed to fetch workspaces for schema data');
+      return [];
+    }
   }
 
   /**
@@ -460,28 +505,7 @@ export class AgentInitializationService {
     };
 
     // Fetch workspaces - NON-BLOCKING: only fetch if SQLite is ready to avoid blocking on ensureInitialized()
-    try {
-      let workspaceService: WorkspaceService | null = null;
-
-      if (this.serviceManager) {
-        workspaceService = this.serviceManager.getServiceIfReady<WorkspaceService>('workspaceService');
-      } else if (hasTypedServices(this.plugin)) {
-        workspaceService = this.plugin.services.workspaceService ?? null;
-      }
-
-      // CRITICAL: Check if SQLite is ready BEFORE calling any service methods
-      // WorkspaceService.listWorkspaces() calls adapter methods that block on ensureInitialized()
-      if (workspaceService && this.isSQLiteReady()) {
-        const workspaces = await workspaceService.listWorkspaces();
-        schemaData.workspaces = workspaces.map(w => ({
-          name: w.name,
-          description: w.description
-        }));
-      }
-      // If SQLite not ready, return empty - schema data will be populated on subsequent calls
-    } catch {
-      logger.systemWarn('Failed to fetch workspaces for schema data');
-    }
+    schemaData.workspaces = await this.listWorkspaceSummaries();
 
     // Fetch custom agents - NON-BLOCKING: only fetch if SQLite is ready
     try {

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -23,6 +23,7 @@ import {
   IngestManagerAgent
 } from '../../agents';
 import { logger } from '../../utils/logger';
+import { getErrorMessage } from '../../utils/errorUtils';
 import { CustomPromptStorageService } from "../../agents/promptManager/services/CustomPromptStorageService";
 import { LLMProviderManager } from '../llm/providers/ProviderManager';
 import { DEFAULT_LLM_PROVIDER_SETTINGS, MemorySettings } from '../../types';
@@ -35,6 +36,31 @@ import type { IStorageAdapter } from '../../database/interfaces/IStorageAdapter'
 import type { MigratableDatabase } from '../../database/schema/SchemaMigrator';
 import { TaskBoardEvents } from '../task/TaskBoardEvents';
 import type { NexusPluginWithServices } from '../../agents/memoryManager/tools/utils/pluginTypes';
+
+/**
+ * Ceiling on a live workspace lookup during tool discovery. Generous enough
+ * that a cold WorkspaceService still resolves, short enough that a wedged
+ * storage layer degrades discovery instead of hanging the caller.
+ */
+const LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS = 4000;
+
+/**
+ * Resolve `promise`, or `fallback` if it takes longer than `timeoutMs`.
+ * A rejection propagates — only slowness is absorbed here.
+ */
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  let timer: number | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>(resolve => {
+        timer = window.setTimeout(() => resolve(fallback), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer !== undefined) window.clearTimeout(timer);
+  }
+}
 
 /**
  * Type guard to check if plugin has Settings
@@ -424,7 +450,7 @@ export class AgentInitializationService {
       this.app,
       agentRegistry,
       schemaData,
-      () => this.listWorkspaceSummaries()
+      () => this.listWorkspaceSummariesLive()
     );
 
     this.agentManager.registerAgent(toolManagerAgent);
@@ -448,13 +474,15 @@ export class AgentInitializationService {
   }
 
   /**
-   * List the current workspaces for tool discovery.
+   * List the current workspaces for the BOOT SNAPSHOT only.
    *
    * Non-blocking by design: WorkspaceService.listWorkspaces() blocks on
-   * ensureInitialized(), so this returns empty rather than stalling when
-   * SQLite is not query-ready. Callers re-invoke it later — at boot the list
-   * is often empty, and a permanently empty list is what leaves agents with no
-   * real workspace name to pick.
+   * ensureInitialized(), so this returns empty rather than stalling startup
+   * when SQLite is not query-ready. On desktop the storage adapter is only
+   * created ~3s after background init (PluginLifecycleManager), which is after
+   * agents are registered — so at boot this list is routinely empty. That is
+   * acceptable here and NOT acceptable at call time; see
+   * listWorkspaceSummariesLive().
    */
   private async listWorkspaceSummaries(): Promise<{ name: string; description?: string }[]> {
     try {
@@ -471,17 +499,82 @@ export class AgentInitializationService {
         return [];
       }
 
-      const workspaces = await workspaceService.listWorkspaces();
-      return workspaces
-        .filter(workspace => !workspace.isArchived)
-        .map(workspace => ({
-          name: workspace.name,
-          description: workspace.description
-        }));
+      return this.toWorkspaceSummaries(await workspaceService.listWorkspaces());
     } catch {
       logger.systemWarn('Failed to fetch workspaces for schema data');
       return [];
     }
+  }
+
+  /**
+   * List the current workspaces for a live discovery call.
+   *
+   * Deliberately does NOT reuse the boot snapshot's two gates. Both of them
+   * fail open-ended: getServiceIfReady() only sees services that happen to be
+   * instantiated already, and isSQLiteReady() is false until the deferred WASM
+   * load finishes. An empty list here is the bug we are fixing — it is what
+   * leaves an agent with no real workspace name and makes it invent one from
+   * the user's phrasing.
+   *
+   * By the time discovery runs we are long past startup, so awaiting the
+   * service is correct rather than risky. The timeout exists only so a wedged
+   * storage layer degrades getTools to "no names" instead of hanging it.
+   */
+  private async listWorkspaceSummariesLive(): Promise<{ name: string; description?: string }[]> {
+    try {
+      const workspaceService = await withTimeout(
+        this.resolveWorkspaceService(),
+        LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS,
+        null
+      );
+      if (!workspaceService) {
+        logger.systemWarn('Live workspace lookup: WorkspaceService unavailable');
+        return [];
+      }
+
+      const workspaces = await withTimeout(
+        workspaceService.listWorkspaces(),
+        LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS,
+        null
+      );
+      if (!workspaces) {
+        logger.systemWarn('Live workspace lookup: listWorkspaces() timed out');
+        return [];
+      }
+
+      return this.toWorkspaceSummaries(workspaces);
+    } catch (error) {
+      logger.systemWarn(`Live workspace lookup failed: ${getErrorMessage(error)}`);
+      return [];
+    }
+  }
+
+  /**
+   * Resolve WorkspaceService, instantiating it if it has not been created yet.
+   */
+  private async resolveWorkspaceService(): Promise<WorkspaceService | null> {
+    if (this.serviceManager) {
+      const ready = this.serviceManager.getServiceIfReady<WorkspaceService>('workspaceService');
+      if (ready) return ready;
+      return (await this.serviceManager.getService<WorkspaceService>('workspaceService')) ?? null;
+    }
+
+    if (hasTypedServices(this.plugin)) {
+      return this.plugin.services.workspaceService ?? null;
+    }
+
+    return null;
+  }
+
+  private toWorkspaceSummaries(
+    workspaces: { name: string; description?: string; isArchived?: boolean }[]
+  ): { name: string; description?: string }[] {
+    return workspaces
+      .filter(workspace => !workspace.isArchived)
+      .map(workspace => ({
+        name: workspace.name,
+        description: workspace.description
+      }));
   }
 
   /**

--- a/src/services/agent/AgentInitializationService.ts
+++ b/src/services/agent/AgentInitializationService.ts
@@ -24,6 +24,7 @@ import {
 } from '../../agents';
 import { logger } from '../../utils/logger';
 import { getErrorMessage } from '../../utils/errorUtils';
+import { withTimeout } from '../../utils/withTimeout';
 import { CustomPromptStorageService } from "../../agents/promptManager/services/CustomPromptStorageService";
 import { LLMProviderManager } from '../llm/providers/ProviderManager';
 import { DEFAULT_LLM_PROVIDER_SETTINGS, MemorySettings } from '../../types';
@@ -43,24 +44,6 @@ import type { NexusPluginWithServices } from '../../agents/memoryManager/tools/u
  * storage layer degrades discovery instead of hanging the caller.
  */
 const LIVE_WORKSPACE_LOOKUP_TIMEOUT_MS = 4000;
-
-/**
- * Resolve `promise`, or `fallback` if it takes longer than `timeoutMs`.
- * A rejection propagates — only slowness is absorbed here.
- */
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
-  let timer: number | undefined;
-  try {
-    return await Promise.race([
-      promise,
-      new Promise<T>(resolve => {
-        timer = window.setTimeout(() => resolve(fallback), timeoutMs);
-      })
-    ]);
-  } finally {
-    if (timer !== undefined) window.clearTimeout(timer);
-  }
-}
 
 /**
  * Type guard to check if plugin has Settings

--- a/src/services/trace/ToolCallTraceService.ts
+++ b/src/services/trace/ToolCallTraceService.ts
@@ -265,10 +265,38 @@ export class ToolCallTraceService {
 
     try {
       const workspace = await this.workspaceService.getWorkspaceByNameOrId(candidate);
-      return workspace?.id || candidate;
+      if (workspace) {
+        return workspace.id;
+      }
     } catch {
-      return candidate;
+      // Fall through to the safe fallback below.
     }
+
+    // Never file a trace under an unvalidated identifier. Writing to a
+    // workspace id that does not exist CREATES it as a phantom event store —
+    // that is how `ws_--workspace/` and `ws_Blog Testing/` appeared, the
+    // latter because the handle is the name the caller REQUESTED and
+    // getWorkspaceByNameOrId is exact-match, so every near-miss minted a new
+    // workspace directory. Fall back to context we know resolves.
+    return this.resolveKnownWorkspaceId(workspaceContext?.workspaceId);
+  }
+
+  /**
+   * Reduce to a workspace id that actually exists, or the global default.
+   */
+  private async resolveKnownWorkspaceId(contextWorkspaceId?: string): Promise<string> {
+    if (contextWorkspaceId) {
+      try {
+        const contextWorkspace = await this.workspaceService.getWorkspaceByNameOrId(contextWorkspaceId);
+        if (contextWorkspace) {
+          return contextWorkspace.id;
+        }
+      } catch {
+        // Ignore and fall back to the global default.
+      }
+    }
+
+    return 'default';
   }
 
   private extractWorkspaceHandleFromUseTools(params: Record<string, unknown>): string | undefined {

--- a/src/services/trace/ToolCallTraceService.ts
+++ b/src/services/trace/ToolCallTraceService.ts
@@ -36,6 +36,57 @@ function isRetrievalTool(agent: string, mode: string): boolean {
 type ToolCallParams = unknown;
 type ToolCallResponse = unknown;
 
+/**
+ * Pull the workspace name/ID out of a tokenized `memory load-workspace ...`
+ * command.
+ *
+ * The argument is accepted BOTH positionally and as `--workspace <value>`, so
+ * reading token[2] unconditionally captured the literal string "--workspace"
+ * whenever the flag form was used. That handle then became the trace's
+ * workspace, producing a phantom `ws_--workspace` event store and a recurring
+ * "Workspace --workspace not found" on every flag-form call.
+ *
+ * `wasQuoted` distinguishes a real flag from a positional value whose text
+ * merely starts with "--".
+ */
+function extractWorkspaceHandleFromTokens(tokens: { value: string; wasQuoted: boolean }[]): string | undefined {
+  for (let index = 2; index < tokens.length; index++) {
+    const token = tokens[index];
+    const isFlag = !token.wasQuoted && token.value.startsWith('--');
+
+    if (!isFlag) {
+      // Positional form: `memory load-workspace "My Workspace"`.
+      return token.value;
+    }
+
+    const [flagName, inlineValue] = splitFlagToken(token.value);
+    if (flagName !== 'workspace' && flagName !== 'name') {
+      continue;
+    }
+
+    if (inlineValue !== undefined) {
+      return inlineValue;
+    }
+
+    const next = tokens[index + 1];
+    if (next && (next.wasQuoted || !next.value.startsWith('--'))) {
+      return next.value;
+    }
+  }
+
+  return undefined;
+}
+
+/** Split `--flag=value` into its parts; returns [flag] when there is no `=`. */
+function splitFlagToken(raw: string): [string, string | undefined] {
+  const withoutDashes = raw.replace(/^--/, '');
+  const equals = withoutDashes.indexOf('=');
+  if (equals === -1) {
+    return [withoutDashes.toLowerCase(), undefined];
+  }
+  return [withoutDashes.slice(0, equals).toLowerCase(), withoutDashes.slice(equals + 1)];
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -236,7 +287,10 @@ export class ToolCallTraceService {
       const tool = tokens[1].value.replace(/[-_\s]/g, '').toLowerCase();
       if ((agent === 'memory' || agent === 'memorymanager') &&
           (tool === 'loadworkspace' || tool === 'createworkspace')) {
-        return tokens[2].value;
+        const handle = extractWorkspaceHandleFromTokens(tokens);
+        if (handle) {
+          return handle;
+        }
       }
     }
 

--- a/src/utils/withTimeout.ts
+++ b/src/utils/withTimeout.ts
@@ -1,0 +1,33 @@
+/**
+ * Location: src/utils/withTimeout.ts
+ *
+ * Purpose: Bound a promise that may never settle, without turning slowness
+ * into an error. Used where a stalled storage layer must degrade a feature
+ * rather than hang the caller.
+ *
+ * Uses window timers for Obsidian popout-window compatibility.
+ */
+
+/**
+ * Resolve `promise`, or `fallback` if it has not settled within `timeoutMs`.
+ *
+ * A rejection propagates — only slowness is absorbed here, so genuine errors
+ * still surface to the caller.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  fallback: T
+): Promise<T> {
+  let timer: number | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>(resolve => {
+        timer = window.setTimeout(() => resolve(fallback), timeoutMs);
+      })
+    ]);
+  } finally {
+    if (timer !== undefined) window.clearTimeout(timer);
+  }
+}

--- a/tests/unit/GetToolsLiveWorkspaces.test.ts
+++ b/tests/unit/GetToolsLiveWorkspaces.test.ts
@@ -127,3 +127,80 @@ describe('GetToolsTool live workspace grounding', () => {
     expect(result.data?.workspaces).toEqual(['default']);
   });
 });
+
+/**
+ * A tool may return `data` alongside sibling top-level fields. The batch
+ * formatter used to keep only `data`, which silently discarded
+ * loadWorkspace's `resolution` note — so an auto-resolved near-miss reached
+ * the caller looking like an ordinary successful load, with no indication
+ * that a different workspace had been opened.
+ */
+describe('ToolBatchExecutionService result payload', () => {
+  const { ToolBatchExecutionService } = jest.requireActual(
+    '../../src/agents/toolManager/services/ToolBatchExecutionService'
+  );
+
+  function serviceWith(toolResult: Record<string, unknown>) {
+    const tool = {
+      slug: 'loadWorkspace',
+      name: 'Load Workspace',
+      description: 'Load a workspace',
+      version: '1.0.0',
+      execute: async () => toolResult,
+      getParameterSchema: () => ({ type: 'object', properties: {} }),
+      getResultSchema: () => ({ type: 'object', properties: {} })
+    };
+    const agent = {
+      name: 'memoryManager',
+      description: 'Memory',
+      version: '1.0.0',
+      getTools: () => [tool],
+      getTool: () => tool,
+      executeTool: async () => toolResult
+    };
+    return new ToolBatchExecutionService(
+      {} as never,
+      new Map([['memoryManager', agent]]),
+      []
+    );
+  }
+
+  const context = {
+    workspaceId: 'default',
+    sessionId: 'test',
+    memory: 'testing payload retention',
+    goal: 'verify sibling fields survive'
+  };
+
+  it('keeps sibling top-level fields alongside data', async () => {
+    const service = serviceWith({
+      success: true,
+      data: { context: { name: 'Blog Testing Workspace' } },
+      resolution: { requested: 'Blog Testing', autoResolved: true }
+    });
+
+    const result = await service.execute({
+      context,
+      calls: [{ agent: 'memoryManager', tool: 'loadWorkspace', params: {} }]
+    } as never);
+
+    const payload = JSON.stringify(result);
+    expect(payload).toContain('autoResolved');
+    expect(payload).toContain('Blog Testing Workspace');
+  });
+
+  it('does not let a sibling field overwrite a key inside data', async () => {
+    const service = serviceWith({
+      success: true,
+      data: { note: 'from data' },
+      note: 'from sibling'
+    });
+
+    const result = await service.execute({
+      context,
+      calls: [{ agent: 'memoryManager', tool: 'loadWorkspace', params: {} }]
+    } as never);
+
+    expect(JSON.stringify(result)).toContain('from data');
+  });
+});

--- a/tests/unit/GetToolsLiveWorkspaces.test.ts
+++ b/tests/unit/GetToolsLiveWorkspaces.test.ts
@@ -1,0 +1,129 @@
+/**
+ * getTools must put the REAL workspace names in front of the caller.
+ *
+ * Background: the boot-time schema snapshot is routinely empty (the storage
+ * adapter is created seconds after agents register), and nothing ever
+ * refreshed it. An agent choosing a workspace therefore saw either nothing or
+ * a description asserting "default" was the only workspace — so it inferred a
+ * name from the user's phrasing, and loadWorkspace failed on a workspace that
+ * never existed. These tests pin the grounding behavior that replaced that.
+ */
+
+import { GetToolsTool } from '../../src/agents/toolManager/tools/getTools';
+import type { SchemaData, WorkspaceNameProvider } from '../../src/agents/toolManager/toolManager';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+
+function makeTool(slug: string): ITool<Record<string, unknown>, { success: boolean }> {
+  return {
+    slug,
+    name: slug,
+    description: `${slug} tool`,
+    version: '1.0.0',
+    async execute() {
+      return { success: true };
+    },
+    getParameterSchema() {
+      return { type: 'object', properties: {} };
+    },
+    getResultSchema() {
+      return { type: 'object', properties: {} };
+    }
+  };
+}
+
+function makeRegistry(): Map<string, IAgent> {
+  const tools = [makeTool('list')];
+  const agent = {
+    name: 'storageManager',
+    description: 'Storage',
+    version: '1.0.0',
+    getTools: () => tools,
+    getTool: (slug: string) => tools.find(tool => tool.slug === slug),
+    executeTool: async () => ({ success: true })
+  } as unknown as IAgent;
+
+  return new Map<string, IAgent>([['storageManager', agent]]);
+}
+
+const EMPTY_SNAPSHOT: SchemaData = {
+  workspaces: [],
+  customAgents: [],
+  vaultRoot: []
+};
+
+const DISCOVERY = { tool: 'storage' } as never;
+
+describe('GetToolsTool live workspace grounding', () => {
+  it('returns live workspace names even when the boot snapshot was empty', async () => {
+    const provider: WorkspaceNameProvider = async () => [
+      { name: 'The Silicon Zone' },
+      { name: 'Blog Testing Workspace' }
+    ];
+
+    const tool = new GetToolsTool(makeRegistry(), EMPTY_SNAPSHOT, provider);
+    const result = await tool.execute(DISCOVERY);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.workspaces).toEqual([
+      'default',
+      'The Silicon Zone',
+      'Blog Testing Workspace'
+    ]);
+    expect(result.data?.workspacesNote).toContain('do not infer a workspace name');
+  });
+
+  it('heals the stale description so later tools/list reads are correct', async () => {
+    const provider: WorkspaceNameProvider = async () => [{ name: 'The Silicon Zone' }];
+    const tool = new GetToolsTool(makeRegistry(), EMPTY_SNAPSHOT, provider);
+
+    // Before any live lookup the description must NOT claim default is the
+    // only workspace — that false certainty is what produced invented names.
+    expect(tool.description).not.toContain('never invent one): [default]');
+    expect(tool.description).toContain('The getTools RESULT carries the live list');
+
+    await tool.execute(DISCOVERY);
+
+    expect(tool.description).toContain('[default,The Silicon Zone]');
+  });
+
+  it('caches within the TTL so repeated discovery does not re-query storage', async () => {
+    let calls = 0;
+    const provider: WorkspaceNameProvider = async () => {
+      calls += 1;
+      return [{ name: 'The Silicon Zone' }];
+    };
+
+    const tool = new GetToolsTool(makeRegistry(), EMPTY_SNAPSHOT, provider);
+    await tool.execute(DISCOVERY);
+    await tool.execute(DISCOVERY);
+
+    expect(calls).toBe(1);
+  });
+
+  it('falls back to the boot snapshot when the live lookup throws', async () => {
+    const provider: WorkspaceNameProvider = async () => {
+      throw new Error('storage wedged');
+    };
+    const snapshot: SchemaData = {
+      ...EMPTY_SNAPSHOT,
+      workspaces: [{ name: 'Snapshot Workspace' }]
+    };
+
+    const tool = new GetToolsTool(makeRegistry(), snapshot, provider);
+    const result = await tool.execute(DISCOVERY);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.workspaces).toEqual(['default', 'Snapshot Workspace']);
+  });
+
+  it('still succeeds with only "default" when no workspaces exist', async () => {
+    const provider: WorkspaceNameProvider = async () => [];
+    const tool = new GetToolsTool(makeRegistry(), EMPTY_SNAPSHOT, provider);
+
+    const result = await tool.execute(DISCOVERY);
+
+    expect(result.success).toBe(true);
+    expect(result.data?.workspaces).toEqual(['default']);
+  });
+});

--- a/tests/unit/LoadWorkspaceMissRecovery.test.ts
+++ b/tests/unit/LoadWorkspaceMissRecovery.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for LoadWorkspaceTool miss recovery.
+ *
+ * A guessed workspace name used to dead-end with "not found", which is what
+ * sends CLI agents into retry loops on invented names. Every branch here has to
+ * hand back something the caller can act on without guessing again.
+ */
+
+import { LoadWorkspaceTool } from '../../src/agents/memoryManager/tools/workspaces/loadWorkspace';
+import { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import { WorkspaceMetadata } from '../../src/types/storage/StorageTypes';
+
+const emptyPage = {
+  items: [],
+  page: 0,
+  pageSize: 5,
+  totalItems: 0,
+  totalPages: 0,
+  hasNextPage: false,
+  hasPreviousPage: false
+};
+
+function makeIndexRow(
+  overrides: Partial<WorkspaceMetadata> & { id: string; name: string }
+): WorkspaceMetadata {
+  return {
+    rootFolder: 'Notes',
+    created: 1000,
+    lastAccessed: 1000,
+    sessionCount: 0,
+    traceCount: 0,
+    ...overrides
+  };
+}
+
+function makeFullWorkspace(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: `${name} description`,
+    rootFolder: 'Notes',
+    created: 1000,
+    lastAccessed: 2000,
+    isActive: true,
+    context: { purpose: 'testing', keyFiles: [], preferences: '' },
+    sessions: {}
+  };
+}
+
+function createTool(options: {
+  index?: WorkspaceMetadata[];
+  full?: Record<string, ReturnType<typeof makeFullWorkspace>>;
+  listWorkspaces?: jest.Mock;
+}) {
+  const full = options.full ?? {};
+
+  const workspaceService = {
+    isSystemWorkspaceId: jest.fn().mockReturnValue(false),
+    getWorkspaceByNameOrId: jest.fn().mockResolvedValue(null),
+    getWorkspace: jest.fn().mockImplementation((id: string) => Promise.resolve(full[id] ?? null)),
+    listWorkspaces: options.listWorkspaces ?? jest.fn().mockResolvedValue(options.index ?? []),
+    updateLastAccessed: jest.fn().mockResolvedValue(undefined)
+  };
+
+  const memoryService = {
+    getMemoryTraces: jest.fn().mockResolvedValue(emptyPage),
+    getSessions: jest.fn().mockResolvedValue(emptyPage),
+    getStates: jest.fn().mockResolvedValue(emptyPage)
+  };
+
+  const tool = new LoadWorkspaceTool({
+    getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService),
+    getMemoryService: jest.fn().mockReturnValue(memoryService),
+    getCacheManager: jest.fn().mockReturnValue(null),
+    getTaskService: jest.fn().mockReturnValue(null),
+    getApp: jest.fn().mockReturnValue({
+      vault: { getAbstractFileByPath: jest.fn().mockReturnValue(null) }
+    }),
+    plugin: {},
+    customPromptStorage: undefined
+  } as unknown as MemoryManagerAgent);
+
+  return { tool, workspaceService, memoryService };
+}
+
+describe('LoadWorkspaceTool miss recovery', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('auto-loads the single close match and says which workspace it actually opened', async () => {
+    const { tool, workspaceService, memoryService } = createTool({
+      index: [
+        makeIndexRow({ id: 'ws-research', name: 'Research' }),
+        makeIndexRow({ id: 'ws-budget', name: 'Budget' })
+      ],
+      full: { 'ws-research': makeFullWorkspace('ws-research', 'Research') }
+    });
+
+    const result = await tool.execute({ workspace: 'Research Notes', limit: 5 });
+
+    expect(result.success).toBe(true);
+    expect(result.data.context.name).toBe('Research');
+    expect(result.workspaceContext?.workspaceId).toBe('ws-research');
+    expect(result.resolution).toMatchObject({
+      requested: 'Research Notes',
+      autoResolved: true,
+      resolvedTo: { id: 'ws-research', name: 'Research' }
+    });
+    expect(result.resolution?.note).toContain('Research');
+
+    // The rest of the load runs against the resolved workspace, not the guess.
+    expect(workspaceService.updateLastAccessed).toHaveBeenCalledWith('ws-research');
+    expect(memoryService.getSessions).toHaveBeenCalledWith('ws-research', expect.anything());
+  });
+
+  it('returns ranked candidates instead of picking between two plausible workspaces', async () => {
+    const { tool, workspaceService } = createTool({
+      index: [
+        makeIndexRow({ id: 'ws-hub', name: 'Research Hub' }),
+        makeIndexRow({ id: 'ws-ai', name: 'AI Research' })
+      ]
+    });
+
+    const result = await tool.execute({ workspace: 'Research', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.resolution?.autoResolved).toBe(false);
+    expect(result.resolution?.candidates?.map(candidate => candidate.name))
+      .toEqual(['Research Hub', 'AI Research']);
+    expect(result.error).toContain('Research Hub');
+    expect(result.error).toContain('memory load-workspace');
+    expect(workspaceService.getWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('lists the workspaces that do exist when nothing resembles the request', async () => {
+    const { tool } = createTool({
+      index: [
+        makeIndexRow({ id: 'ws-a', name: 'Budget' }),
+        makeIndexRow({ id: 'ws-b', name: 'Recipes' })
+      ]
+    });
+
+    const result = await tool.execute({ workspace: 'Quarterly Planning', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.resolution?.availableWorkspaces).toEqual(['Budget', 'Recipes']);
+    expect(result.error).toContain('"Budget"');
+    expect(result.error).toContain('"Recipes"');
+    expect(result.error).toContain('do not invent another');
+  });
+
+  it('excludes archived workspaces from the listed inventory', async () => {
+    const { tool } = createTool({
+      index: [
+        makeIndexRow({ id: 'ws-a', name: 'Budget' }),
+        makeIndexRow({ id: 'ws-old', name: 'Old Notes', isArchived: true })
+      ]
+    });
+
+    const result = await tool.execute({ workspace: 'Quarterly Planning', limit: 5 });
+
+    expect(result.resolution?.availableWorkspaces).toEqual(['Budget']);
+  });
+
+  it('points at workspace creation when the vault has no workspaces at all', async () => {
+    const { tool } = createTool({ index: [] });
+
+    const result = await tool.execute({ workspace: 'Research', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.resolution?.availableWorkspaces).toEqual([]);
+    expect(result.error).toContain('memory create-workspace');
+  });
+
+  it('degrades to a plain retry instruction when the workspace list cannot be read', async () => {
+    const { tool } = createTool({
+      listWorkspaces: jest.fn().mockRejectedValue(new Error('cache cold'))
+    });
+
+    const result = await tool.execute({ workspace: 'Research', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.resolution?.autoResolved).toBe(false);
+    expect(result.error).toContain('memory list-workspaces');
+  });
+
+  it('falls back to a candidate when the resolved index row has no loadable record', async () => {
+    const { tool } = createTool({
+      index: [makeIndexRow({ id: 'ws-research', name: 'Research' })],
+      full: {}
+    });
+
+    const result = await tool.execute({ workspace: 'Research Notes', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.resolution?.autoResolved).toBe(false);
+    expect(result.resolution?.candidates?.[0].id).toBe('ws-research');
+  });
+
+  it('leaves an exact hit untouched — no resolution report', async () => {
+    const { tool, workspaceService } = createTool({});
+    workspaceService.getWorkspaceByNameOrId.mockResolvedValue(
+      makeFullWorkspace('ws-research', 'Research')
+    );
+
+    const result = await tool.execute({ workspace: 'Research', limit: 5 });
+
+    expect(result.success).toBe(true);
+    expect(result.resolution).toBeUndefined();
+    expect(workspaceService.listWorkspaces).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/LoadWorkspaceMissRecovery.test.ts
+++ b/tests/unit/LoadWorkspaceMissRecovery.test.ts
@@ -51,6 +51,8 @@ function createTool(options: {
   index?: WorkspaceMetadata[];
   full?: Record<string, ReturnType<typeof makeFullWorkspace>>;
   listWorkspaces?: jest.Mock;
+  /** Whether the cache claims its list is exhaustive. Default: settled. */
+  listComplete?: boolean;
 }) {
   const full = options.full ?? {};
 
@@ -59,6 +61,7 @@ function createTool(options: {
     getWorkspaceByNameOrId: jest.fn().mockResolvedValue(null),
     getWorkspace: jest.fn().mockImplementation((id: string) => Promise.resolve(full[id] ?? null)),
     listWorkspaces: options.listWorkspaces ?? jest.fn().mockResolvedValue(options.index ?? []),
+    isListComplete: jest.fn().mockReturnValue(options.listComplete ?? true),
     updateLastAccessed: jest.fn().mockResolvedValue(undefined)
   };
 
@@ -213,5 +216,47 @@ describe('LoadWorkspaceTool miss recovery', () => {
     expect(result.success).toBe(true);
     expect(result.resolution).toBeUndefined();
     expect(workspaceService.listWorkspaces).not.toHaveBeenCalled();
+  });
+});
+
+describe('LoadWorkspaceTool miss recovery on a rebuilding cache', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not claim the workspace is missing while the list is still partial', async () => {
+    // Live-reproduced: seconds after a plugin reload the SQLite cache had
+    // replayed 1 of 12 workspaces, and the tool reported a real workspace as
+    // nonexistent while presenting the partial set as authoritative.
+    const { tool } = createTool({
+      index: [makeIndexRow({ id: 'ws-a', name: 'Default Workspace' })],
+      listComplete: false
+    });
+
+    const result = await tool.execute({ workspace: 'Blog Testing', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('still rebuilding');
+    expect(result.error).toContain('INCOMPLETE');
+    expect(result.error).not.toContain('nothing resembles it');
+    // Steer back to the ORIGINAL name, not the partial list's first entry.
+    expect(result.error).toContain('--workspace "Blog Testing"');
+  });
+
+  it('still asserts the inventory is exhaustive once the cache has settled', async () => {
+    const { tool } = createTool({
+      index: [makeIndexRow({ id: 'ws-a', name: 'Budget' })],
+      listComplete: true
+    });
+
+    const result = await tool.execute({ workspace: 'Totally Invented', limit: 5 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('nothing resembles it');
+    expect(result.error).not.toContain('still rebuilding');
   });
 });

--- a/tests/unit/ToolCallTraceService.test.ts
+++ b/tests/unit/ToolCallTraceService.test.ts
@@ -407,3 +407,89 @@ describe('ToolCallTraceService', () => {
     });
   });
 });
+
+/**
+ * Traces must never be filed under an identifier that does not resolve.
+ *
+ * The workspace id is used as an event-store key, so writing to one that
+ * does not exist CREATES it: observed live as Nexus/data/workspaces/
+ * ws_--workspace/ and ws_Blog Testing/. The latter came from a near-miss —
+ * the handle is the name the caller REQUESTED, and getWorkspaceByNameOrId is
+ * exact-match, so every guessed name minted its own phantom directory.
+ */
+describe('ToolCallTraceService — unresolvable workspace handles', () => {
+  function build(options: {
+    lookup: jest.Mock;
+    context?: { workspaceId: string } | null;
+  }) {
+    const memoryService = { recordActivityTrace: jest.fn().mockResolvedValue('trace-1') };
+    const sessionContextManager = {
+      getWorkspaceContext: jest.fn().mockReturnValue(options.context ?? null),
+      setWorkspaceContext: jest.fn()
+    };
+    const workspaceService = { getWorkspaceByNameOrId: options.lookup };
+    const service = new ToolCallTraceService(
+      memoryService as never,
+      sessionContextManager as never,
+      workspaceService as never,
+      {} as never
+    );
+    return { service, memoryService };
+  }
+
+  const call = (service: ToolCallTraceService, tool: string) =>
+    service.captureToolCall(
+      'toolManager_useTools',
+      {
+        workspaceId: 'default',
+        sessionId: 'session-1',
+        memory: 'm',
+        goal: 'g',
+        tool
+      },
+      { success: true },
+      true,
+      5
+    );
+
+  it('does not file a trace under a near-miss name that resolves to nothing', async () => {
+    const { service, memoryService } = build({
+      lookup: jest.fn().mockResolvedValue(null)
+    });
+
+    await call(service, 'memory load-workspace --workspace "Blog Testing"');
+
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'default' })
+    );
+    const recorded = memoryService.recordActivityTrace.mock.calls[0][0];
+    expect(recorded.workspaceId).not.toBe('Blog Testing');
+  });
+
+  it('falls back to the session workspace when it resolves', async () => {
+    const { service, memoryService } = build({
+      lookup: jest.fn().mockImplementation((id: string) =>
+        Promise.resolve(id === 'ctx-uuid' ? { id: 'ctx-uuid', name: 'Ctx' } : null)
+      ),
+      context: { workspaceId: 'ctx-uuid' }
+    });
+
+    await call(service, 'memory load-workspace --workspace "Invented Name"');
+
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'ctx-uuid' })
+    );
+  });
+
+  it('falls back to default when the lookup throws', async () => {
+    const { service, memoryService } = build({
+      lookup: jest.fn().mockRejectedValue(new Error('cache cold'))
+    });
+
+    await call(service, 'memory load-workspace --workspace "Anything"');
+
+    expect(memoryService.recordActivityTrace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'default' })
+    );
+  });
+});

--- a/tests/unit/TraceWorkspaceHandle.test.ts
+++ b/tests/unit/TraceWorkspaceHandle.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The trace service derives a workspace handle from the raw useTools command
+ * string so a load-workspace call is attributed to the workspace it opened.
+ *
+ * `memory load-workspace` accepts its argument BOTH positionally and as
+ * `--workspace <value>`, but the extractor read the third token
+ * unconditionally — so the flag form yielded the literal string "--workspace".
+ * That became the trace's workspace id, creating a phantom `ws_--workspace`
+ * event store and logging "Workspace --workspace not found" on every such call.
+ */
+
+import { tokenizeWithMeta } from '../../src/agents/toolManager/services/ToolCliNormalizer';
+
+// The extractor is module-private; exercise it through the same tokenizer the
+// service uses, mirroring its selection rules.
+function extractWorkspaceHandle(command: string): string | undefined {
+  const tokens = tokenizeWithMeta(command);
+  if (tokens.length < 3) return undefined;
+
+  for (let index = 2; index < tokens.length; index++) {
+    const token = tokens[index];
+    const isFlag = !token.wasQuoted && token.value.startsWith('--');
+    if (!isFlag) return token.value;
+
+    const withoutDashes = token.value.replace(/^--/, '');
+    const equals = withoutDashes.indexOf('=');
+    const flagName = (equals === -1 ? withoutDashes : withoutDashes.slice(0, equals)).toLowerCase();
+    const inlineValue = equals === -1 ? undefined : withoutDashes.slice(equals + 1);
+
+    if (flagName !== 'workspace' && flagName !== 'name') continue;
+    if (inlineValue !== undefined) return inlineValue;
+
+    const next = tokens[index + 1];
+    if (next && (next.wasQuoted || !next.value.startsWith('--'))) return next.value;
+  }
+
+  return undefined;
+}
+
+describe('trace workspace-handle extraction', () => {
+  it('reads the flag form instead of capturing the flag itself', () => {
+    expect(extractWorkspaceHandle('memory load-workspace --workspace "Blog Testing"'))
+      .toBe('Blog Testing');
+  });
+
+  it('still reads the positional form', () => {
+    expect(extractWorkspaceHandle('memory load-workspace "Blog Testing"'))
+      .toBe('Blog Testing');
+  });
+
+  it('reads the unquoted --workspace=value form', () => {
+    // Only the unquoted form is a flag here, because ToolCliNormalizer uses
+    // the same `!wasQuoted && startsWith("--")` rule. The extractor MUST agree
+    // with the parser, or a trace is attributed differently than the call ran.
+    // (`--workspace="X"` parses as a positional system-wide — a pre-existing
+    // normalizer limitation, not something this extractor should diverge on.)
+    expect(extractWorkspaceHandle('memory load-workspace --workspace=BlogTesting'))
+      .toBe('BlogTesting');
+  });
+
+  it('skips unrelated flags before the workspace flag', () => {
+    expect(extractWorkspaceHandle('memory load-workspace --recursive --workspace "Blog Testing"'))
+      .toBe('Blog Testing');
+  });
+
+  it('does not mistake a quoted value that starts with dashes for a flag', () => {
+    expect(extractWorkspaceHandle('memory load-workspace "--weird-name"'))
+      .toBe('--weird-name');
+  });
+
+  it('returns nothing when the workspace flag has no value', () => {
+    expect(extractWorkspaceHandle('memory load-workspace --workspace --recursive'))
+      .toBeUndefined();
+  });
+
+  it('never returns the literal flag token', () => {
+    for (const command of [
+      'memory load-workspace --workspace "A"',
+      'memory load-workspace --workspace=B',
+      'memory create-workspace --workspace "C"'
+    ]) {
+      expect(extractWorkspaceHandle(command)).not.toBe('--workspace');
+    }
+  });
+});

--- a/tests/unit/WorkspaceMatcher.test.ts
+++ b/tests/unit/WorkspaceMatcher.test.ts
@@ -285,3 +285,67 @@ describe('resolveWorkspaceIdentifier', () => {
       .toBe('auto');
   });
 });
+
+describe('resolveWorkspaceIdentifier — noise rows must not veto a clear name match', () => {
+  const ws = (
+    id: string,
+    name: string,
+    description?: string
+  ): WorkspaceMetadata => ({
+    id,
+    name,
+    description,
+    rootFolder: '/',
+    lastAccessed: 0
+  } as WorkspaceMetadata);
+
+  it('auto-resolves a strong name match despite a description-only rival', () => {
+    // Live-reproduced case: "Blog Testing" scored 0.8 on the real workspace's
+    // name, while an unrelated workspace scored 0.075 because its description
+    // ended "...handle testing". That noise used to force a shortlist.
+    const workspaces = [
+      ws('a', 'Blog Testing Workspace'),
+      ws('b', 'E2E Workspace Name Handle Test Updated', 'Updated during end-to-end workspace name handle testing.')
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'Blog Testing');
+
+    expect(resolution.kind).toBe('auto');
+    if (resolution.kind === 'auto') {
+      expect(resolution.match.workspace.name).toBe('Blog Testing Workspace');
+    }
+  });
+
+  it('still refuses to pick between two genuine name matches', () => {
+    const workspaces = [
+      ws('a', 'Research Notes'),
+      ws('b', 'Research Archive')
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'Research');
+
+    expect(resolution.kind).toBe('candidates');
+  });
+
+  it('returns candidates — never auto — when only descriptions matched', () => {
+    const workspaces = [
+      ws('a', 'Alpha', 'notes about testing'),
+      ws('b', 'Beta', 'more testing notes')
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'testing');
+
+    expect(resolution.kind).toBe('candidates');
+  });
+
+  it('lists the noise row as a candidate when nothing wins on identity', () => {
+    const workspaces = [ws('b', 'Beta', 'end-to-end testing')];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'testing');
+
+    expect(resolution.kind).toBe('candidates');
+    if (resolution.kind === 'candidates') {
+      expect(resolution.candidates).toHaveLength(1);
+    }
+  });
+});

--- a/tests/unit/WorkspaceMatcher.test.ts
+++ b/tests/unit/WorkspaceMatcher.test.ts
@@ -2,7 +2,10 @@
  * Tests for WorkspaceMatcher - pure scoring for workspace search.
  */
 
-import { matchWorkspaces } from '../../src/agents/memoryManager/services/WorkspaceMatcher';
+import {
+  matchWorkspaces,
+  resolveWorkspaceIdentifier
+} from '../../src/agents/memoryManager/services/WorkspaceMatcher';
 import { WorkspaceMetadata } from '../../src/types/storage/StorageTypes';
 
 function makeWorkspace(overrides: Partial<WorkspaceMetadata> & { id: string; name: string }): WorkspaceMetadata {
@@ -154,5 +157,131 @@ describe('matchWorkspaces', () => {
 
     expect(matches.map(m => m.workspace.id)).toEqual(['both', 'one']);
     expect(matches[0].score).toBeGreaterThan(matches[1].score);
+  });
+});
+
+describe('resolveWorkspaceIdentifier', () => {
+  it('reports none when nothing matches at all', () => {
+    const workspaces = [makeWorkspace({ id: 'a', name: 'Research' })];
+
+    expect(resolveWorkspaceIdentifier(workspaces, 'Quarterly Budget')).toEqual({ kind: 'none' });
+  });
+
+  it('reports none for an empty workspace list', () => {
+    expect(resolveWorkspaceIdentifier([], 'Research')).toEqual({ kind: 'none' });
+  });
+
+  it('auto-resolves a lone confident near-miss', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'research', name: 'Research' }),
+      makeWorkspace({ id: 'budget', name: 'Budget' })
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'Research Notes');
+
+    expect(resolution.kind).toBe('auto');
+    if (resolution.kind === 'auto') {
+      expect(resolution.match.workspace.id).toBe('research');
+    }
+  });
+
+  it('auto-resolves a longer invented name against the real shorter one', () => {
+    // The shape agents actually produce: extra words the real name lacks.
+    const workspaces = [makeWorkspace({ id: 'research', name: 'Research' })];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'Research Notes Workspace');
+
+    expect(resolution.kind).toBe('auto');
+  });
+
+  it('ignores the filler word "workspace" in the requested name', () => {
+    const workspaces = [makeWorkspace({ id: 'research', name: 'Research' })];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'Research Workspace');
+
+    expect(resolution.kind).toBe('auto');
+    if (resolution.kind === 'auto') {
+      // Stripped down to "Research", so this reads as an exact name hit.
+      expect(resolution.match.isExact).toBe(true);
+    }
+  });
+
+  it('still resolves a workspace actually named "Workspace"', () => {
+    const workspaces = [makeWorkspace({ id: 'w', name: 'Workspace', description: 'catch-all' })];
+
+    // Stripping would empty the query, so the original is used instead.
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'workspace');
+
+    expect(resolution.kind).toBe('auto');
+  });
+
+  it('does not auto-resolve a lone description-only match', () => {
+    // Nothing about the name resembles the request, so this is not evidence
+    // the caller meant this workspace.
+    const workspaces = [
+      makeWorkspace({ id: 'a', name: 'Research', description: 'Long term planning notes' })
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'planning');
+
+    expect(resolution.kind).toBe('candidates');
+    if (resolution.kind === 'candidates') {
+      expect(resolution.candidates.map(c => c.workspace.id)).toEqual(['a']);
+    }
+  });
+
+  it('does not auto-resolve a lone rootFolder-only match', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'a', name: 'Alpha', rootFolder: 'Clients/Acme' })
+    ];
+
+    expect(resolveWorkspaceIdentifier(workspaces, 'acme').kind).toBe('candidates');
+  });
+
+  it('does not auto-resolve when barely any of the query matches the name', () => {
+    const workspaces = [makeWorkspace({ id: 'a', name: 'Research' })];
+
+    // One of five tokens hits — too thin to redirect on.
+    const resolution = resolveWorkspaceIdentifier(
+      workspaces,
+      'quarterly client research budget review'
+    );
+
+    expect(resolution.kind).toBe('candidates');
+  });
+
+  it('returns a ranked shortlist rather than picking between two plausible matches', () => {
+    const workspaces = [
+      makeWorkspace({ id: 'hub', name: 'Research Hub' }),
+      makeWorkspace({ id: 'ai', name: 'AI Research' })
+    ];
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'research');
+
+    expect(resolution.kind).toBe('candidates');
+    if (resolution.kind === 'candidates') {
+      expect(resolution.candidates.map(c => c.workspace.id)).toEqual(['hub', 'ai']);
+    }
+  });
+
+  it('caps the shortlist at five candidates', () => {
+    const workspaces = Array.from({ length: 8 }, (_, index) =>
+      makeWorkspace({ id: `ws-${index}`, name: `Research ${index}` })
+    );
+
+    const resolution = resolveWorkspaceIdentifier(workspaces, 'research');
+
+    expect(resolution.kind).toBe('candidates');
+    if (resolution.kind === 'candidates') {
+      expect(resolution.candidates).toHaveLength(5);
+    }
+  });
+
+  it('ignores archived workspaces unless asked for them', () => {
+    const workspaces = [makeWorkspace({ id: 'old', name: 'Research', isArchived: true })];
+
+    expect(resolveWorkspaceIdentifier(workspaces, 'Research Notes')).toEqual({ kind: 'none' });
+    expect(resolveWorkspaceIdentifier(workspaces, 'Research Notes', { includeArchived: true }).kind)
+      .toBe('auto');
   });
 });


### PR DESCRIPTION
## Problem

CLI/MCP agents invented Nexus workspace names, failed `loadWorkspace`, and retry-looped on more invented names.

The stated ask was better error recovery, but the cause was upstream: at the moment an agent chooses a workspace, it was shown **zero** real names, so it inferred one from the user's phrasing. Recovery is the backstop; grounding is the fix.

## Root cause

`GetToolsTool` built its workspace line from a boot-time snapshot that is empty unless `isSQLiteReady()` passes at agent-registration time. On desktop the storage adapter is created on a 3-second timer *after* the connector registers agents, so the snapshot is empty on essentially every boot. `refreshSchemaData()` existed to repair this and was never called by anything.

Two related defects made it worse: `loadWorkspace` dead-ended on a miss, and the description asserted `[default]` was the complete list — a confident falsehood on every vault that had workspaces.

## What changed

- **Live grounding.** `getTools` resolves workspace names at call time (5s cache) and returns them in `data.workspaces`. The provider awaits `WorkspaceService` and does not depend on the boot-time gates; the boot snapshot keeps its non-blocking behavior, where blocking startup is the real risk.
- **Miss recovery.** A single confident name/id match auto-loads and reports the substitution in a `resolution` field; 2+ matches return a ranked shortlist plus the exact retry command; 0 matches return the real inventory. No branch dead-ends.
- **Readiness gating.** No surface claims a list is exhaustive unless the cache says it is.
- **Trace attribution.** Traces can no longer be filed under an unresolvable identifier.

## Defects found by live testing

Unit tests could not see these; each was found by running the plugin against a real vault.

| # | Defect | Impact |
|---|---|---|
| 1 | Partial list asserted as complete | Cache had replayed **1 of 12** workspaces and `getTools` called them "the only workspaces that exist" |
| 2 | `loadWorkspace` declared a real workspace nonexistent | Same cold-cache window |
| 3 | A 0.075 description-only match vetoed a 0.8 name match | The auto-load this PR exists to provide never fired |
| 4 | `resolution` note silently dropped by the batch formatter | An auto-resolved near-miss looked like an ordinary load; the agent was never told a different workspace was opened |
| 5 | Unquoted retry command | `--workspace Blog Testing Workspace` — three arguments to any agent copying it |
| 6 | `plugin.workspaceService` does not exist on `NexusPlugin` | The invalid-workspace validation branch was silently dead |
| 7 | UNIQUE-name recovery re-ran the lookup that had just failed | `Failed to persist session` on the first CLI call after every reload |
| 8 | `resolveWorkspaceId` passed unvalidated strings through as workspace ids | Every unmatched name minted a phantom event store; `ws_--workspace/` had been accumulating since 2026-07-19 |

They are one disease: **a surface stating something with more confidence than it had earned.** The original hallucination bug is the same thing one level up.

## Verification

Verified live against a real vault, before and after each fix:

- `getTools` returns all real workspace names (previously: no `workspaces` field, description claiming `[default]`)
- Description self-heals after the first live lookup, so later `tools/list` reads are correct
- Near-miss auto-loads and reports the substitution; ambiguous returns a ranked shortlist without loading; nonsense returns the real inventory
- Cold cache reports INCOMPLETE and steers to retry the original name, rather than declaring the workspace missing
- No phantom workspace directories created, under either the positional or flag form
- Re-verified after rebasing onto `main`'s `nexus use` argv rework

Full suite **4213 passed / 1 failed / 23 skipped**. The single failure is `LocalCliInstaller › on Windows › reports a namesake command that appears earlier on PATH`, confirmed pre-existing by running it with these changes stashed. Build and lint clean.

## Notes

Two adjacent issues surfaced and are **not** addressed here, deliberately:

- The post-load cache rebuild window measured **18 seconds** on the test vault, and every defect above lived inside it. Root causes are fixed; nothing tells a caller how long to wait.
- `logger.systemWarn` and `logger.systemLog` are **no-ops**, which is why the workspace-lookup failure stayed invisible. Anything relying on them for diagnostics is silently doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)