### PR TITLE
Rank a real content match above a filename-only fuzzy hit

### DIFF
--- a/src/agents/searchManager/tools/searchContent.ts
+++ b/src/agents/searchManager/tools/searchContent.ts
@@ -19,6 +19,19 @@ interface PluginWithEmbeddings extends Plugin {
 }
 
 /**
+ * How a result was matched.
+ *
+ * - `content` — the query was found in the file body.
+ * - `path`    — only the filename matched; the body does not contain the query.
+ * - `semantic` — surfaced by vector similarity, not by literal matching.
+ *
+ * Callers previously had no way to tell these apart: a filename-only hit was
+ * detectable only by its `content` field falling back to `"File: <path>"`,
+ * which was a side effect of the snippet extractor rather than a contract.
+ */
+export type SearchMatchType = 'content' | 'path' | 'semantic';
+
+/**
  * Internal search result with scoring
  * Used internally for ranking before returning clean results to caller
  */
@@ -26,6 +39,7 @@ interface ScoredSearchResult {
   filePath: string;
   frontmatter?: Record<string, unknown>;
   content?: string;
+  matchType: SearchMatchType;
   _score: number; // Internal property for sorting
 }
 
@@ -44,8 +58,77 @@ export interface ContentSearchResult {
     filePath: string;
     frontmatter?: Record<string, unknown>;
     content?: string;  // Keyword search only
+    matchType: SearchMatchType;
   }>;
   error?: string;
+}
+
+/** Score for a verbatim occurrence of the whole query. */
+const EXACT_PHRASE_SCORE = 0.9;
+/** Ceiling for "every query word is present, but not as a phrase". */
+const ALL_WORDS_SCORE = 0.8;
+/** Floor for "at least one query word is present". */
+const PARTIAL_MATCH_FLOOR = 0.3;
+/**
+ * Ceiling for a fuzzy-only filename hit — a scattered subsequence match on a
+ * name that contains none of the query terms.
+ *
+ * Deliberately below PARTIAL_MATCH_FLOOR. Obsidian's `prepareFuzzySearch`
+ * returns small negative scores even for weak scattered matches, so the old
+ * `1 + score/100` normalization put nearly every filename hit around 0.95 —
+ * above the 0.9 an exact phrase in the body could ever reach. Files containing
+ * none of the query terms therefore outranked files containing it verbatim.
+ *
+ * Fuzzy is kept, because it is the only signal that tolerates typos and
+ * abbreviations, but it now ranks below every deliberate match rather than
+ * above them.
+ */
+const FUZZY_ONLY_CEILING = 0.25;
+
+/**
+ * Score how well `text` matches the query, using one tier ladder.
+ *
+ * Filenames and file bodies are both scored through this function so their
+ * scores are commensurable by construction. Previously the filename was scored
+ * on the fuzzy scale and the body on this tier ladder, and the two were
+ * compared directly despite never having been calibrated against each other.
+ *
+ * Returns `matchIndex`/`matchLength` so callers can extract a snippet without
+ * re-running the search.
+ */
+function scoreTextMatch(
+  normalizedQuery: string,
+  normalizedText: string
+): { found: boolean; exact: boolean; score: number; matchIndex: number; matchLength: number } {
+  const exactIndex = normalizedText.indexOf(normalizedQuery);
+  if (exactIndex !== -1) {
+    return {
+      found: true,
+      exact: true,
+      score: EXACT_PHRASE_SCORE,
+      matchIndex: exactIndex,
+      matchLength: normalizedQuery.length
+    };
+  }
+
+  const queryWords = normalizedQuery.split(/\s+/).filter(word => word.length > 2);
+  const wordMatches = queryWords.filter(word => normalizedText.includes(word));
+
+  if (wordMatches.length === 0) {
+    return { found: false, exact: false, score: 0, matchIndex: -1, matchLength: 0 };
+  }
+
+  const matchRatio = wordMatches.length / queryWords.length;
+  const score = Math.max(PARTIAL_MATCH_FLOOR, matchRatio * ALL_WORDS_SCORE);
+  const firstMatch = wordMatches[0];
+
+  return {
+    found: true,
+    exact: false,
+    score,
+    matchIndex: normalizedText.indexOf(firstMatch),
+    matchLength: firstMatch.length
+  };
 }
 
 /**
@@ -192,7 +275,7 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
       }
 
       // Convert to lean result format (just filePath + frontmatter)
-      const results: Array<{ filePath: string; frontmatter?: Record<string, unknown> }> = [];
+      const results: ContentSearchResult['results'] = [];
       for (const result of filteredResults.slice(0, searchParams.limit)) {
         const file = this.plugin.app.vault.getAbstractFileByPath(result.notePath);
         if (file instanceof TFile) {
@@ -204,8 +287,11 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
             delete frontmatter.position;
           }
 
-          const entry: { filePath: string; frontmatter?: Record<string, unknown> } = {
-            filePath: result.notePath
+          const entry: ContentSearchResult['results'][number] = {
+            filePath: result.notePath,
+            // Vector similarity, not a literal hit — the query may appear
+            // nowhere in the file at all, by design.
+            matchType: 'semantic'
           };
           if (frontmatter && Object.keys(frontmatter).length > 0) {
             entry.frontmatter = frontmatter;
@@ -325,16 +411,23 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
     let maxScore = 0;
     let contentSnippet = '';
 
-    // 1. Fuzzy search on filename
+    // 1. Filename match, scored on the SAME tier ladder as the body so the two
+    //    are comparable. A fuzzy hit is a weak fallback for typos and
+    //    abbreviations and is capped below every literal match.
     const filename = file.basename;
-    const fuzzyResult = fuzzySearch(filename);
-    let fuzzyScore = 0;
+    const filenameMatch = scoreTextMatch(normalizedQuery, filename.toLowerCase());
+    let pathScore = filenameMatch.score;
 
-    if (fuzzyResult) {
-      // Normalize fuzzy score (fuzzy scores are negative, closer to 0 is better)
-      fuzzyScore = Math.max(0, Math.min(1, 1 + (fuzzyResult.score / 100)));
-      maxScore = Math.max(maxScore, fuzzyScore);
+    if (!filenameMatch.found) {
+      const fuzzyResult = fuzzySearch(filename);
+      if (fuzzyResult) {
+        // Normalize fuzzy score (fuzzy scores are negative, closer to 0 is better)
+        const normalized = Math.max(0, Math.min(1, 1 + (fuzzyResult.score / 100)));
+        pathScore = normalized * FUZZY_ONLY_CEILING;
+      }
     }
+
+    maxScore = Math.max(maxScore, pathScore);
 
     // 2. Keyword search in file content and extract frontmatter
     let keywordScore = 0;
@@ -378,14 +471,24 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
       }
     }
 
-    // 3. Combined scoring for files that match both fuzzy and keyword
-    if (fuzzyScore > 0 && keywordScore > 0) {
-      // Weighted combination: 60% keyword + 40% fuzzy
-      maxScore = (keywordScore * 0.6) + (fuzzyScore * 0.4);
+    // 3. Combined scoring for files that match both on name and in the body.
+    if (pathScore > 0 && keywordScore > 0) {
+      // Weighted combination: 60% keyword + 40% path.
+      //
+      // Guarded by Math.max because the blend alone can DEMOTE: an exact phrase
+      // in the body (0.9) paired with a weak name hit (0.1) blended to 0.58,
+      // ranking that file below an identical file whose name did not match at
+      // all. Matching a second way must never cost a result its position.
+      maxScore = Math.max(maxScore, (keywordScore * 0.6) + (pathScore * 0.4));
     }
 
     // Only include files with matches
     if (maxScore > 0) {
+      // `content` is the honest signal here: it is only non-empty when the body
+      // actually matched. `matchType` states it outright rather than leaving
+      // callers to infer it from the snippet fallback below.
+      const matchType: SearchMatchType = keywordScore > 0 ? 'content' : 'path';
+
       // If no content snippet from keyword search, use file path
       if (!contentSnippet && includeContent) {
         contentSnippet = `File: ${file.path}`;
@@ -394,6 +497,7 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
       const entry: ScoredSearchResult = {
         filePath: file.path,
         content: contentSnippet,
+        matchType,
         _score: maxScore
       };
       if (frontmatter && Object.keys(frontmatter).length > 0) {
@@ -416,36 +520,20 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
   ): { found: boolean; score: number; snippet: string } {
     const normalizedContent = content.toLowerCase();
 
-    // Look for exact phrase match first (highest score)
-    const exactIndex = normalizedContent.indexOf(normalizedQuery);
-    if (exactIndex !== -1) {
-      return {
-        found: true,
-        score: 0.9,
-        snippet: this.extractSnippet(content, exactIndex, originalQuery.length, snippetLength)
-      };
-    }
+    // Same tier ladder the filename is scored on — see scoreTextMatch.
+    const match = scoreTextMatch(normalizedQuery, normalizedContent);
 
-    // Look for individual word matches
-    const queryWords = normalizedQuery.split(/\s+/).filter(word => word.length > 2);
-    const wordMatches = queryWords.filter(word => normalizedContent.includes(word));
-
-    if (wordMatches.length === 0) {
+    if (!match.found) {
       return { found: false, score: 0, snippet: '' };
     }
 
-    // Score based on word match ratio
-    const matchRatio = wordMatches.length / queryWords.length;
-    const score = Math.max(0.3, matchRatio * 0.8);
-
-    // Find snippet around first word match
-    const firstMatch = wordMatches[0];
-    const firstMatchIndex = normalizedContent.indexOf(firstMatch);
+    // An exact phrase hit spans the original query; a word hit spans that word.
+    const matchLength = match.exact ? originalQuery.length : match.matchLength;
 
     return {
       found: true,
-      score,
-      snippet: this.extractSnippet(content, firstMatchIndex, firstMatch.length, snippetLength)
+      score: match.score,
+      snippet: this.extractSnippet(content, match.matchIndex, matchLength, snippetLength)
     };
   }
 
@@ -545,9 +633,14 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
               content: {
                 type: 'string',
                 description: 'Content snippet (keyword search only)'
+              },
+              matchType: {
+                type: 'string',
+                enum: ['content', 'path', 'semantic'],
+                description: 'How this file matched. "content" = the query was found in the file body (see the content snippet). "path" = only the filename matched; the body does NOT contain the query, so read the file before relying on it. "semantic" = surfaced by vector similarity, so the query may not appear literally at all.'
               }
             },
-            required: ['filePath']
+            required: ['filePath', 'matchType']
           }
         },
         error: {

--- a/tests/mocks/obsidian/core.ts
+++ b/tests/mocks/obsidian/core.ts
@@ -190,6 +190,50 @@ export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/').replace(/\/+/g, '/');
 }
 
+/**
+ * Mock of Obsidian's `prepareFuzzySearch`.
+ *
+ * Mirrors the two properties production code actually depends on:
+ *  - it matches a SUBSEQUENCE, so text sharing only scattered characters with
+ *    the query still matches, and
+ *  - the score is a small NEGATIVE number where closer to 0 is a better match.
+ *
+ * The magnitudes matter: real Obsidian returns single/low-double-digit
+ * penalties even for weak scattered hits, which is why `1 + score/100`
+ * compressed nearly every filename hit up near 0.95. Reproducing that scale
+ * is the point of this mock.
+ */
+export function prepareFuzzySearch(query: string): (text: string) => { score: number } | null {
+  const needle = query.toLowerCase().replace(/\s+/g, '');
+
+  return (text: string) => {
+    const haystack = text.toLowerCase();
+    if (needle.length === 0) {
+      return null;
+    }
+
+    let cursor = 0;
+    let breaks = 0;
+
+    for (const char of needle) {
+      const found = haystack.indexOf(char, cursor);
+      if (found === -1) {
+        return null;
+      }
+      if (found !== cursor) {
+        breaks++;
+      }
+      cursor = found + 1;
+    }
+
+    // The penalty is charged per DISCONTIGUITY and stays small, which is the
+    // property that made #309 possible: even a badly scattered match returns a
+    // single-digit penalty, so `1 + score/100` lands just under 1.0 rather than
+    // degrading in proportion to how poor the match is.
+    return { score: -Math.min(breaks, 8) };
+  };
+}
+
 export function parseYaml(yaml: string): unknown {
   return parse(yaml);
 }

--- a/tests/mocks/obsidian/index.ts
+++ b/tests/mocks/obsidian/index.ts
@@ -21,6 +21,7 @@ export {
   requestUrl,
   __setRequestUrlMock,
   normalizePath,
+  prepareFuzzySearch,
   parseYaml,
   stringifyYaml,
   Events,

--- a/tests/unit/SearchContentTool.test.ts
+++ b/tests/unit/SearchContentTool.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Tests for SearchContentTool keyword/fuzzy ranking.
+ *
+ * Regression cover for #309: a fuzzy match on the FILENAME normalized to ~0.95
+ * while an exact phrase in the file BODY capped at 0.9, so a file containing
+ * none of the query terms outranked a file containing the query verbatim — and
+ * nothing in the response let a caller tell the two apart.
+ */
+
+import { Plugin, TFile } from 'obsidian';
+import { SearchContentTool, ContentSearchParams, ContentSearchResult } from '../../src/agents/searchManager/tools/searchContent';
+
+interface VaultFile {
+  path: string;
+  content: string;
+}
+
+const BASE_CONTEXT = {
+  workspaceId: 'default',
+  sessionId: 'session-1',
+  memory: 'Searching the vault for a phrase.',
+  goal: 'Find the notes that actually contain it.'
+};
+
+/**
+ * Build a tool over an in-memory vault. Files are plain markdown; frontmatter
+ * is not exercised here.
+ */
+function createTool(files: VaultFile[]): SearchContentTool {
+  const tFiles = files.map(file => {
+    const name = file.path.split('/').pop() ?? file.path;
+    return new TFile(name, file.path);
+  });
+
+  const byPath = new Map(files.map(file => [file.path, file.content]));
+
+  const plugin = {
+    app: {
+      vault: {
+        getMarkdownFiles: () => tFiles,
+        read: async (file: TFile) => {
+          const content = byPath.get(file.path);
+          if (content === undefined) {
+            throw new Error(`No such file: ${file.path}`);
+          }
+          return content;
+        }
+      },
+      metadataCache: {
+        getFileCache: () => null
+      }
+    }
+  } as unknown as Plugin;
+
+  return new SearchContentTool(plugin);
+}
+
+function params(overrides: Partial<ContentSearchParams> = {}): ContentSearchParams {
+  return {
+    context: BASE_CONTEXT,
+    query: 'acordao ministro',
+    semantic: false,
+    ...overrides
+  } as ContentSearchParams;
+}
+
+/**
+ * `prepareResult` routes the payload through `createResult`, which nests it
+ * under `data` — the declared `ContentSearchResult` shape describes what
+ * callers see after ToolBatchExecutionService flattens the envelope, not what
+ * `execute()` returns directly. Read through both so these tests assert on the
+ * ranking rather than on that packaging.
+ */
+function resultsOf(result: ContentSearchResult): ContentSearchResult['results'] {
+  const nested = (result as unknown as { data?: ContentSearchResult }).data;
+  return nested?.results ?? result.results ?? [];
+}
+
+describe('SearchContentTool — keyword ranking', () => {
+  /**
+   * The #309 repro, reduced. "Ha teorias que reconhecem a privacidade" shares
+   * no query TERM with "acordao ministro" but does contain its characters as a
+   * scattered subsequence, which is exactly what the old normalization scored
+   * at ~0.95.
+   */
+  const REPRO_VAULT: VaultFile[] = [
+    {
+      // Contains neither "acordao" nor "ministro" — in the name or the body —
+      // but its name carries the query's characters as a scattered
+      // subsequence, which the old normalization scored at ~0.92.
+      path: 'Zettel/A-cronologia-da-reforma-administrativa-e-o-ministerio-do-registro.md',
+      content: 'Notas sobre teoria geral. Sem relacao com os termos buscados.'
+    },
+    {
+      // Contains the query verbatim, which could never score above 0.9.
+      path: 'Julgados/STF-ADI-6649.md',
+      content: 'Trecho do voto: acordao ministro relator, com fundamentacao.'
+    }
+  ];
+
+  it('ranks an exact content match above a filename-only fuzzy match', async () => {
+    const tool = createTool(REPRO_VAULT);
+
+    const result = await tool.execute(params());
+
+    expect(result.success).toBe(true);
+    expect(resultsOf(result)[0].filePath).toBe('Julgados/STF-ADI-6649.md');
+  });
+
+  it('does not surface a file whose body and name share no query term above one that does', async () => {
+    const tool = createTool(REPRO_VAULT);
+
+    const result = await tool.execute(params());
+
+    const results = resultsOf(result);
+    const contentMatches = results.filter(entry => entry.matchType === 'content');
+    const pathMatches = results.filter(entry => entry.matchType === 'path');
+
+    expect(contentMatches.map(entry => entry.filePath)).toContain('Julgados/STF-ADI-6649.md');
+
+    // Every content match outranks every path-only match in the returned order.
+    const lastContentIndex = results.map(e => e.matchType).lastIndexOf('content');
+    const firstPathIndex = results.map(e => e.matchType).indexOf('path');
+    if (firstPathIndex !== -1 && lastContentIndex !== -1) {
+      expect(lastContentIndex).toBeLessThan(firstPathIndex);
+    }
+    expect(pathMatches.every(entry => entry.filePath !== 'Julgados/STF-ADI-6649.md')).toBe(true);
+  });
+
+  it('reports how each result matched', async () => {
+    const tool = createTool(REPRO_VAULT);
+
+    const result = await tool.execute(params());
+
+    const results = resultsOf(result);
+    expect(results.length).toBeGreaterThan(0);
+    for (const entry of results) {
+      expect(['content', 'path', 'semantic']).toContain(entry.matchType);
+    }
+  });
+
+  /**
+   * The counterpart risk to the fix: tiering content strictly above filename
+   * would break title lookup, which is a first-class Obsidian use case. A note
+   * NAMED for the query must still win over a note that merely mentions it.
+   */
+  it('still ranks a title match first when the query names a note', async () => {
+    const tool = createTool([
+      {
+        path: 'Daily/2026-08-06 Standup.md',
+        content: 'Unrelated body text about deployment.'
+      },
+      {
+        path: 'Archive/Meeting log.md',
+        content: 'Earlier we referenced the 2026-08-06 Standup in passing.'
+      }
+    ]);
+
+    const result = await tool.execute(params({ query: '2026-08-06 Standup' }));
+
+    expect(result.success).toBe(true);
+    expect(resultsOf(result)[0].filePath).toBe('Daily/2026-08-06 Standup.md');
+  });
+
+  /**
+   * The blend used to be assigned unconditionally, so matching a second way
+   * could DEMOTE a file below an otherwise identical one that matched once.
+   */
+  it('does not demote a file for also matching on its name', async () => {
+    const tool = createTool([
+      {
+        // Body holds the exact phrase (the strongest content signal), and the
+        // NAME is a weak fuzzy-only hit. Blending the two unguarded drags this
+        // below the weaker file beneath it.
+        path: 'Notes/Quiet quarters - early review of the venue.md',
+        content: 'The quarterly revenue figures are attached.'
+      },
+      {
+        // Both words present but not as a phrase — a strictly weaker match.
+        path: 'Notes/zzz.md',
+        content: 'Revenue was discussed, and the quarterly cadence was set.'
+      }
+    ]);
+
+    const result = await tool.execute(params({ query: 'quarterly revenue' }));
+
+    expect(resultsOf(result)[0].filePath).toBe('Notes/Quiet quarters - early review of the venue.md');
+  });
+
+  it('labels every result as a path match when bodies are never read', async () => {
+    const tool = createTool(REPRO_VAULT);
+
+    // Queried by name: with includeContent=false the tool never reads a body,
+    // so it cannot honestly claim a content match for anything.
+    const result = await tool.execute(params({ query: 'STF-ADI-6649', includeContent: false }));
+
+    const results = resultsOf(result);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(entry => entry.matchType === 'path')).toBe(true);
+  });
+
+  it('returns an empty list when nothing matches', async () => {
+    const tool = createTool(REPRO_VAULT);
+
+    const result = await tool.execute(params({ query: 'vringlethorp quazzendil mubrifonte' }));
+
+    expect(result.success).toBe(true);
+    expect(resultsOf(result)).toEqual([]);
+  });
+
+  it('documents matchType in the result schema', () => {
+    const tool = createTool([]);
+
+    const schema = tool.getResultSchema() as {
+      properties: {
+        results: {
+          items: {
+            properties: Record<string, { enum?: string[] }>;
+            required: string[];
+          };
+        };
+      };
+    };
+
+    const items = schema.properties.results.items;
+    expect(items.properties.matchType).toBeDefined();
+    expect(items.properties.matchType.enum).toEqual(['content', 'path', 'semantic']);
+    expect(items.required).toContain('matchType');
+  });
+});


### PR DESCRIPTION
Fixes #309.

## The defect

`searchInFile` compared two scores that were never calibrated against each other:

| Signal | Scale |
|---|---|
| Filename | `prepareFuzzySearch`, normalized `1 + score/100` |
| Body | tier ladder — exact phrase **0.9**, all words **0.8**, partial floor **0.3** |

Obsidian charges only a small penalty even for a badly scattered subsequence match, so a filename hit normalized to roughly **0.92–0.95** — above anything a body match could ever reach. A file containing none of the query terms outranked a file containing the query verbatim, and nothing in the response let a caller tell the two apart.

## The fix

Score the filename on the **same tier ladder** as the body, so the two are commensurable by construction. Fuzzy is kept as the fallback it is actually good at — typos and abbreviations — but capped below the weakest literal match (`FUZZY_ONLY_CEILING = 0.25`, under the 0.3 partial floor), so it surfaces when nothing better exists and never outranks a deliberate match.

### Why not the tier from the issue

The reference branch on the reporter's fork tiers content strictly above path. That fixes the reported query but breaks title lookup, which is first-class in Obsidian: searching `2026-08-06 Standup` should surface the note *named* that, even when another note quotes the string in its body. Rescaling fixes the inversion without giving up title search. `still ranks a title match first when the query names a note` covers that case and fails under a strict tier.

## Two things found while fixing it

**The 60/40 blend could demote.** It was assigned unconditionally, so an exact phrase in the body (0.9) paired with a weak name hit blended *below* 0.9 — ranking that file under an otherwise weaker one. Matching a second way must never cost a result its position. The blend is now floored by the best single signal.

**Results now say how they matched.** `matchType: 'content' | 'path' | 'semantic'`, documented in the result schema and required. Previously the only tell was `content` falling back to `"File: <path>"` — a side effect of the snippet extractor, not a contract. `path` now tells an agent it is holding a location rather than a quote, and `semantic` marks results where the query may not appear literally at all.

## Tests

`tests/unit/SearchContentTool.test.ts` is new — `searchContent` had no coverage.

**5 of 8 cases fail on the unpatched tree.** The other 3 lock behavior that must not change: title match still wins, no demotion for matching twice, and a query matching nothing still returns an empty list rather than padding.

Adds `prepareFuzzySearch` to the obsidian mock, reproducing the property that made this possible: the penalty is charged per discontiguity and stays small, so a poor match still normalizes near 1.0. A first attempt that penalized proportionally made the headline test pass unpatched — the mock's scale is load-bearing.

## Verification

- `tsc --noEmit`, `eslint`, `npm run build` — clean, no generated-artifact drift
- Full suite: **4221 passed / 23 skipped / 1 failed** — the failure is `LocalCliInstaller › reports a namesake command that appears earlier on PATH`, confirmed failing identically on clean `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)