### PR TITLE
Rank a note named for the query above one that merely mentions it

### DIFF
--- a/src/agents/searchManager/tools/searchContent.ts
+++ b/src/agents/searchManager/tools/searchContent.ts
@@ -65,6 +65,18 @@ export interface ContentSearchResult {
 
 /** Score for a verbatim occurrence of the whole query. */
 const EXACT_PHRASE_SCORE = 0.9;
+/**
+ * Score for a filename that contains the whole query verbatim.
+ *
+ * Above EXACT_PHRASE_SCORE on purpose. In a note-taking vault, "the note is
+ * NAMED this" is a stronger signal than "some note mentions this", so looking
+ * up `2026-08-06 Standup` must return the note called that ahead of a meeting
+ * log that references it in passing.
+ *
+ * Without this, both land on EXACT_PHRASE_SCORE and the winner is decided by
+ * whichever file the vault happened to enumerate first.
+ */
+const TITLE_EXACT_SCORE = 0.95;
 /** Ceiling for "every query word is present, but not as a phrase". */
 const ALL_WORDS_SCORE = 0.8;
 /** Floor for "at least one query word is present". */
@@ -416,7 +428,9 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
     //    abbreviations and is capped below every literal match.
     const filename = file.basename;
     const filenameMatch = scoreTextMatch(normalizedQuery, filename.toLowerCase());
-    let pathScore = filenameMatch.score;
+    // A title carrying the query verbatim outranks a body that merely mentions
+    // it; weaker filename tiers stay on the shared ladder.
+    let pathScore = filenameMatch.exact ? TITLE_EXACT_SCORE : filenameMatch.score;
 
     if (!filenameMatch.found) {
       const fuzzyResult = fuzzySearch(filename);

--- a/tests/unit/SearchContentTool.test.ts
+++ b/tests/unit/SearchContentTool.test.ts
@@ -146,13 +146,17 @@ describe('SearchContentTool — keyword ranking', () => {
    */
   it('still ranks a title match first when the query names a note', async () => {
     const tool = createTool([
-      {
-        path: 'Daily/2026-08-06 Standup.md',
-        content: 'Unrelated body text about deployment.'
-      },
+      // Enumerated FIRST on purpose. Both files match the query verbatim — one
+      // in its body, one in its name — so if they scored the same rung this
+      // would win on position alone and the assertion below would prove
+      // nothing. It has to lose on score.
       {
         path: 'Archive/Meeting log.md',
         content: 'Earlier we referenced the 2026-08-06 Standup in passing.'
+      },
+      {
+        path: 'Daily/2026-08-06 Standup.md',
+        content: 'Unrelated body text about deployment.'
       }
     ]);
 
@@ -160,6 +164,7 @@ describe('SearchContentTool — keyword ranking', () => {
 
     expect(result.success).toBe(true);
     expect(resultsOf(result)[0].filePath).toBe('Daily/2026-08-06 Standup.md');
+    expect(resultsOf(result)[0].matchType).toBe('path');
   });
 
   /**


### PR DESCRIPTION
Follow-up to #312 (issue #309), caught by testing in the live vault rather than in jest.

## The defect

Searching `2026-08-06 Standup` returned `Archive/Meeting log.md` — which references the phrase in passing — **ahead of the note actually called `2026-08-06 Standup`**.

A filename containing the query verbatim and a body containing it verbatim both landed on `EXACT_PHRASE_SCORE` (0.9). With the scores tied, the winner was whichever file the vault happened to enumerate first.

## The fix

`TITLE_EXACT_SCORE = 0.95` for a filename that carries the whole query verbatim. In a note-taking vault, "the note is NAMED this" is a stronger signal than "some note mentions this".

Weaker filename tiers stay on the shared ladder, and fuzzy-only hits keep their `0.25` cap below every literal match — so the #309 inversion stays fixed. This only separates two signals that were previously indistinguishable at the top of the ladder.

## The test was vacuous

`still ranks a title match first when the query names a note` asserted exactly this behavior and passed anyway. Both fixture files tied at 0.9, and the expected winner happened to be first in the array, so stable-sort position carried it — it would have passed against almost any implementation.

Reordered so the expected winner is enumerated **last** and has to win on score. Reverting the one-line fix now fails it.

## Verification

Re-ran the #309 repro and the title case in the live vault, not just jest:

- `acordao ministro` → verbatim body match first (`content`), filename-only fuzzy hit second (`path`) — the original inversion stays fixed
- `2026-08-06 Standup` → the note named that comes first

`tsc --noEmit`, `eslint`, `npm run build` clean. Full suite 4221 passed / 23 skipped / 1 failed — `LocalCliInstaller › reports a namesake command that appears earlier on PATH`, failing identically on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)