### PR TITLE
Match a kebab-cased filename against a spaced query

### DIFF
--- a/src/agents/searchManager/tools/searchContent.ts
+++ b/src/agents/searchManager/tools/searchContent.ts
@@ -98,6 +98,22 @@ const PARTIAL_MATCH_FLOOR = 0.3;
 const FUZZY_ONLY_CEILING = 0.25;
 
 /**
+ * Fold the separators used in filenames into spaces.
+ *
+ * Vault filenames are routinely kebab- or snake-cased (`citation-gap-audit`),
+ * while the query is typed as words (`citation gap audit`). Compared verbatim
+ * the phrase is not a substring of the name, so the note LITERALLY NAMED for
+ * the query fell to the word tier and lost to any body that happened to
+ * contain the phrase — observed at rank 12 in a real vault.
+ *
+ * Applied to the filename side only. Body matching stays byte-exact so the
+ * snippet offsets it returns keep pointing at the real text.
+ */
+function foldSeparators(text: string): string {
+  return text.toLowerCase().replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Score how well `text` matches the query, using one tier ladder.
  *
  * Filenames and file bodies are both scored through this function so their
@@ -427,7 +443,9 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
     //    are comparable. A fuzzy hit is a weak fallback for typos and
     //    abbreviations and is capped below every literal match.
     const filename = file.basename;
-    const filenameMatch = scoreTextMatch(normalizedQuery, filename.toLowerCase());
+    // Both sides folded, so `citation-gap-audit` and `Citation Gap Audit` are
+    // each reachable from either spelling of the query.
+    const filenameMatch = scoreTextMatch(foldSeparators(normalizedQuery), foldSeparators(filename));
     // A title carrying the query verbatim outranks a body that merely mentions
     // it; weaker filename tiers stay on the shared ladder.
     let pathScore = filenameMatch.exact ? TITLE_EXACT_SCORE : filenameMatch.score;

--- a/tests/unit/SearchContentTool.test.ts
+++ b/tests/unit/SearchContentTool.test.ts
@@ -168,6 +168,46 @@ describe('SearchContentTool — keyword ranking', () => {
   });
 
   /**
+   * Kebab- and snake-cased names are the norm in a vault, and the query is
+   * typed as words. Compared verbatim the phrase is not a substring of the
+   * name, so the note named for the query lost to any body that mentioned it —
+   * observed at rank 12 in a real vault before this was folded.
+   */
+  it('treats a kebab-cased filename as a title match for a spaced query', async () => {
+    const tool = createTool([
+      {
+        path: 'Notes/references.md',
+        content: 'See the citation gap audit for the full table of findings.'
+      },
+      {
+        path: 'Notes/citation-gap-audit.md',
+        content: 'Body text that does not repeat the phrase.'
+      }
+    ]);
+
+    const result = await tool.execute(params({ query: 'citation gap audit' }));
+
+    expect(resultsOf(result)[0].filePath).toBe('Notes/citation-gap-audit.md');
+  });
+
+  it('finds a spaced filename from a kebab-cased query', async () => {
+    const tool = createTool([
+      {
+        path: 'Notes/references.md',
+        content: 'See the citation gap audit for the full table of findings.'
+      },
+      {
+        path: 'Notes/Citation Gap Audit.md',
+        content: 'Body text that does not repeat the phrase.'
+      }
+    ]);
+
+    const result = await tool.execute(params({ query: 'citation-gap-audit' }));
+
+    expect(resultsOf(result)[0].filePath).toBe('Notes/Citation Gap Audit.md');
+  });
+
+  /**
    * The blend used to be assigned unconditionally, so matching a second way
    * could DEMOTE a file below an otherwise identical one that matched once.
    */


### PR DESCRIPTION
Follow-up to #313 (issue #309), found by searching the real vault.

## The defect

Searching `citation gap audit` put the note literally named `citation-gap-audit.md` at **rank 12**, behind eleven notes that merely mention the phrase.

The filename comparison was verbatim, so `citation gap audit` is not a substring of `citation-gap-audit`. The title-exact tier never fired, the name fell to the word tier (0.8), and it lost to any body carrying the phrase (0.9).

Kebab- and snake-cased filenames are the norm in a vault, so the title ranking added in #313 was not reaching most of the notes it was meant for.

## The fix

Fold `-` and `_` to spaces on both sides of the **filename** comparison, so either spelling of the query reaches either spelling of the name.

Body matching is untouched and stays byte-exact — `scoreTextMatch` returns match offsets that snippet extraction uses, and those have to keep pointing at real text.

## Tests

Two new cases, both failing without the fold:

- `treats a kebab-cased filename as a title match for a spaced query`
- `finds a spaced filename from a kebab-cased query`

Full suite **4223 passed / 23 skipped / 1 failed** — `LocalCliInstaller › reports a namesake command that appears earlier on PATH`, failing identically on clean `main`. `tsc --noEmit`, `eslint`, `npm run build` clean.

## Note

The unit suite was green across this entire class of filenames before this. It took searching the vault to surface it — same as #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)