### PR TITLE
Treat a note that moved mid-flight as a skip, not an error

### DIFF
--- a/src/services/embeddings/NoteEmbeddingService.ts
+++ b/src/services/embeddings/NoteEmbeddingService.ts
@@ -29,6 +29,26 @@ import { EmbeddingAdapter, type QueryAdapter } from './adapter/EmbeddingAdapter'
 
 const asQueryParams = (params: unknown[]): QueryParams => params as unknown as QueryParams;
 
+/**
+ * True when an error means the note is no longer at the path we read.
+ *
+ * `embedNote` already checks the vault index before reading, but the index and
+ * the filesystem disagree for a moment while a file is being moved, so the
+ * guard can pass and the read still fail. Re-embedding is debounced by ten
+ * seconds, which makes that window easy to hit: create a note and move or
+ * delete it shortly after and the timer fires against the old path.
+ *
+ * That is a normal outcome rather than a failure. The vault's rename and
+ * delete handlers own re-pointing and removing the embedding, so there is
+ * nothing here to repair and nothing worth reporting.
+ */
+function isMissingFileError(error: unknown): boolean {
+  if (typeof error === 'object' && error !== null && (error as { code?: unknown }).code === 'ENOENT') {
+    return true;
+  }
+  return error instanceof Error && /ENOENT|no such file or directory/i.test(error.message);
+}
+
 export interface SimilarNote {
   notePath: string;
   distance: number;
@@ -127,7 +147,14 @@ export class NoteEmbeddingService {
         );
       }
     } catch (error) {
-      console.error(`[NoteEmbeddingService] Failed to embed note ${notePath}:`, error);
+      if (isMissingFileError(error)) {
+        // The note moved or was deleted between scheduling and now.
+        return;
+      }
+
+      // Deliberately not logged here. Every caller — EmbeddingWatcher,
+      // IndexingQueue — already reports failures with its own context, so
+      // logging and rethrowing printed each one twice, with two stacks.
       throw error;
     }
   }

--- a/tests/unit/NoteEmbeddingServiceMissingFile.test.ts
+++ b/tests/unit/NoteEmbeddingServiceMissingFile.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for how NoteEmbeddingService.embedNote reports failures.
+ *
+ * Re-embedding is debounced by ten seconds, so a note can move or be deleted
+ * between being scheduled and being read. The existence guard at the top of
+ * embedNote checks the vault INDEX while the read hits DISK, and those
+ * disagree for a moment during a move — so the guard passes and the read
+ * throws ENOENT anyway.
+ *
+ * That is a normal outcome, not a failure: the vault's rename and delete
+ * handlers own re-pointing and removing the embedding. It used to surface as
+ * a console error with a full stack, printed twice because the service logged
+ * and rethrew while every caller logged again.
+ */
+
+import { App, TFile } from 'obsidian';
+import { NoteEmbeddingService } from '../../src/services/embeddings/NoteEmbeddingService';
+import type { EmbeddingEngine } from '../../src/services/embeddings/EmbeddingEngine';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+
+const NOTE_PATH = 'Notes/moved-away.md';
+
+function enoent(path: string): NodeJS.ErrnoException {
+  const error = new Error(
+    `ENOENT: no such file or directory, open '${path}'`
+  ) as NodeJS.ErrnoException;
+  error.code = 'ENOENT';
+  return error;
+}
+
+/**
+ * Build a service whose vault still lists the note (a stale index) but whose
+ * read fails with `readError`.
+ */
+function createService(readError: Error): {
+  service: NoteEmbeddingService;
+  queryOne: jest.Mock;
+} {
+  const file = new TFile('moved-away.md', NOTE_PATH);
+
+  const app = {
+    vault: {
+      getAbstractFileByPath: (path: string) => (path === NOTE_PATH ? file : null),
+      read: async () => { throw readError; }
+    }
+  } as unknown as App;
+
+  // Reached only if the read unexpectedly succeeds.
+  const queryOne = jest.fn().mockResolvedValue(undefined);
+  const db = { queryOne, run: jest.fn() } as unknown as SQLiteCacheManager;
+
+  const engine = {
+    generateEmbedding: jest.fn(),
+    getModelInfo: () => ({ id: 'test-model' })
+  } as unknown as EmbeddingEngine;
+
+  return { service: new NoteEmbeddingService(app, db, engine), queryOne };
+}
+
+describe('NoteEmbeddingService.embedNote — a note that moved mid-flight', () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('skips a note whose file is gone instead of failing', async () => {
+    const { service } = createService(enoent(`/vault/${NOTE_PATH}`));
+
+    await expect(service.embedNote(NOTE_PATH)).resolves.toBeUndefined();
+  });
+
+  it('says nothing on the console when a note simply moved', async () => {
+    const { service } = createService(enoent(`/vault/${NOTE_PATH}`));
+
+    await service.embedNote(NOTE_PATH);
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('recognises a missing file from the message alone, without an errno code', async () => {
+    // Not every layer preserves `code` — Obsidian's adapter and the various
+    // promise wrappers between here and fs can hand back a plain Error.
+    const { service } = createService(
+      new Error(`ENOENT: no such file or directory, open '/vault/${NOTE_PATH}'`)
+    );
+
+    await expect(service.embedNote(NOTE_PATH)).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('still propagates a real failure to the caller', async () => {
+    const { service } = createService(new Error('disk is on fire'));
+
+    await expect(service.embedNote(NOTE_PATH)).rejects.toThrow('disk is on fire');
+  });
+
+  it('leaves reporting a real failure to the caller, which has the context', async () => {
+    const { service } = createService(new Error('disk is on fire'));
+
+    await expect(service.embedNote(NOTE_PATH)).rejects.toThrow();
+
+    // The service used to log AND rethrow, so EmbeddingWatcher and
+    // IndexingQueue each printed the same failure a second time.
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The noise

```
[NoteEmbeddingService] Failed to embed note _scratch/citation-gap-audit.md: Error: ENOENT: no such file or directory
[EmbeddingWatcher] Failed to re-embed _scratch/citation-gap-audit.md: Error: ENOENT: no such file or directory
```

Two errors with full stacks, for something that is not a failure.

## Why it happens

Re-embedding is debounced by 10s ([EmbeddingWatcher.ts:33](src/services/embeddings/EmbeddingWatcher.ts:33)), so a note can move or be deleted between being scheduled and being read. `embedNote` already guards for a missing file — but it checks the vault **index** ([NoteEmbeddingService.ts:63](src/services/embeddings/NoteEmbeddingService.ts:63)) while `vault.read` hits **disk**, and those disagree for a moment during a move. The guard passes and the read throws anyway.

Any user who creates a note and moves or deletes it within ten seconds hits this.

## Why it is safe to swallow

I checked whether anything was actually broken before silencing it, since a folder move could plausibly orphan child embeddings — the watcher's rename/delete handlers guard on `file instanceof TFile` and a folder move delivers a `TFolder`.

Probed against a live vault: created a note, confirmed it embedded, moved its folder, searched again.

```
before move:  _embed-move-probe/original-note.md
after move:   _embed-move-probe-moved/original-note.md
```

Obsidian emits per-descendant rename events, so the guard is reached and `updatePath` re-points correctly. Nothing orphans, and there is nothing for `embedNote` to repair — hence a quiet return.

## Also: it was reported twice

The service logged **and** rethrew, while every caller (`EmbeddingWatcher`, `IndexingQueue`) logs with its own context. The service now only throws; the callers keep reporting, since they know whether this was a watcher fire or a bulk index pass.

## Tests

New `tests/unit/NoteEmbeddingServiceMissingFile.test.ts` — 5 cases, **4 fail before the fix**. Includes the case where `code` is absent and only the message identifies ENOENT, since not every layer between here and `fs` preserves the errno.

Full suite **4252 passed / 27 skipped / 1 failed** — `LocalCliInstaller › reports a namesake command that appears earlier on PATH`, failing identically on clean `main`. `tsc --noEmit`, `eslint`, `npm run build` clean.

Surfaced by the live smoke test added in #315, whose cleanup archives scratch notes inside the debounce window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)