### PR TITLE
Accept a workspace passed by name off the live list (fixes #317)

### DIFF
--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -247,6 +247,12 @@ export class ToolBatchExecutionService {
       return null;
     }
 
+    // Fast path over the boot-time snapshot, to skip the async lookup below on
+    // vaults where SQLite WAS query-ready at registration. It may only ACCEPT:
+    // a miss falls through to the live list rather than rejecting, so a stale or
+    // empty snapshot can never reject a real workspace. Do not add a rejection
+    // here — that asymmetry is what keeps this from being a second source of
+    // truth for the guard (#317).
     const byName = this.knownWorkspaces.find(workspace =>
       workspace.name.toLowerCase() === workspaceId.toLowerCase()
     );
@@ -271,9 +277,17 @@ export class ToolBatchExecutionService {
         return null;
       }
 
+      // Accept by id OR name off the LIVE list. Checking the name only against
+      // `knownWorkspaces` (above) rejected real workspaces on any vault whose
+      // boot snapshot was empty, while the message below — already built from
+      // the live list — named that same workspace as the closest match. Both
+      // halves must read the same list or the guard contradicts itself (#317).
       const workspaces = await workspaceService.listWorkspaces();
-      const byUuid = workspaces.find(workspace => workspace.id === workspaceId);
-      if (byUuid) {
+      const target = workspaceId.toLowerCase();
+      const byIdOrName = workspaces.find(workspace =>
+        workspace.id === workspaceId || workspace.name.toLowerCase() === target
+      );
+      if (byIdOrName) {
         return null;
       }
 

--- a/tests/unit/EnvelopeWorkspaceValidation.test.ts
+++ b/tests/unit/EnvelopeWorkspaceValidation.test.ts
@@ -1,0 +1,173 @@
+/**
+ * tests/unit/EnvelopeWorkspaceValidation.test.ts — issue #317.
+ *
+ * The envelope guard rejected a workspace passed by NAME and then offered that
+ * same workspace back as its closest match:
+ *
+ *   Invalid workspace "Desenvolvedor". Closest match: "Desenvolvedor". …
+ *
+ * Cause: acceptance and suggestion read different lists. The name was only ever
+ * tested against `knownWorkspaces` — the boot-time SchemaData snapshot, which is
+ * empty whenever SQLite was not query-ready at agent registration — while the id
+ * was tested against the live `listWorkspaces()`. The error message was already
+ * built off the live list (#311), so on exactly the vaults #311 targeted the
+ * guard could only ever suggest a name it had never checked for acceptance.
+ *
+ * This mattered because `getTools` grounds the caller with the LIVE names and
+ * instructs it to pass one of them verbatim; `useTools` then answered "do not
+ * infer a workspace name from the user's wording". An agent following the
+ * grounding perfectly was told it invented the name.
+ */
+import { ToolBatchExecutionService } from '../../src/agents/toolManager/services/ToolBatchExecutionService';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+
+const LIVE_WORKSPACES = [
+    { id: 'a8fbad11-7412-49c8-bce0-5690e2c1d197', name: 'Desenvolvedor', isArchived: false },
+    { id: 'b1000000-0000-0000-0000-000000000002', name: 'Dev', isArchived: false },
+    { id: 'c2000000-0000-0000-0000-000000000003', name: 'Reflexao', isArchived: false },
+    { id: 'd3000000-0000-0000-0000-000000000004', name: 'Retired', isArchived: true },
+];
+
+function createTool(): { tool: ITool; execute: jest.Mock } {
+    const execute = jest.fn().mockResolvedValue({ success: true, projects: [] });
+    const tool = {
+        slug: 'listProjects',
+        name: 'List Projects',
+        description: '',
+        version: '1.0.0',
+        execute,
+        getParameterSchema: jest.fn().mockReturnValue({ type: 'object', properties: {} }),
+        getResultSchema: jest.fn(),
+    } as unknown as ITool;
+    return { tool, execute };
+}
+
+function createAgent(tool: ITool): IAgent {
+    return {
+        name: 'taskManager',
+        description: 'Task manager',
+        version: '1.0.0',
+        getTools: () => [tool],
+        getTool: (slug: string) => (slug === tool.slug ? tool : undefined),
+        initialize: jest.fn().mockResolvedValue(undefined),
+        executeTool: jest.fn(),
+        setAgentManager: jest.fn(),
+    };
+}
+
+/**
+ * An app whose plugin resolves and whose workspaceService answers with the live
+ * list — i.e. the guard's happy path, where it fails CLOSED rather than open.
+ */
+function createApp(): unknown {
+    const plugin = {
+        services: {
+            workspaceService: {
+                listWorkspaces: jest.fn().mockResolvedValue(LIVE_WORKSPACES),
+            },
+        },
+    };
+    return {
+        plugins: { getPlugin: (id: string) => (id === 'nexus' || id === 'claudesidian-mcp' ? plugin : null) },
+    };
+}
+
+/**
+ * Run one envelope. `knownWorkspaces` defaults to EMPTY — the boot snapshot on a
+ * vault where SQLite was not query-ready, which is the reported condition.
+ */
+async function runEnvelope(
+    workspaceId: string,
+    knownWorkspaces: Array<{ name: string; description?: string }> = []
+): Promise<{ success: boolean; error?: string; executed: boolean }> {
+    const { tool, execute } = createTool();
+    const registry = new Map<string, IAgent>([['taskManager', createAgent(tool)]]);
+    const service = new ToolBatchExecutionService(
+        createApp() as never,
+        registry,
+        knownWorkspaces as never
+    );
+
+    const result = await service.execute({
+        context: {
+            workspaceId,
+            sessionId: 'nexus-cli',
+            memory: 'Listing projects for the active workspace.',
+            goal: 'List active projects.',
+        },
+        calls: [{ agent: 'taskManager', tool: 'listProjects', params: { status: 'active' } }],
+    } as never);
+
+    return {
+        success: result.success !== false,
+        error: (result as { error?: string }).error,
+        executed: execute.mock.calls.length > 0,
+    };
+}
+
+describe('envelope workspace validation (issue #317)', () => {
+    it('accepts a workspace passed by NAME when the boot snapshot is empty', async () => {
+        // The reported failure: getTools hands back "Desenvolvedor" from the live
+        // list, the caller passes it verbatim, and the guard rejects it.
+        const result = await runEnvelope('Desenvolvedor');
+
+        expect(result.error).toBeUndefined();
+        expect(result.executed).toBe(true);
+    });
+
+    it('accepts the same workspace by UUID (this path already worked)', async () => {
+        // Pins the defect to the by-name path rather than to the guard as a whole.
+        const result = await runEnvelope('a8fbad11-7412-49c8-bce0-5690e2c1d197');
+
+        expect(result.error).toBeUndefined();
+        expect(result.executed).toBe(true);
+    });
+
+    it('accepts a name case-insensitively, matching the snapshot path', async () => {
+        const result = await runEnvelope('desenvolvedor');
+
+        expect(result.error).toBeUndefined();
+        expect(result.executed).toBe(true);
+    });
+
+    it('accepts an archived workspace by name, as the id path already does', async () => {
+        // Acceptance is symmetric: the id branch matches the full list, so the
+        // name branch must too, or the two forms disagree for archived rows.
+        expect((await runEnvelope('d3000000-0000-0000-0000-000000000004')).error).toBeUndefined();
+        expect((await runEnvelope('Retired')).error).toBeUndefined();
+    });
+
+    it('still rejects an identifier that resolves to nothing', async () => {
+        // The guard must keep working — this is not a "accept everything" fix.
+        const result = await runEnvelope('--workspaceId');
+
+        expect(result.executed).toBe(false);
+        expect(result.error).toMatch(/Invalid workspace "--workspaceId"/);
+        expect(result.error).toMatch(/Available: "default" \(global\), "Desenvolvedor", "Dev", "Reflexao"/);
+        // Archived workspaces stay out of the suggestion list.
+        expect(result.error).not.toMatch(/Retired/);
+    });
+
+    it('accepts "default" without consulting any list', async () => {
+        expect((await runEnvelope('default')).error).toBeUndefined();
+    });
+
+    /**
+     * Self-contradiction lock. Rather than another hand-picked case, this asserts
+     * the invariant the bug violated: the guard may never reject a value while
+     * naming that same value as the closest match. Any future divergence between
+     * the list it accepts from and the list it suggests from fails here,
+     * whichever direction it drifts.
+     */
+    it('never rejects a value while offering that same value as the closest match', async () => {
+        for (const workspace of LIVE_WORKSPACES) {
+            for (const identifier of [workspace.name, workspace.id]) {
+                const { error } = await runEnvelope(identifier);
+                if (error) {
+                    expect(`${identifier}: ${error}`).not.toContain(`Closest match: "${identifier}"`);
+                }
+            }
+        }
+    });
+});


### PR DESCRIPTION
Fixes #317.

## The bug

`validateWorkspaceId` tested the name and the id against **different lists**:

```ts
const byName = this.knownWorkspaces.find(...)        // boot-time snapshot
const byUuid = workspaces.find(w => w.id === ...)    // live listWorkspaces()
```

This file's own comment, three lines below, notes that the snapshot "is taken at boot and is empty whenever SQLite was not ready then" — which is exactly why #311 moved the *error message* to the live list. The acceptance check never moved with it.

So on the vaults #311 was written for, the guard could only ever suggest a name it had never checked for acceptance, and the rejection refuted itself:

```
Invalid workspace "Desenvolvedor". Closest match: "Desenvolvedor". Use one of these
exact values — do not infer a workspace name from the user's wording.
```

That also put the two halves of the mandatory pair in contradiction: `getTools` grounds the caller with the live names and instructs it to pass one verbatim, then `useTools` answers *"do not infer a workspace name from the user's wording."* An agent following the grounding perfectly was told it invented the name, and every by-name envelope stayed unusable until callers were rewritten to pass UUIDs — the opposite of what #311 introduced.

## Fix

Match id **or** name against the live list in one pass, so acceptance and suggestion read the same source.

The snapshot fast path stays — it avoids the async lookup on vaults where the snapshot is populated — but is now documented as **accept-only**: a miss falls through to the live list rather than rejecting, so a stale or empty snapshot can never reject a real workspace. That asymmetry is what keeps it from becoming a second source of truth again, and there's a comment saying so.

## Tests

`tests/unit/EnvelopeWorkspaceValidation.test.ts`, 7 cases, RED verified before the fix: the name cases failed while the id case and the legitimate rejection passed, which pins the defect to the by-name path rather than to the guard as a whole. Removing the name clause afterwards puts the same 4 back to red, confirming it is load-bearing.

Two cases beyond the reported repro:

- **Archived workspace by name.** The id branch matches the full list, so the name branch must too, or the two forms disagree for archived rows.
- **A self-contradiction lock** rather than another hand-picked case: for every live workspace, a rejection may never name that same value as its closest match. Any future divergence between the list the guard accepts from and the list it suggests from fails there, whichever direction it drifts.

That lock plus the rejection case earned their keep during this change: a dropped `listWorkspaces()` line mid-fix sent a `ReferenceError` into the enclosing `catch` and made the guard **fail open**, accepting everything. Three of the acceptance tests went green for the wrong reason; the rejection case caught it. Worth keeping in mind for this guard generally — a fail-open regression is indistinguishable from a fix if only the happy path is asserted.

## Verification

`tsc --noEmit` clean, `eslint` clean, full suite **4257 passed**. The single failure is the pre-existing `LocalCliInstaller` "namesake command earlier on PATH" case, unrelated and untouched.

## Credit

Reported with an accurate diagnosis and a proposed patch by @gcp007-ops. The fix here was verified independently against the code rather than applied as given, and lands as a single combined id-or-name lookup instead of a second `find`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dqXjmfKkH27qMhVAtS6JH)_