### PR TITLE
Align the workspace resolvers, report ambiguous names usefully (fixes #319, #320)

### DIFF
--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -291,6 +291,19 @@ export class ToolBatchExecutionService {
         return null;
       }
 
+      // Last resort before rejecting: ask the canonical resolver. The reserved
+      // guides workspace is resolvable by either identifier but is deliberately
+      // absent from `listWorkspaces()`, so the list alone cannot see it — the
+      // gate would reject the one workspace the product intentionally hides.
+      // Only the ACCEPT path consults the resolver; the suggestions below stay
+      // on the visible list, so a hidden workspace is never advertised back to
+      // the caller. Reaching this only on an otherwise-certain rejection also
+      // keeps the extra lookup off the common path (#319).
+      const resolved = await workspaceService.getWorkspaceByNameOrId?.(workspaceId);
+      if (resolved) {
+        return null;
+      }
+
       // Name the alternatives off the LIVE list, not `knownWorkspaces` — that
       // snapshot is taken at boot and is empty whenever SQLite was not ready
       // then, which produced "Available: (none created yet)" on vaults that

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -338,14 +338,6 @@ export class WorkspaceRepository
     };
   }
 
-  async getByName(name: string): Promise<WorkspaceMetadata | null> {
-    const row = await this.sqliteCache.queryOne<WorkspaceRow>(
-      'SELECT * FROM workspaces WHERE name = ?',
-      [name]
-    );
-    return row ? this.rowToEntity(row) : null;
-  }
-
   async updateLastAccessed(id: string): Promise<void> {
     const now = Date.now();
 

--- a/src/database/repositories/interfaces/IWorkspaceRepository.ts
+++ b/src/database/repositories/interfaces/IWorkspaceRepository.ts
@@ -61,14 +61,6 @@ export interface IWorkspaceRepository extends IRepository<WorkspaceMetadata> {
   getWorkspaces(options?: QueryOptions): Promise<PaginatedResult<WorkspaceMetadata>>;
 
   /**
-   * Get a workspace by name
-   *
-   * @param name - Workspace name
-   * @returns Workspace metadata or null if not found
-   */
-  getByName(name: string): Promise<WorkspaceMetadata | null>;
-
-  /**
    * Update the last accessed timestamp for a workspace
    *
    * @param id - Workspace ID

--- a/src/database/sync/resolveWorkspaceId.ts
+++ b/src/database/sync/resolveWorkspaceId.ts
@@ -27,6 +27,14 @@ export interface ResolveResult {
   warning?: string;
   /** All matching UUIDs when ambiguous (caller can surface these to the user) */
   matchingIds?: string[];
+  /**
+   * All matching workspaces when ambiguous, most-recently-accessed first.
+   *
+   * Carries the NAME alongside the id because the candidates can differ only in
+   * capitalization ("Dev" vs "dev"), and a list of bare UUIDs gives the caller
+   * no way to tell which is which.
+   */
+  matches?: Array<{ id: string; name: string }>;
 }
 
 /**
@@ -69,8 +77,11 @@ export async function resolveWorkspaceId(
   // but the table holds single digits to low dozens of rows on real vaults and
   // this branch is only reached after the id lookup misses, so no expression
   // index is warranted yet.
-  const byName = await sqliteCache.query<{ id: string; lastAccessed: number }>(
-    'SELECT id, lastAccessed FROM workspaces WHERE LOWER(name) = LOWER(?) AND isArchived = 0',
+  // `name` is selected so an ambiguous result can name each candidate, and the
+  // ordering is explicit so the message is deterministic and leads with the
+  // workspace the caller most likely meant.
+  const byName = await sqliteCache.query<{ id: string; name: string; lastAccessed: number }>(
+    'SELECT id, name, lastAccessed FROM workspaces WHERE LOWER(name) = LOWER(?) AND isArchived = 0 ORDER BY lastAccessed DESC, id ASC',
     [rawId]
   );
 
@@ -80,13 +91,23 @@ export async function resolveWorkspaceId(
   }
 
   if (byName.length > 1) {
-    // Multiple matches — return null with nudge listing all UUIDs
-    const ids = byName.map(w => w.id);
+    // Multiple matches. `UNIQUE(name)` on the workspaces table has no
+    // COLLATE NOCASE, so it forbids exact duplicates while permitting
+    // case-variants — which means two rows can only land here by differing in
+    // capitalization, and the message below can say so as fact. It also means a
+    // bare id list is useless: the names look identical to the caller, so each
+    // NAME must be paired with its own id.
+    const matches = byName.map(w => ({ id: w.id, name: w.name }));
+    const listed = matches.map(m => `  - "${m.name}" — ${m.id}`).join('\n');
     return {
       id: null,
       resolvedFromName: false,
-      warning: `Multiple workspaces named "${rawId}" found. Please retry with the specific workspace UUID: [${ids.join(', ')}]`,
-      matchingIds: ids,
+      warning:
+        `Multiple workspaces match the name "${rawId}":\n${listed}\n` +
+        'They differ only in capitalization, so the name is ambiguous. Retry with ' +
+        'workspaceId set to the id of the one you want (copied exactly from above), not the name.',
+      matchingIds: matches.map(m => m.id),
+      matches,
     };
   }
   // 3. No match at all

--- a/src/database/sync/resolveWorkspaceId.ts
+++ b/src/database/sync/resolveWorkspaceId.ts
@@ -53,9 +53,24 @@ export async function resolveWorkspaceId(
     return { id: rawId, resolvedFromName: false };
   }
 
-  // 2. Try name match (prefer non-archived workspaces)
+  // 2. Try name match (prefer non-archived workspaces).
+  //
+  // Case-insensitive, to agree with the other two resolvers:
+  // `WorkspaceService.getWorkspaceByNameOrId` (the canonical one) and
+  // `ToolBatchExecutionService.validateWorkspaceId` (the envelope guard) both
+  // compare lowercased. This one used `name = ?`, so a name differing only in
+  // case passed the guard and was then rejected here with "not found" — the
+  // gate and the layer behind it disagreeing on the same input (#320).
+  //
+  // `isArchived = 0` is intentionally unchanged: how a name is compared is a
+  // separate decision from which rows are eligible.
+  //
+  // `idx_workspaces_name` is on the raw column and will not serve LOWER(name),
+  // but the table holds single digits to low dozens of rows on real vaults and
+  // this branch is only reached after the id lookup misses, so no expression
+  // index is warranted yet.
   const byName = await sqliteCache.query<{ id: string; lastAccessed: number }>(
-    'SELECT id, lastAccessed FROM workspaces WHERE name = ? AND isArchived = 0',
+    'SELECT id, lastAccessed FROM workspaces WHERE LOWER(name) = LOWER(?) AND isArchived = 0',
     [rawId]
   );
 

--- a/tests/unit/EnvelopeWorkspaceValidation.test.ts
+++ b/tests/unit/EnvelopeWorkspaceValidation.test.ts
@@ -22,6 +22,11 @@ import { ToolBatchExecutionService } from '../../src/agents/toolManager/services
 import type { IAgent } from '../../src/agents/interfaces/IAgent';
 import type { ITool } from '../../src/agents/interfaces/ITool';
 
+// Reserved guides workspace — resolvable by the canonical resolver, deliberately
+// absent from listWorkspaces(). See SystemGuidesWorkspaceProvider.
+const SYSTEM_WORKSPACE_ID = '__system_guides__';
+const SYSTEM_WORKSPACE_NAME = 'Assistant guides';
+
 const LIVE_WORKSPACES = [
     { id: 'a8fbad11-7412-49c8-bce0-5690e2c1d197', name: 'Desenvolvedor', isArchived: false },
     { id: 'b1000000-0000-0000-0000-000000000002', name: 'Dev', isArchived: false },
@@ -65,6 +70,16 @@ function createApp(): unknown {
         services: {
             workspaceService: {
                 listWorkspaces: jest.fn().mockResolvedValue(LIVE_WORKSPACES),
+                // Mirrors WorkspaceService.getWorkspaceByNameOrId: it short-circuits
+                // on the reserved guides identifiers BEFORE any table lookup, so it
+                // resolves a workspace that never appears in listWorkspaces().
+                getWorkspaceByNameOrId: jest.fn(async (identifier: string) => {
+                    const id = identifier.toLowerCase();
+                    if (id === SYSTEM_WORKSPACE_ID || id === SYSTEM_WORKSPACE_NAME.toLowerCase()) {
+                        return { id: SYSTEM_WORKSPACE_ID, name: SYSTEM_WORKSPACE_NAME };
+                    }
+                    return LIVE_WORKSPACES.find(w => w.id === identifier || w.name.toLowerCase() === id) ?? null;
+                }),
             },
         },
     };
@@ -169,5 +184,37 @@ describe('envelope workspace validation (issue #317)', () => {
                 }
             }
         }
+    });
+
+    /**
+     * Issue #319. The guard reads `listWorkspaces()`, which omits the reserved
+     * guides workspace BY DESIGN — `WorkspaceService.getWorkspaceByNameOrId`
+     * short-circuits to it before any table lookup, and a repo test pins that it
+     * never appears in listings. So the one workspace the product deliberately
+     * hides is the one the gate cannot accept, by either identifier. Same shape
+     * as #317: the accepting source and the authoritative source differ.
+     */
+    describe('reserved guides workspace (issue #319)', () => {
+        it('accepts the guides workspace by its reserved id', async () => {
+            expect((await runEnvelope('__system_guides__')).error).toBeUndefined();
+        });
+
+        it('accepts the guides workspace by its display name', async () => {
+            expect((await runEnvelope('Assistant guides')).error).toBeUndefined();
+        });
+
+        it('accepts the guides workspace name case-insensitively', async () => {
+            expect((await runEnvelope('assistant guides')).error).toBeUndefined();
+        });
+
+        it('never advertises the hidden workspace in a rejection message', async () => {
+            // Accepting it must not leak it into the alternatives — the suggestion
+            // path stays on listWorkspaces() precisely because it is hidden.
+            const { error } = await runEnvelope('totally-unknown-workspace');
+
+            expect(error).toMatch(/Invalid workspace/);
+            expect(error).not.toMatch(/Assistant guides/);
+            expect(error).not.toMatch(/__system_guides__/);
+        });
     });
 });

--- a/tests/unit/ResolveWorkspaceIdCase.test.ts
+++ b/tests/unit/ResolveWorkspaceIdCase.test.ts
@@ -1,0 +1,119 @@
+/**
+ * tests/unit/ResolveWorkspaceIdCase.test.ts — issue #320.
+ *
+ * `sync/resolveWorkspaceId` matched names with `WHERE name = ?` while the other
+ * two resolvers in the codebase compare case-insensitively:
+ *
+ *   ToolBatchExecutionService.validateWorkspaceId  name.toLowerCase() === id.toLowerCase()
+ *   WorkspaceService.getWorkspaceByNameOrId        ws.name.toLowerCase() === lookupName.toLowerCase()
+ *   sync/resolveWorkspaceId                        WHERE name = ?            <- the outlier
+ *
+ * The third is the one wired into TaskService (AgentInitializationService), so a
+ * name differing only in case was ACCEPTED by the envelope guard and then
+ * rejected one layer down with "Workspace ... not found. Call loadWorkspace or
+ * createWorkspace first" — telling the caller to create a workspace that exists.
+ *
+ * Aligned to the other two rather than the reverse: `getWorkspaceByNameOrId` is
+ * the canonical resolver, and the guard's lowercasing predates the guard going
+ * live, so `name = ?` is the odd one out.
+ *
+ * NOTE: `isArchived = 0` is deliberately untouched here. How a name is compared
+ * is a separate decision from which rows are eligible, and the archived
+ * exclusion is pinned below so a future change to it is a conscious one.
+ */
+import { resolveWorkspaceId } from '../../src/database/sync/resolveWorkspaceId';
+import type { ISQLiteCacheManager } from '../../src/database/sync/SyncCoordinator';
+
+interface Row { id: string; name: string; isArchived: number; lastAccessed: number }
+
+const ROWS: Row[] = [
+    { id: 'a8fbad11-7412-49c8-bce0-5690e2c1d197', name: 'Desenvolvedor', isArchived: 0, lastAccessed: 3 },
+    { id: 'b1000000-0000-0000-0000-000000000002', name: 'Dev', isArchived: 0, lastAccessed: 2 },
+    { id: 'd3000000-0000-0000-0000-000000000004', name: 'Retired', isArchived: 1, lastAccessed: 1 },
+];
+
+/**
+ * Executes the resolver's real SQL against in-memory rows, honouring whichever
+ * comparison the query actually asks for. The point of these cases is the SQL
+ * itself, so the mock must not paper over it: `name = ?` stays case-sensitive
+ * here exactly as SQLite would treat it.
+ */
+function createCache(rows: Row[] = ROWS): ISQLiteCacheManager {
+    const nameMatches = (sql: string, rowName: string, param: string): boolean =>
+        /LOWER\(\s*name\s*\)/i.test(sql)
+            ? rowName.toLowerCase() === param.toLowerCase()
+            : rowName === param;
+
+    return {
+        queryOne: jest.fn(async (sql: string, params: unknown[]) => {
+            if (/FROM workspaces WHERE id = \?/i.test(sql)) {
+                return rows.find(row => row.id === params[0]) ?? null;
+            }
+            return null;
+        }),
+        query: jest.fn(async (sql: string, params: unknown[]) => {
+            if (/FROM workspaces WHERE/i.test(sql)) {
+                return rows.filter(row =>
+                    nameMatches(sql, row.name, String(params[0]))
+                    && (!/isArchived = 0/i.test(sql) || row.isArchived === 0)
+                );
+            }
+            return [];
+        }),
+    } as unknown as ISQLiteCacheManager;
+}
+
+describe('resolveWorkspaceId name matching (issue #320)', () => {
+    it('resolves a name differing only in case', async () => {
+        // The reported failure: the envelope guard accepted "desenvolvedor",
+        // then TaskService's resolver threw "Workspace not found".
+        const result = await resolveWorkspaceId('desenvolvedor', createCache());
+
+        expect(result.id).toBe('a8fbad11-7412-49c8-bce0-5690e2c1d197');
+        expect(result.resolvedFromName).toBe(true);
+    });
+
+    it('resolves an all-caps name', async () => {
+        expect((await resolveWorkspaceId('DESENVOLVEDOR', createCache())).id)
+            .toBe('a8fbad11-7412-49c8-bce0-5690e2c1d197');
+    });
+
+    it('still resolves the exact name (unchanged)', async () => {
+        const result = await resolveWorkspaceId('Desenvolvedor', createCache());
+
+        expect(result.id).toBe('a8fbad11-7412-49c8-bce0-5690e2c1d197');
+        expect(result.resolvedFromName).toBe(true);
+    });
+
+    it('still prefers a direct id match over any name lookup', async () => {
+        const result = await resolveWorkspaceId('b1000000-0000-0000-0000-000000000002', createCache());
+
+        expect(result.id).toBe('b1000000-0000-0000-0000-000000000002');
+        expect(result.resolvedFromName).toBe(false);
+    });
+
+    it('still returns null for a name that matches nothing', async () => {
+        expect((await resolveWorkspaceId('no-such-workspace', createCache())).id).toBeNull();
+    });
+
+    it('still excludes archived workspaces, in any case form', async () => {
+        // Case-insensitivity must not quietly widen row eligibility — these are
+        // separate decisions, and this pins the one that was NOT changed.
+        expect((await resolveWorkspaceId('Retired', createCache())).id).toBeNull();
+        expect((await resolveWorkspaceId('retired', createCache())).id).toBeNull();
+    });
+
+    it('still reports ambiguity when several workspaces share a name', async () => {
+        const duplicates: Row[] = [
+            { id: 'id-one', name: 'Shared', isArchived: 0, lastAccessed: 2 },
+            { id: 'id-two', name: 'shared', isArchived: 0, lastAccessed: 1 },
+        ];
+        // Case-folding makes these two collide where they previously did not, so
+        // the ambiguity branch must report both rather than silently pick one.
+        const result = await resolveWorkspaceId('SHARED', createCache(duplicates));
+
+        expect(result.id).toBeNull();
+        expect(result.matchingIds).toEqual(['id-one', 'id-two']);
+        expect(result.warning).toMatch(/Multiple workspaces named "SHARED"/);
+    });
+});

--- a/tests/unit/ResolveWorkspaceIdCase.test.ts
+++ b/tests/unit/ResolveWorkspaceIdCase.test.ts
@@ -53,10 +53,16 @@ function createCache(rows: Row[] = ROWS): ISQLiteCacheManager {
         }),
         query: jest.fn(async (sql: string, params: unknown[]) => {
             if (/FROM workspaces WHERE/i.test(sql)) {
-                return rows.filter(row =>
+                const matched = rows.filter(row =>
                     nameMatches(sql, row.name, String(params[0]))
                     && (!/isArchived = 0/i.test(sql) || row.isArchived === 0)
                 );
+                // Honour the query's own ordering so the message order under test
+                // is the order SQLite would actually produce.
+                if (/ORDER BY\s+lastAccessed\s+DESC/i.test(sql)) {
+                    return [...matched].sort((a, b) => b.lastAccessed - a.lastAccessed || a.id.localeCompare(b.id));
+                }
+                return matched;
             }
             return [];
         }),
@@ -103,17 +109,69 @@ describe('resolveWorkspaceId name matching (issue #320)', () => {
         expect((await resolveWorkspaceId('retired', createCache())).id).toBeNull();
     });
 
-    it('still reports ambiguity when several workspaces share a name', async () => {
+    /**
+     * Case-folding makes `Dev` and `dev` collide where they previously resolved
+     * separately — the schema permits both, since `UNIQUE(name)` on the
+     * workspaces table has no COLLATE NOCASE. So the ambiguity branch is now
+     * reachable in a way it effectively was not before, and it has to be
+     * actionable: listing bare UUIDs is useless when the candidates differ ONLY
+     * in capitalization, because the caller cannot tell which is which.
+     */
+    describe('ambiguous name reporting', () => {
         const duplicates: Row[] = [
-            { id: 'id-one', name: 'Shared', isArchived: 0, lastAccessed: 2 },
-            { id: 'id-two', name: 'shared', isArchived: 0, lastAccessed: 1 },
+            { id: 'b1000000-0000-0000-0000-000000000002', name: 'Dev', isArchived: 0, lastAccessed: 2 },
+            { id: 'e4000000-0000-0000-0000-000000000005', name: 'dev', isArchived: 0, lastAccessed: 9 },
         ];
-        // Case-folding makes these two collide where they previously did not, so
-        // the ambiguity branch must report both rather than silently pick one.
-        const result = await resolveWorkspaceId('SHARED', createCache(duplicates));
 
-        expect(result.id).toBeNull();
-        expect(result.matchingIds).toEqual(['id-one', 'id-two']);
-        expect(result.warning).toMatch(/Multiple workspaces named "SHARED"/);
+        it('reports every match with BOTH its name and its id', async () => {
+            const result = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(result.id).toBeNull();
+            for (const row of duplicates) {
+                expect(result.warning).toContain(row.name);
+                expect(result.warning).toContain(row.id);
+            }
+        });
+
+        it('pairs each name with its own id, not just lists both separately', async () => {
+            // The whole point is telling the two apart, so name and id must be
+            // adjacent in the text rather than in two unrelated lists.
+            const { warning } = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(warning).toMatch(/"Dev"[^\n]*b1000000-0000-0000-0000-000000000002/);
+            expect(warning).toMatch(/"dev"[^\n]*e4000000-0000-0000-0000-000000000005/);
+        });
+
+        it('tells the caller to retry with the id', async () => {
+            const { warning } = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(warning).toMatch(/workspaceId/i);
+            expect(warning).toMatch(/\bid\b/i);
+        });
+
+        it('exposes the matches structurally, not only in prose', async () => {
+            const result = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(result.matches).toEqual([
+                { id: 'e4000000-0000-0000-0000-000000000005', name: 'dev' },
+                { id: 'b1000000-0000-0000-0000-000000000002', name: 'Dev' },
+            ]);
+        });
+
+        it('keeps matchingIds populated for existing callers', async () => {
+            // AgentInitializationService gates on matchingIds.length > 1 to decide
+            // whether to throw, so this stays a supported field.
+            const result = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(result.matchingIds).toHaveLength(2);
+            expect(result.matchingIds).toEqual(expect.arrayContaining(duplicates.map(d => d.id)));
+        });
+
+        it('orders candidates most-recently-accessed first', async () => {
+            // Deterministic, and the likeliest intended workspace leads.
+            const { matches } = await resolveWorkspaceId('DEV', createCache(duplicates));
+
+            expect(matches?.[0].name).toBe('dev');
+        });
     });
 });


### PR DESCRIPTION
Fixes #319. Fixes #320.

Two more instances of the #317 shape — a gate and the layer behind it disagreeing about the same identifier — plus a cleanup and an error-message improvement.

## #319 — the guard rejects the workspace the product hides on purpose

`WorkspaceService.getWorkspaceByNameOrId` short-circuits to the reserved guides workspace *before any table lookup* (`WorkspaceService.ts:736`), and `listWorkspaces()` never returns it. There's a repo test pinning exactly that asymmetry as intended. The envelope guard validates against the list, so `Assistant guides` / `__system_guides__` were rejected by the gate while the canonical resolver accepts them.

**Fix:** ask the resolver as a last step before rejecting. Accept-path only — the suggestions still come off `listWorkspaces()`, so a hidden workspace is never advertised back in an error message, and a test pins that. Reaching the resolver only on an otherwise-certain rejection also keeps the extra lookup off the common path.

## #320 — a case-only name accepted by the gate, rejected below it

`sync/resolveWorkspaceId` matched `WHERE name = ?` while the other two resolvers compare lowercased — and that one is wired into TaskService. So `desenvolvedor` passed the guard and then hit *"Workspace not found. Call loadWorkspace or createWorkspace first"*, telling the caller to create a workspace that already exists.

**Fix:** `LOWER(name) = LOWER(?)`, aligning to the canonical resolver rather than the reverse. `isArchived = 0` is deliberately untouched — how a name is compared is a separate decision from which rows are eligible, and the archived exclusion is now pinned so changing it has to be conscious.

## Ambiguous names now say which is which

Folding case makes `Dev` and `dev` collide where they previously resolved separately. `UNIQUE(name)` on the workspaces table has no `COLLATE NOCASE`, so it forbids exact duplicates while permitting case-variants — meaning two rows can *only* reach the ambiguity branch by differing in capitalization, and a list of bare UUIDs is useless because the names look identical.

```
Multiple workspaces match the name "dev":
  - "dev" — e4000000-0000-0000-0000-000000000005
  - "Dev" — b1000000-0000-0000-0000-000000000002
They differ only in capitalization, so the name is ambiguous. Retry with
workspaceId set to the id of the one you want (copied exactly from above), not the name.
```

Each name is paired with **its own** id on the same line — a test asserts that adjacency, since two separate lists wouldn't let a caller tell them apart. `ResolveResult` gains `matches: Array<{id, name}>` so callers get this structurally instead of parsing prose; `matchingIds` stays populated because `AgentInitializationService` gates on it to decide whether to throw. The query orders `lastAccessed DESC, id ASC`, so the message is deterministic and leads with the workspace most likely meant.

## Cleanup: `WorkspaceRepository.getByName` removed

Zero call sites, zero tests, no dynamic dispatch — and `WorkspaceService` never touches the repository at all, resolving through `adapter.getWorkspaces` / `indexManager`. It was a fourth name-matching implementation sitting unused beside three live ones, which is exactly how it got mistaken for a latent bug during review of #320.

Retrieval by name and by id is unaffected and stays covered: `WorkspaceServiceSystemGuides` (by id, and by name case-insensitively), `ResolveWorkspaceIdCase` (id preferred over name; exact and case-variant names), and the envelope guard tests. All 49 tests across the five workspace-retrieval suites pass.

This deliberately does **not** touch `ProjectRepository.getByName`, which is live and also case-sensitive — that agrees with its own `UNIQUE(workspaceId, name)` constraint, so folding case there would put the code and the schema in conflict.

## Tests

`EnvelopeWorkspaceValidation` extended to 11 cases, `ResolveWorkspaceIdCase` new at 12. Both RED-verified first: the 3 guides acceptances failed while the do-not-advertise case passed both ways, scoping #319 to the accept path; the 2 case-variant resolver cases failed while exact-name, id-preference, no-match and archived-exclusion passed, scoping #320 to the comparison.

`ResolveWorkspaceIdCase` is a new file — that resolver had no direct coverage. Its mock runs the resolver's real SQL against in-memory rows and honours whichever comparison and ordering the query actually asks for, so `name = ?` stays case-sensitive there exactly as SQLite would treat it. Without that the assertions would be vacuous.

## Verification

`tsc --noEmit` clean, `eslint` clean, suite **4273 passed**. The single failure is the pre-existing `LocalCliInstaller` "namesake command earlier on PATH" case, unrelated and untouched.

## Credit

Both reported and diagnosed by @gcp007-ops, who also built and tested #319 before I got to it. Verified independently against the code rather than applied as given; #319 lands in the shape they proposed, #320 additionally reworks the ambiguity reporting that case-folding makes reachable.

---
_Generated by [Claude Code](https://claude.ai/code/session_016dqXjmfKkH27qMhVAtS6JH)_