### PR TITLE
Harden delta-shadow reconciliation and bundle verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 		"schemas:tools": "node scripts/generate-tool-schemas.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"test": "jest",
+		"test:delta-shadow-contract": "jest --runInBand tests/unit/ShardedJsonlStreamStore.test.ts tests/unit/conflictCopyMatching.test.ts tests/unit/SQLiteSyncStateStore.test.ts tests/integration/reconcilePipelineSilentOverwrite.test.ts tests/unit/SyncCoordinator.test.ts",
+		"verify:installed-delta-shadow-contract": "node scripts/verify-installed-delta-shadow-contract.mjs",
 		"test:coverage": "jest --coverage --coverageThreshold='{\"global\":{\"branches\":80,\"functions\":80,\"lines\":80,\"statements\":80}}'",
 		"smoke:google-live": "node scripts/smoke-google-live.mjs",
 		"lint": "npm run lint:obsidian",

--- a/scripts/verify-installed-delta-shadow-contract.mjs
+++ b/scripts/verify-installed-delta-shadow-contract.mjs
@@ -1,0 +1,84 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCHEMA = 'thinkbox-nexus-delta-shadow-contract/v1';
+const EXPECTED_ID = 'nexus';
+const EXPECTED_VERSION = '5.14.2';
+const SOURCE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function readManifest(directory, label) {
+  const path = join(directory, 'manifest.json');
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(path, 'utf8'));
+  } catch (error) {
+    fail(`${label} manifest unavailable or invalid at ${path}: ${String(error)}`);
+  }
+
+  if (manifest?.id !== EXPECTED_ID || manifest?.version !== EXPECTED_VERSION) {
+    fail(
+      `${label} manifest must identify ${EXPECTED_ID}@${EXPECTED_VERSION}; ` +
+      `received ${String(manifest?.id)}@${String(manifest?.version)}`
+    );
+  }
+  return manifest;
+}
+
+async function hashMain(directory, label) {
+  const path = join(directory, 'main.js');
+  let content;
+  try {
+    content = await readFile(path);
+  } catch (error) {
+    fail(`${label} main.js unavailable at ${path}: ${String(error)}`);
+  }
+  return createHash('sha256').update(content).digest('hex');
+}
+
+async function main() {
+  const installedDirValue = process.env.NEXUS_PLUGIN_DIR;
+  if (!installedDirValue) {
+    fail('NEXUS_PLUGIN_DIR is required');
+  }
+  const installedDir = resolve(installedDirValue);
+
+  const sourceManifest = await readManifest(SOURCE_DIR, 'source');
+  const installedManifest = await readManifest(installedDir, 'installed');
+  if (
+    sourceManifest.id !== installedManifest.id
+    || sourceManifest.version !== installedManifest.version
+  ) {
+    fail(
+      'source and installed manifests differ semantically: ' +
+      `${sourceManifest.id}@${sourceManifest.version} != ` +
+      `${installedManifest.id}@${installedManifest.version}`
+    );
+  }
+
+  const sourceMainSha256 = await hashMain(SOURCE_DIR, 'source');
+  const installedMainSha256 = await hashMain(installedDir, 'installed');
+  const bundleParity = sourceMainSha256 === installedMainSha256;
+  const result = {
+    schema: SCHEMA,
+    version: EXPECTED_VERSION,
+    sourceMainSha256,
+    installedMainSha256,
+    bundleParity
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+  if (!bundleParity) {
+    fail('source and installed main.js SHA-256 differ; deployment is required');
+  }
+}
+
+main().catch(error => {
+  console.error(`[delta-shadow-contract] ${String(error)}`);
+  process.exitCode = 1;
+});

--- a/scripts/verify-installed-delta-shadow-contract.mjs
+++ b/scripts/verify-installed-delta-shadow-contract.mjs
@@ -5,7 +5,6 @@ import { fileURLToPath } from 'node:url';
 
 const SCHEMA = 'thinkbox-nexus-delta-shadow-contract/v1';
 const EXPECTED_ID = 'nexus';
-const EXPECTED_VERSION = '5.14.2';
 const SOURCE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
 function fail(message) {
@@ -21,9 +20,16 @@ async function readManifest(directory, label) {
     fail(`${label} manifest unavailable or invalid at ${path}: ${String(error)}`);
   }
 
-  if (manifest?.id !== EXPECTED_ID || manifest?.version !== EXPECTED_VERSION) {
+  if (
+    manifest === null
+    || typeof manifest !== 'object'
+    || typeof manifest.id !== 'string'
+    || manifest.id.length === 0
+    || typeof manifest.version !== 'string'
+    || manifest.version.length === 0
+  ) {
     fail(
-      `${label} manifest must identify ${EXPECTED_ID}@${EXPECTED_VERSION}; ` +
+      `${label} manifest must contain non-empty string id and version; ` +
       `received ${String(manifest?.id)}@${String(manifest?.version)}`
     );
   }
@@ -49,6 +55,13 @@ async function main() {
   const installedDir = resolve(installedDirValue);
 
   const sourceManifest = await readManifest(SOURCE_DIR, 'source');
+  if (sourceManifest.id !== EXPECTED_ID) {
+    fail(
+      `source manifest must identify ${EXPECTED_ID}; ` +
+      `received ${sourceManifest.id}@${sourceManifest.version}`
+    );
+  }
+
   const installedManifest = await readManifest(installedDir, 'installed');
   if (
     sourceManifest.id !== installedManifest.id
@@ -66,7 +79,7 @@ async function main() {
   const bundleParity = sourceMainSha256 === installedMainSha256;
   const result = {
     schema: SCHEMA,
-    version: EXPECTED_VERSION,
+    version: sourceManifest.version,
     sourceMainSha256,
     installedMainSha256,
     bundleParity

--- a/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
+++ b/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
@@ -40,6 +40,7 @@ export interface ShardDescriptor {
   relativePath: string;
   size: number;
   modTime: number | null;
+  conflictMarker: string | null;
 }
 
 export interface AppendEventResult<TEvent> {
@@ -48,6 +49,17 @@ export interface AppendEventResult<TEvent> {
   recordBytes: number;
   rotated: boolean;
   shard: ShardDescriptor;
+}
+
+export function latestCanonicalShard(
+  shards: readonly ShardDescriptor[]
+): ShardDescriptor | null {
+  for (let index = shards.length - 1; index >= 0; index -= 1) {
+    if (shards[index].conflictMarker === null) {
+      return shards[index];
+    }
+  }
+  return null;
 }
 
 export function formatShardFileName(index: number, width = DEFAULT_SHARD_FILE_WIDTH): string {
@@ -62,8 +74,9 @@ export function formatShardFileName(index: number, width = DEFAULT_SHARD_FILE_WI
  * siblings (e.g. `shard-000001 (1).jsonl`, `shard-000001 [Conflict].jsonl`),
  * `conflictMarker` carries the suffix string for telemetry.
  *
- * Callers index by `baseIndex`; `conflictMarker` is consumed only at the
- * telemetry warn site in `ShardedJsonlStreamStore.listShards`.
+ * Callers index by `baseIndex`; `conflictMarker` is retained on shard
+ * descriptors so readers can include conflict siblings while writers select
+ * canonical shards only.
  */
 export function parseShardFileNameWithConflict(
   fileName: string
@@ -177,7 +190,8 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
         index: parsed.baseIndex,
         relativePath: this.buildRelativePath(relativeStreamPath, fileName),
         size: stat.size,
-        modTime: stat.mtime ?? null
+        modTime: stat.mtime ?? null,
+        conflictMarker: parsed.conflictMarker
       });
     }
 
@@ -202,7 +216,7 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
     return this.locks.acquire(streamPath, async () => {
       const appended: TEvent[] = [];
       let shards = await this.listShards(relativeStreamPath);
-      let currentShard = shards.length > 0 ? shards[shards.length - 1] : null;
+      let currentShard = latestCanonicalShard(shards);
 
       for (const event of events) {
         const result = await this.appendEventToLockedStream(relativeStreamPath, event, currentShard);
@@ -303,7 +317,7 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
     currentShardOverride: ShardDescriptor | null = null
   ): Promise<AppendEventResult<TEvent>> {
     const shards = currentShardOverride ? [currentShardOverride] : await this.listShards(relativeStreamPath);
-    const currentShard = shards.length > 0 ? shards[shards.length - 1] : null;
+    const currentShard = latestCanonicalShard(shards);
     const serializedEvent = JSON.stringify(event);
     const serializedRecord = `${serializedEvent}\n`;
     const recordBytes = this.getUtf8ByteLength(serializedRecord);
@@ -342,7 +356,8 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
         index: targetIndex,
         relativePath: this.buildRelativePath(relativeStreamPath, fileName),
         size: stat?.size ?? recordBytes,
-        modTime: stat?.mtime ?? null
+        modTime: stat?.mtime ?? null,
+        conflictMarker: null
       }
     };
   }

--- a/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
+++ b/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
@@ -66,6 +66,20 @@ export function formatShardFileName(index: number, width = DEFAULT_SHARD_FILE_WI
   return `shard-${String(index).padStart(width, '0')}.jsonl`;
 }
 
+function compareFileNameBytes(left: string, right: string): number {
+  const leftBytes = TEXT_ENCODER.encode(left);
+  const rightBytes = TEXT_ENCODER.encode(right);
+  const sharedLength = Math.min(leftBytes.length, rightBytes.length);
+
+  for (let index = 0; index < sharedLength; index += 1) {
+    if (leftBytes[index] !== rightBytes[index]) {
+      return leftBytes[index] - rightBytes[index];
+    }
+  }
+
+  return leftBytes.length - rightBytes.length;
+}
+
 /**
  * Parse a shard filename into its base index and optional conflict marker.
  *
@@ -195,7 +209,9 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
       });
     }
 
-    return descriptors.sort((left, right) => left.index - right.index);
+    return descriptors.sort((left, right) => (
+      left.index - right.index || compareFileNameBytes(left.fileName, right.fileName)
+    ));
   }
 
   async appendEvent(relativeStreamPath: string, event: TEvent): Promise<AppendEventResult<TEvent>> {

--- a/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
+++ b/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
@@ -232,17 +232,13 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
     return this.locks.acquire(streamPath, async () => {
       const appended: TEvent[] = [];
       let shards = await this.listShards(relativeStreamPath);
-      let currentShard = latestCanonicalShard(shards);
 
       for (const event of events) {
-        const result = await this.appendEventToLockedStream(relativeStreamPath, event, currentShard);
+        const result = await this.appendEventToLockedStream(relativeStreamPath, event, shards);
         appended.push(result.event);
-        currentShard = result.shard;
-        if (result.createdShard) {
-          shards = [...shards, result.shard];
-        } else {
-          shards = shards.map((shard) => shard.index === result.shard.index ? result.shard : shard);
-        }
+        shards = result.createdShard
+          ? [...shards, result.shard]
+          : shards.map((shard) => shard.fullPath === result.shard.fullPath ? result.shard : shard);
       }
 
       return appended;
@@ -330,10 +326,14 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
   private async appendEventToLockedStream(
     relativeStreamPath: string,
     event: TEvent,
-    currentShardOverride: ShardDescriptor | null = null
+    shardSnapshot?: readonly ShardDescriptor[]
   ): Promise<AppendEventResult<TEvent>> {
-    const shards = currentShardOverride ? [currentShardOverride] : await this.listShards(relativeStreamPath);
+    const shards = shardSnapshot ?? await this.listShards(relativeStreamPath);
     const currentShard = latestCanonicalShard(shards);
+    const maxObservedIndex = shards.reduce(
+      (highestIndex, shard) => Math.max(highestIndex, shard.index),
+      0
+    );
     const serializedEvent = JSON.stringify(event);
     const serializedRecord = `${serializedEvent}\n`;
     const recordBytes = this.getUtf8ByteLength(serializedRecord);
@@ -343,11 +343,12 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
       currentShard.size > 0 &&
       currentShard.size + recordBytes > this.maxShardBytes;
 
+    const canonicalIsAtObservedMaximum = currentShard?.index === maxObservedIndex;
     const targetIndex = currentShard === null
-      ? 1
-      : shouldRotate
-        ? currentShard.index + 1
-        : currentShard.index;
+      ? maxObservedIndex + 1
+      : canonicalIsAtObservedMaximum && !shouldRotate
+        ? currentShard.index
+        : maxObservedIndex + 1;
 
     const targetPath = this.getShardPath(relativeStreamPath, targetIndex);
     const existedBeforeWrite = await this.app.vault.adapter.exists(targetPath);

--- a/src/database/sync/ReconcilePipeline.ts
+++ b/src/database/sync/ReconcilePipeline.ts
@@ -51,10 +51,10 @@ import type {
   ConversationEvent,
   TaskEvent
 } from '../interfaces/StorageEvents';
-import type { ISQLiteCacheManager } from './SyncCoordinator';
 import type { WorkspaceEventApplier } from './WorkspaceEventApplier';
 import type { ConversationEventApplier } from './ConversationEventApplier';
 import type { TaskEventApplier } from './TaskEventApplier';
+import { AsyncLock } from '../../utils/AsyncLock';
 
 export interface ReconcileResult {
   success: boolean;
@@ -78,12 +78,18 @@ export interface ReconcileResult {
 export interface ReconcilePipelineOptions {
   vaultEventStore: VaultEventStore;
   syncStateStore: SQLiteSyncStateStore;
-  sqliteCache: ISQLiteCacheManager;
+  sqliteCache: TransactionalEventCache;
   workspaceApplier: WorkspaceEventApplier;
   conversationApplier: ConversationEventApplier;
   taskApplier: TaskEventApplier;
   /** Owning device id. Used as the cursor partition key. */
   deviceId: string;
+}
+
+export interface TransactionalEventCache {
+  isEventApplied(eventId: string): Promise<boolean>;
+  markEventApplied(eventId: string): Promise<void>;
+  transaction<T>(fn: () => Promise<T>): Promise<T>;
 }
 
 /** Minimum event shape consumed by the pipeline. All storage events satisfy this. */
@@ -104,15 +110,19 @@ export interface ParsedShardPath {
 }
 
 export class ReconcilePipeline {
+  private readonly eventTransactionLock = new AsyncLock();
   private readonly vaultEventStore: VaultEventStore;
   private readonly syncStateStore: SQLiteSyncStateStore;
-  private readonly sqliteCache: ISQLiteCacheManager;
+  private readonly sqliteCache: TransactionalEventCache;
   private readonly workspaceApplier: WorkspaceEventApplier;
   private readonly conversationApplier: ConversationEventApplier;
   private readonly taskApplier: TaskEventApplier;
   private readonly deviceId: string;
 
   constructor(options: ReconcilePipelineOptions) {
+    if (typeof options.sqliteCache.transaction !== 'function') {
+      throw new Error('ReconcilePipeline requires transactional SQLite cache capability');
+    }
     this.vaultEventStore = options.vaultEventStore;
     this.syncStateStore = options.syncStateStore;
     this.sqliteCache = options.sqliteCache;
@@ -265,15 +275,25 @@ export class ReconcilePipeline {
 
     for (const event of sorted) {
       try {
-        if (await this.sqliteCache.isEventApplied(event.id)) {
+        const outcome = await this.eventTransactionLock.acquire(() => (
+          this.sqliteCache.transaction(async () => {
+            if (await this.sqliteCache.isEventApplied(event.id)) {
+              return 'skipped' as const;
+            }
+            await this.applyEvent(parsed.category, event);
+            await this.sqliteCache.markEventApplied(event.id);
+            return 'applied' as const;
+          })
+        ));
+
+        if (outcome === 'skipped') {
           totals.eventsSkipped += 1;
           continue;
         }
-        await this.applyEvent(parsed.category, event);
-        await this.sqliteCache.markEventApplied(event.id);
         totals.eventsApplied += 1;
       } catch (error) {
         totals.errors.push(`apply ${parsed.category}/${event.id}: ${String(error)}`);
+        break;
       }
     }
 
@@ -474,15 +494,38 @@ async function readEventsFromShardFile(
   }
 
   const events: AnyStorageEvent[] = [];
-  for (const line of content.split(/\r?\n/)) {
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
     const trimmed = line.trim();
     if (!trimmed) continue;
+
+    let value: unknown;
     try {
-      events.push(JSON.parse(trimmed) as AnyStorageEvent);
+      value = JSON.parse(trimmed) as unknown;
     } catch {
-      // Match the existing ShardedJsonlStreamStore behavior — skip malformed.
-      console.warn(`[ReconcilePipeline] Skipping malformed line in ${shardFullPath}`);
+      throw new Error(`Malformed JSONL at ${shardFullPath}:${index + 1}`);
     }
+
+    if (
+      typeof value !== 'object'
+      || value === null
+      || Array.isArray(value)
+    ) {
+      throw new Error(`Invalid storage event at ${shardFullPath}:${index + 1}`);
+    }
+
+    const candidate = value as Record<string, unknown>;
+    if (
+      typeof candidate.id !== 'string'
+      || candidate.id.trim().length === 0
+      || typeof candidate.timestamp !== 'number'
+      || !Number.isFinite(candidate.timestamp)
+    ) {
+      throw new Error(`Invalid storage event at ${shardFullPath}:${index + 1}`);
+    }
+
+    events.push(value as AnyStorageEvent);
   }
   return events;
 }

--- a/src/database/sync/ReconcilePipeline.ts
+++ b/src/database/sync/ReconcilePipeline.ts
@@ -71,6 +71,8 @@ export interface ReconcileResult {
   errors: string[];
   /** Wall-clock duration in milliseconds. */
   duration: number;
+  /** Full vault-relative paths opened and nominally examined. */
+  filesProcessed: string[];
 }
 
 export interface ReconcilePipelineOptions {
@@ -234,6 +236,7 @@ export class ReconcilePipeline {
     // reads are a future optimization — applied_events PK already keeps the
     // apply path O(1) per duplicate event.
     const events = await this.readShardEvents(handle, parsed.shardFileName);
+    totals.filesProcessed.push(shardFullPath);
 
     // Layer 1 — cursor fast-path: if the last applied event matches the
     // shard's tail event, this shard has no new events for us.
@@ -321,7 +324,7 @@ export class ReconcilePipeline {
     const shards = await handle.shardStore.listShards(handle.relativeStreamPath);
     const target = shards.find((s) => s.fileName === shardFileName);
     if (!target) {
-      return [];
+      throw new Error(`Shard not found: ${handle.absoluteStreamPath}/${shardFileName}`);
     }
     return readEventsFromShardFile(handle, target.fullPath);
   }
@@ -375,7 +378,8 @@ export class ReconcilePipeline {
       shardsFastPathed: 0,
       silentOverwriteRescans: 0,
       errors: [],
-      duration: 0
+      duration: 0,
+      filesProcessed: []
     };
   }
 
@@ -386,6 +390,11 @@ export class ReconcilePipeline {
     into.shardsFastPathed += from.shardsFastPathed;
     into.silentOverwriteRescans += from.silentOverwriteRescans;
     into.errors.push(...from.errors);
+    for (const path of from.filesProcessed) {
+      if (!into.filesProcessed.includes(path)) {
+        into.filesProcessed.push(path);
+      }
+    }
   }
 
   private finalize(result: ReconcileResult, start: number): ReconcileResult {

--- a/src/database/sync/ReconcilePipeline.ts
+++ b/src/database/sync/ReconcilePipeline.ts
@@ -150,8 +150,12 @@ export class ReconcilePipeline {
         try {
           const result = await this.reconcileStreamInternal(category, streamId);
           this.accumulate(totals, result);
+          if (!result.success) {
+            return this.finalize(totals, start);
+          }
         } catch (error) {
           totals.errors.push(`Failed to reconcile ${category}/${streamId}: ${String(error)}`);
+          return this.finalize(totals, start);
         }
       }
     }
@@ -228,6 +232,9 @@ export class ReconcilePipeline {
         shardFileName: shard.fileName
       });
       this.accumulate(totals, result);
+      if (!result.success) {
+        break;
+      }
     }
 
     return this.finalize(totals, start);

--- a/src/database/sync/ReconcilePipeline.ts
+++ b/src/database/sync/ReconcilePipeline.ts
@@ -277,9 +277,14 @@ export class ReconcilePipeline {
       }
     }
 
-    // Cursor advances to the tail of the sorted run regardless of whether new
-    // events were applied. A re-run after a partial failure still fast-paths
-    // correctly because the tail event lives in `applied_events` (Layer 2).
+    // Cursor advances only after every event was either applied and marked or
+    // skipped as already applied. Leaving it unchanged on partial failure
+    // forces a later reconcile through Layer 2 instead of incorrectly taking
+    // the cursor fast-path past the failed event.
+    if (totals.errors.length > 0) {
+      return this.finalize(totals, start);
+    }
+
     const tail = sorted.length > 0 ? sorted[sorted.length - 1] : null;
     const nextCursor: ShardCursor = {
       deviceId: this.deviceId,
@@ -461,7 +466,7 @@ async function readEventsFromShardFile(
   }).app.vault.adapter;
 
   if (!(await adapter.exists(shardFullPath))) {
-    return [];
+    throw new Error(`Shard disappeared before read: ${shardFullPath}`);
   }
   const content = await adapter.read(shardFullPath);
   if (!content.trim()) {

--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -203,16 +203,32 @@ export class SyncCoordinator {
       // recovery still goes through `fullRebuild` above.
       if (this.reconcilePipeline) {
         const reconcile = await this.reconcilePipeline.reconcileAll();
+        eventsApplied = reconcile.eventsApplied;
+        eventsSkipped = reconcile.eventsSkipped;
+        errors.push(...reconcile.errors);
+        filesProcessed.push(...reconcile.filesProcessed);
+
+        if (!reconcile.success) {
+          return this.createResult(
+            false,
+            eventsApplied,
+            eventsSkipped,
+            errors,
+            startTime,
+            filesProcessed
+          );
+        }
+
         await this.sqliteCache.updateSyncState(this.deviceId, Date.now(), {});
         await this.sqliteCache.save();
         options.onProgress?.('Complete', 1, 1);
         return this.createResult(
-          reconcile.success,
-          reconcile.eventsApplied,
-          reconcile.eventsSkipped,
-          reconcile.errors,
+          true,
+          eventsApplied,
+          eventsSkipped,
+          errors,
           startTime,
-          reconcile.filesProcessed
+          filesProcessed
         );
       }
 

--- a/src/database/sync/SyncCoordinator.ts
+++ b/src/database/sync/SyncCoordinator.ts
@@ -212,7 +212,7 @@ export class SyncCoordinator {
           reconcile.eventsSkipped,
           reconcile.errors,
           startTime,
-          []
+          reconcile.filesProcessed
         );
       }
 

--- a/tests/integration/reconcilePipelineSilentOverwrite.test.ts
+++ b/tests/integration/reconcilePipelineSilentOverwrite.test.ts
@@ -127,6 +127,7 @@ interface FakeStreamHandle {
 class FakeVaultEventStore {
   /** Map<category/streamId, Map<fileName, jsonlContent>>. */
   private readonly shards = new Map<string, Map<string, string>>();
+  private readonly disappearAfterList = new Set<string>();
 
   getRootPath(): string {
     return ROOT_PATH;
@@ -154,6 +155,10 @@ class FakeVaultEventStore {
     events: { id: string; timestamp: number; deviceId?: string }[]
   ): void {
     this.setShardContent(category, streamId, fileName, events);
+  }
+
+  removeShardAfterNextList(category: string, streamId: string, fileName: string): void {
+    this.disappearAfterList.add(`${category}/${streamId}/${fileName}`);
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -221,6 +226,12 @@ class FakeVaultEventStore {
             modTime: 0
           });
         }
+        for (const descriptor of descriptors) {
+          const disappearanceKey = `${key}/${descriptor.fileName}`;
+          if (this.disappearAfterList.delete(disappearanceKey)) {
+            files.delete(descriptor.fileName);
+          }
+        }
         return descriptors.sort((a, b) => a.index - b.index);
       },
       app: { vault: { adapter } }
@@ -237,7 +248,13 @@ class FakeVaultEventStore {
 }
 
 class FakeSqliteCache {
+  private readonly failMarkOnceFor = new Set<string>();
+
   constructor(private readonly applied: FakeAppliedEventsStore) {}
+
+  failNextMark(eventId: string): void {
+    this.failMarkOnceFor.add(eventId);
+  }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async isEventApplied(eventId: string): Promise<boolean> {
@@ -246,6 +263,9 @@ class FakeSqliteCache {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async markEventApplied(eventId: string): Promise<void> {
+    if (this.failMarkOnceFor.delete(eventId)) {
+      throw new Error(`Fake sqlite cache: mark failed for ${eventId}`);
+    }
     this.applied.mark({ id: eventId, category: '<unknown>', timestamp: 0 });
   }
 }
@@ -255,6 +275,7 @@ interface PipelineHarness {
   store: FakeVaultEventStore;
   cursors: FakeSyncStateStore;
   applied: FakeAppliedEventsStore;
+  sqliteCache: FakeSqliteCache;
   appliers: { workspace: FakeApplier; conversation: FakeApplier; task: FakeApplier };
 }
 
@@ -280,7 +301,7 @@ function makeHarness(deviceId = 'desktop-A'): PipelineHarness {
     deviceId
   });
 
-  return { pipeline, store, cursors, applied, appliers };
+  return { pipeline, store, cursors, applied, sqliteCache, appliers };
 }
 
 const SHARD = 'shard-000001.jsonl';
@@ -614,6 +635,88 @@ describe('ReconcilePipeline nominal shard coverage receipt', () => {
 
     expect(result.success).toBe(false);
     expect(result.filesProcessed).toEqual([]);
+  });
+
+  it('fails closed when a listed shard disappears before adapter read', async () => {
+    const { pipeline, store, cursors } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, DELTA_SHARD, [
+      { id: 'delta-vanished', timestamp: 1, deviceId: 'B' }
+    ]);
+    store.removeShardAfterNextList('conversations', STREAM, DELTA_SHARD);
+
+    const result = await pipeline.reconcileShard(DELTA_SHARD_VAULT_PATH);
+
+    expect(result.success).toBe(false);
+    expect(result.filesProcessed).toEqual([]);
+    expect(cursors.upsertCalls).toBe(0);
+  });
+});
+
+describe('ReconcilePipeline incomplete shard application', () => {
+  it('retries a failed apply without advancing the cursor or duplicating applied event ids', async () => {
+    const { pipeline, store, cursors, applied, appliers } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, SHARD, [
+      { id: 'e1', timestamp: 1, deviceId: 'A' },
+      { id: 'e2', timestamp: 2, deviceId: 'A' },
+      { id: 'e3', timestamp: 3, deviceId: 'A' }
+    ]);
+    const originalApply = appliers.conversation.apply.bind(appliers.conversation);
+    let failE2Once = true;
+    jest.spyOn(appliers.conversation, 'apply').mockImplementation(async (event) => {
+      if (event.id === 'e2' && failE2Once) {
+        failE2Once = false;
+        throw new Error('Fake applier: apply failed for e2');
+      }
+      await originalApply(event);
+    });
+
+    const failed = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+
+    expect(failed.success).toBe(false);
+    expect(failed.filesProcessed).toEqual([SHARD_VAULT_PATH]);
+    expect(await cursors.getCursor('desktop-A', SHARD_VAULT_PATH)).toBeNull();
+    expect(cursors.upsertCalls).toBe(0);
+    expect(applied.has('e1')).toBe(true);
+    expect(applied.has('e2')).toBe(false);
+    expect(applied.has('e3')).toBe(true);
+
+    const retried = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+
+    expect(retried.success).toBe(true);
+    expect(retried.eventsApplied).toBe(1);
+    expect(retried.eventsSkipped).toBe(2);
+    expect((await cursors.getCursor('desktop-A', SHARD_VAULT_PATH))?.lastEventId).toBe('e3');
+    expect(cursors.upsertCalls).toBe(1);
+    const appliedIds = appliers.conversation.applied.map((event) => event.id);
+    expect(appliedIds.filter((id) => id === 'e1')).toHaveLength(1);
+    expect(appliedIds.filter((id) => id === 'e2')).toHaveLength(1);
+    expect(appliedIds.filter((id) => id === 'e3')).toHaveLength(1);
+
+    const fastPathed = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+    expect(fastPathed.shardsFastPathed).toBe(1);
+  });
+
+  it('does not advance the cursor when applied_events marking fails', async () => {
+    const { pipeline, store, cursors, sqliteCache } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, SHARD, [
+      { id: 'e1', timestamp: 1, deviceId: 'A' },
+      { id: 'e2', timestamp: 2, deviceId: 'A' }
+    ]);
+    sqliteCache.failNextMark('e2');
+
+    const failed = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+
+    expect(failed.success).toBe(false);
+    expect(failed.filesProcessed).toEqual([SHARD_VAULT_PATH]);
+    expect(await cursors.getCursor('desktop-A', SHARD_VAULT_PATH)).toBeNull();
+    expect(cursors.upsertCalls).toBe(0);
+
+    const retried = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+    expect(retried.success).toBe(true);
+    expect((await cursors.getCursor('desktop-A', SHARD_VAULT_PATH))?.lastEventId).toBe('e2');
+
+    const fastPathed = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+    expect(fastPathed.shardsFastPathed).toBe(1);
   });
 });
 

--- a/tests/integration/reconcilePipelineSilentOverwrite.test.ts
+++ b/tests/integration/reconcilePipelineSilentOverwrite.test.ts
@@ -63,6 +63,17 @@ class FakeAppliedEventsStore {
   getAll(): AppliedEvent[] {
     return Array.from(this.applied.values());
   }
+
+  snapshot(): Map<string, AppliedEvent> {
+    return new Map(this.applied);
+  }
+
+  restore(snapshot: ReadonlyMap<string, AppliedEvent>): void {
+    this.applied.clear();
+    for (const [id, event] of snapshot) {
+      this.applied.set(id, event);
+    }
+  }
 }
 
 class FakeSyncStateStore {
@@ -96,6 +107,14 @@ class FakeApplier {
   // eslint-disable-next-line @typescript-eslint/require-await
   async apply(event: { id: string }): Promise<void> {
     this.applied.push({ id: event.id, payload: event });
+  }
+
+  snapshot(): { id: string; payload: unknown }[] {
+    return [...this.applied];
+  }
+
+  restore(snapshot: readonly { id: string; payload: unknown }[]): void {
+    this.applied.splice(0, this.applied.length, ...snapshot);
   }
 }
 
@@ -145,6 +164,19 @@ class FakeVaultEventStore {
     }
     const lines = events.map((e) => JSON.stringify(e)).join('\n');
     this.shards.get(key)!.set(fileName, lines);
+  }
+
+  setShardRawContent(
+    category: string,
+    streamId: string,
+    fileName: string,
+    content: string
+  ): void {
+    const key = `${category}/${streamId}`;
+    if (!this.shards.has(key)) {
+      this.shards.set(key, new Map());
+    }
+    this.shards.get(key)!.set(fileName, content);
   }
 
   /** Simulates GDrive last-writer-wins overwrite of an existing shard file. */
@@ -249,8 +281,12 @@ class FakeVaultEventStore {
 
 class FakeSqliteCache {
   private readonly failMarkOnceFor = new Set<string>();
+  transactionCalls = 0;
 
-  constructor(private readonly applied: FakeAppliedEventsStore) {}
+  constructor(
+    private readonly applied: FakeAppliedEventsStore,
+    private readonly transactionParticipants: readonly FakeApplier[]
+  ) {}
 
   failNextMark(eventId: string): void {
     this.failMarkOnceFor.add(eventId);
@@ -268,6 +304,24 @@ class FakeSqliteCache {
     }
     this.applied.mark({ id: eventId, category: '<unknown>', timestamp: 0 });
   }
+
+  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+    this.transactionCalls += 1;
+    const appliedSnapshot = this.applied.snapshot();
+    const participantSnapshots = this.transactionParticipants.map(participant => (
+      participant.snapshot()
+    ));
+
+    try {
+      return await fn();
+    } catch (error) {
+      this.applied.restore(appliedSnapshot);
+      this.transactionParticipants.forEach((participant, index) => {
+        participant.restore(participantSnapshots[index]);
+      });
+      throw error;
+    }
+  }
 }
 
 interface PipelineHarness {
@@ -283,12 +337,12 @@ function makeHarness(deviceId = 'desktop-A'): PipelineHarness {
   const store = new FakeVaultEventStore();
   const cursors = new FakeSyncStateStore();
   const applied = new FakeAppliedEventsStore();
-  const sqliteCache = new FakeSqliteCache(applied);
   const appliers = {
     workspace: new FakeApplier(),
     conversation: new FakeApplier(),
     task: new FakeApplier()
   };
+  const sqliteCache = new FakeSqliteCache(applied, Object.values(appliers));
 
   const pipeline = new ReconcilePipeline({
     // The pipeline only uses the slice we satisfy here.
@@ -310,6 +364,45 @@ const SHARD_VAULT_PATH = `${ROOT_PATH}/conversations/${STREAM}/${SHARD}`;
 const DELTA_SHARD =
   'shard-000003 (Syncthing Delta sha256-' + 'b'.repeat(64) + ').jsonl';
 const DELTA_SHARD_VAULT_PATH = `${ROOT_PATH}/conversations/${STREAM}/${DELTA_SHARD}`;
+
+describe('ReconcilePipeline transaction boundary', () => {
+  it('rejects a cache without transactional capability at construction', () => {
+    const store = new FakeVaultEventStore();
+    const cursors = new FakeSyncStateStore();
+    const applier = new FakeApplier();
+
+    expect(() => new ReconcilePipeline({
+      vaultEventStore: store as unknown as ConstructorParameters<typeof ReconcilePipeline>[0]['vaultEventStore'],
+      syncStateStore: cursors as unknown as ConstructorParameters<typeof ReconcilePipeline>[0]['syncStateStore'],
+      sqliteCache: {
+        isEventApplied: async () => false,
+        markEventApplied: async () => undefined
+      } as never,
+      workspaceApplier: applier as unknown as ConstructorParameters<typeof ReconcilePipeline>[0]['workspaceApplier'],
+      conversationApplier: applier as unknown as ConstructorParameters<typeof ReconcilePipeline>[0]['conversationApplier'],
+      taskApplier: applier as unknown as ConstructorParameters<typeof ReconcilePipeline>[0]['taskApplier'],
+      deviceId: 'desktop-A'
+    })).toThrow('transaction');
+  });
+
+  it('serializes concurrent duplicate checks with apply and mark in the same transaction', async () => {
+    const { pipeline, store, applied, sqliteCache, appliers } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, SHARD, [
+      { id: 'e1', timestamp: 1, deviceId: 'A' }
+    ]);
+
+    const results = await Promise.all([
+      pipeline.reconcileShard(SHARD_VAULT_PATH),
+      pipeline.reconcileShard(SHARD_VAULT_PATH)
+    ]);
+
+    expect(results.reduce((total, result) => total + result.eventsApplied, 0)).toBe(1);
+    expect(results.reduce((total, result) => total + result.eventsSkipped, 0)).toBe(1);
+    expect(sqliteCache.transactionCalls).toBe(2);
+    expect(applied.has('e1')).toBe(true);
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual(['e1']);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // P1.7.a — Silent-overwrite GREEN-BAR (architect §6)
@@ -650,10 +743,37 @@ describe('ReconcilePipeline nominal shard coverage receipt', () => {
     expect(result.filesProcessed).toEqual([]);
     expect(cursors.upsertCalls).toBe(0);
   });
+
+  it.each([
+    ['malformed JSON', '{"id":'],
+    ['null event', 'null'],
+    ['array event', '[]'],
+    ['numeric id', '{"id":42,"timestamp":2}'],
+    ['blank id', '{"id":"   ","timestamp":2}'],
+    ['non-numeric timestamp', '{"id":"e2","timestamp":"2"}'],
+    ['non-finite timestamp', '{"id":"e2","timestamp":1e309}']
+  ])('fails closed on a non-empty %s line', async (_label, invalidLine) => {
+    const { pipeline, store, cursors, applied, appliers } = makeHarness('desktop-A');
+    store.setShardRawContent(
+      'conversations',
+      STREAM,
+      SHARD,
+      `${JSON.stringify({ id: 'e1', timestamp: 1, deviceId: 'A' })}\n${invalidLine}\n`
+    );
+
+    const result = await pipeline.reconcileShard(SHARD_VAULT_PATH);
+
+    expect(result.success).toBe(false);
+    expect(result.filesProcessed).toEqual([]);
+    expect(await cursors.getCursor('desktop-A', SHARD_VAULT_PATH)).toBeNull();
+    expect(cursors.upsertCalls).toBe(0);
+    expect(applied.count()).toBe(0);
+    expect(appliers.conversation.applied).toEqual([]);
+  });
 });
 
 describe('ReconcilePipeline incomplete shard application', () => {
-  it('retries a failed apply without advancing the cursor or duplicating applied event ids', async () => {
+  it('stops at the first failed apply and retries the committed prefix in event order', async () => {
     const { pipeline, store, cursors, applied, appliers } = makeHarness('desktop-A');
     store.setShardContent('conversations', STREAM, SHARD, [
       { id: 'e1', timestamp: 1, deviceId: 'A' },
@@ -678,13 +798,14 @@ describe('ReconcilePipeline incomplete shard application', () => {
     expect(cursors.upsertCalls).toBe(0);
     expect(applied.has('e1')).toBe(true);
     expect(applied.has('e2')).toBe(false);
-    expect(applied.has('e3')).toBe(true);
+    expect(applied.has('e3')).toBe(false);
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual(['e1']);
 
     const retried = await pipeline.reconcileShard(SHARD_VAULT_PATH);
 
     expect(retried.success).toBe(true);
-    expect(retried.eventsApplied).toBe(1);
-    expect(retried.eventsSkipped).toBe(2);
+    expect(retried.eventsApplied).toBe(2);
+    expect(retried.eventsSkipped).toBe(1);
     expect((await cursors.getCursor('desktop-A', SHARD_VAULT_PATH))?.lastEventId).toBe('e3');
     expect(cursors.upsertCalls).toBe(1);
     const appliedIds = appliers.conversation.applied.map((event) => event.id);
@@ -696,11 +817,12 @@ describe('ReconcilePipeline incomplete shard application', () => {
     expect(fastPathed.shardsFastPathed).toBe(1);
   });
 
-  it('does not advance the cursor when applied_events marking fails', async () => {
-    const { pipeline, store, cursors, sqliteCache } = makeHarness('desktop-A');
+  it('rolls back event effects and marker when applied_events marking fails', async () => {
+    const { pipeline, store, cursors, applied, sqliteCache, appliers } = makeHarness('desktop-A');
     store.setShardContent('conversations', STREAM, SHARD, [
       { id: 'e1', timestamp: 1, deviceId: 'A' },
-      { id: 'e2', timestamp: 2, deviceId: 'A' }
+      { id: 'e2', timestamp: 2, deviceId: 'A' },
+      { id: 'e3', timestamp: 3, deviceId: 'A' }
     ]);
     sqliteCache.failNextMark('e2');
 
@@ -710,10 +832,17 @@ describe('ReconcilePipeline incomplete shard application', () => {
     expect(failed.filesProcessed).toEqual([SHARD_VAULT_PATH]);
     expect(await cursors.getCursor('desktop-A', SHARD_VAULT_PATH)).toBeNull();
     expect(cursors.upsertCalls).toBe(0);
+    expect(applied.has('e1')).toBe(true);
+    expect(applied.has('e2')).toBe(false);
+    expect(applied.has('e3')).toBe(false);
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual(['e1']);
 
     const retried = await pipeline.reconcileShard(SHARD_VAULT_PATH);
     expect(retried.success).toBe(true);
-    expect((await cursors.getCursor('desktop-A', SHARD_VAULT_PATH))?.lastEventId).toBe('e2');
+    expect(retried.eventsApplied).toBe(2);
+    expect(retried.eventsSkipped).toBe(1);
+    expect((await cursors.getCursor('desktop-A', SHARD_VAULT_PATH))?.lastEventId).toBe('e3');
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual(['e1', 'e2', 'e3']);
 
     const fastPathed = await pipeline.reconcileShard(SHARD_VAULT_PATH);
     expect(fastPathed.shardsFastPathed).toBe(1);

--- a/tests/integration/reconcilePipelineSilentOverwrite.test.ts
+++ b/tests/integration/reconcilePipelineSilentOverwrite.test.ts
@@ -773,6 +773,55 @@ describe('ReconcilePipeline nominal shard coverage receipt', () => {
 });
 
 describe('ReconcilePipeline incomplete shard application', () => {
+  it('stops the full sweep before later shards and streams after the first failure', async () => {
+    const { pipeline, store, cursors, applied, appliers } = makeHarness('desktop-A');
+    const laterStream = 'conv_zeta';
+    const laterStreamShardPath = `${ROOT_PATH}/conversations/${laterStream}/${SHARD}`;
+    store.setShardContent('conversations', STREAM, SHARD, [
+      { id: 'e1', timestamp: 1, deviceId: 'A' },
+      { id: 'e2', timestamp: 2, deviceId: 'A' }
+    ]);
+    store.setShardContent('conversations', STREAM, DELTA_SHARD, [
+      { id: 'e3', timestamp: 3, deviceId: 'A' }
+    ]);
+    store.setShardContent('conversations', laterStream, SHARD, [
+      { id: 'e4', timestamp: 4, deviceId: 'A' }
+    ]);
+    const originalApply = appliers.conversation.apply.bind(appliers.conversation);
+    let failE2Once = true;
+    jest.spyOn(appliers.conversation, 'apply').mockImplementation(async (event) => {
+      if (event.id === 'e2' && failE2Once) {
+        failE2Once = false;
+        throw new Error('Fake applier: apply failed for e2');
+      }
+      await originalApply(event);
+    });
+
+    const failed = await pipeline.reconcileAll();
+
+    expect(failed.success).toBe(false);
+    expect(failed.filesProcessed).toEqual([SHARD_VAULT_PATH]);
+    expect(applied.has('e1')).toBe(true);
+    expect(applied.has('e2')).toBe(false);
+    expect(applied.has('e3')).toBe(false);
+    expect(applied.has('e4')).toBe(false);
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual(['e1']);
+    expect(await cursors.getCursor('desktop-A', DELTA_SHARD_VAULT_PATH)).toBeNull();
+    expect(await cursors.getCursor('desktop-A', laterStreamShardPath)).toBeNull();
+
+    const retried = await pipeline.reconcileAll();
+
+    expect(retried.success).toBe(true);
+    expect(retried.eventsApplied).toBe(3);
+    expect(retried.eventsSkipped).toBe(1);
+    expect(appliers.conversation.applied.map(event => event.id)).toEqual([
+      'e1',
+      'e2',
+      'e3',
+      'e4'
+    ]);
+  });
+
   it('stops at the first failed apply and retries the committed prefix in event order', async () => {
     const { pipeline, store, cursors, applied, appliers } = makeHarness('desktop-A');
     store.setShardContent('conversations', STREAM, SHARD, [

--- a/tests/integration/reconcilePipelineSilentOverwrite.test.ts
+++ b/tests/integration/reconcilePipelineSilentOverwrite.test.ts
@@ -286,6 +286,9 @@ function makeHarness(deviceId = 'desktop-A'): PipelineHarness {
 const SHARD = 'shard-000001.jsonl';
 const STREAM = 'conv_abc';
 const SHARD_VAULT_PATH = `${ROOT_PATH}/conversations/${STREAM}/${SHARD}`;
+const DELTA_SHARD =
+  'shard-000003 (Syncthing Delta sha256-' + 'b'.repeat(64) + ').jsonl';
+const DELTA_SHARD_VAULT_PATH = `${ROOT_PATH}/conversations/${STREAM}/${DELTA_SHARD}`;
 
 // ---------------------------------------------------------------------------
 // P1.7.a — Silent-overwrite GREEN-BAR (architect §6)
@@ -535,7 +538,82 @@ describe('P1.7.f — watcher external-mutation → reconcileStream flow', () => 
 
     expect(result.success).toBe(false);
     expect(result.errors[0]).toContain('Cannot parse shard path');
+    expect(result.filesProcessed).toEqual([]);
     expect(applied.count()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nominal shard coverage receipt
+// ---------------------------------------------------------------------------
+
+describe('ReconcilePipeline nominal shard coverage receipt', () => {
+  it('reports a scanned delta path once and applies its exclusive event', async () => {
+    const { pipeline, store, applied } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, DELTA_SHARD, [
+      { id: 'delta-exclusive', timestamp: 1, deviceId: 'B' }
+    ]);
+
+    const result = await pipeline.reconcileShard(DELTA_SHARD_VAULT_PATH);
+
+    expect(result.success).toBe(true);
+    expect(result.shardsScanned).toBe(1);
+    expect(result.filesProcessed).toEqual([DELTA_SHARD_VAULT_PATH]);
+    expect(result.eventsApplied).toBe(1);
+    expect(applied.has('delta-exclusive')).toBe(true);
+  });
+
+  it('reports a cursor-fast-pathed delta without applying its event twice', async () => {
+    const { pipeline, store, applied } = makeHarness('desktop-A');
+    store.setShardContent('conversations', STREAM, DELTA_SHARD, [
+      { id: 'delta-exclusive', timestamp: 1, deviceId: 'B' }
+    ]);
+    await pipeline.reconcileShard(DELTA_SHARD_VAULT_PATH);
+    const appliedAfterFirst = applied.count();
+
+    const second = await pipeline.reconcileShard(DELTA_SHARD_VAULT_PATH);
+
+    expect(second.success).toBe(true);
+    expect(second.shardsFastPathed).toBe(1);
+    expect(second.eventsApplied).toBe(0);
+    expect(second.filesProcessed).toEqual([DELTA_SHARD_VAULT_PATH]);
+    expect(applied.count()).toBe(appliedAfterFirst);
+  });
+
+  it('aggregates stream coverage in first-seen order without duplicate paths', async () => {
+    const { pipeline, store } = makeHarness('desktop-A');
+    store.setShardContent('conversations', 'conv_alpha', DELTA_SHARD, [
+      { id: 'alpha-exclusive', timestamp: 1, deviceId: 'A' }
+    ]);
+    store.setShardContent('conversations', 'conv_beta', SHARD, [
+      { id: 'beta-exclusive', timestamp: 2, deviceId: 'B' }
+    ]);
+    jest.spyOn(store, 'listFiles').mockImplementation(async (category) =>
+      category === 'conversations'
+        ? [
+            'conversations/conv_alpha.jsonl',
+            'conversations/conv_alpha.jsonl',
+            'conversations/conv_beta.jsonl'
+          ]
+        : []
+    );
+
+    const result = await pipeline.reconcileAll();
+
+    expect(result.success).toBe(true);
+    expect(result.filesProcessed).toEqual([
+      `${ROOT_PATH}/conversations/conv_alpha/${DELTA_SHARD}`,
+      `${ROOT_PATH}/conversations/conv_beta/${SHARD}`
+    ]);
+  });
+
+  it('does not claim coverage for a missing parseable shard', async () => {
+    const { pipeline } = makeHarness('desktop-A');
+
+    const result = await pipeline.reconcileShard(DELTA_SHARD_VAULT_PATH);
+
+    expect(result.success).toBe(false);
+    expect(result.filesProcessed).toEqual([]);
   });
 });
 

--- a/tests/unit/HybridStorageAdapter.phase0.test.ts
+++ b/tests/unit/HybridStorageAdapter.phase0.test.ts
@@ -326,7 +326,10 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
         getAppliers: jest.Mock;
         setReconcilePipeline: jest.Mock;
       };
-      sqliteCache: { getSyncStateStore: jest.Mock };
+      sqliteCache: {
+        getSyncStateStore: jest.Mock;
+        transaction: jest.Mock;
+      };
       queryCache: { clear: jest.Mock };
       reconcilePipeline: unknown;
     };
@@ -368,7 +371,10 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
         }),
         setReconcilePipeline: jest.fn()
       };
-      adapter.sqliteCache = { getSyncStateStore: jest.fn().mockReturnValue({}) };
+      adapter.sqliteCache = {
+        getSyncStateStore: jest.fn().mockReturnValue({}),
+        transaction: jest.fn(async <T>(fn: () => Promise<T>): Promise<T> => fn())
+      };
       adapter.queryCache = { clear: jest.fn() };
       adapter.reconcilePipeline = null;
       return adapter;

--- a/tests/unit/SQLiteSyncStateStore.test.ts
+++ b/tests/unit/SQLiteSyncStateStore.test.ts
@@ -57,6 +57,29 @@ describe('SQLiteSyncStateStore', () => {
     );
   });
 
+  it('deduplicates repeated complete event ids and looks them up without truncation', async () => {
+    const { store, queryOne, run } = createStore();
+    const eventId = 'evt/device-A/2026-07-18T12:34:56.789Z/sha256-' + 'a'.repeat(64);
+    run
+      .mockResolvedValueOnce({ changes: 1, lastInsertRowid: 1 })
+      .mockResolvedValueOnce({ changes: 0, lastInsertRowid: 1 });
+    queryOne.mockResolvedValue({ eventId });
+
+    await store.markEventApplied(eventId);
+    await store.markEventApplied(eventId);
+    await expect(store.isEventApplied(eventId)).resolves.toBe(true);
+
+    expect(run).toHaveBeenCalledTimes(2);
+    for (const [sql, params] of run.mock.calls) {
+      expect(sql).toContain('INSERT OR IGNORE INTO applied_events');
+      expect(params?.[0]).toBe(eventId);
+    }
+    expect(queryOne).toHaveBeenCalledWith(
+      'SELECT eventId FROM applied_events WHERE eventId = ?',
+      [eventId]
+    );
+  });
+
   it('persists sync state as JSON', async () => {
     const { store, run } = createStore();
     run.mockResolvedValue({ changes: 1, lastInsertRowid: 0 });

--- a/tests/unit/ShardedJsonlStreamStore.test.ts
+++ b/tests/unit/ShardedJsonlStreamStore.test.ts
@@ -58,6 +58,87 @@ describe('ShardedJsonlStreamStore', () => {
     );
   });
 
+  it('ignores a larger conflict sibling when selecting the append target', async () => {
+    const canonical = `${JSON.stringify(makeEvent('evt-canonical'))}\n`;
+    const delta = `${JSON.stringify({
+      id: 'evt-delta',
+      type: 'test_event',
+      payload: 'x'.repeat(500)
+    })}\n`;
+    const base = 'Assistant data/tasks/tasks_default';
+    const deltaName =
+      `shard-000003 (Syncthing Delta sha256-${'a'.repeat(64)}).jsonl`;
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/shard-000003.jsonl`]: canonical,
+      [`${base}/${deltaName}`]: delta
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data',
+      maxShardBytes: canonical.length + 200
+    });
+
+    const result = await store.appendEvent('tasks/tasks_default', makeEvent('evt-new'));
+
+    expect(result.rotated).toBe(false);
+    expect(result.shard.fileName).toBe('shard-000003.jsonl');
+    expect(adapter.append).toHaveBeenCalledWith(
+      `${base}/shard-000003.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new'))}\n`
+    );
+    expect(adapter.write).not.toHaveBeenCalledWith(
+      `${base}/shard-000004.jsonl`,
+      expect.any(String)
+    );
+
+    const shards = await store.listShards('tasks/tasks_default');
+    expect(shards.map(shard => shard.fileName)).toEqual([
+      'shard-000003.jsonl',
+      deltaName
+    ]);
+  });
+
+  it('ignores a larger conflict sibling when appending multiple events', async () => {
+    const canonical = `${JSON.stringify(makeEvent('evt-canonical'))}\n`;
+    const deltaName =
+      `shard-000003 (Syncthing Delta sha256-${'b'.repeat(64)}).jsonl`;
+    const delta = `${JSON.stringify({
+      id: 'evt-delta',
+      type: 'test_event',
+      payload: 'x'.repeat(500)
+    })}\n`;
+    const base = 'Assistant data/tasks/tasks_default';
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/shard-000003.jsonl`]: canonical,
+      [`${base}/${deltaName}`]: delta
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data',
+      maxShardBytes: canonical.length + 200
+    });
+
+    await store.appendEvents('tasks/tasks_default', [
+      makeEvent('evt-new-1'),
+      makeEvent('evt-new-2')
+    ]);
+
+    expect(adapter.append).toHaveBeenNthCalledWith(
+      1,
+      `${base}/shard-000003.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new-1'))}\n`
+    );
+    expect(adapter.append).toHaveBeenNthCalledWith(
+      2,
+      `${base}/shard-000003.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new-2'))}\n`
+    );
+    expect(adapter.write).not.toHaveBeenCalledWith(
+      `${base}/shard-000004.jsonl`,
+      expect.any(String)
+    );
+  });
+
   it('rotates to a new shard when the next append would cross the byte limit', async () => {
     const initialContent = `${JSON.stringify(makeEvent('evt-1', { payload: 'x'.repeat(20) }))}\n`;
     const { app, adapter } = createMockApp({ initialFiles: {

--- a/tests/unit/ShardedJsonlStreamStore.test.ts
+++ b/tests/unit/ShardedJsonlStreamStore.test.ts
@@ -58,7 +58,7 @@ describe('ShardedJsonlStreamStore', () => {
     );
   });
 
-  it('ignores a larger conflict sibling when selecting the append target', async () => {
+  it('preserves the canonical append target when a conflict sibling shares the same maximum index', async () => {
     const canonical = `${JSON.stringify(makeEvent('evt-canonical'))}\n`;
     const delta = `${JSON.stringify({
       id: 'evt-delta',
@@ -98,7 +98,7 @@ describe('ShardedJsonlStreamStore', () => {
     ]);
   });
 
-  it('ignores a larger conflict sibling when appending multiple events', async () => {
+  it('preserves the canonical batch append target when a conflict sibling shares the same maximum index', async () => {
     const canonical = `${JSON.stringify(makeEvent('evt-canonical'))}\n`;
     const deltaName =
       `shard-000003 (Syncthing Delta sha256-${'b'.repeat(64)}).jsonl`;
@@ -135,6 +135,96 @@ describe('ShardedJsonlStreamStore', () => {
     );
     expect(adapter.write).not.toHaveBeenCalledWith(
       `${base}/shard-000004.jsonl`,
+      expect.any(String)
+    );
+  });
+
+  it('creates shard 6 instead of appending shard 3 when a higher conflict-only shard exists', async () => {
+    const base = 'Assistant data/tasks/tasks_default';
+    const conflictName = `shard-000005 (Syncthing Delta sha256-${'c'.repeat(64)}).jsonl`;
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/shard-000003.jsonl`]: `${JSON.stringify(makeEvent('evt-canonical'))}\n`,
+      [`${base}/${conflictName}`]: `${JSON.stringify(makeEvent('evt-conflict'))}\n`
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data',
+      maxShardBytes: 1024
+    });
+
+    const result = await store.appendEvent('tasks/tasks_default', makeEvent('evt-new'));
+
+    expect(result.shard.fileName).toBe('shard-000006.jsonl');
+    expect(adapter.write).toHaveBeenCalledWith(
+      `${base}/shard-000006.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new'))}\n`
+    );
+    expect(adapter.append).not.toHaveBeenCalledWith(
+      `${base}/shard-000003.jsonl`,
+      expect.any(String)
+    );
+    expect((await store.readEvents('tasks/tasks_default')).map(event => event.id)).toEqual([
+      'evt-canonical', 'evt-conflict', 'evt-new'
+    ]);
+  });
+
+  it('creates shard 6 rather than shard 1 when the stream has only conflict shard 5', async () => {
+    const base = 'Assistant data/tasks/tasks_default';
+    const conflictName = `shard-000005 (Syncthing Delta sha256-${'d'.repeat(64)}).jsonl`;
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/${conflictName}`]: `${JSON.stringify(makeEvent('evt-conflict'))}\n`
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data',
+      maxShardBytes: 1024
+    });
+
+    const result = await store.appendEvent('tasks/tasks_default', makeEvent('evt-new'));
+
+    expect(result.shard.fileName).toBe('shard-000006.jsonl');
+    expect(adapter.write).toHaveBeenCalledWith(
+      `${base}/shard-000006.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new'))}\n`
+    );
+    expect(adapter.write).not.toHaveBeenCalledWith(
+      `${base}/shard-000001.jsonl`,
+      expect.any(String)
+    );
+  });
+
+  it('uses the newly created canonical shard 6 as the cursor for the rest of a batch', async () => {
+    const base = 'Assistant data/tasks/tasks_default';
+    const conflictName = `shard-000005 (Syncthing Delta sha256-${'e'.repeat(64)}).jsonl`;
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/shard-000003.jsonl`]: `${JSON.stringify(makeEvent('evt-canonical'))}\n`,
+      [`${base}/${conflictName}`]: `${JSON.stringify(makeEvent('evt-conflict'))}\n`
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data',
+      maxShardBytes: 1024
+    });
+
+    await store.appendEvents('tasks/tasks_default', [
+      makeEvent('evt-new-1'),
+      makeEvent('evt-new-2')
+    ]);
+
+    expect(adapter.write).toHaveBeenCalledWith(
+      `${base}/shard-000006.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new-1'))}\n`
+    );
+    expect(adapter.append).toHaveBeenCalledWith(
+      `${base}/shard-000006.jsonl`,
+      `${JSON.stringify(makeEvent('evt-new-2'))}\n`
+    );
+    expect(adapter.write).not.toHaveBeenCalledWith(
+      `${base}/shard-000001.jsonl`,
+      expect.any(String)
+    );
+    expect(adapter.append).not.toHaveBeenCalledWith(
+      `${base}/shard-000003.jsonl`,
       expect.any(String)
     );
   });

--- a/tests/unit/ShardedJsonlStreamStore.test.ts
+++ b/tests/unit/ShardedJsonlStreamStore.test.ts
@@ -93,8 +93,8 @@ describe('ShardedJsonlStreamStore', () => {
 
     const shards = await store.listShards('tasks/tasks_default');
     expect(shards.map(shard => shard.fileName)).toEqual([
-      'shard-000003.jsonl',
-      deltaName
+      deltaName,
+      'shard-000003.jsonl'
     ]);
   });
 
@@ -201,6 +201,36 @@ describe('ShardedJsonlStreamStore', () => {
       'shard-000002.jsonl',
       'shard-000003.jsonl'
     ]);
+  });
+
+  it('uses a UTF-8 filename byte tie-break independent of adapter listing order', async () => {
+    const base = 'Assistant data/tasks/tasks_default';
+    const deltaA = `shard-000003 (Syncthing Delta sha256-${'a'.repeat(64)}).jsonl`;
+    const deltaB = `shard-000003 (Syncthing Delta sha256-${'b'.repeat(64)}).jsonl`;
+    const { app, adapter } = createMockApp({ initialFiles: {
+      [`${base}/shard-000003.jsonl`]: `${JSON.stringify(makeEvent('evt-canonical'))}\n`,
+      [`${base}/${deltaB}`]: `${JSON.stringify(makeEvent('evt-b'))}\n`,
+      [`${base}/${deltaA}`]: `${JSON.stringify(makeEvent('evt-a'))}\n`
+    }});
+    const store = new ShardedJsonlStreamStore({
+      app,
+      rootPath: 'Assistant data'
+    });
+    const list = adapter.list.getMockImplementation();
+    if (!list) {
+      throw new Error('Mock adapter list implementation is unavailable');
+    }
+
+    const first = await store.listShards('tasks/tasks_default');
+    adapter.list.mockImplementation(async path => {
+      const listing = await list(path);
+      return { ...listing, files: [...listing.files].reverse() };
+    });
+    const reversed = await store.listShards('tasks/tasks_default');
+
+    const expected = [deltaA, deltaB, 'shard-000003.jsonl'];
+    expect(first.map(shard => shard.fileName)).toEqual(expected);
+    expect(reversed.map(shard => shard.fileName)).toEqual(expected);
   });
 
   describe('error paths', () => {

--- a/tests/unit/SyncCoordinator.test.ts
+++ b/tests/unit/SyncCoordinator.test.ts
@@ -1,5 +1,48 @@
 import type { StorageEvent } from '../../src/database/interfaces/StorageEvents';
+import type { ReconcileResult } from '../../src/database/sync/ReconcilePipeline';
 import { SyncCoordinator, type IJSONLWriter, type ISQLiteCacheManager, type SyncState } from '../../src/database/sync/SyncCoordinator';
+
+function createReconcileCoordinator(
+  reconcileResult: ReconcileResult,
+  persistenceFailure?: 'updateSyncState' | 'save'
+): {
+  coordinator: SyncCoordinator;
+  reconcileAll: jest.Mock<Promise<ReconcileResult>, []>;
+  sqliteCache: ISQLiteCacheManager;
+} {
+  const jsonlWriter: IJSONLWriter = {
+    getDeviceId: jest.fn(() => 'mobile-device'),
+    listFiles: jest.fn(async () => []),
+    getFileModTime: jest.fn(async () => null),
+    readEvents: jest.fn(async () => []),
+    getEventsNotFromDevice: jest.fn(async () => [])
+  };
+  const sqliteCache: ISQLiteCacheManager = {
+    getSyncState: jest.fn(async () => null),
+    updateSyncState: jest.fn(async () => {
+      if (persistenceFailure === 'updateSyncState') {
+        throw new Error('updateSyncState failed');
+      }
+    }),
+    isEventApplied: jest.fn(async () => false),
+    markEventApplied: jest.fn(async () => undefined),
+    run: jest.fn(async () => ({ changes: 1, lastInsertRowid: 1 })),
+    query: jest.fn(async () => []),
+    queryOne: jest.fn(async () => null),
+    clearAllData: jest.fn(async () => undefined),
+    rebuildFTSIndexes: jest.fn(async () => undefined),
+    save: jest.fn(async () => {
+      if (persistenceFailure === 'save') {
+        throw new Error('save failed');
+      }
+    })
+  };
+  const reconcileAll = jest.fn(async () => reconcileResult);
+  const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
+  coordinator.setReconcilePipeline({ reconcileAll } as never);
+
+  return { coordinator, reconcileAll, sqliteCache };
+}
 
 describe('SyncCoordinator', () => {
   it('saves full rebuild once after replaying all JSONL files', async () => {
@@ -351,29 +394,10 @@ describe('SyncCoordinator', () => {
   });
 
   it('propagates exact ReconcilePipeline paths through filesProcessed', async () => {
-    const jsonlWriter: IJSONLWriter = {
-      getDeviceId: jest.fn(() => 'mobile-device'),
-      listFiles: jest.fn(async () => []),
-      getFileModTime: jest.fn(async () => null),
-      readEvents: jest.fn(async () => []),
-      getEventsNotFromDevice: jest.fn(async () => [])
-    };
-    const sqliteCache: ISQLiteCacheManager = {
-      getSyncState: jest.fn(async () => null),
-      updateSyncState: jest.fn(async () => undefined),
-      isEventApplied: jest.fn(async () => false),
-      markEventApplied: jest.fn(async () => undefined),
-      run: jest.fn(async () => ({ changes: 1, lastInsertRowid: 1 })),
-      query: jest.fn(async () => []),
-      queryOne: jest.fn(async () => null),
-      clearAllData: jest.fn(async () => undefined),
-      rebuildFTSIndexes: jest.fn(async () => undefined),
-      save: jest.fn(async () => undefined)
-    };
     const delta =
       'nexus-data/data/tasks/tasks_default/' +
       'shard-000003 (Syncthing Delta sha256-' + 'b'.repeat(64) + ').jsonl';
-    const reconcileAll = jest.fn(async () => ({
+    const reconcileResult: ReconcileResult = {
       success: true,
       eventsApplied: 1,
       eventsSkipped: 41,
@@ -383,9 +407,8 @@ describe('SyncCoordinator', () => {
       errors: [],
       duration: 1,
       filesProcessed: [delta]
-    }));
-    const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
-    coordinator.setReconcilePipeline({ reconcileAll } as never);
+    };
+    const { coordinator } = createReconcileCoordinator(reconcileResult);
 
     const result = await coordinator.sync();
 
@@ -393,4 +416,75 @@ describe('SyncCoordinator', () => {
     expect(result.errors).toEqual([]);
     expect(result.filesProcessed).toEqual([delta]);
   });
+
+  it('returns a failed reconcile receipt without persistence or Complete progress', async () => {
+    const delta = 'Nexus/data/tasks/tasks_default/shard-000003.jsonl';
+    const reconcileResult: ReconcileResult = {
+      success: false,
+      eventsApplied: 1,
+      eventsSkipped: 2,
+      shardsScanned: 1,
+      shardsFastPathed: 0,
+      silentOverwriteRescans: 0,
+      errors: ['apply tasks/e2: failed'],
+      duration: 1,
+      filesProcessed: [delta]
+    };
+    const { coordinator, sqliteCache } = createReconcileCoordinator(reconcileResult);
+    const onProgress = jest.fn();
+
+    const result = await coordinator.sync({ onProgress });
+
+    expect(result).toMatchObject({
+      success: false,
+      eventsApplied: 1,
+      eventsSkipped: 2,
+      errors: ['apply tasks/e2: failed'],
+      filesProcessed: [delta]
+    });
+    expect(sqliteCache.updateSyncState).not.toHaveBeenCalled();
+    expect(sqliteCache.save).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalledWith('Complete', 1, 1);
+  });
+
+  it.each(['updateSyncState', 'save'] as const)(
+    'preserves the reconcile receipt when %s persistence fails',
+    async persistenceFailure => {
+      const filesProcessed = [
+        'Nexus/data/tasks/tasks_default/shard-000003.jsonl',
+        'Nexus/data/workspaces/ws_default/shard-000004.jsonl'
+      ];
+      const reconcileResult: ReconcileResult = {
+        success: true,
+        eventsApplied: 7,
+        eventsSkipped: 9,
+        shardsScanned: 2,
+        shardsFastPathed: 0,
+        silentOverwriteRescans: 0,
+        errors: [],
+        duration: 1,
+        filesProcessed
+      };
+      const { coordinator, sqliteCache } = createReconcileCoordinator(
+        reconcileResult,
+        persistenceFailure
+      );
+      const onProgress = jest.fn();
+
+      const result = await coordinator.sync({ onProgress });
+
+      expect(result).toMatchObject({
+        success: false,
+        eventsApplied: 7,
+        eventsSkipped: 9,
+        errors: [`Sync failed: Error: ${persistenceFailure} failed`],
+        filesProcessed
+      });
+      expect(sqliteCache.updateSyncState).toHaveBeenCalledTimes(1);
+      expect(sqliteCache.save).toHaveBeenCalledTimes(
+        persistenceFailure === 'save' ? 1 : 0
+      );
+      expect(onProgress).not.toHaveBeenCalledWith('Complete', 1, 1);
+    }
+  );
 });

--- a/tests/unit/SyncCoordinator.test.ts
+++ b/tests/unit/SyncCoordinator.test.ts
@@ -349,4 +349,48 @@ describe('SyncCoordinator', () => {
       { 'conversations/conv-1.jsonl': 500 }
     );
   });
+
+  it('propagates exact ReconcilePipeline paths through filesProcessed', async () => {
+    const jsonlWriter: IJSONLWriter = {
+      getDeviceId: jest.fn(() => 'mobile-device'),
+      listFiles: jest.fn(async () => []),
+      getFileModTime: jest.fn(async () => null),
+      readEvents: jest.fn(async () => []),
+      getEventsNotFromDevice: jest.fn(async () => [])
+    };
+    const sqliteCache: ISQLiteCacheManager = {
+      getSyncState: jest.fn(async () => null),
+      updateSyncState: jest.fn(async () => undefined),
+      isEventApplied: jest.fn(async () => false),
+      markEventApplied: jest.fn(async () => undefined),
+      run: jest.fn(async () => ({ changes: 1, lastInsertRowid: 1 })),
+      query: jest.fn(async () => []),
+      queryOne: jest.fn(async () => null),
+      clearAllData: jest.fn(async () => undefined),
+      rebuildFTSIndexes: jest.fn(async () => undefined),
+      save: jest.fn(async () => undefined)
+    };
+    const delta =
+      'nexus-data/data/tasks/tasks_default/' +
+      'shard-000003 (Syncthing Delta sha256-' + 'b'.repeat(64) + ').jsonl';
+    const reconcileAll = jest.fn(async () => ({
+      success: true,
+      eventsApplied: 1,
+      eventsSkipped: 41,
+      shardsScanned: 1,
+      shardsFastPathed: 0,
+      silentOverwriteRescans: 0,
+      errors: [],
+      duration: 1,
+      filesProcessed: [delta]
+    }));
+    const coordinator = new SyncCoordinator(jsonlWriter, sqliteCache);
+    coordinator.setReconcilePipeline({ reconcileAll } as never);
+
+    const result = await coordinator.sync();
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.filesProcessed).toEqual([delta]);
+  });
 });

--- a/tests/unit/conflictCopyMatching.test.ts
+++ b/tests/unit/conflictCopyMatching.test.ts
@@ -43,6 +43,7 @@ const PARSER_FIXTURES: ParserExpectation[] = [
   { fileName: 'shard-000001_conf(1).jsonl',                                             expected: { kind: 'conflict', baseIndex: 1, conflictMarker: '(1)' },             notes: 'GDrive _conf variant' },
   { fileName: 'shard-000001 (Conflicted copy 2026-05-06).jsonl',                        expected: { kind: 'conflict', baseIndex: 1, conflictMarker: '(Conflicted copy 2026-05-06)' }, notes: 'defensive Dropbox-style' },
   { fileName: "shard-000001 (joseph's conflicted copy 2026-05-06 14-22-01).jsonl",      expected: { kind: 'conflict', baseIndex: 1, conflictMarker: "(joseph's conflicted copy 2026-05-06 14-22-01)" }, notes: 'Dropbox' },
+  { fileName: `shard-000003 (Syncthing Delta sha256-${'a'.repeat(64)}).jsonl`,             expected: { kind: 'conflict', baseIndex: 3, conflictMarker: `(Syncthing Delta sha256-${'a'.repeat(64)})` }, notes: 'managed Nexus delta shadow' },
   { fileName: 'shard-000001 2.jsonl',                                                   expected: { kind: 'conflict', baseIndex: 1, conflictMarker: '2' },               notes: 'iCloud' },
   // Rejects
   { fileName: 'shard-000001-backup.jsonl',                                              expected: { kind: 'reject' },                                                    notes: 'reject' },

--- a/tests/unit/verifyInstalledDeltaShadowContract.test.ts
+++ b/tests/unit/verifyInstalledDeltaShadowContract.test.ts
@@ -1,0 +1,83 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const REPOSITORY_ROOT = resolve(__dirname, '../..');
+const VERIFIER = resolve(REPOSITORY_ROOT, 'scripts/verify-installed-delta-shadow-contract.mjs');
+const SOURCE_MANIFEST_PATH = resolve(REPOSITORY_ROOT, 'manifest.json');
+const SOURCE_MAIN_PATH = resolve(REPOSITORY_ROOT, 'main.js');
+
+type PluginManifest = { id: string; version: string };
+let sourceManifest: PluginManifest;
+let sourceMain: Buffer;
+let temporaryDirectories: string[] = [];
+
+async function createInstalledPlugin(options: {
+  manifest?: PluginManifest;
+  main?: Buffer;
+} = {}): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'nexus-delta-shadow-contract-'));
+  temporaryDirectories.push(directory);
+  await writeFile(join(directory, 'manifest.json'), JSON.stringify(options.manifest ?? sourceManifest));
+  await writeFile(join(directory, 'main.js'), options.main ?? sourceMain);
+  return directory;
+}
+
+function runVerifier(installedDirectory: string) {
+  return spawnSync(process.execPath, [VERIFIER], {
+    cwd: REPOSITORY_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, NEXUS_PLUGIN_DIR: installedDirectory }
+  });
+}
+
+beforeAll(async () => {
+  sourceManifest = JSON.parse(await readFile(SOURCE_MANIFEST_PATH, 'utf8')) as PluginManifest;
+  sourceMain = await readFile(SOURCE_MAIN_PATH);
+});
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.map(directory => rm(directory, { recursive: true, force: true })));
+  temporaryDirectories = [];
+});
+
+describe('verify-installed-delta-shadow-contract', () => {
+  it('accepts matching source and installed bundles and reports the source version', async () => {
+    expect(sourceManifest.id).toBe('nexus');
+    expect(typeof sourceManifest.version).toBe('string');
+    expect(sourceManifest.version.length).toBeGreaterThan(0);
+    const result = runVerifier(await createInstalledPlugin());
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      schema: 'thinkbox-nexus-delta-shadow-contract/v1',
+      version: sourceManifest.version,
+      bundleParity: true
+    });
+    expect(result.stderr).toBe('');
+  });
+
+  it('rejects an installed manifest with a different version before hashing', async () => {
+    const result = runVerifier(await createInstalledPlugin({
+      manifest: { ...sourceManifest, version: '5.16.1' }
+    }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('source and installed manifests differ semantically');
+    expect(result.stderr).toContain(`nexus@${sourceManifest.version} != nexus@5.16.1`);
+  });
+
+  it('rejects a byte-different installed main.js after matching manifest identity', async () => {
+    const result = runVerifier(await createInstalledPlugin({
+      main: Buffer.concat([sourceMain, Buffer.from('\n// byte mismatch\n')])
+    }));
+
+    expect(result.status).toBe(1);
+    expect(JSON.parse(result.stdout)).toMatchObject({
+      version: sourceManifest.version,
+      bundleParity: false
+    });
+    expect(result.stderr).toContain('source and installed main.js SHA-256 differ');
+  });
+});


### PR DESCRIPTION
## Summary

- preserve conflict-copy shards as readable delta shadows while keeping writes canonical
- make reconciliation receipts fail closed and advance state only after complete, atomic application
- stop full sweeps after the first incomplete shard and report the exact covered shard paths
- verify the semantic delta-shadow contract and source/installed bundle parity
- derive deployment verification identity from the current source manifest instead of a stale version literal
- keep append indices monotonic when the highest observed shard exists only as a conflict copy

## Why

Conflict copies are part of the readable event history, but they must never become write targets. The original series established that contract across writer selection, reconciliation, receipts, and sync state. Review then found two remaining gaps:

1. installed-bundle verification was pinned to `5.14.2`, so it rejected the current `5.16.2` source before parity could be checked;
2. append selection considered only the latest canonical shard, so a higher conflict-only sibling could make a new event land behind the reconciliation order or reset an all-conflict stream to shard 1.

The verifier now treats the source manifest as the version authority while still requiring the `nexus` plugin id and comparing installed identity before hashing. Append selection now uses the maximum index across the complete canonical-plus-conflict snapshot and creates a new canonical shard at `max + 1` when necessary. Batch appends retain that complete snapshot and update the canonical cursor by full path.

## Validation

- focused review regressions: 24/24 passing
- delta-shadow contract: 111/111 passing
- production build and Obsidian lint: passing
- `git diff --check`: passing
- full suite: 4282 passing, 29 skipped, with one preexisting failure in `LocalCliInstaller` (`reports a namesake command that appears earlier on PATH`); the same failure reproduces on the clean baseline and is unrelated to this series

## Operational note

The branch is intentionally based on Nexus `5.16.2`, matching the locally deployed patch target. Local deployment validation is tracked separately from merge/release.

Relates to #290.
