### PR TITLE
Stop claiming the CLI is on PATH without asking the shell

### DIFF
--- a/src/services/cli/LocalCliInstaller.ts
+++ b/src/services/cli/LocalCliInstaller.ts
@@ -32,6 +32,8 @@ const WINDOWS_SKILL_MARKER = '.nexus-managed';
 const WINDOWS_SKILL_MARKER_CONTENT = 'Managed by the Nexus local CLI installer.\n';
 const WINDOWS_SHIM = '@echo off\r\nnode "%~dp0nexus-cli.js" %*\r\n';
 const MINIMUM_NODE_MAJOR = 18;
+/** status() runs on every settings render; a login shell costs ~100ms to spawn. */
+const SHELL_PROBE_TTL_MS = 5_000;
 
 /** The agent providers the CLI can wire into. */
 export type CliProviderId = 'claudeCode' | 'cursor' | 'codex';
@@ -59,6 +61,18 @@ export interface CliInstallPaths {
     codexAgentsPath: string;
 }
 
+/**
+ * The exact edit a POSIX user must make for `nexus` to resolve in their shell.
+ * Nexus never writes to shell profiles itself — these are the user's files, and
+ * a managed block in them is far harder to reason about than one pasted line.
+ */
+export interface CliPathFix {
+    shell: string;
+    profilePath: string;
+    exportLine: string;
+    reloadCommand: string;
+}
+
 export interface CliInstallStatus {
     supported: boolean;
     installed: boolean;
@@ -71,6 +85,8 @@ export interface CliInstallStatus {
     codexLinked: boolean;
     detected: DetectedAgents;
     paths: CliInstallPaths;
+    /** Present only when the CLI is installed but the shell cannot resolve it. */
+    pathFix: CliPathFix | null;
 }
 
 export interface CliInstallResult {
@@ -80,6 +96,8 @@ export interface CliInstallResult {
 }
 
 export class LocalCliInstaller {
+    private shellProbe: { key: string; at: number; resolves: boolean } | null = null;
+
     private fs(): FsModule { return desktopRequire<FsModule>('node:fs'); }
     private os(): OsModule { return desktopRequire<OsModule>('node:os'); }
     private path(): PathModule { return desktopRequire<PathModule>('node:path'); }
@@ -137,6 +155,7 @@ export class LocalCliInstaller {
                 skillLinked: false, cursorLinked: false, codexLinked: false,
                 detected: { claudeCode: false, codex: false, cursor: false },
                 paths: {} as CliInstallPaths,
+                pathFix: null,
             };
         }
         const fs = this.fs();
@@ -156,12 +175,16 @@ export class LocalCliInstaller {
         const pathConfigured = Platform.isWin
             ? fs.existsSync(paths.binPath) && this.dirOnPath(paths.binDir)
             : this.pointsTo(paths.binPath, paths.cliJsPath);
+        // `pathConfigured` only means "our symlink/shim is in place". Whether the
+        // command actually resolves is a separate question on every platform, and
+        // answering it needs the user's shell — not Obsidian's inherited env.
+        const onPath = Platform.isWin
+            ? pathConfigured && this.windowsCommandResolvesTo(paths.binPath)
+            : pathConfigured && this.posixCommandResolvesTo(paths.binPath);
         return {
             supported: true,
             installed,
-            onPath: Platform.isWin
-                ? pathConfigured && this.windowsCommandResolvesTo(paths.binPath)
-                : pathConfigured,
+            onPath,
             pathConfigured,
             runtimeReady: this.nodeRuntimeReady(),
             stale,
@@ -170,6 +193,7 @@ export class LocalCliInstaller {
             codexLinked: this.hasCodexBlock(paths.codexAgentsPath),
             detected: this.detectAgents(),
             paths,
+            pathFix: installed && !onPath ? this.describePathFix() : null,
         };
     }
 
@@ -243,8 +267,12 @@ export class LocalCliInstaller {
         } else {
             fs.mkdirSync(paths.binDir, { recursive: true });
             if (this.linkReplace(paths.binPath, paths.cliJsPath, warnings)) created.push(paths.binPath);
-            if (!this.dirOnPath(paths.binDir)) {
-                warnings.push(`${paths.binDir} is not on your PATH — add it, or call the CLI by full path.`);
+            this.shellProbe = null; // the symlink just changed — re-probe, don't trust a stale answer
+            if (!this.posixCommandResolvesTo(paths.binPath)) {
+                const fix = this.describePathFix();
+                warnings.push(fix
+                    ? `${paths.binDir} is not on your shell PATH — add ${fix.exportLine} to ${fix.profilePath}, then run ${fix.reloadCommand}.`
+                    : `${paths.binDir} is not on your PATH — add it, or call the CLI by full path.`);
             }
         }
 
@@ -327,6 +355,7 @@ export class LocalCliInstaller {
         const paths = this.getPaths();
         const created: string[] = [];
         const warnings: string[] = [];
+        this.shellProbe = null;
 
         // Remove our symlinks only if they still point at us; never clobber user files.
         for (const [link, target] of [
@@ -548,6 +577,102 @@ export class LocalCliInstaller {
             }
             return false;
         } catch { return true; }
+    }
+
+    /**
+     * The exact shell-profile edit that puts our bin dir on PATH, or null on
+     * Windows (where enable() persists the user PATH itself). Returned so the UI
+     * can show a line the user can paste instead of a dead-end "not on PATH".
+     */
+    describePathFix(): CliPathFix | null {
+        if (!this.isSupported() || Platform.isWin) return null;
+        const path = this.path();
+        const home = this.os().homedir();
+        const binDir = this.getPaths().binDir;
+        const shell = path.basename(process.env.SHELL || '/bin/zsh');
+        // Prefer $HOME-relative so the pasted line survives a different username.
+        const relative = path.relative(home, binDir);
+        const binDirExpr = relative && !relative.startsWith('..')
+            ? `$HOME/${relative.split(path.sep).join('/')}`
+            : binDir;
+
+        if (shell === 'fish') {
+            const profilePath = path.join(home, '.config', 'fish', 'config.fish');
+            return {
+                shell,
+                profilePath,
+                exportLine: `fish_add_path ${binDirExpr}`,
+                reloadCommand: `source ${this.tildify(profilePath, home)}`,
+            };
+        }
+        const profileName = shell === 'bash'
+            ? (Platform.isMacOS ? '.bash_profile' : '.bashrc')
+            : shell === 'zsh' ? '.zshrc' : '.profile';
+        const profilePath = path.join(home, profileName);
+        return {
+            shell,
+            profilePath,
+            exportLine: `export PATH="${binDirExpr}:$PATH"`,
+            reloadCommand: `source ${this.tildify(profilePath, home)}`,
+        };
+    }
+
+    private tildify(p: string, home: string): string {
+        const path = this.path();
+        const relative = path.relative(home, p);
+        return relative && !relative.startsWith('..')
+            ? `~/${relative.split(path.sep).join('/')}`
+            : p;
+    }
+
+    /** True only when the user's login shell resolves `nexus` to our symlink. */
+    private posixCommandResolvesTo(expectedPath: string): boolean {
+        if (Platform.isWin) return false;
+        const shell = process.env.SHELL || '/bin/zsh';
+        const key = `${shell} ${expectedPath}`;
+        const now = Date.now();
+        if (this.shellProbe && this.shellProbe.key === key && now - this.shellProbe.at < SHELL_PROBE_TTL_MS) {
+            return this.shellProbe.resolves;
+        }
+        const resolves = this.probeLoginShell(shell, expectedPath);
+        this.shellProbe = { key, at: now, resolves };
+        return resolves;
+    }
+
+    /**
+     * Ask a login shell — the same thing a fresh terminal window starts — whether
+     * `nexus` resolves to us. Obsidian launched from Finder/the Start menu inherits
+     * a minimal PATH, so process.env.PATH answers a different question than "will
+     * this work in the user's terminal?", in both directions. PATH is deliberately
+     * dropped from the child env so the shell's own profiles establish it; keeping
+     * it would let a PATH Obsidian happened to inherit mask a missing profile line.
+     */
+    private probeLoginShell(shell: string, expectedPath: string): boolean {
+        try {
+            const env = { ...process.env };
+            delete env.PATH;
+            const result = this.childProcess().spawnSync(shell, ['-lc', 'command -v nexus'], {
+                encoding: 'utf-8',
+                timeout: 5_000,
+                windowsHide: true,
+                env,
+            });
+            if (result.error || result.status !== 0) return false;
+            const resolved = String(result.stdout || '').trim().split(/\r?\n/)[0]?.trim();
+            return resolved ? this.samePath(resolved, expectedPath) : false;
+        } catch {
+            return false;
+        }
+    }
+
+    /** Path equality that also accepts a link/target pair resolving to one file. */
+    private samePath(a: string, b: string): boolean {
+        try {
+            if (this.path().resolve(a) === this.path().resolve(b)) return true;
+        } catch { /* fall through to realpath */ }
+        try {
+            return this.fs().realpathSync(a) === this.fs().realpathSync(b);
+        } catch { return false; }
     }
 
     private dirOnPath(dir: string): boolean {

--- a/src/settings/tabs/GetStartedTab.ts
+++ b/src/settings/tabs/GetStartedTab.ts
@@ -15,7 +15,7 @@ import { getPrimaryServerKey } from '../../constants/branding';
 import { ConfigStatus, getClaudeDesktopConfigPath, getConfigStatus } from '../getStartedStatus';
 import { resolveDesktopBinaryPath } from '../../utils/binaryDiscovery';
 import { CONNECTOR_JS_CONTENT } from '../../utils/connectorContent';
-import { LocalCliInstaller, CliProviderId, CliInstallTargets } from '../../services/cli/LocalCliInstaller';
+import { LocalCliInstaller, CliProviderId, CliInstallTargets, CliPathFix } from '../../services/cli/LocalCliInstaller';
 import {
     appendCodexMcpTomlSnippet,
     buildCodexMcpTomlSnippet,
@@ -720,6 +720,12 @@ export class GetStartedTab {
             }
         }
 
+        // Installed but the shell can't find it — the one failure mode that looks
+        // like nothing is wrong. Show the exact edit rather than a bare warning.
+        if (status.installed && status.runtimeReady && !status.onPath && status.pathFix) {
+            this.renderCliPathFix(block, status.pathFix, installer);
+        }
+
         const details = block.createEl('details', { cls: 'nexus-manual-details' });
         details.createEl('summary', { text: status.installed ? 'What’s installed' : 'What this installs' });
         const disclosureBody = details.createDiv('nexus-manual-body');
@@ -730,6 +736,47 @@ export class GetStartedTab {
             text: 'All paths are outside your vault (nothing is synced), and everything here is reversible with uninstall.',
             cls: 'setting-item-description'
         });
+    }
+
+    /**
+     * The `nexus` command exists but the user's shell cannot resolve it. Nexus does
+     * not edit shell profiles — they are the user's files — so hand over the exact
+     * line, where it goes, and how to reload, with a copy button.
+     */
+    private renderCliPathFix(block: HTMLElement, fix: CliPathFix, installer: LocalCliInstaller): void {
+        const component = this.services.component;
+        const panel = block.createDiv('nexus-cli-pathfix');
+        panel.createEl('p', {
+            text: `The nexus command is installed, but your ${fix.shell} shell can’t find it yet. Add this line to ${fix.profilePath}:`,
+            cls: 'setting-item-description'
+        });
+
+        const row = panel.createDiv('nx-pathrow');
+        row.createSpan({ text: fix.exportLine, cls: 'nx-inline-path' });
+        const copyBtn = row.createEl('button', { text: 'Copy' });
+        if (component) {
+            component.registerDomEvent(copyBtn, 'click', () => {
+                void navigator.clipboard.writeText(fix.exportLine)
+                    .then(() => new Notice('Copied. Paste it into your shell profile.'))
+                    .catch(() => new Notice('Could not copy — select the line and copy it manually.'));
+            });
+        }
+
+        panel.createEl('p', {
+            text: `Then run ${fix.reloadCommand} in any open terminal, or just open a new one.`,
+            cls: 'setting-item-description'
+        });
+
+        const recheckBtn = panel.createEl('button', { text: 'Re-check' });
+        if (component) {
+            component.registerDomEvent(recheckBtn, 'click', () => {
+                const updated = installer.status();
+                new Notice(updated.onPath
+                    ? 'Nexus CLI resolves in your shell now.'
+                    : 'Still not resolving — make sure the line was saved, then open a new terminal.');
+                this.render();
+            });
+        }
     }
 
     private enableLocalCli(installer: LocalCliInstaller, targets?: Partial<CliInstallTargets>): void {

--- a/styles.css
+++ b/styles.css
@@ -5084,6 +5084,28 @@ body.is-mobile .message-action-btn.message-branch-next {
     word-break: break-all;
 }
 
+/* Local CLI installed but unresolvable in the user's shell — actionable fix panel */
+.nexus-cli-pathfix {
+    margin-top: 10px;
+    padding: 10px 12px;
+    border: 1px solid var(--background-modifier-border);
+    border-left: 3px solid var(--text-warning);
+    border-radius: var(--radius-s);
+    background-color: var(--background-secondary);
+}
+
+.nexus-cli-pathfix p {
+    margin: 0 0 4px 0;
+}
+
+.nexus-cli-pathfix .nx-inline-path {
+    user-select: all;
+}
+
+.nexus-cli-pathfix button {
+    margin-top: 8px;
+}
+
 /* Reasoning - Compact Inline */
 .nexus-thinking-section {
     margin-top: 12px;

--- a/tests/services/cli/LocalCliInstaller.test.ts
+++ b/tests/services/cli/LocalCliInstaller.test.ts
@@ -12,6 +12,7 @@ import * as realPath from 'path';
 let TEST_HOME = '';
 const ORIGINAL_LOCALAPPDATA = process.env.LOCALAPPDATA;
 const ORIGINAL_PATH = process.env.PATH;
+const ORIGINAL_SHELL = process.env.SHELL;
 const mockSpawnSync = jest.fn();
 const DEFAULT_NODE_PATH = '/resolved/bin/node';
 const mockResolveDesktopBinaryPath = jest.fn(() => DEFAULT_NODE_PATH);
@@ -24,11 +25,19 @@ interface MockSpawnResult {
 }
 
 const nodeOk: MockSpawnResult = { status: 0, stdout: 'v20.19.0\n', stderr: '' };
+const TEST_SHELL = '/bin/zsh';
+/** What the mocked login shell reports for `command -v nexus` (null = not found). */
+let loginShellResolves: string | null = null;
 
 function mockNodeAndPowerShell(...powerShellResults: MockSpawnResult[]): void {
     let powerShellIndex = 0;
     mockSpawnSync.mockImplementation((command: string) => {
         if (command === DEFAULT_NODE_PATH) return nodeOk;
+        if (command === TEST_SHELL) {
+            return loginShellResolves === null
+                ? { status: 1, stdout: '', stderr: '' }
+                : { status: 0, stdout: `${loginShellResolves}\n`, stderr: '' };
+        }
         return powerShellResults[powerShellIndex++] ?? { status: 0, stdout: 'PRESENT\n', stderr: '' };
     });
 }
@@ -80,6 +89,8 @@ describe('LocalCliInstaller', () => {
         else process.env.LOCALAPPDATA = ORIGINAL_LOCALAPPDATA;
         if (ORIGINAL_PATH === undefined) delete process.env.PATH;
         else process.env.PATH = ORIGINAL_PATH;
+        process.env.SHELL = TEST_SHELL;
+        loginShellResolves = null;
         mockSpawnSync.mockReset();
         mockResolveDesktopBinaryPath.mockReset();
         mockResolveDesktopBinaryPath.mockReturnValue(DEFAULT_NODE_PATH);
@@ -98,6 +109,8 @@ describe('LocalCliInstaller', () => {
         else process.env.LOCALAPPDATA = ORIGINAL_LOCALAPPDATA;
         if (ORIGINAL_PATH === undefined) delete process.env.PATH;
         else process.env.PATH = ORIGINAL_PATH;
+        if (ORIGINAL_SHELL === undefined) delete process.env.SHELL;
+        else process.env.SHELL = ORIGINAL_SHELL;
     });
 
     posixIt('enable() writes the CLI, skill, PATH symlink, Claude + Cursor skill links, and Codex block', () => {
@@ -118,13 +131,82 @@ describe('LocalCliInstaller', () => {
 
     posixIt('status() reflects an installed, on-PATH, linked state', () => {
         installer.enable();
-        const s = installer.status();
+        loginShellResolves = installer.getPaths().binPath;
+        const s = new LocalCliInstaller().status();
         expect(s.installed).toBe(true);
         expect(s.onPath).toBe(true);
+        expect(s.pathFix).toBeNull();
         expect(s.stale).toBe(false);
         expect(s.skillLinked).toBe(true);
         expect(s.cursorLinked).toBe(true);
         expect(s.codexLinked).toBe(true);
+    });
+
+    // Regression: onPath used to be a bare symlink check on POSIX, so a correctly
+    // installed CLI that no shell could resolve still reported "on your PATH".
+    posixIt('status() does not claim onPath when the login shell cannot resolve nexus', () => {
+        installer.enable();
+        loginShellResolves = null;
+        const s = new LocalCliInstaller().status();
+
+        expect(s.installed).toBe(true);
+        expect(s.pathConfigured).toBe(true); // our symlink is in place...
+        expect(s.onPath).toBe(false);        // ...but the shell still can't find it
+        expect(s.pathFix).not.toBeNull();
+    });
+
+    posixIt('status() ignores a namesake nexus that resolves ahead of ours', () => {
+        installer.enable();
+        loginShellResolves = '/usr/local/bin/nexus';
+        expect(new LocalCliInstaller().status().onPath).toBe(false);
+    });
+
+    posixIt('probes a login shell rather than trusting the PATH Obsidian inherited', () => {
+        const p = installer.getPaths();
+        process.env.PATH = `${p.binDir}:/usr/bin`; // Obsidian sees it; the shell does not
+        installer.enable();
+        loginShellResolves = null;
+
+        expect(new LocalCliInstaller().status().onPath).toBe(false);
+        const shellCalls = mockSpawnSync.mock.calls.filter((call) => call[0] === TEST_SHELL);
+        expect(shellCalls.length).toBeGreaterThan(0);
+        expect(shellCalls[0][1]).toEqual(['-lc', 'command -v nexus']);
+        // PATH is dropped so the shell's own profiles decide, not Obsidian's env.
+        expect((shellCalls[0][2] as { env: Record<string, string> }).env.PATH).toBeUndefined();
+    });
+
+    posixIt('enable() warns with the exact profile edit when the shell cannot resolve nexus', () => {
+        loginShellResolves = null;
+        const result = installer.enable();
+
+        const warning = result.warnings.find((w) => w.includes('not on your shell PATH'));
+        expect(warning).toBeDefined();
+        expect(warning).toContain('export PATH="$HOME/.local/bin:$PATH"');
+        expect(warning).toContain(realPath.join(TEST_HOME, '.zshrc'));
+    });
+
+    posixIt('enable() stays quiet about PATH when the shell already resolves nexus', () => {
+        loginShellResolves = realPath.join(TEST_HOME, '.local', 'bin', 'nexus');
+        const result = installer.enable();
+        expect(result.warnings.filter((w) => w.toLowerCase().includes('path'))).toEqual([]);
+    });
+
+    posixIt('describePathFix() targets the profile for the running shell', () => {
+        process.env.SHELL = '/bin/bash';
+        expect(new LocalCliInstaller().describePathFix()).toEqual({
+            shell: 'bash',
+            profilePath: realPath.join(TEST_HOME, '.bash_profile'), // isMacOS is true here
+            exportLine: 'export PATH="$HOME/.local/bin:$PATH"',
+            reloadCommand: 'source ~/.bash_profile',
+        });
+
+        process.env.SHELL = '/opt/homebrew/bin/fish';
+        expect(new LocalCliInstaller().describePathFix()).toEqual({
+            shell: 'fish',
+            profilePath: realPath.join(TEST_HOME, '.config', 'fish', 'config.fish'),
+            exportLine: 'fish_add_path $HOME/.local/bin',
+            reloadCommand: 'source ~/.config/fish/config.fish',
+        });
     });
 
     posixIt('accepts Node.js 24 discovered outside Obsidian\'s inherited PATH', () => {
@@ -388,7 +470,10 @@ describe('LocalCliInstaller', () => {
             const otherBin = realPath.join(TEST_HOME, 'other-bin');
             realFs.mkdirSync(otherBin, { recursive: true });
             realFs.writeFileSync(realPath.join(otherBin, 'nexus.cmd'), '@echo other\r\n', 'utf-8');
-            process.env.PATH = `${otherBin};C:\\Windows\\System32`;
+            // Join with the host's delimiter: the code under test splits PATH with
+            // the real path module, so a hardcoded ';' never splits on a POSIX host
+            // and the namesake in otherBin would be invisible to the lookup.
+            process.env.PATH = [otherBin, 'C:\\Windows\\System32'].join(realPath.delimiter);
             mockNodeAndPowerShell({ status: 0, stdout: 'ADDED\n', stderr: '' });
 
             const result = installer.enable({ claudeCode: false, cursor: false, codex: false });


### PR DESCRIPTION
## The bug

On macOS and Linux, `status().onPath` was a bare symlink check:

```ts
const pathConfigured = Platform.isWin
    ? fs.existsSync(paths.binPath) && this.dirOnPath(paths.binDir)
    : this.pointsTo(paths.binPath, paths.cliJsPath);   // ← POSIX: symlink only
onPath: Platform.isWin
    ? pathConfigured && this.windowsCommandResolvesTo(paths.binPath)
    : pathConfigured,
```

If `~/.local/bin/nexus` pointed at our CLI, settings reported **"Installed and on your PATH"** — whether or not any shell could resolve `nexus`. Hit in the wild by a user whose account had no shell profile at all: green status in settings, `command not found` in the terminal, nothing pointing at the cause.

Three things compounded it:

1. **No remediation off Windows.** The "Add to path" button is gated on `Platform.isWin`, and `addToWindowsUserPath()` throws on macOS. Windows persists a real user PATH entry via PowerShell; POSIX got nothing.
2. **The one POSIX signal was swallowed.** `enable()` pushed `"…is not on your PATH — add it, or call the CLI by full path"`, but that was only `console.warn`'d behind a generic Notice about "wiring preserved or unavailable" — no file, no line.
3. **It was computed from the wrong PATH anyway.** `dirOnPath()` reads `process.env.PATH` — Obsidian's. Launched from Finder that's the minimal launchd PATH, so it's wrong in both directions. `nodeRuntimeReady()` directly below it already carries a comment about exactly this and routes through `resolveDesktopBinaryPath`; the PATH check never got the same treatment.

## The fix

**`onPath` now asks a shell.** `posixCommandResolvesTo()` runs `$SHELL -lc 'command -v nexus'` and requires the answer to be *our* symlink, so a namesake earlier on PATH correctly reports false — matching Windows. PATH is deliberately dropped from the child env so the shell's own profiles establish it; inheriting Obsidian's PATH would let a PATH it happened to pick up mask a missing profile line, which is the exact false-green being fixed. Cached ~5s, since `status()` runs on every settings render and spawning a login shell isn't free.

**Failure is now actionable.** `describePathFix()` returns the exact edit for the running shell — zsh → `~/.zshrc`, bash → `~/.bash_profile` (macOS) / `~/.bashrc` (Linux), fish → `fish_add_path` in `config.fish`, else `~/.profile` — expressed `$HOME`-relative so the line survives a different username. Settings renders it as a copyable line with the target file, the reload command, and a Re-check button. The install-time warning carries the same line.

**Nexus does not write to shell profiles.** They're the user's files, and a managed marker block in them is much harder to reason about than one pasted line. A POSIX equivalent of the Windows "Add to path" button was scoped and deliberately not built.

## Verification

- Full suite **4306 passed / 0 failed**; `npm run lint` clean; `tsc --noEmit` clean; `npm run build` green.
- Six new POSIX tests. The direct regression — symlink correct, shell can't resolve → `pathConfigured: true`, `onPath: false`, `pathFix` populated — **fails against the old code**.
- Replaced `status() reflects an installed, on-PATH, linked state`, which asserted `onPath === true` while never putting `binDir` on any PATH. It passed *because of* the bug.

## Drive-by

The Windows namesake test built its PATH with a hardcoded `';'`. The installer splits with the real `path.delimiter`, so on a POSIX host that string never splits — the lookup skipped the namesake, found our own shim, and the test failed on every host except Windows. Now joins with `realPath.delimiter`. Confirmed pre-existing via `git stash`.

## Risk

Some users will see status flip from "Installed and on your PATH" to "Installed (not yet on your PATH)". That is the bug surfacing, not a regression — those installs were already unusable from the terminal, and they now get the line that fixes it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ucuw8vEH2xBdjgbMbSFfdK)_