### PR TITLE
Add Gemini 3.7 Flash (Google + OpenRouter)

### DIFF
--- a/src/services/llm/adapters/google/GoogleModels.ts
+++ b/src/services/llm/adapters/google/GoogleModels.ts
@@ -1,11 +1,33 @@
 /**
  * Google Model Specifications
- * Updated July 2026 — added Gemini 3.6 Flash and Gemini 3.5 Flash-Lite.
+ * Updated August 2026 — added Gemini 3.7 Flash.
+ *
+ * Gemini 3.7 Flash pricing is Google's introductory rate ($0.75/$3.75 per 1M)
+ * which holds through December 31, 2026; it doubles to $1.50/$7.50 on
+ * January 1, 2027. Revisit this entry then.
  */
 
 import { ModelSpec } from '../modelTypes';
 
 export const GOOGLE_MODELS: ModelSpec[] = [
+  // Gemini 3.7 models
+  {
+    provider: 'google',
+    name: 'Gemini 3.7 Flash',
+    apiName: 'gemini-3.7-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.75,
+    outputCostPerMillion: 3.75,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
   // Gemini 3.6 models
   {
     provider: 'google',

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -268,6 +268,25 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     }
   },
   {
+    // Google list price for the introductory period (through Dec 31, 2026);
+    // doubles to $1.50/$7.50 on Jan 1, 2027. OpenRouter is currently running an
+    // additional 50% promo ($0.375/$1.875), so real spend is lower than shown.
+    provider: 'openrouter',
+    name: 'Gemini 3.7 Flash',
+    apiName: 'google/gemini-3.7-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.75,
+    outputCostPerMillion: 3.75,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
     provider: 'openrouter',
     name: 'Gemini 3.6 Flash',
     apiName: 'google/gemini-3.6-flash',

--- a/tests/eval/configs/gemini-3.7-flash.yaml
+++ b/tests/eval/configs/gemini-3.7-flash.yaml
@@ -1,0 +1,23 @@
+mode: live
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - google/gemini-3.7-flash
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -163,6 +163,7 @@ describe('ModelRegistry Gemini 3.5 Flash models', () => {
 
 describe('ModelRegistry latest Gemini Flash models', () => {
   it.each([
+    ['gemini-3.7-flash', 'Gemini 3.7 Flash', 0.75, 3.75],
     ['gemini-3.6-flash', 'Gemini 3.6 Flash', 1.5, 7.5],
     ['gemini-3.5-flash-lite', 'Gemini 3.5 Flash-Lite', 0.3, 2.5]
   ])('registers %s for Google', (id, name, input, output) => {
@@ -183,6 +184,7 @@ describe('ModelRegistry latest Gemini Flash models', () => {
   });
 
   it.each([
+    ['google/gemini-3.7-flash', 'Gemini 3.7 Flash', 0.75, 3.75],
     ['google/gemini-3.6-flash', 'Gemini 3.6 Flash', 1.5, 7.5],
     ['google/gemini-3.5-flash-lite', 'Gemini 3.5 Flash-Lite', 0.3, 2.5]
   ])('registers %s for OpenRouter', (id, name, input, output) => {


### PR DESCRIPTION
Gemini 3.7 Flash shipped today (2026-08-13). This adds it as an **opt-in** model on the direct Google adapter and OpenRouter.

## Facts (verified against primary sources)

| | |
|---|---|
| Model code | `gemini-3.7-flash` / `google/gemini-3.7-flash` |
| Context / max output | 1,048,576 / 65,536 |
| Inputs | text, image, audio, video, PDF |
| Features | thinking (low/med/high), function calling, structured outputs, streaming |
| Price | $0.75 / $3.75 per 1M through 2026-12-31, then $1.50 / $7.50 |

Sources: [Gemini API model page](https://ai.google.dev/gemini-api/docs/models/gemini-3.7-flash), [Gemini API pricing](https://ai.google.dev/gemini-api/docs/pricing), [Google blog](https://blog.google/innovation-and-ai/models-and-research/gemini-models/introducing-gemini-3-7-flash/), and OpenRouter's live `/v1/models`.

## Pricing judgment call

Entries carry Google's list price for the introductory period, matching how the neighboring 3.5/3.6 entries mirror Google pricing rather than per-router promos. Two caveats are in code comments: the Jan 1 2027 doubling, and OpenRouter's current extra 50% promo ($0.375/$1.875 live) which makes OR cost read high rather than low.

## No code-path changes

`GoogleAdapter`'s thinking gate is `model.startsWith('gemini-3')`, which already covers it.

## Defaults unchanged

Eval harness scored **29/37 = 78%**, the skill's mid band → ship opt-in, do not promote. Baselines: Sonnet 4.6 97%, GPT-5.4-mini 94%, GPT-5.4 77%, older Gemini 3 Flash 46%. So it's a large jump over the previous Flash and lands just above GPT-5.4.

Five of the eight board failures are the **known harness-wide search-then-read satisficing gap** (model searches, gets `{path, score}`, answers without reading) that no cloud model has passed and that the 3-bucket system-prompt rewrite didn't move — tracked as item B in `docs/plans/gettools-loop-breaker-plan.md`, not a 3.7-specific defect. The genuine model slips are one wrong param name (`newPath` vs `destination`), one hallucinated `searchManager_memory`, and one zero-tool-call round.

Worth re-running `tests/eval/configs/gemini-3.7-flash.yaml` after the result-decoration fix lands to see whether it clears 80% for Google default.

## Verification

- ModelRegistry + GoogleAdapter + OpenAICodexAdapter: 54/54 pass
- `npm run build` clean, no `connectorContent.ts` churn
- Live smoke passes on **google** and **openrouter** at `MODEL_SMOKE_MAX_TOKENS=4096` (raised per the thinking-mode budget rule)
- Not touched: Requesty (slugs need live `/v1/models` verification; never got 3.6 either) and the `google-gemini-cli`/agy catalog (fixed by the CLI's own model list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwUVt9J2bPSqBC31UdPHMJ
