### PR TITLE
Add DeepSeek V4 Pro 0813 (OpenRouter)

### DIFF
--- a/src/services/llm/adapters/deepseek/DeepSeekModels.ts
+++ b/src/services/llm/adapters/deepseek/DeepSeekModels.ts
@@ -49,8 +49,13 @@ export const DEEPSEEK_MODELS: ModelSpec[] = [
     }
   },
 
-  // Pro — higher quality. Pricing reflects 75% promotional discount valid through 2026-05-31.
-  // Original list price: $1.74 input / $3.48 output per 1M tokens.
+  // Pro — higher quality. $0.435/$0.87 is the standard published rate as of
+  // 2026-08-13 (re-verified against the official pricing page), not a discount:
+  // what used to be the promotional rate became the list rate. The undated
+  // `deepseek-v4-pro` id below now resolves to the DeepSeek-V4-Pro-0813 GA
+  // snapshot, so no separate dated entry is needed here.
+  // Pricing note: DeepSeek switches to peak/off-peak billing on 2026-08-16
+  // 16:00 UTC, with off-peak at half the peak rate. Revisit these numbers then.
   {
     provider: 'deepseek',
     name: 'DeepSeek V4 Pro',

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -172,6 +172,31 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     }
   },
   {
+    // GA snapshot of DeepSeek V4 Pro (released 2026-08-13). On the direct
+    // DeepSeek API the undated `deepseek-v4-pro` alias already resolves to this
+    // same snapshot; OpenRouter serves the dated id separately from its own
+    // undated `deepseek/deepseek-v4-pro` route, which is priced higher.
+    // Text-only — no image input. maxTokens is capped at 64K rather than the
+    // API's 384K ceiling, matching the DeepSeek direct entries (downstream
+    // buildLLMResponse safety).
+    // Pricing note: DeepSeek switches to peak/off-peak billing on 2026-08-16
+    // 16:00 UTC, with off-peak at half the peak rate. Revisit then.
+    provider: 'openrouter',
+    name: 'DeepSeek V4 Pro 0813',
+    apiName: 'deepseek/deepseek-v4-pro-0813',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 0.435,
+    outputCostPerMillion: 0.87,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: false,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
     provider: 'openrouter',
     name: 'GLM 5.1',
     apiName: 'z-ai/glm-5.1',
@@ -268,6 +293,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     }
   },
   {
+    provider: 'openrouter',
+    name: 'Gemini 3.6 Flash',
+    apiName: 'google/gemini-3.6-flash',
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    inputCostPerMillion: 1.50,
+    outputCostPerMillion: 7.50,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
     // Google list price for the introductory period (through Dec 31, 2026);
     // doubles to $1.50/$7.50 on Jan 1, 2027. OpenRouter is currently running an
     // additional 50% promo ($0.375/$1.875), so real spend is lower than shown.
@@ -278,22 +319,6 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     maxTokens: 65536,
     inputCostPerMillion: 0.75,
     outputCostPerMillion: 3.75,
-    capabilities: {
-      supportsJSON: true,
-      supportsImages: true,
-      supportsFunctions: true,
-      supportsStreaming: true,
-      supportsThinking: true
-    }
-  },
-  {
-    provider: 'openrouter',
-    name: 'Gemini 3.6 Flash',
-    apiName: 'google/gemini-3.6-flash',
-    contextWindow: 1048576,
-    maxTokens: 65536,
-    inputCostPerMillion: 1.50,
-    outputCostPerMillion: 7.50,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,

--- a/tests/eval/configs/deepseek-v4-pro-0813.yaml
+++ b/tests/eval/configs/deepseek-v4-pro-0813.yaml
@@ -1,0 +1,23 @@
+mode: live
+testVaultPath: tests/eval/test-vault/
+
+providers:
+  openrouter:
+    apiKeyEnv: OPENROUTER_API_KEY
+    models:
+      - deepseek/deepseek-v4-pro-0813
+    enabled: true
+
+defaults:
+  temperature: 0
+  maxRetries: 1
+  retryDelayMs: 2000
+  timeout: 120000
+  systemPrompt: default
+
+capture:
+  enabled: true
+  dumpOnFailure: true
+  artifactsDir: test-artifacts/
+
+scenarios: tests/eval/scenarios/**/*.eval.yaml

--- a/tests/unit/ModelRegistry.test.ts
+++ b/tests/unit/ModelRegistry.test.ts
@@ -203,6 +203,33 @@ describe('ModelRegistry latest Gemini Flash models', () => {
   });
 });
 
+describe('ModelRegistry DeepSeek V4 Pro 0813 model', () => {
+  it('registers the dated GA snapshot for OpenRouter as a text-only thinking model', () => {
+    expect(ModelRegistry.findModel('openrouter', 'deepseek/deepseek-v4-pro-0813')).toEqual(expect.objectContaining({
+      name: 'DeepSeek V4 Pro 0813',
+      contextWindow: 1048576,
+      maxTokens: 65536,
+      inputCostPerMillion: 0.435,
+      outputCostPerMillion: 0.87,
+      capabilities: expect.objectContaining({
+        supportsJSON: true,
+        supportsImages: false,
+        supportsFunctions: true,
+        supportsStreaming: true,
+        supportsThinking: true
+      })
+    }));
+  });
+
+  it('keeps the direct DeepSeek provider on the undated alias that resolves to 0813', () => {
+    expect(ModelRegistry.findModel('deepseek', 'deepseek-v4-pro')).toEqual(expect.objectContaining({
+      inputCostPerMillion: 0.435,
+      outputCostPerMillion: 0.87
+    }));
+    expect(ModelRegistry.findModel('deepseek', 'deepseek-v4-pro-0813')).toBeUndefined();
+  });
+});
+
 describe('ModelRegistry Kimi K3 model', () => {
   it('registers Kimi K3 for OpenRouter with current pricing and capabilities', () => {
     expect(ModelRegistry.findModel('openrouter', 'moonshotai/kimi-k3')).toEqual(expect.objectContaining({


### PR DESCRIPTION
DeepSeek V4 Pro left preview on 2026-08-13 as the dated GA snapshot `deepseek-v4-pro-0813`.

## Scope: OpenRouter only, deliberately

[DeepSeek's docs](https://api-docs.deepseek.com/quick_start/parameter_settings) state the undated `deepseek-v4-pro` id **has been updated to point at the 0813 snapshot**. So the direct DeepSeek provider already serves this model through its existing entry, and adding a dated duplicate there would mean shipping an unverified wire id. The registry gap was on OpenRouter — which had **no DeepSeek entries at all** before this.

| | |
|---|---|
| Slug | `deepseek/deepseek-v4-pro-0813` |
| Context | 1,048,576 |
| Modalities | **text only** — no image input |
| Features | tools, reasoning, `response_format` |
| Price | $0.435 / $0.87 per 1M |

Verified against OpenRouter's live `/v1/models` and [DeepSeek's pricing page](https://api-docs.deepseek.com/quick_start/pricing).

`maxTokens` is capped at 64K rather than the API's 384K ceiling, matching the rationale already documented on the DeepSeek direct entries (downstream `buildLLMResponse` safety).

## Stale comment corrected

`DeepSeekModels.ts` claimed $0.435/$0.87 was a 75% promo expiring **2026-05-31**, with $1.74/$3.48 as the list price to return to. That date has passed and the pricing page now publishes $0.435/$0.87 as the standard rate — the numbers were correct, but the note would have invited a wrong "restore list price" edit.

Both files now flag the change that is actually coming: **peak/off-peak billing starts 2026-08-16 16:00 UTC**, off-peak at half the peak rate. That is three days out and will need a revisit.

## Drive-by

Fixes the ordering slip from #326 — the file asks to be alphabetized by display name and Gemini 3.7 Flash was inserted before 3.6.

## Eval: 29/37 = 78%

Same score as Gemini 3.7 Flash, and the failures overlap heavily — 5 of the 8 are the same scenarios, dominated by the known harness-wide **search-then-read satisficing gap** (model searches, gets `{path, score}`, answers without reading) tracked as item B in `docs/plans/gettools-loop-breaker-plan.md`. Also repeats the `newPath` vs `destination` param slip and reaches for `storage.list` where a `storage.move` was expected.

Mid band per the skill → opt-in, **no default changes**.

## Verification

- ModelRegistry + both DeepSeekAdapter suites: 56/56 pass
- `npm run build` clean, no `connectorContent.ts` churn
- Live smoke passes through OpenRouter at `MODEL_SMOKE_MAX_TOKENS=4096`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwUVt9J2bPSqBC31UdPHMJ
