### PR TITLE
docs: three design plans from the obsidian-skills review, plus a CLAUDE.md audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,9 @@
 <!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->
 # PACT Framework and Managed Project Memory
 
-
 <!-- SESSION_START -->
 ## Current Session
 <!-- Auto-managed by session_init hook. Overwritten each session. -->
-- Resume: `claude --resume b3cecaa5-b21c-4ff1-8986-75b0d0d92091`
-- Team: `session-b3cecaa5`
-- Session dir: `/Users/jrosenbaum/.claude/pact-sessions/claudesidian-mcp/b3cecaa5-b21c-4ff1-8986-75b0d0d92091`
-- Plugin root: `/Users/jrosenbaum/.claude/plugins/cache/pact-marketplace/PACT/4.4.49`
-- Started: 2026-07-01 14:48:23 UTC
 <!-- SESSION_END -->
 
 <!-- PACT_MEMORY_START -->
@@ -19,19 +13,27 @@
 
 <!-- pinned: 2026-06-02 -->
 ### Tool-schema `required`/`oneOf`/`enum` is NOT runtime-validated (no ajv)
-Agent tool param schemas (`getParameterSchema`) are DOCUMENTATION + CLI-normalizer hints only — there is NO ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A schema `required: [...]`, `oneOf`, or `enum` does NOT reject a malformed payload at runtime; bad input flows straight to the service. **Validation guards MUST live in the service/normalizer layer, not the schema.** Discovered v5.9.x (PR #236): a `createTask.linkedNotes` oneOf object missing `notePath` silently persisted `notePath:undefined` until an explicit guard was added in `normalizeLinkedNote` (TaskService). Rule: when a tool accepts structured input, add explicit field guards in the service/normalizer — never rely on the schema to enforce.
+Agent tool param schemas (`getParameterSchema`) are DOCUMENTATION + CLI-normalizer hints only — there is NO ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A schema `required: [...]`, `oneOf`, or `enum` does NOT reject a malformed payload at runtime; bad input flows straight to the service. **Validation guards MUST live in the service/normalizer layer, not the schema.** Origin: a `createTask.linkedNotes` oneOf object missing `notePath` silently persisted `notePath:undefined` until an explicit guard was added in `normalizeLinkedNote` (`src/agents/taskManager/services/TaskService.ts:78`). Rule: when a tool accepts structured input, add explicit field guards in the service/normalizer — never rely on the schema to enforce.
 
 <!-- pinned: 2026-04-20 -->
-### Line endings: LF canonical via `.gitattributes` (as of v5.8.2 / PR #169)
-Repo has `.gitattributes` declaring LF canonical across `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.json`/`.md`/`.css`/`.html`/`.yml`/`.sh` + binary markers for images/audio/fonts/pdfs. If you see CRLF in the tree, it's a local-editor bug — fix the editor, don't chase it with tool normalization. Never reintroduce CRLF. If 500+ files show modified with tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF — re-run `git add --renormalize .` on that subset, don't let it land.
+### Line endings: LF canonical via `.gitattributes`
+`.gitattributes` declares LF canonical across `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.json`/`.md`/`.css`/`.html`/`.yml`/`.sh` + binary markers for images/audio/fonts/pdfs. If you see CRLF in the tree, it's a local-editor bug — fix the editor, don't chase it with tool normalization. If 500+ files show modified with a tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF — re-run `git add --renormalize .` on that subset, don't let it land.
 
 <!-- pinned: 2026-04-23 -->
 ### Dynamic ToolManager sync: deferred refactor (issue #174)
-`AgentRegistrationService.syncToolManagerAgent` + `ToolManagerAgent.registerDynamicAgent/unregisterDynamicAgent` is a callback-wrap bridge that keeps `getTools` discovery in sync when `AppManager` installs/uninstalls app agents at runtime (v5.8.4). Works today because `AppManager` is the only dynamic registrar. **Does not compose** for a second one. When a remote-MCP loader / plugin-extension agent / other dynamic registrar lands, refactor to event-based: add `onAgentRegistered`/`onAgentUnregistered` to `AgentManager`, have `ToolManagerAgent` subscribe in its constructor, delete the bridge + the `instanceof ToolManagerAgent` concrete import in `AgentRegistrationService`. Do NOT do this refactor speculatively — wait for the triggering consumer. Tracking: https://github.com/ProfSynapse/nexus/issues/174.
+`AgentRegistrationService.syncToolManagerAgent` (`src/services/agent/AgentRegistrationService.ts:85`) + `ToolManagerAgent.registerDynamicAgent/unregisterDynamicAgent` (`src/agents/toolManager/toolManager.ts:117`) is a callback-wrap bridge that keeps `getTools` discovery in sync when `AppManager` installs/uninstalls app agents at runtime. Works today because `AppManager` is the only dynamic registrar. **Does not compose** for a second one. When a remote-MCP loader / plugin-extension agent / other dynamic registrar lands, refactor to event-based: add `onAgentRegistered`/`onAgentUnregistered` to `AgentManager`, have `ToolManagerAgent` subscribe in its constructor, delete the bridge + the `instanceof ToolManagerAgent` concrete import. Do NOT do this refactor speculatively — wait for the triggering consumer. Tracking: https://github.com/ProfSynapse/nexus/issues/174.
 
-<!-- pinned: 2026-04-20, updated 2026-05-11 -->
-### ToolManager MCP contract: CLI-first only (as of v5.8.2 / PR #170; replace migrated v5.9.0)
-`useTools`/`getTools` accept ONLY top-level CLI shape: `tool` string + context fields (`workspaceId`, `sessionId`, `memory`, `goal`, `constraints?`) at top level. Legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` throw `Deprecated payload shape` at `src/agents/toolManager/services/ToolCliNormalizer.ts:444/462/495`. `UseToolParams` has no `calls`/`request` fields. `executePrompts` actions: `replace` uses 4-field pattern-anchored shape `{path, start, end, content}` (was `oldContent` + `startLine` + `endLine` + `position` pre-v5.9.0; old shape gets a clean validation error, no compat shim); `append`/`prepend` route to `insert`; `position < 1` rejected. CLI parser decodes `\uXXXX` in quoted strings.
+<!-- pinned: 2026-04-20, updated 2026-08-14 -->
+### ToolManager MCP contract: CLI-first only
+`useTools`/`getTools` accept ONLY the top-level CLI shape: a `tool` string plus context fields (`workspaceId`, `sessionId`, `memory`, `goal`, `constraints?`) at the top level. Optional top-level `strategy: 'serial' | 'parallel'` and `values: Record<string, string>` (see below). Legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` throw `Deprecated payload shape` at `src/agents/toolManager/services/ToolCliNormalizer.ts:757/775/808`. `UseToolParams` has no `calls`/`request` fields.
+
+`content replace` and `executePrompts.replace` use the 4-field pattern-anchored shape `{path, start, end, content}` — `start`/`end` are TEXT anchors matched as whole lines (Unicode-normalized, so straight vs curly quotes compare equal), never line numbers. The pre-v5.9.0 `{oldContent, newContent, startLine, endLine}` shape gets a clean validation error, no compat shim. In `executePrompts`, `append`/`prepend` route to `insert`; `position < 1` is rejected. The CLI parser decodes `\uXXXX` in quoted strings.
+
+**Context contract is now ENFORCED** (not just declared): `ToolCliNormalizer.collectContextContractViolations()` / `validateExecutionContext()` are called first in `useTools.ts:37` and throw a *recoverable steering error* when `memory`/`goal` are empty or placeholder. `workspaceId`/`sessionId` keep silent defaults and only steer on present-junk; `constraints` is optional. getTools/discovery is exempt. The eval harness imports the same validator (single source).
+
+**Verbatim / multiline value transports** (do not flatten multiline content):
+- MCP/chat: top-level `values` map, referenced from the tool string as `@key`. Substituted *after* tokenization with NO escape processing, so backslashes, quotes, and newlines survive exactly (`C:\temp`, LaTeX `\alpha`, regex `\d`). Quoting the token (`"@key"`) passes the literal text. A missing key, or a declared key the command never references, fails loud.
+- Terminal CLI: `--<flag>-stdin` and `--<flag>-file <path>` hydrate *any* value-taking flag, not just `--content`. One `-stdin` per command (stdin reads once); several `-file` transports may coexist; a flag must not arrive both directly and via a transport.
 
 <!-- pinned: 2026-03-29 -->
 ### pdfjs-dist in Obsidian/Electron (legacy build + shared loader)
@@ -48,31 +50,25 @@ Use `loadPdfJs()` from `PdfJsLoader.ts` in both `PdfTextExtractor.ts` and `PdfPa
 
 <!-- pinned: 2026-04-05 -->
 ### Shared Transcription Infrastructure
-Transcription extracted from ingest into shared service at `src/services/llm/TranscriptionService.ts`. Five providers fully integrated:
-- **OpenAI** (`whisper-1`, `gpt-4o-transcribe`) — word timestamps via `verbose_json`
-- **Groq** — word timestamps, fastest inference
-- **Mistral** (`voxtral-mini`) — word timestamps + diarization
-- **Deepgram** — word timestamps, utterances, diarization, keyword biasing
-- **AssemblyAI** — word timestamps, speaker labels
+Shared service at `src/services/llm/TranscriptionService.ts`; adapters at `src/services/llm/adapters/{provider}/`; types at `src/services/llm/types/VoiceTypes.ts`. Providers with word-level timestamps: **OpenAI** (`verbose_json`), **Groq**, **Mistral** (+diarization), **Deepgram** (+utterances, diarization, keyword biasing), **AssemblyAI** (+speaker labels).
 
-Adapters at `src/services/llm/adapters/{provider}/`. Types at `src/services/llm/types/VoiceTypes.ts`.
-⚠️ Ingest shim at `src/agents/ingestManager/tools/services/TranscriptionService.ts` strips word-level data — audio editor must call shared service directly.
-- **Drag-drop file path**: Browser `File.name` is basename only — use `vault.getFiles().find(f => f.name === file.name)` to get vault-relative path in `handleIngestFiles`.
+⚠️ The ingest shim at `src/agents/ingestManager/tools/services/TranscriptionService.ts` strips word-level data — callers that need word timings must use the shared service directly.
+
+**Drag-drop file path**: browser `File.name` is basename only — use `vault.getFiles().find(f => f.name === file.name)` to recover the vault-relative path in `handleIngestFiles`.
 
 ## Working Memory
 <!-- Auto-managed by pact-memory skill. Last 3 memories shown. Full history searchable via pact-memory skill. -->
 
 <!-- PACT_MEMORY_END -->
-
 <!-- PACT_MANAGED_END -->
 
 # Claude Code Context Document
-Last Updated: 2026-08-06
+Last Updated: 2026-08-14
 
 ## Project Overview
-- **Name**: Nexus (package: claudesidian-mcp)
+- **Name**: Nexus (package: `claudesidian-mcp`, manifest id `nexus`)
 - **Version**: 5.16.4
-- **Type**: Obsidian Community Plugin
+- **Type**: Obsidian Community Plugin (`isDesktopOnly: false`, minAppVersion 1.8.7)
 - **Purpose**: MCP integration for Obsidian with AI-powered vault operations
 - **Architecture**: Agent-Tool pattern with domain-driven design
 - **Stack**: TypeScript, Node.js, Obsidian Plugin API, MCP SDK
@@ -87,6 +83,7 @@ Full guidelines: `docs/obsidian-plugin-guidelines.md`
 - `registerDomEvent` for all DOM events (not `addEventListener` — causes memory leaks)
 - Use `requestUrl()` not `fetch()` for HTTP; `normalizePath()` for paths
 - `vault.adapter` is acceptable for direct storage-path access when needed; normalize paths and resolve Nexus storage roots from settings instead of hardcoding `.nexus` or `Nexus`
+- `normalizePath()` does NOT strip `..` — path confinement needs an explicit `assertInside`-style guard at every write/copy/remove boundary
 
 ### Mobile Compatibility (Critical)
 
@@ -105,121 +102,113 @@ Full guidelines: `docs/obsidian-plugin-guidelines.md`
 1. **Never** top-level import Node.js built-ins — use `desktopRequire()` from `src/utils/desktopRequire.ts`
 2. **Never** top-level import npm packages that depend on Node.js built-ins (mammoth, jszip, xlsx, yaml, etc.) — use dynamic `await import()` inside async functions
 3. **Replace** `EventEmitter` with Obsidian's `Events` class (cross-platform)
-4. **Desktop-only features** (ingestion, composer, OAuth, CLI, MCP transports): ensure all Node.js-dependent imports are lazy
+4. **Desktop-only features** (ingestion, composer, OAuth, CLI, MCP transports, data analysis): ensure all Node.js-dependent imports are lazy
 
 **Known desktop-only npm packages**: mammoth, jszip, xlsx, yaml (all have Node.js transitive deps)
 
 ## Recent Changes
 
-**Current Version**: 5.16.2
-Full changelog: `docs/changelog.md`
+**Current version**: 5.16.4. Full changelog: `docs/changelog.md` — that file is the changelog; do not retell releases here. Only entries with a live, forward-looking consequence belong below.
 
-**Latest**:
-- **v5.16.2** (2026-08-06) — Search ranking + CLI grounding. `searchContent.ts` tier ladder is now single-scale: `TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8 > PARTIAL_MATCH_FLOOR 0.3 > FUZZY_ONLY_CEILING 0.25`; filename fuzzy was previously normalized to `1 + score/100` (~0.92–0.95), an incommensurable scale that let a coincidental name beat a verbatim body match (PRs #312/#313/#314, issue #309). `foldSeparators()` folds `-`/`_` to spaces on both sides so a kebab filename matches a spaced query. Results carry `matchType: 'content' | 'path' | 'semantic'`. **Test methodology changed (#315)** — three defects shipped past a green suite, all found by searching the real vault: `tests/unit/SearchContentTool.test.ts` now runs every ranking assertion twice with the vault enumerated in both orders and fails loudly if the order decides it (a tie is not a ranking rule), plus a naming-style × query-style cross-product; `tests/debug/search-ranking-live-smoke.test.ts` (`RUN_SEARCH_SMOKE=1`) drives a live vault through the `nexus` CLI so the real `prepareFuzzySearch` is exercised. The `prepareFuzzySearch` mock in `tests/mocks/obsidian/core.ts` charges a small per-discontiguity penalty **capped at 8** — this reproduces why the bug existed; do not make it proportional or the tests go vacuous. Also: `nexus --vault X use … -- storage list` no longer strips the agent name (#310); `NoteEmbeddingService.embedNote` treats ENOENT as a skip, not an error, and no longer logs-and-rethrows (callers already log) (#316); task metadata shallow-merges (#307, issue #305); `load-state` returns current tags (#308, issue #306).
-- **v5.9.7** — Archive visibility fix for tagged states (PR #218, commit `eae5f507` + version bump `05ce7199`): drops the `stateMeta.tags ? null :` shortcut at `MemoryService.getStates:555` so `adapter.getState` always runs. Pre-fix, the SQLite-metadata fast-path skipped JSONL content fetch for tagged states, and the skeleton return path never surfaced `state.metadata.isArchived` — UI list filter and AI-facing `listStates` filter both saw archived tagged states as active. Surgical 1 LoC + 3 regression tests (`MemoryServiceGetStates.test.ts`). Both UI and AI filters inherit the fix (read from same `getStates` output). Manually verified in Obsidian. Tech-debt follow-up tracked in **issue #219** (denormalize `is_archived` into SQLite metadata, ~80–120 LoC, v13 migration — restores the perf shortcut without correctness cost).
-- **v5.9.6 + #215 / #216** (manually verified, **issue #215 closed**) — state CRUA tools (`updateState` + `archiveState`) added to MemoryManager + states management UI section under workspace settings. Contract: AI gets archive-only (soft, reversible); UI gets archive AND delete (humans can permanently destroy). No `deleteState` MCP tool exists. Storage extension: `state_updated` event mirroring `state_deleted` (~80 LoC across 9 files). 2 remediation cycles during review: Cycle 1 (B1 archiveState skeleton-corruption for tagged states, B2/B3 StateRepository event-fold + archive round-trip tests), Cycle 2 (M1 MemoryService.deleteState latent landmine — routed through `HybridStorageAdapter.deleteState` via `withDualBackend`). Post-merge manual-test surfaced the archive-visibility bug (fixed in v5.9.7 above). Frontend polish F1-F4 still open in **issue #217**.
-- **v5.9.6** — Startup hydration recovery (PR #211, commit `3cf6d3f5` + version bump `f16356ac`): self-healing for stalled startup hydration in `StartupHydrationController`.
-- **v5.9.0** — Pattern-anchored `content replace` (PR #206): hard schema break from `{path, oldContent, newContent, startLine, endLine}` to 4-field `{path, start, end, content}` on both `ContentManager.replace` and `executePrompts.replace`. No compat shim — old shape returns clean validation error. See the pinned ToolManager MCP contract entry for the full contract.
-- **v5.8.14** — DeepSeek as first-class cloud provider (PR #205, resolves #204): direct DeepSeek API alongside other cloud providers. 4 models (`deepseek-v4-flash`/`-pro` + `-thinking` variants), thinking mode via existing `ThinkingEffortMapper`. Mobile-compatible. ⚠️ Untested in production. Known follow-up: `ProviderManager.ts` (659 LoC) and `ProvidersTab.ts` (645 LoC) crossed 600-line maintainability threshold from wiring additions; refactor when next touched.
-- **v5.8.13** — Cache backend re-run loop hotfix (PR #203): fixes v5.8.12 regression on Windows. `PluginScopedStorageCoordinator.saveState` was clobbering `cacheBackend` on every boot; `runJanitor` `cache.db` delete now retries with backoff. Cross-platform fix — Mac was masking the loop via JANITOR fast-path.
-- **v5.8.12** — Cloud-sync-aware cache backend (PR #202): IndexedDB on desktop (cloud-sync-immune), `vault.adapter` file backend on mobile. Foreground-blocking migration FSM on first launch. Resolves GDrive Shared Drive boot-hang. New `Nexus: Rebuild cache` command.
-- **v5.8.11** — CLI tool array-bracket fix (PR #201, fixes #200): `ToolCliNormalizer` strips outer JSON-array-literal `[...]` pair on CSV-fallback when inner content fails `JSON.parse`. Fixes wikilink corruption in `content set-property --value "[[[A]],[[B]]]"`.
-- **v5.8.10** — Sync-safe storage reconcile Phase 1: conflict-copy regex relax + new `ReconcilePipeline` (3-layer idempotency) + v11→v12 `shard_cursors` migration. Resolves GDrive task-revert incident. Phase 2 (cache.db relocation) was superseded by v5.8.12.
-
-Older versions: see `docs/changelog.md`.
+- **v5.16.4** — multiline/verbatim value transports (`values` map, `--<flag>-stdin`/`--<flag>-file`) and honest CLI PATH reporting. The transport contract is pinned above; it is load-bearing for anything that passes content through a tool.
+- **v5.16.2** — search ranking is a **single-scale tier ladder** in `src/agents/searchManager/tools/searchContent.ts`: `TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8 > PARTIAL_MATCH_FLOOR 0.3 > FUZZY_ONLY_CEILING 0.25`. Never reintroduce a second scale (filename fuzzy used to be normalized to `1 + score/100`, which let a coincidental name beat a verbatim body match). `foldSeparators()` folds `-`/`_` to spaces on both sides. Results carry `matchType: 'content' | 'path' | 'semantic'`.
+  **Test methodology rule that came out of it** — three defects shipped past a green suite. `tests/unit/SearchContentTool.test.ts` runs every ranking assertion twice with the vault enumerated in both orders and fails loudly if order decides it (a tie is not a ranking rule). `tests/debug/search-ranking-live-smoke.test.ts` (`RUN_SEARCH_SMOKE=1`) drives a live vault through the `nexus` CLI so the real `prepareFuzzySearch` runs. **The `prepareFuzzySearch` mock in `tests/mocks/obsidian/core.ts` charges a per-discontiguity penalty capped at 8 — do not make it proportional, or the tests go vacuous.**
 
 ## Quick Navigation
 
 ### Core Directories
-- `/src/agents/` - Agent implementations (PromptManager, ContentManager, etc.)
-- `/src/services/` - Shared services (LLM providers, memory, conversations)
-- `/src/components/` - UI components (chat view, settings, modals)
-- `/src/types/` - TypeScript type definitions
-- `/src/utils/` - Utility functions and helpers
+- `/src/agents/` - Agent implementations (see Agent Architecture below)
+- `/src/services/` - Shared services (LLM providers, memory, conversations, chat)
+- `/src/components/`, `/src/ui/`, `/src/settings/` - UI components, chat view, settings tabs
+- `/src/database/` - Storage adapters, SQLite cache, schema migrations
+- `/src/types/`, `/src/utils/` - Type definitions and helpers
 
 ### Key Files
-- `main.ts` - Plugin entry point and lifecycle management
-- `connector.ts` - MCP server connector for Claude Desktop
-- `src/agents/index.ts` - Agent registry and initialization
-- `src/services/conversationService.ts` - Chat conversation management
-- `src/services/llmService.ts` - LLM provider abstraction layer
+- `src/main.ts` - Plugin entry point and lifecycle management
+- `src/connector.ts` - MCP server connector for Claude Desktop
+- `src/agents/index.ts` - Agent registry
+- `src/services/ConversationService.ts` - Chat conversation management
+- `src/services/llm/core/LLMService.ts` - LLM provider abstraction layer
+- `src/ui/chat/ChatView.ts` - Chat view
+- `src/components/ConfigModal.ts` - Settings modal
+- `src/utils/cliAssets.ts` - Shipped CLI guidance/help text (single-sourced to prod + docs)
 
 ## Agent Architecture
 
 ### Available Agents
 
 **ToolManager** (`src/agents/toolManager/`) - **MCP Entry Point** (Two-Tool Architecture)
-   - `getTools`: Discovery - returns tool schemas for requested agents/tools
-   - `useTools`: Execution - unified context-first tool execution
-   - *Only these 2 tools are exposed to Claude Desktop. All other agents work internally.*
+- `getTools`: Discovery — returns tool schemas for requested agents/tools
+- `useTools`: Execution — unified context-first tool execution
+- *Only these 2 tools are exposed to Claude Desktop. All other agents work internally.*
 
 > Tool names below are the **CLI form** (`agent tool-name`, kebab-case) — what a
-> caller actually types and what `getTools`/`useTools` resolve. Verify against
-> `src/agents/**` (`slug:`) before trusting; the `/nexus-release` skill gates on
-> refreshing this list, and `tests/unit/shippedGuidanceCommands.test.ts` fails
-> when shipped docs name a tool that does not exist.
+> caller types and what `getTools`/`useTools` resolve. Source of truth is the
+> `slug:` field under `src/agents/**` (camelCase there, kebab-cased for CLI).
+> Regenerate `cli-first-tool-schemas.json` with `npm run schemas:tools`.
+> `tests/unit/shippedGuidanceCommands.test.ts` fails when shipped docs name a
+> tool that does not exist.
 
-1. **PromptManager** (`src/agents/promptManager/`) - Custom prompts and LLM integration
-   - `prompt`: execute, create, get, list, update, archive, sub, list-models,
+**Always-on agents (8, 56 tools):**
+
+1. **PromptManager** (`src/agents/promptManager/`) — custom prompts and LLM integration
+   - `prompt`: execute, subagent, create, get, list, update, archive, list-models,
      generate-image, generate-audio, generate-video, check-generated-artifact
    - No delete — the AI gets `archive` (reversible). Media generation is async:
      `generate-*` returns a job, poll `check-generated-artifact <jobId>`.
-
-2. **ContentManager** (`src/agents/contentManager/`) - Note reading/editing operations
+2. **ContentManager** (`src/agents/contentManager/`) — note reading/editing
    - `content`: read, write, replace, insert, set-property
-   - `read` requires `--start-line`. `replace` is pattern-anchored
-     `{path, start, end, content}` — anchor TEXT, not line numbers.
-
-3. **StorageManager** (`src/agents/storageManager/`) - File/folder management
+   - `read` requires `--start-line`. `replace` is pattern-anchored (see pinned contract).
+3. **StorageManager** (`src/agents/storageManager/`) — file/folder management
    - `storage`: list, create-folder, move, copy, archive, open
-
-4. **SearchManager** (`src/agents/searchManager/`) - Advanced search operations
+4. **SearchManager** (`src/agents/searchManager/`) — search
    - `search`: content, directory, memory, query-notes
-
-5. **MemoryManager** (`src/agents/memoryManager/`) - Workspace/state/workflow management
+5. **MemoryManager** (`src/agents/memoryManager/`) — workspace/state/workflow management
    - `memory`: create-workspace, list-workspaces, search-workspaces, load-workspace,
      update-workspace, archive-workspace, create-state, list-states, load-state,
      update-state, archive-state, run
    - No session tools — sessions are context fields, not tools. `memory run`
-     triggers a workflow (`--workflow-id`/`--workflow-name`).
-
-6. **CanvasManager** (`src/agents/canvasManager/`) - Obsidian canvas operations
+     triggers a workflow (`--workflow-id`/`--workflow-name`). AI gets archive-only
+     for states (soft, reversible); permanent delete is UI-only, there is no
+     `deleteState` MCP tool.
+6. **CanvasManager** (`src/agents/canvasManager/`) — Obsidian canvas
    - `canvas`: read, write, update, list
-
-7. **TaskManager** (`src/agents/taskManager/`) - Workspace-scoped project/task management with DAG dependencies
+7. **TaskManager** (`src/agents/taskManager/`) — workspace-scoped projects/tasks with DAG dependencies
    - `task`: create-project, list-projects, update-project, archive-project,
      create, list, update, move, query, open, link-note
    - Note the asymmetry: project tools are suffixed (`create-project`), task tools
      are bare (`create`, `list`, `update`, `move`, `query`).
-   - Services: TaskService (business facade), DAGService (pure computation)
-   - Auto-loads task summary when workspace loads
-
-8. **IngestManager** (`src/agents/ingestManager/`) - PDF/audio ingestion
+   - Services: TaskService (business facade), DAGService (pure computation).
+     Auto-loads a task summary when a workspace loads.
+8. **IngestManager** (`src/agents/ingestManager/`) — PDF/audio ingestion
    - `ingest`: run, capabilities
 
-9. **WebToolsAgent** (`src/agents/apps/webTools/`) - Headless browser tools (desktop-only)
+**Opt-in app agents (5, 18 tools)** — a vault only exposes the apps it enables:
+
+9. **WebToolsAgent** (`src/agents/apps/webTools/`) — headless browser (desktop-only)
    - `web`: open, capture-markdown, capture-png, capture-pdf, links
-
-10. **ComposerAgent** (`src/agents/apps/composer/`) - Multimodal file composition
+10. **ComposerAgent** (`src/agents/apps/composer/`) — multimodal file composition
     - `composer`: compose, list-formats
-
-11. **ElevenLabsAgent** (`src/agents/apps/elevenlabs/`) - AI audio (app, opt-in)
+11. **ElevenLabsAgent** (`src/agents/apps/elevenlabs/`) — AI audio
     - `elevenlabs`: list-voices, sound-effects, generate-music
-    - No text-to-speech tool; TTS runs through `prompt generate-audio` using the
-      ElevenLabs Voice defaults.
-
-12. **DataAnalysisAgent** (`src/agents/apps/dataAnalysis/`) - Pyodide pandas (app, opt-in, desktop-only)
+    - No text-to-speech tool; TTS runs through `prompt generate-audio`.
+12. **DataAnalysisAgent** (`src/agents/apps/dataAnalysis/`) — Pyodide pandas (desktop-only)
     - `data`: run-python, list-capabilities
-
-13. **SkillsAgent** (`src/agents/apps/skills/`) - Skills Protocol (app, opt-in)
+13. **SkillsAgent** (`src/agents/apps/skills/`) — Skills Protocol
     - `skills`: list-skills, load-skill, create-skill, update-skill, archive-skill, sync-skills
+    - Design: `docs/plans/skills-protocol-integration-plan.md`. Skills live under
+      `<root>/skills/<provider>/<name>/SKILL.md`, indexed in the SQLite `skills`
+      table; `sync-skills` mirrors to/from vault-root `.{provider}/skills/`
+      (last-writer-wins) and **writes into the user's real provider dotfolders** —
+      confirm scope before changing that behavior. Path confinement lives in
+      `skillPaths.ts` (`resolveVaultPath`/`assertInside`/`isSafePathSegment`).
 
 ### Agent Structure Pattern
 ```
 agents/
   [agentName]/
     [agentName].ts          # Main agent class extending BaseAgent
-    tools/                   # Operation tools
+    tools/                  # Operation tools
       [toolName].ts
       services/             # Tool-specific services
     services/               # Agent-level shared services
@@ -227,94 +216,180 @@ agents/
     utils/
 ```
 
+App agents additionally extend `BaseAppAgent` (`src/agents/apps/BaseAppAgent.ts`) and
+may opt into `AppRuntimeContext` (`src/agents/apps/AppRuntimeContext.ts`) for settings,
+storage-adapter, and session-context access.
+
 ### Base Classes
-- **BaseAgent** (`src/agents/baseAgent.ts`) - Common agent functionality
-- **BaseTool** (`src/agents/baseTool.ts`) - Common tool functionality with generic types
-- **IAgent** (`src/agents/interfaces/IAgent.ts`) - Agent interface contract
-- **ITool** (`src/agents/interfaces/ITool.ts`) - Tool interface contract
+- **BaseAgent** (`src/agents/baseAgent.ts`)
+- **BaseTool** (`src/agents/baseTool.ts`) — generic `BaseTool<Params, Result>`
+- **IAgent** (`src/agents/interfaces/IAgent.ts`), **ITool** (`src/agents/interfaces/ITool.ts`)
 
-## Current Work
+## Current Work / Open Items
 
-**Active branch**: `main` (feature work on `feat/agy-cli-reroute`, `fix/issue-272-taskboard-pagination`, `fix/issue-271-chat-loading-state`). **Open PRs**: #275 (#272 task-board undercount fix), #276 (#271a/b spinner + CLI process bound) — both await manual test + merge.
+No in-flight uncommitted work is tracked here — the working tree is clean at 5.16.4.
+Check `git log` and `docs/plans/` for what is actually in progress.
 
-**v5.12.0 RELEASED 2026-06-13** (PRs #265–#267 + commits `abf26e03`/`780905f0`; workflow run 27475645444 success, 3 assets + attestations, no connector.js). Marquee: **Adaptive Search / self-improving local retrieval (#265)** — query-side low-rank adapter over the frozen MiniLM encoder, learned from implicit search→open feedback during idle 45-min "dream" cycles (`src/services/embeddings/adapter/`, ~3.1k LoC + 11 test files). On-by-default (opt-out `embeddings.retrievalLearning:false`), desktop-only, identity-safe (only promotes a tuning that beats a held-out test → "search can't get worse"), reversible (delete `<root>/data/embeddings/adapter.json`), fully local. Command: "Consolidate retrieval memory (dream now)". Default bake-off trains InfoNCE/BPR/KTO each round, best-on-held-out wins. User guide already shipped: `guide/adaptive-search.md` (README links it 3×). Also: **Task Board delete-task icon + cold-start empty-board fix (#267)** — board card now has a confirm-gated trash icon next to edit; `TaskBoardDataController.loadBoardData` now awaits `adapter.waitForQueryReady()` before reading (was rendering "No tasks" on cold cache because `workspaceService.getWorkspaces()` had no hydration gate, only TaskService did). **MCP read-batching nudge (#266)** — agent-facing prompt guidance only (batch known multi-file reads into one parallel `useTools` call); the learned next-tool predictor + eager prefetch were both measured against real vault traces and SHELVED. Framing decided with user: minor bump, headline-but-conservative on the learning feature, keep on-by-default. **Release-skill gap now CLOSED**: `versions.json` bump (5th file) is in the skill as of `abf26e03`; followed it correctly this release.
+**Proposed, planned but not started** (each has a design plan and a tracking issue):
+- **Web capture via Defuddle** — `docs/plans/web-capture-defuddle-plan.md`. Replace the
+  Web Viewer `save-to-vault` dependency in `web capture-markdown` with Defuddle core
+  plus Obsidian's `htmlToMarkdown()`; adds a mobile-capable fetch transport.
+- **BasesManager agent** — `docs/plans/bases-manager-agent-plan.md`. `.base` file
+  read/write/update/list plus `analyze`, which executes the query through Obsidian's
+  own engine. The agent is not registered at all when Bases is disabled.
+- **In-app verification via the Obsidian CLI** — `docs/plans/obsidian-cli-verification-plan.md`.
+  build → `plugin:reload` → `dev:errors` → screenshot, so "works in Obsidian" stops
+  being a human-only check.
 
-**v5.11.2 RELEASED 2026-06-12** (PRs #250–#264 + `c91631c0` + same-day fixes; workflow success, 3 assets + attestations). Same-day pre-release findings, all shipped in the release: Requesty live smoke found+fixed `google/gemini-3.5-flash` → `vertex/gemini-3.5-flash` (Requesty has no google/ alias for 3.5 Flash; other 12 slugs verified via live `/v1/models`); `tests/debug/provider-model-live-smoke.test.ts` extended with `requesty`+`anthropic` providers; eslint crash on `version-bump.mjs` fixed (`disableTypeChecked` doesn't cover third-party typed rules — explicit `obsidianmd/*: off` + `globals.node` in the JS/MJS block); changelog backfilled for 5.11.0/5.11.1. **Release-skill gap**: `versions.json` needs the new version entry (release.yml guard from #255) — skill's 3-file list is incomplete. **Remaining manual checks** (`docs/testing/manual-test-plan-post-5.11.1.md`, local-only): MCP socket connect on installed build, secure-key-storage round-trip. `action-gh-release` bumped v2→v3 for the June 16, 2026 Node 24 forced upgrade (next-release verify).
+**Deferred, with a live decision attached:**
+- **Reasoning-LEVEL (low/medium/high) UI for local models — WON'T DO** unless
+  re-requested. The gap is real and 3-part: (1) `ChatSettingsRenderer.renderReasoningControls`
+  gates on `staticModelsService.findModel`, which has no `lmstudio`/`ollama` case;
+  (2) `OllamaAdapter` sends `think:<boolean>` (Ollama accepts `"low"|"medium"|"high"|"max"`
+  for gpt-oss) and `LMStudioAdapter` sends no `reasoning_effort`; (3) `ThinkingEffortMapper`
+  has no Ollama/LM Studio entries. **User decision: users set reasoning effort in
+  LM Studio's own UI where available.** Do not build this speculatively.
+- **getTools loop-breaker — scoped, NOT built.** Plan: `docs/plans/gettools-loop-breaker-plan.md`.
+  (A) a per-exchange getTools tracker in `ToolContinuationService` that steers on
+  ≥3 consecutive or repeated-selector getTools calls; (B) decorate getTools and
+  search/list *results* with "these are schemas/locations — call useTools / content
+  read next". Partial (B) has landed in the system prompt (`SystemPromptBuilder`),
+  `searchWorkspaces`, and shipped CLI guidance, but generic search/list result
+  decoration and the tracker do not exist. Steers must never block; keep
+  `TOOL_ITERATION_LIMIT=15` as the backstop.
+- **Canonical Message Pipeline — Phase 3**: drop the redundant
+  `LLMService.generateResponseStream` remap; accept `ConversationMessage[]` directly.
+  ~3–5h, medium risk. Plan: `docs/plans/canonical-message-pipeline-plan.md`.
+  Phases 1+2 shipped. Phase 4 (single canonical message type) deferred to the
+  next provider add.
 
-**In-flight (not yet PR'd):**
-- **DEFERRED (won't-do, 2026-06-28): reasoning-LEVEL (low/medium/high) UI for local models.** Confirmed the gap is real & 3-part — (1) `ChatSettingsRenderer.renderReasoningControls` gates on `staticModelsService.findModel` which has NO `lmstudio`/`ollama` case (falls to `default: return []`), so the Reasoning toggle/effort-slider never renders for local providers; (2) adapters don't pass a level anyway — `OllamaAdapter` sends `think:<boolean>` (Ollama actually accepts `think:"low"|"medium"|"high"|"max"` for gpt-oss; verified via docs), `LMStudioAdapter` sends NO `reasoning_effort` (LM Studio defers to OpenAI param semantics, so gpt-oss WOULD honor `reasoning_effort`); (3) `ThinkingEffortMapper` has Anthropic/Google/Groq/DeepSeek/OpenAI entries but none for Ollama/LM Studio. Per-model nuance: levels apply only to gpt-oss-class; qwen3-thinking is always-on (`/api/v1/models` → `capabilities.reasoning.allowed_options:["on"]`). **User decision: leave it — users set reasoning effort in LM Studio's own UI where available.** Do NOT build A+B+C unless re-requested.
-- **Local-model (LM Studio + Ollama) thinking / streaming / speculative-decoding fixes — UNCOMMITTED on `main`, awaiting user manual test (2026-06-26).** Build green (`main.js` rebuilt), lint+tsc clean, LMStudioAdapter tests 10/10, full sweep clean except the known pre-existing `TaskBoardEditCoordinator` jsdom-Modal failure. **DO NOT COMMIT until user tests** (standing constraint). Root cause found by live-curling the user's LM Studio: sending `draft_model` for speculative decoding against a **batched MLX** target returns `SpeculativeDecodingNotSupportedError` as an **in-stream `{"error":{...}}` frame over HTTP 200** (not an HTTP error) → `processNodeStream` silently swallowed it (no extractor matched) → empty stream → blank bubble / blank inspect / "stuck in reasoning". Fixes: (1) NEW `extractError` hook on `SSEStreamOptions` + `processNodeStream` (`BaseAdapter.ts`) — in-stream error frames now throw `LLMProviderError('…','PROVIDER_STREAM_ERROR')` instead of ending empty; (2) `LMStudioAdapter.generateStreamAsync` refactored to `streamChatOnce(requestBody)` private generator + try/catch that, on a draft error (HTTP **or** in-stream) before any real output, calls `markDraftIncompatible`, deletes `draft_model`, and `yield*`-retries without speculative → chat ALWAYS produces output (also covers tokenizer/vocab-mismatch drafts); (3) `ensureModelLoaded` — **restored `parallel:1`** in the load body (verified via `echo_load_config` that LM Studio DOES honor `parallel` despite it being absent from the public REST docs; MLX speculative needs a non-batched parallel:1 instance), now scans ALL `loaded_instances` and skips only when a suitable one exists (context match; parallel:1 required when a draft is configured) so it neither reloads every turn nor piles up duplicate instances; **flash_attention is passed through but NEVER compared** (llama.cpp-only; MLX no-op + unreported → comparing it caused infinite reloads — this was the "loads a NEW model every chat" bug). Endpoints confirmed correct/official: `/api/v1/models`, `/api/v1/models/load`. **MLX = the culprit**: batched-MLX bans speculative decoding and vision MLX never supports it; user is switching to **GGUF** (no batched restriction) — pair a GGUF target with a SAME-FAMILY GGUF draft for matching vocab. Also note `/api/v1/models` natively reports `capabilities.vision` + `capabilities.reasoning` (could later replace the name-regex thinking detection + vision gating). **Thinking rendering**: confirmed end-to-end WORKING — `reasoning_content`→`chunk.reasoning`→`MessageStreamHandler` synthetic `reasoning`-type tool call → `toolDisplayNormalizer.buildReasoningGroup` ("Reasoning" group, live) + persisted to `message.reasoning`. **REASONING-RENDER GAP — FIXED (2026-06-26, same uncommitted batch).** Root cause: reasoning flowed through every layer and was persisted to `message.reasoning`, but the FINAL render dropped it — `MessageBubble` computed `state.activeReasoning` and never used it, and the live path emitted a fragile synthetic `reasoning`-type tool call that the tool coordinator never rendered. Fix (7 files): NEW `onReasoningUpdate(messageId,text,isComplete)` event on `StreamHandlerEvents`/`MessageManagerEvents` replacing the synthetic tool call in `MessageStreamHandler` (deleted `createReasoningToolCall`); `ChatView.onReasoningUpdate` → `MessageDisplay.updateMessageReasoning` → `MessageBubble.updateReasoning` (live writer) + `MessageBubble.syncReasoningBlock` renders a collapsible `<details class="message-reasoning">` "Thinking" block from `getActiveReasoning` (auto-expands while streaming, collapses on complete) wired into both `createStandardMessageContainer` and `updateWithNewMessage`; `styles.css` `.message-reasoning*`; `ToolInspectionModal` now includes messages with reasoning (think-only responses appear) via `hasInspectableContent` + a default-open "Reasoning" data block. Build+lint+tsc clean; LMStudioAdapter 10/10, MessageStreamHandler+MessageManager tests pass. Touched files: `src/services/llm/streaming/SSEStreamProcessor.ts`, `src/services/llm/adapters/BaseAdapter.ts`, `src/services/llm/adapters/lmstudio/LMStudioAdapter.ts`, `src/services/llm/adapters/ollama/OllamaAdapter.ts`, `src/services/llm/adapters/shared/thinkingModels.ts` (NEW), `src/agents/toolManager/tools/getTools.ts` + `services/ToolCliNormalizer.ts` + `types.ts` (getTools compact-discovery bloat cap, ~25k→~3k), `src/components/llm-provider/providers/LMStudioProviderModal.ts` (speculative pair gating layers 1&2), + tests. Also uncommitted from earlier in same session: getTools compact-discovery cap, native thinking for LM Studio (`reasoning_content`) & Ollama (`think:true`/`message.thinking`), speculative-pair UI gating via `/api/v0/models` metadata.
-- **AGY CLI re-route (issue #271c) — adapter swap in progress on `feat/agy-cli-reroute`** (`.worktrees/feat-agy-cli-reroute`, off current main). Plan: `docs/plans/agy-cli-reroute-plan.md` (APPROVED). Replaces deprecated `gemini` CLI runtime with Google Antigravity CLI (`agy` v1.0.10, `~/.local/bin/agy`) in the `google-gemini-cli` provider (provider id UNCHANGED for settings compat). **2 commits landed**: `518007fd` slice e (UI relabel → "Antigravity CLI"/"Google (Antigravity)", 3 files), `7d4b765c` slices a/b/c+R7 (binary swap geminiCli.ts:49; DELETE the gemini `--output-format json` JSON-parse pipeline → `parseAgyOutput`=stdout.trim seam, agy emits PLAIN TEXT + NO token usage; NEW `geminiCliModelNormalize.ts` FAIL-CLOSED allowlist — agy `--model` fails OPEN on bad slug so Nexus must reject; R7 `GeminiCliAuthService` strict→tolerant `access_token`-presence scan, boolean-only). Build green, adapter test rewritten to agy contract 6/6, suite 3601/0. **agy contract (verified v1.0.10)**: plain-text only (no `--output-format json`); `--model` takes human labels (`agy models`: "Gemini 3.5 Flash (Medium/High/Low)", "Gemini 3.1 Pro", "Claude Sonnet/Opus 4.6", "GPT-OSS 120B") and FAILS OPEN; no token usage; auth file-based `~/.gemini/oauth_creds.json` (may be multi-object → tolerant parse); **IGNORES `GEMINI_CLI_SYSTEM_SETTINGS_PATH`** (verified — so the old env-pointed temp-settings mechanism is dead for agy); native tool-restriction = `--sandbox` + permission-prompting (no `--dangerously-skip-permissions`). **Slice d PENDING** (invocation flags + tool-restriction posture + env-strip + deferred UI runtime strings): under focused agy-security re-review (Task #38) — leading design is `agy --print --model <label> --print-timeout <ms> --sandbox` with NO config write at all (eliminates the persistent-`~/.gemini`-write HIGH risk). Then TEST + peer-review. **Related**: PRs #275 (#272 task-board undercount) + #276 (#271a/b spinner+CLI-bound) OPEN, await manual test + merge; AGY branch rebases onto main after #276 to inherit the idle watchdog. SECURITY non-negotiables: auth probe boolean-only (never read/log/return token); no persistent ~/.gemini writes; no `--dangerously-skip-permissions`; allowlist-validate model labels.
-- **Skills App (Skills Protocol integration) — FEATURE-COMPLETE on `feat/skills-app`, not yet PR'd** (`.worktrees/feat-skills-app`; 6 commits `07d50e3b`→`6302c460`). Full design: `docs/plans/skills-protocol-integration-plan.md`. Installable App (`src/agents/apps/skills/`, ComposerAgent-shaped, cross-platform, no creds), one-line registration in `AppManager.getBuiltInAppRegistry`. ALL phases shipped: discovery+index (v13 SQLite), loadSkill (loadWorkspace-shaped + usage history), CRUA (create/update/archive, archive-then-replace), import + sync-back (vault-root `.{provider}/skills/` ⇄ mirror, last-writer-wins), cross-context usage history (§9, trace `metadataJson.activeSkills` stamping, zero-migration), and the Settings → Apps → Skills management UI (via new `AppCustomSection` framework hook + `SkillsSectionRenderer`). Generic `AppRuntimeContext` (settings + storage-adapter + sessionContextManager getters) added to `BaseAppAgent` — opt-in, future apps reuse it. **Pre-PR adversarial audit (2026-05-31, 3 parallel auditors) → ALL findings fixed**: 5 BLOCKING (4 path-traversal/destructive-write — root cause: §7 "no traversal" never implemented + `normalizePath` doesn't strip `..`; + 1 scanner `(provider,name)` key-fork) + 5 MAJOR + 6 MINOR. Fix = new `skillPaths.ts` (`resolveVaultPath`/`assertInside`/`isSafePathSegment`) wired at every write/copy/remove boundary, provider validation, archived-exclusion on `findByName`, safe provider-scoped prune, `AppCustomSection` disposer hook (Component-leak fix), `hashSkillContent` (CRLF-normalized), LIKE-escape. Audit + resolution table: `docs/review/skills-app-prePR-audit-2026-05-31.md` (gitignored). **Full suite 3051 passed / 17 skipped / 0 failed; build+lint clean.** Net-new tests ~131 (incl. +41 audit-fix). ⚠️ Verified by unit tests + build only — NOT yet manually tested in Obsidian; mirror is empty until syncSkills import or createSkill runs. ⚠️ m5 (`adapter.list('')`→`'/'` vault-root discovery) still needs a manual MOBILE smoke check. **Next: PR + merge to main.** _(build history below.)_ **Phase 0 DONE (commit `07d50e3b`)**: app scaffold + 6 tool stubs, `types.ts`, `SkillValidator` (28 tests) + `SkillScanner` (7 tests — walks `<root>/skills/<provider>/<name>/SKILL.md` via `vault.adapter`, ignores `_`/`.`-prefixed, inline FNV-1a hash), **v13 SQLite migration** (`skills` table, UNIQUE(provider,name), CURRENT_SCHEMA_VERSION 12→13). **Phase 1 DONE (commit `e72e725b`)**: generic `AppRuntimeContext` injection (settings + storage-adapter getters → `BaseAppAgent.setRuntimeContext`, threaded via AppManager 5th ctor arg from AgentRegistrationService; `HybridStorageAdapter.getSqliteCache()` accessor) — opt-in, future apps reuse it. `SkillIndexService` (pure SQLite cache over `skills`; `syncFromScan` UPSERT preserves owned `is_archived`/`last_loaded_at`; recency-ordered `list`; `findByName`/`touchLoaded`; 12 tests). `SkillsContext.resolveSkillsRuntime` (settings→`<root>/skills` via resolveVaultRoot, vault.adapter, SQLite index+scanner; friendly errors). **listSkills + loadSkill now functional** (scan→sync→list/findByName; loadSkill §12-shaped: instructions+files+nudge+alternatives). Build+lint clean, 45 skills tests green. **Next**: CRUA (createSkill/updateSkill/archiveSkill via SkillValidator) + `SkillSyncService` (import from vault-root `.{provider}/skills/` + sync-back, archive-then-replace last-writer-wins, co-located `_archive/`) + usage-history attribution via `memory_traces.metadataJson.activeSkills` (§9) + settings UI for manual editing. ⚠️ mirror is empty until import/create lands, so listSkills returns [] today. ⚠️ sync-back WRITES to the user's real provider dotfolders — confirm scope before building.
-- **Settings UI redesign — Wave 3 (Workspaces tab)**: v3.1 mockup blessed 2026-05-26 (`docs/mockups/workspace-tab-redesign-v3-subpages.html`). 4-PR slice plan at `docs/plans/workspace-tab-redesign-plan.md`. **PR1 MERGED** (PR #220, squashed to main 2026-05-27): BoxedSection + ConfirmModal primitives, WorkspaceDetailRenderer/WorkspaceFormRenderer/StatesSectionRenderer shell ports preserving PR #216 v5.9.7 archive-visibility chain, ConfirmModal sweep across 3 call sites with `variant=delete` uniform on `confirmDangerousAction`, `styles.css` `.ws-section` family + breadcrumb fix at :5045. +2270/-246 across 13 files; full suite 2863 passed / 17 skipped; build+lint clean. Peer-reviewed by architect+frontend+test (0 Blocking, 8 Minor + 4 Future dispositioned). Review synthesis: `docs/review/pr220-wave3-pr1-2026-05-27.md`. **PR2 carry-forwards** (user-approved disposition, bundled into PR2 scope per plan §PR-Slicing): Group A — ConfirmModal hardening pre-task (~30 LoC: require `component`, add `onResolve`+`ConfirmModal.confirm()` helper, async error handling); Group B — `--space-*` token sweep on `.ws-section` family + wire `variant=remove` to workflow/keyfile × buttons; Group C — UX-outcome test layer (handler-wrapping integration tests + toggle-flip + re-instantiation coverage). **F-4 mobile-compat lint guard** tracked as #221. **Next**: PR2 (row primitives + checkbox sweep + Group A/B/C carry-forwards), PR3 (TaskDetail + Dependencies/Linked notes — production-ahead), PR4 (WorkflowEditor + FilePicker + mobile breakpoint).
-- **Canonical Message Pipeline — Phase 3**: drop redundant `LLMService.generateResponseStream` remap; accept `ConversationMessage[]` directly. ~3-5h, medium risk. Plan: `docs/plans/canonical-message-pipeline-plan.md`. Phase 1+2 shipped in PR #142. Phase 4 (single canonical message type) deferred to next-provider-add.
-- **Issue #88 — CustomPromptStorageService dual-write desync**: fix committed (3447d8c5) on `fix/issue-88-dual-write-desync` worktree, awaiting PR.
-- **Context Budget Service**: `feat/context-budget-service` branch, work ongoing.
-- **LLM Eval Harness** (`tests/eval/`, ~3500 lines, plan in `docs/plans/llm-eval-harness-plan.md`): grades two-tool MCP usage via `RUN_EVAL=1`. Skill: `/nexus-model-eval`. Cloud leaderboard (mock mode, 35 scenarios): gemma-4-31b-it 91%, gemma-4-26b-a4b-it 89%, qwen3.6-27b 83%, qwen3.5-9b 80%, laguna-xs.2 80%. **PR #269 merged** the app-fidelity fixes (always-meta surface, CLI-arg parsing, search-slug corrections). **Local-model grading (uncommitted on main, 2026-06-19)**: `EvalRunner.ts`/`ConfigLoader.ts` add keyless `ollama`/`lmstudio` providers via `LMStudioAdapter`→`localhost/v1`; `eval.test.ts` now caps concurrency (`EVAL_CONCURRENCY`, defaults to **serial=1 for local single-slot servers** — concurrent fan-out at Ollama's one inference slot caused a 120s-timeout 500-storm that discarded the whole run), streams per-case progress to `test-artifacts/eval-progress-<ts>.log`, and treats per-job throws as non-fatal failed scenarios. gemma4:e4b on Mac ≈ 19 tok/s gen, ~30–56s/scenario, ~20–30 min full run. **Jest test-timeout now scales with serial lane count** (`eval.test.ts`; was a fixed ~8min that killed serial runs at 9/35; override `EVAL_TEST_TIMEOUT_MS`).
+**Open bug follow-ups (deferred, not blocking):**
+- `CONFLICT_COPY_PATTERNS` (`src/database/migration/CacheBackendMigration.ts:12`)
+  does not match the Dropbox `cache (User's conflicted copy YYYY-MM-DD).db` form —
+  the closing paren before `.db` breaks the anchor.
+- `waitForQueryReady` post-migration race — first-boot transient timeout is papered
+  over with a sticky restart Notice; root cause not investigated.
+- `FilePickerRenderer.getRootFolder()` (`src/components/workspace/FilePickerRenderer.ts:191`)
+  passes `/blog-test`-style paths to `getAbstractFileByPath()`, which expects no
+  leading slash. Fix: `normalizePath()` or strip the leading slash.
+- Claude Code `ENAMETOOLONG` (issue #64) — an earlier fix may not have fully
+  resolved it. UNVERIFIED against current code; needs re-investigation.
 
-**Failure-pattern analysis + system-prompt iteration (uncommitted on main, 2026-06-19):** (1) **JSON report output** — `ReportGenerator.generateReportJson`/`saveReportJson` emit a `.json` sibling next to every `.md` (per-model + aggregate): untruncated tool-call args as objects, sorted `byModel` leaderboard, full turns/errors. Wired at both save sites in `eval.test.ts`. (2) **`excludeFromBoard` scenario flag** (`types.ts` → `ScenarioResult.excludedFromBoard`, stamped in the `finish()` choke point in `eval.test.ts`, honored in JSON `byModel`): run+reported but not scored, for known fixture bugs. (3) **Scenario filter already exists**: `EVAL_SCENARIO_NAMES=a,b,c` (comma-sep, via `config.scenarioNames`/`shouldRunScenario`) — use for targeted retests, no new code. (4) **System prompt reframed** (`SystemPromptBuilder.buildWorkingStrategySection`): two-phase EXPLORE/ACT → three buckets **exploration (search/list) → inspection (read) → exploitation (write/move/etc)** + soft one-line "after search you're encouraged to read the relevant file(s); search/list results are locations, not contents." Shared by prod+eval via `fixtures/system-prompt.ts`. (5) **multi-intent fixture bug fixed** (`vague-prompts.eval.yaml`): single `useTools` turn returned todo content for EVERY read, so following a search hit looped/bailed; rewrote as deterministic 3-round chain w/ `sequentialMockResponses` (api read returns real content), `excludeFromBoard:true` until re-verified. **Targeted cloud retest (n=1, mock):** 3-bucket prompt NET-POSITIVE on discovery/protocol — all-agents +3 fixed, get-tools/topic-switch qwen3.6 fixed, write-new-note laguna stopped hallucinating, vague-organize laguna+qwen3.6 fixed; BUT **search-then-read-chain unmoved (0/5)** — models search, get `{path,score}` (no content), fabricate the answer; soft prompt nudge does NOT overcome it. **Next lever (proposed): decorate the search/list tool RESULT** ("this is a location — call content read --path X"; result-side nudge the model can't ignore, doubles as recovery steer). **Op gotchas:** on test timeout the report-save block never runs (reports lost, only progress log survives) → recover from progress log, or make save timeout-resilient. **getTools-loop ROOT CAUSE found + `vague-organize` FIXED:** the scripted getTools mock is SELECTOR-INSENSITIVE (returns the same fixed blob for every call); `vague-organize` exposed only storage tools, so a model that planned to SEARCH for 2024 notes asked getTools for `search`, got storage back, read it as "discovery broken," and looped getTools forever at temp 0 (gemma-31b 24 calls/1307s). NOT an agent-name bug — both prod + eval `toKebabCase` strip `Manager` so `search`→`searchManager` resolves fine. Fix (`vague-prompts.eval.yaml`): getTools mock now exposes BOTH storage+search; result mocks switched to DOMAIN-tool keys (`storageManager_list`/`searchManager_content`/`storageManager_move`) so the executor's useTools fallback dispatches per inner command in ANY order/round; expectations relaxed to `getTools`(name-only, no params → selector check skipped) + the two `storage move`s, so list→move AND search→move both pass. VERIFIED: gemma-4-31b now PASS in 102s (was 1307s loop). **Production loop-breaker scoped (NOT built):** `docs/plans/gettools-loop-breaker-plan.md` — (A) `ToolContinuationService` per-exchange getTools tracker → steer on ≥3 consecutive or repeated-selector getTools ("you already discovered [...]; getTools returns schemas not data — call useTools"); (B) decorate getTools + search/list RESULTS with "these are schemas/locations — call useTools/content read next" (also fixes the search→read satisfice the system prompt couldn't). Steers never block; keep `TOOL_ITERATION_LIMIT=15` as final backstop. **`EVAL_TEMP` knob added** (`ConfigLoader.applyDefaultEnvOverrides`): overrides `defaults.temperature`; per-scenario `temperature:` still wins over it (precedence: scenario > EVAL_TEMP > config). All grading is temp 0 (deterministic) — which is also the WORST case for the getTools loop (greedy decoding can't jitter out of a stuck state). **Report-save now timeout-resilient** (`eval.test.ts`): `allResults` is populated incrementally in the per-scenario `finish()` (was pushed only after `mapWithConcurrency` resolved, so a mid-run test-timeout lost ALL reports — bit us twice: cloud targeted + qwen local); `afterAll` now saves partial JSON/MD on timeout. **qwen3.5:4b LOCAL graded (2026-06-19, new prompt, enforcement off, serial; full 38 across two runs after first timed out at 32):** BOARD 21 PASS / 16 FAIL of 37 (~57%, multi-intent excluded). Report-save-on-timeout fix + vague-organize de-loop both VERIFIED on the 6-scenario completion run (JSON+MD saved; vague-organize failed in 246s on a malformed getTools call, NOT the 1307s loop). Failures concentrate on PROTOCOL COMPREHENSION not chain-completion (the 4B wall): Pattern C skips getTools→calls useTools directly (~5: simple-read, create-new-note, expand-toolset, debug-two-exchange), Pattern B wrong agent/selector in getTools (~4: topic-switch asked for `prompt.*`, search-by-keyword `-help.search`, update-note dumped context-object into args.tool). Not bad for 4B; the loop-breaker + result-decoration (plan b) + 3-bucket prompt would help this size most. Next: headless agent stack — replace fake tool schemas with real agents on TestVault.
-
-- **Context-contract enforcement + recovery testing (uncommitted on main, 2026-06-19):** PRODUCTION change — `useTools` now enforces the context contract that was previously declared-but-not-enforced (schema `required` is doc-only, no ajv). `ToolCliNormalizer` gained pure shared helpers `collectContextContractViolations()` / `formatContextContractError()` + method `validateExecutionContext()`; `UseToolTool.execute()` calls it first and throws a **recoverable steering error** when `memory`/`goal` are empty/placeholder (workspaceId/sessionId keep silent defaults, steer only on present-junk; constraints optional). getTools/discovery is exempt. 13 unit tests (`ToolManagerContextContract.test.ts`); full suite 3636 pass (only pre-existing `TaskBoardEditCoordinator` jsdom-Modal failure). The eval harness imports the SAME validator (single source) — `EvalToolExecutor` enforces it (`enforceContextContract` / `EVAL_ENFORCE_CONTEXT=1`) AND supports `forceContextSteering: N` (deterministically rejects the first N useTools calls with the real steering error to test recovery regardless of model behavior); `EvalRunner` grades recovery within `maxRecoveryRounds` (default 3); `tests/eval/scenarios/context-recovery.eval.yaml`. VERIFIED on gemma4:e4b: forced steering pushed it from `memory:'N/A'` to a real summary, then it re-issued and completed (steer=1, recovered=True, PASS). Insight: validation-driven recovery is non-deterministic (models send `''` vs `'N/A (First turn)'`), so `forceContextSteering` is the reliable test path. Follow-up: per-round mock response queue (current mock is name-keyed last-write-wins) for non-context recovery patterns (read→error→read→success); harness unit tests for the executor recovery logic.
-
-**Open follow-ups (deferred, not blocking):**
-- **Issue #217** — Frontend polish from PR #216 review: F1 (empty-name silent ignore in StateEditModal), F2 (no-op save fires noisy state_updated event), F3 (double-click race on Archive/Restore/Delete with no in-flight disable), F4 (stale-promise stomp on rapid workspace re-render). All Minor severity; not blocking.
-- **Issue #219** — Denormalize `state.isArchived` into SQLite metadata (perf follow-up to v5.9.7 / #218). ~80–120 LoC + v12→v13 migration. Restores the fast-path read shortcut without sacrificing correctness. Not blocking until power-user workspaces hit 100–500+ states.
-- `CONFLICT_COPY_PATTERNS` regex widening for Dropbox `cache (User's conflicted copy YYYY-MM-DD).db` form (closing paren before `.db` breaks the anchor).
-- `waitForQueryReady` post-migration race — first-boot transient timeout papered over with sticky restart Notice in v5.8.12; root-cause investigation deferred.
-- Issue #64 — Claude Code ENAMETOOLONG: PR #73 fix may not have fully resolved. Needs re-investigation.
-- File Picker rootFolder leading-slash: `FilePickerRenderer.getRootFolder()` passes `/blog-test`-style paths to `getAbstractFileByPath()` which expects no leading slash. Fix: `normalizePath()` or strip leading slash.
+**UNVERIFIED older items** (predate this clone's history; status unknown — confirm on GitHub before acting):
+- Issue #217 — frontend polish from the states-management UI review: empty-name
+  silent ignore in StateEditModal, no-op save firing a noisy `state_updated`,
+  double-click race on Archive/Restore/Delete, stale-promise stomp on rapid
+  workspace re-render. All Minor.
+- Issue #219 — denormalize `state.isArchived` into SQLite metadata to restore the
+  fast-path read shortcut lost in the archive-visibility fix. ~80–120 LoC + a
+  migration. Not blocking until workspaces hit 100–500+ states.
+- Issue #221 — mobile-compat lint guard.
+- Issue #88 — `CustomPromptStorageService` dual-write desync.
+- Settings UI redesign Waves/PRs 2–4 (row primitives, TaskDetail, WorkflowEditor +
+  mobile breakpoint). Plan: `docs/plans/workspace-tab-redesign-plan.md`.
 
 ### Branch Architecture
 
 A branch IS a conversation with parent metadata:
 - `metadata.parentConversationId`: parent conversation
 - `metadata.parentMessageId`: message the branch is attached to
-- `metadata.branchType`: 'alternative' | 'subagent'
+- `metadata.branchType`: `'alternative' | 'subagent'`
 
-**Key Files**:
-- `src/services/chat/BranchService.ts` - Facade over ConversationService
-- `src/ui/chat/controllers/SubagentController.ts` - Subagent infrastructure
-- `src/ui/chat/controllers/NexusLoadingController.ts` - Loading overlays
-- `src/ui/chat/services/ContextTracker.ts` - Token/cost tracking
+**Key files**: `src/services/chat/BranchService.ts` (facade over ConversationService),
+`src/ui/chat/controllers/SubagentController.ts`, `src/ui/chat/controllers/NexusLoadingController.ts`,
+`src/ui/chat/services/ContextTracker.ts` (token/cost tracking).
 
 ### Known Issues
 
-- **Workspace Delete Persistence** (Feb 2): deleted workspaces may reappear on reload. Backend delete logic looks correct; suspect UI cache issue.
-- **WebLLM/Nexus**: multi-turn tool continuations may crash on Apple Silicon (WebGPU issue). If startup hangs on "loading cache", clear site data.
+- **Workspace Delete Persistence**: deleted workspaces may reappear on reload.
+  Backend delete logic looks correct; suspect UI cache. UNVERIFIED — long-standing,
+  re-confirm it still reproduces before spending time on it.
+- **WebLLM / Nexus Quark**: multi-turn tool continuations may crash on Apple Silicon
+  (WebGPU). If startup hangs on "loading cache", clear site data.
 
 ## Development Notes
 
 ### Build Commands
-- `npm run dev` - Development build with watch mode
-- `npm run build` - Production build (TypeScript + esbuild)
-- `npm run test` - Run Jest test suite
-- `npm run lint` - Run ESLint
-- `npm run deploy` - Build and deploy via PowerShell script
-- **Release**: Use `/nexus-release` skill for version bumping and GitHub release creation
+- `npm run dev` — esbuild dev build
+- `npm run build` — full production build (obsidian lint → CLI build → CLI content gen → `tsc --noEmit` → esbuild → connector tsc → connector content gen)
+- `npm run build:cli` — CLI bundle + generated CLI content only
+- `npm run test` — Jest
+- `npm run lint` — ESLint (alias of `lint:obsidian`)
+- `npm run schemas:tools` — regenerate `cli-first-tool-schemas.json`
+- `npm run sync:agent-context` / `npm run sync:skills` — sync shipped agent context/skills
+- `npm run deploy` — build + PowerShell deploy (Windows)
+- **Release**: use the `/nexus-release` skill. It bumps `package.json`, `manifest.json`,
+  `versions.json`, and the changelog — `versions.json` is guarded by the release
+  workflow, so it is not optional.
 
 ### Testing Approach
-- **Unit Tests**: Jest for core logic and services (1200+ tests)
-- **Integration Tests**: Manual testing in Obsidian environment
-- **MCP Testing**: Via Claude Desktop connection
+- **Unit tests**: Jest, ~346 test files under `tests/`
+- **Integration**: manual testing in Obsidian
+- **MCP**: via Claude Desktop connection
+- **LLM eval harness** (`tests/eval/`, `RUN_EVAL=1`, skill `/nexus-model-eval`):
+  grades two-tool MCP usage. Plan: `docs/plans/llm-eval-harness-plan.md`.
+  Useful knobs: `EVAL_SCENARIO_NAMES=a,b,c` (targeted retest), `EVAL_CONCURRENCY`
+  (**defaults to serial=1** — local single-slot servers 500-storm under fan-out),
+  `EVAL_TEMP`, `EVAL_TEST_TIMEOUT_MS`, `EVAL_ENFORCE_CONTEXT=1`. Per-case progress
+  streams to `test-artifacts/eval-progress-<ts>.log`; reports save incrementally
+  so a mid-run timeout still produces JSON + MD. Scenarios with known fixture bugs
+  can set `excludeFromBoard: true` to run without scoring.
+  **Harness gotcha**: the scripted getTools mock is selector-insensitive — it returns
+  the same blob for every call. A scenario that exposes only some agents will make a
+  model conclude "discovery is broken" and loop getTools forever at temp 0. Expose
+  every agent the scenario could plausibly need.
 
 ### Code Patterns
 
-- **Agents**: Extend `BaseAgent`, register tools in constructor
-- **Tools**: Extend `BaseTool<Params, Result>`, implement `execute()`, `getParameterSchema()`, `getResultSchema()`
-- **Results**: Return `{ success: boolean, ...data }` or `{ success: false, error: string }`
-- **Services**: Singletons with dependency injection via constructor
-- **Adding a new agent**: (1) Add `initializeYourAgent()` to `AgentInitializationService.ts`, (2) Add `safeInitialize('yourAgent', ...)` to a phase in `AgentRegistrationService.doInitializeAllAgents()`. No factory classes, no ServiceDefinitions entry.
+- **Agents**: extend `BaseAgent`, register tools in the constructor
+- **Tools**: extend `BaseTool<Params, Result>`, implement `execute()`, `getParameterSchema()`, `getResultSchema()`
+- **Results**: return `{ success: boolean, ...data }` or `{ success: false, error: string }`
+- **Services**: singletons with constructor dependency injection
+- **Adding a new agent**: (1) add `initializeYourAgent()` to
+  `src/services/agent/AgentInitializationService.ts`, (2) add
+  `safeInitialize('yourAgent', ...)` to a phase in
+  `AgentRegistrationService.doInitializeAllAgents()`. No factory classes, no
+  ServiceDefinitions entry.
 
 ### Dependencies
-See `package.json`. Key: MCP SDK, express, winston, uuid. LLM provider SDKs removed — direct HTTP via ProviderHttpClient.
+See `package.json`. Key: MCP SDK, express, winston, uuid. LLM provider SDKs were
+removed — providers talk direct HTTP via `ProviderHttpClient`.
 
 ## Code Quality
 
-Full tech debt tracker: `docs/tech-debt.md`
+Large-file punchlist: `docs/plans/large-file-refactor-punchlist.md`.
 
-**600+ line files to watch**: WorkspaceService (965), ModelAgentManager (895), SQLiteCacheManager (856), ConversationService (813), connector (731), ChatSettingsModal (702), ChatView (659), OpenRouterAdapter (640), ProviderManager (659), ProvidersTab (645), ValidationService (625), BatchExecutePromptTool (618), GoogleAdapter (612)
+**600+ line files to watch** (re-measured 2026-08-14 with `wc -l`):
 
-**Plugin store compliance**: `isDesktopOnly: false` is correct. VaultOperations uses `app.fileManager.trashFile()` (constructor takes `App` as first arg).
+| Lines | File |
+|------:|------|
+| 1426 | `src/utils/cliAssets.ts` |
+| 1247 | `src/components/shared/ChatSettingsRenderer.ts` |
+| 1214 | `src/settings/tabs/GetStartedTab.ts` |
+| 1182 | `src/ui/chat/ChatView.ts` |
+| 1167 | `src/agents/toolManager/services/ToolCliNormalizer.ts` |
+| 1150 | `src/settings/tabs/DefaultsTab.ts` |
+| 1052 | `src/services/ConversationService.ts` |
+| 1019 | `src/database/adapters/HybridStorageAdapter.ts` |
+|  999 | `src/ui/chat/services/ModelAgentManager.ts` |
+|  941 | `src/agents/taskManager/services/TaskService.ts` |
+|  916 | `src/agents/searchManager/services/MemorySearchProcessor.ts` |
+|  901 | `src/services/cli/LocalCliInstaller.ts` |
+|  890 | `src/settings/tabs/WorkspacesTab.ts` |
+|  880 | `src/services/llm/adapters/openrouter/OpenRouterAdapter.ts` |
+|  871 | `src/services/llm/adapters/BaseAdapter.ts` |
+|  854 | `src/database/interfaces/StorageEvents.ts` |
+|  846 | `src/services/llm/adapters/google/GoogleAdapter.ts` |
+|  839 | `src/services/llm/adapters/lmstudio/LMStudioAdapter.ts` |
+|  829 | `src/services/llm/adapters/webllm/WebLLMEngine.ts` |
+|  784 | `src/services/llm/adapters/openai/OpenAIAdapter.ts` |
+|  774 | `src/services/WorkspaceService.ts` |
+|  770 | `src/connector.ts` |
+|  710 | `src/database/storage/SQLiteCacheManager.ts`, `src/settings/tabs/ProvidersTab.ts` |
+|  673 | `src/services/llm/providers/ProviderManager.ts` |
+
+**Plugin store compliance**: `isDesktopOnly: false` is correct. VaultOperations uses
+`app.fileManager.trashFile()` (constructor takes `App` as its first arg).
 
 ## MCP Integration
 
@@ -326,73 +401,122 @@ Full tech debt tracker: `docs/tech-debt.md`
 
 ### Two-Tool Architecture
 
-Instead of 50+ tools, MCP exposes just 2: `getTools` (discovery) and `useTools` (execution).
+Instead of 70+ tools, MCP exposes just 2: `getTools` (discovery) and `useTools` (execution).
 
-**Context Schema**: `{ workspaceId, sessionId, memory, goal, constraints? }` - all required except constraints.
+**Context schema**: `{ workspaceId, sessionId, memory, goal, constraints? }` —
+all required except `constraints`, and **enforced at runtime** (see the pinned
+ToolManager contract for exactly what steers vs. silently defaults).
 
 **Flow**: `getTools` → get schemas → `useTools` with the context fields at the top
 level plus a single `tool` string. Batch by separating commands with a top-level
-comma outside quotes: `"storage list --path Notes, content read --path a.md --start-line 1"`.
+comma outside quotes:
+`"storage list --path Notes, content read --path a.md --start-line 1"`.
 
 ⚠️ The `calls: [{agent, tool, params}]` array and the nested `context: {...}` object
 were removed in v5.9.0 and are rejected outright (`Deprecated payload shape`).
 Context fields must NOT appear as CLI flags inside the `tool` string either.
 
-**Benefits**: 95% token reduction (~15,000 → ~500), works with small context models.
+**Benefits**: large token reduction vs. exposing every tool schema; works with
+small-context models.
 
-**Key Files**: `src/agents/toolManager/` (agent + tools), `src/services/trace/ToolCallTraceService.ts`
+**Key files**: `src/agents/toolManager/` (agent + tools),
+`src/services/trace/ToolCallTraceService.ts`, `src/utils/cliAssets.ts` (shipped guidance).
 
-**Tool Count**: 74 tools across 13 agents (not counting ToolManager meta-tools) —
-56 across the 8 always-on agents, plus 18 across the 5 opt-in apps (composer,
-elevenlabs, data, skills, web). A vault only exposes the apps it has enabled, so
-`cli-first-tool-schemas.json` (66/11) reflects the vault it was generated from.
+**Tool count**: 74 tools across 13 agents (excluding the 2 ToolManager meta-tools) —
+56 across the 8 always-on agents, plus 18 across the 5 opt-in apps. The checked-in
+`cli-first-tool-schemas.json` shows 66 tools / 11 agents because it was generated
+from a vault with `skills` and `data` disabled; regenerate with `npm run schemas:tools`.
 
 ## Memory & Workspace System
 
 ### Storage Location
 
-**Primary synced event store**: settings-derived vault root, `settings.storage.rootPath` (default `Nexus`) with managed data under `<rootPath>/data/`:
-- `conversations/<conversationId>/shard-*.jsonl` - sharded append-only conversation events
-- `workspaces/<workspaceId>/shard-*.jsonl` - sharded append-only workspace/session/state/trace events
-- `tasks/<workspaceId>/shard-*.jsonl` - sharded append-only task/project events
-- `_meta/` - storage and migration manifests
+**Primary synced event store**: settings-derived vault root,
+`settings.storage.rootPath` (default `Nexus`), with managed data under `<rootPath>/data/`:
+- `conversations/<conversationId>/shard-*.jsonl` — sharded append-only conversation events
+- `workspaces/<workspaceId>/shard-*.jsonl` — workspace/session/state/trace events
+- `tasks/<workspaceId>/shard-*.jsonl` — task/project events
+- `_meta/` — storage and migration manifests
 
-**Configured root rules**: resolve with `resolveVaultRoot(settings, { configDir })`; never hardcode `Nexus` except as `DEFAULT_STORAGE_SETTINGS.rootPath`, and never hardcode `.nexus` for new writes.
+**Configured root rules**: resolve with `resolveVaultRoot(settings, { configDir })`
+(`src/database/storage/VaultRootResolver.ts:133`). Never hardcode `Nexus` except as
+`DEFAULT_STORAGE_SETTINGS.rootPath`, and never hardcode `.nexus` for new writes.
 
-**Legacy read paths**: `.obsidian/plugins/<plugin-folder>/data/`, compatibility plugin folders (`nexus`, `claudesidian-mcp`), legacy `.nexus/`, and `storage.previousRootPaths` remain read/migration fallback sources. They are not the primary write target.
+**Legacy read paths** (read/migration fallback only, never the write target):
+`.obsidian/plugins/<plugin-folder>/data/`, compatibility plugin folders (`nexus`,
+`claudesidian-mcp`), legacy `.nexus/`, and `storage.previousRootPaths`.
 
 **Local-only cache** (auto-rebuilt from JSONL, never synced):
-- **Desktop (v5.8.12+)**: IndexedDB-backed via `IndexedDBCacheBlobStore`. Cloud-sync-immune. First-launch migration FSM upgrades existing `cache.db` installs.
+- **Desktop**: IndexedDB via `IndexedDBCacheBlobStore` — cloud-sync-immune. A
+  first-launch migration FSM upgrades existing `cache.db` installs.
 - **Mobile**: `vault.adapter` file backend via `VaultAdapterCacheBlobStore`.
+- Chosen by `src/database/storage/CacheBlobStoreFactory.ts`.
 
-**Migration**: On startup, legacy JSONL sources are read/migrated into the configured vault-root event store without deleting old files. Mobile users whose vault syncs after init can run **Nexus: Refresh synced data** from the command palette.
+**Migration**: on startup, legacy JSONL sources are read/migrated into the configured
+vault-root event store without deleting old files. Mobile users whose vault syncs
+after init can run **Nexus: Refresh synced data**. **Nexus: Rebuild cache** recovers
+from a corrupted cache.
 
-**Path resolution**: Use `resolveVaultRoot()` for the configured synced event root and `resolvePluginStorageRoot()` for plugin-scoped compatibility/cache paths.
+**Path resolution**: `resolveVaultRoot()` for the configured synced event root;
+`resolvePluginStorageRoot()` (`src/database/storage/PluginStoragePathResolver.ts:26`)
+for plugin-scoped compatibility/cache paths.
 
 ### Architecture
-- Hybrid JSONL + SQLite: sharded JSONL event store = source of truth, SQLite = rebuildable fast query/vector cache
+- Hybrid JSONL + SQLite: the sharded JSONL event store is the source of truth;
+  SQLite is a rebuildable fast query/vector cache
+- **SQLite schema version 13** (`CURRENT_SCHEMA_VERSION` in
+  `src/database/schema/SchemaMigrator.ts:76`) — v9 added the 4 task tables, v10
+  workflow columns, v11 the archive flag, v12 `shard_cursors`, v13 the `skills` table
 - True database pagination with OFFSET/LIMIT
 - Workspace-scoped sessions and traces
 - Searchable via MemoryManager and SearchManager agents
 
 ## UI Components
 
-- **Chat View**: `src/components/ChatView.ts` - conversations, branching, streaming, tool accordion
-- **Settings**: `src/components/ConfigModal.ts` - tabbed LLM/agent configuration
+- **Chat view**: `src/ui/chat/ChatView.ts` — conversations, branching, streaming, tool accordion
+- **Settings**: `src/components/ConfigModal.ts` + `src/settings/tabs/` — tabbed LLM/agent configuration
 
 ### Chat Suggesters
 | Trigger | Purpose |
 |---------|---------|
 | `/` | Tool hints |
-| `@` | Custom agents |
+| `@` | Custom agents / prompts |
 | `[[` | Note links |
 | `#` | Workspace data |
 
-Key files: `src/ui/chat/components/suggesters/`, `MessageEnhancer.ts`, `SystemPromptBuilder.ts`
+Key files: `src/ui/chat/components/suggesters/` (`ToolSuggester`, `PromptSuggester`,
+`NoteSuggester`, `WorkspaceSuggester` + TextArea/ContentEditable variants,
+`initializeSuggesters.ts`), `src/ui/chat/services/MessageEnhancer.ts`,
+`src/ui/chat/services/SystemPromptBuilder.ts`.
 
 ## Architectural Notes
 
-- **Subagents**: Branch → stream via LLMService → save result. `chunk.toolCalls` are display-only.
-- **WebLLM/Nexus**: Nexus Quark (4B, 4K context), `<tool_call>` format. May crash on Apple Silicon.
-- **Storage**: Branches as JSONL events, SQLite v12 schema (4 task tables added in v9, workflow columns in v10, archive flag in v11, `shard_cursors` added in v12), tool names use `agent_tool` format.
-- **Apps & Vault Access**: App agents that produce files must have vault access wired through `BaseAppAgent`. Use `vault.createBinary()` for binary outputs (audio, images) and `vault.create()` for text. Always ensure parent directories exist before writing.
+- **Subagents**: branch → stream via LLMService → save result. `chunk.toolCalls` are display-only.
+- **Reasoning / thinking rendering**: reasoning streams as `chunk.reasoning`, is
+  emitted via `onReasoningUpdate(messageId, text, isComplete)` on
+  `StreamHandlerEvents`/`MessageManagerEvents`, and renders as a collapsible
+  `<details class="message-reasoning">` block. Do NOT reintroduce a synthetic
+  `reasoning`-type tool call — the tool coordinator never rendered it.
+- **In-stream error frames**: some providers (notably LM Studio) return
+  `{"error":{...}}` frames over HTTP 200. `SSEStreamOptions.extractError` +
+  `processNodeStream` in `BaseAdapter.ts` turn those into
+  `LLMProviderError(..., 'PROVIDER_STREAM_ERROR')` instead of an empty stream.
+  Any new streaming adapter should wire `extractError`.
+- **LM Studio speculative decoding**: a `draft_model` against a batched-MLX target
+  fails; `LMStudioAdapter` marks the draft incompatible and retries without it, so
+  chat always produces output. `ensureModelLoaded` passes `flash_attention` through
+  but **never compares it** (llama.cpp-only; MLX no-ops and does not report it —
+  comparing caused infinite model reloads).
+- **Antigravity CLI (`agy`)**: the `google-gemini-cli` provider id is unchanged for
+  settings compat, but the runtime is `agy`, not the deprecated `gemini` CLI. `agy`
+  emits **plain text** (no JSON output mode) and reports **no token usage**;
+  `--model` takes human labels and **fails open** on an unknown slug, so
+  `geminiCliModelNormalize.ts` is a **fail-closed allowlist** — keep it that way.
+  Auth is a boolean-only presence probe over `~/.gemini/oauth_creds.json`; never
+  read, log, or return the token. No `--dangerously-skip-permissions`.
+- **WebLLM / Nexus Quark**: 4B, 4K context, `<tool_call>` format. May crash on Apple Silicon.
+- **Storage**: branches are JSONL events; tool names use the `agent_tool` format.
+- **Apps & vault access**: app agents that produce files must have vault access
+  wired through `BaseAppAgent`. Use `vault.createBinary()` for binary outputs
+  (audio, images) and `vault.create()` for text. Always ensure parent directories
+  exist before writing.

--- a/docs/plans/bases-manager-agent-plan.md
+++ b/docs/plans/bases-manager-agent-plan.md
@@ -2,47 +2,45 @@
 
 Status: **proposed**
 Date: 2026-08-14
-Related: `src/agents/canvasManager/` (shape to mirror), kepano/obsidian-skills
+Related: `src/agents/canvasManager/` (shape to mirror), Obsidian API ≥ 1.10.0
+(`BasesConfigFile`, `BasesQueryResult`, `registerBasesView`), kepano/obsidian-skills
 `skills/obsidian-bases`
 
 ## Gap
 
 Nexus has no `.base` support of any kind — no reads, no writes, no awareness.
-Bases are Obsidian's native database view (YAML files with filters, formulas and
-views), and they are exactly the artifact an agent should be able to build after
-it has organised a set of notes: "make me a table of every note tagged `task`
-with days-until-due" is a one-file answer today and we can't produce it.
+Bases are Obsidian's native database view, and they're exactly the artifact an
+agent should be able to produce after organising a set of notes: "give me a
+table of every note tagged `task` with days-until-due" is a one-file answer today
+and we can't produce it.
 
 `.canvas` has an agent. `.base` is the other first-class non-Markdown Obsidian
 file type and it doesn't.
 
-## Shape: mirror CanvasManager exactly
+## Tools
 
 New always-on agent, CLI slug `base`, no credentials, cross-platform.
 
-```
-src/agents/basesManager/
-  basesManager.ts            # BaseAgent subclass, lazy-registered tools
-  tools/{read,write,update,list,validate}.ts
-  services/BaseValidator.ts  # pure, dependency-free
-  types.ts
-```
-
-Tools (first four match `canvas` 1:1, so there is nothing new to learn):
-
 | Tool | Behaviour |
 |------|-----------|
-| `read` | Parse a `.base` and return its sections + a normalised summary |
+| `read` | Parse a `.base` and return its sections (the file's *config*) |
 | `write` | Create a NEW `.base`; fails if it exists |
 | `update` | Modify an EXISTING `.base`; fails if it does not exist |
 | `list` | List `.base` files with view/formula counts (mirrors canvas node/edge counts) |
-| `validate` | Validate without writing — the pre-flight for a model-authored base |
+| `analyze` | Execute the base and return the **rows the user would see** |
 
-`update` should replace only the top-level sections the caller supplies
-(`filters`/`formulas`/`properties`/`summaries`/`views`) rather than rewriting the
-file, so a model editing one view doesn't silently drop the user's other views.
-Note this differs from `canvas update`, which replaces whole arrays — the
-divergence is deliberate and should be called out in the tool description.
+There is deliberately **no `validate` tool**. Validation is not a thing a caller
+should have to remember to do — `write` and `update` validate before touching
+disk and reject with the specific reasons on failure. A separate validate tool
+would be a footgun (a model can skip it) and redundant (a rejected write is
+already a dry run that tells you exactly what's wrong). Errors come back as a
+structured list, not a single string, so a model can fix each one.
+
+`update` replaces only the top-level sections supplied (`filters`, `formulas`,
+`properties`, `summaries`, `views`) rather than rewriting the file, so a model
+editing one view doesn't silently drop the user's others. This differs from
+`canvas update`, which replaces whole arrays; the divergence is deliberate and
+belongs in the tool description.
 
 ### Registration (two touchpoints, per CLAUDE.md)
 
@@ -51,69 +49,111 @@ divergence is deliberate and should be called out in the tool description.
 2. `this.safeInitialize('basesManager', …)` alongside the `canvasManager` entry
    in `src/services/agent/AgentRegistrationService.ts:176`.
 
-No factory class, no ServiceDefinitions entry.
+## Schema: use Obsidian's own types, don't hand-roll
 
-## YAML handling
+Obsidian's public typings (verified in `obsidian@1.13.1`) ship the serialized
+`.base` format:
 
-Use Obsidian's `parseYaml` / `stringifyYaml`, **not** the `yaml` npm package —
-that package is on the CLAUDE.md desktop-only list, and `SkillValidator` already
-set this precedent. Always serialise through `stringifyYaml` rather than string
-templates: it handles the quoting rules that are the single largest source of
-broken bases (expressions containing `"`, values containing `:`/`{`/`}`).
+- `BasesConfigFile` — `filters?`, `formulas?`, `properties?`, `summaries?`, `views?`
+- `BasesConfigFileFilter` — `string | { and: … } | { or: … } | { not: … }`
+- `BasesConfigFileView` — `{ type, name, filters?, groupBy?, order?, summaries?, limit? }`
 
-## Schema to model
+So our `types.ts` should re-export those rather than duplicate them, and the
+schema tracks Obsidian automatically. kepano's skill is still the best reference
+for *semantics* — the function catalogue, property namespaces (`file.*`,
+`formula.*`, bare frontmatter), and the documented pitfalls — but the structural
+shape is typed for us.
 
-```yaml
-filters:      # filter node: a string, OR an object with exactly one of and|or|not
-formulas:     # name -> expression string
-properties:   # property key -> { displayName }
-summaries:    # name -> aggregation expression
-views:
-  - type: table | cards | list | map
-    name: string
-    limit: number?
-    groupBy: { property, direction: ASC|DESC }?
-    filters: <filter node>?
-    order: string[]?          # file.x | property | formula.x
-    summaries: { property: SummaryName }?
-```
+YAML via Obsidian's `parseYaml` / `stringifyYaml`, **not** the `yaml` npm package
+(desktop-only per CLAUDE.md; `SkillValidator` set this precedent). Always
+serialise through `stringifyYaml` rather than string templates: it handles the
+quoting rules that are the largest single source of broken bases.
 
-Property namespaces: bare/`note.x` (frontmatter), `file.x` (name, basename, path,
-folder, ext, size, ctime, mtime, tags, links, backlinks, embeds, properties),
-`formula.x` (computed).
+## Validation rules (run automatically on write/update)
 
-Built-in summary names: Average, Min, Max, Sum, Range, Median, Stddev, Earliest,
-Latest, Checked, Unchecked, Empty, Filled, Unique.
+Errors — reject the write:
 
-## Validator rules
-
-These are the documented real-world failure modes, not invented strictness:
-
-1. File parses as YAML; unknown top-level keys rejected.
+1. Parses as YAML; no unknown top-level keys.
 2. Every filter object has **exactly one** key, and it is `and`/`or`/`not`.
-3. `views[].type` is in the enum; `groupBy.direction` is `ASC`/`DESC`.
+3. `groupBy.direction` is `ASC`/`DESC`.
 4. Every `formula.X` referenced from `order`, `properties` or `summaries` exists
-   in the top-level `formulas`.
-5. Every value in a view's `summaries` is either a built-in name or a key in
-   top-level `summaries`.
-6. **Duration lint (warning).** Date subtraction yields a Duration, which has no
-   `.round()`/`.floor()`/`.ceil()`. Flag `(a - b).round(` with no intervening
-   `.days`/`.hours`/`.minutes`/`.seconds` field access. kepano documents this as
-   the number-one pitfall.
-7. Warn when `order` references a frontmatter property that appears in no note
-   in the vault — usually a typo, so warn rather than reject.
+   in top-level `formulas`.
+5. Every value in a view's `summaries` is a built-in summary name (Average, Min,
+   Max, Sum, Range, Median, Stddev, Earliest, Latest, Checked, Unchecked, Empty,
+   Filled, Unique) or a key in top-level `summaries`.
 
-Rules 1–5 are errors, 6–7 warnings. `write`/`update` run the validator and refuse
-on errors; `validate` returns both lists.
+Warnings — write proceeds, warnings returned:
+
+6. `views[].type` outside `table|cards|list|map`. Note `BasesConfigFileView.type`
+   is typed as `string`, not an enum, precisely because plugins register custom
+   view types via `registerBasesView` — so an unknown type is suspicious, not
+   invalid, and must not be a hard reject.
+7. **Duration lint.** Date subtraction yields a Duration, which has no
+   `.round()`/`.floor()`/`.ceil()`. Flag `(a - b).round(` with no intervening
+   `.days`/`.hours`/`.minutes`/`.seconds`. kepano documents this as the
+   number-one authoring error.
+8. `order` references a frontmatter property that appears in no note — usually a
+   typo, but legitimately can precede the notes that will have it.
+
+## `analyze` — returning the data the user would see
+
+This is feasible **without reimplementing anything**, because Obsidian's own
+query engine is exposed. `BasesQueryResult` (public since 1.10.0) carries:
+
+- `data: BasesEntry[]` — filtered, sorted, limited, **formulas already evaluated**
+- `groupedData: BasesEntryGroup[]` — grouped per `groupBy`
+- `properties: BasesPropertyId[]` — the user's visible columns
+- `getSummaryValue(controller, entries, prop, summaryKey)` — footer aggregates
+
+and `BasesEntry.getValue(propertyId): Value | null` reads a cell.
+
+The catch: `QueryController` is an opaque exported class with no public members.
+You cannot construct one and ask it to run a config. The only supported way to
+receive one is `Plugin.registerBasesView(viewId, { name, icon, factory })` —
+Obsidian calls the factory with a live controller when it renders a base using
+that view type.
+
+### Mechanism
+
+1. At init, register a headless view type (`nexus-analyze`) whose `BasesView`
+   subclass renders nothing and simply resolves a promise inside
+   `onDataUpdated()` with a snapshot of `data`.
+2. On `analyze`, copy the target `.base` to a scratch path under our storage
+   root and append a view of type `nexus-analyze` that clones the requested
+   view's `filters`/`order`/`groupBy`/`limit`.
+3. Render `![[<scratch>.base#__nexus_analyze]]` through `MarkdownRenderer.render`
+   into a **detached** container element — embeds support a `#View Name` selector,
+   so this executes the query with no leaf, no tab and no visible flicker.
+4. Harvest rows via `entry.getValue(prop)`, plus summaries via `getSummaryValue`.
+5. Detach the component, delete the scratch file.
+
+Serialise `Value` objects to plain JSON via `toString()`, with `LinkValue`
+preserved as a wikilink so results stay actionable.
+
+### Prerequisites and risks
+
+- `registerBasesView` exists only from **1.10.0** and returns `false` when Bases
+  is disabled in the vault. Our `minAppVersion` is 1.8.7, so guard with a
+  `typeof plugin.registerBasesView === 'function'` capability check and have
+  `analyze` report the reason rather than throw. `read`/`write`/`update`/`list`
+  are plain file operations and stay available regardless.
+- Step 3 is the part to prototype first — if detached rendering doesn't kick off
+  a query, fall back to a background leaf and accept a brief flicker.
+- `this` in a base resolves to the base file itself, so a scratch copy changes
+  what `this` means. Document it; if it bites, inject the temporary view into
+  the original file and restore it in a `finally`.
+- The harvesting layer must be separate from how the controller was obtained, so
+  that if Obsidian later exposes a "run this config" entry point the scaffolding
+  collapses to one call.
+- Cap rows returned and paginate — a base over a large vault can be thousands of
+  entries and this output goes into a model's context.
 
 ## Non-goals for v1
 
-- **Evaluating** filters/formulas against the vault. That is Obsidian's query
-  engine and reimplementing it is a project, not a tool. If a model wants
-  results rather than a view, `search query-notes` already exists.
 - Map-view specific settings (needs the Maps community plugin).
-- Generating bases from task boards / workspaces. Attractive follow-up, out of
-  scope until the file-level tools are proven.
+- Generating bases from task boards / workspaces. Attractive follow-up.
+- Writing our own filter/formula evaluator. If `analyze` can't use Obsidian's
+  engine, the answer is to fix the mechanism, not to reimplement the language.
 
 ## Tests
 
@@ -121,6 +161,9 @@ on errors; `validate` returns both lists.
 - Round-trip: `parseYaml` → mutate → `stringifyYaml` → reparse is stable.
 - Fixtures: the two complete examples from kepano's skill (Task Tracker,
   Reading List) must validate clean — a useful external conformance check.
+- `analyze` can only be covered end-to-end in a running app; it's a natural first
+  customer for the Obsidian CLI smoke lane (see
+  `docs/plans/obsidian-cli-verification-plan.md`).
 - `tests/unit/shippedGuidanceCommands.test.ts` gates shipped docs against real
   tool slugs, so the CLAUDE.md agent list and tool count need updating in the
   same change (13 → 14 agents, 74 → 79 tools).

--- a/docs/plans/bases-manager-agent-plan.md
+++ b/docs/plans/bases-manager-agent-plan.md
@@ -1,175 +1,335 @@
-# BasesManager agent (`.base` files) — plan
+# BasesManager Agent (`.base` files) — Design Plan
 
-Status: **proposed**
-Date: 2026-08-14
-Related: `src/agents/canvasManager/` (shape to mirror), Obsidian API ≥ 1.10.0
-(`BasesConfigFile`, `BasesQueryResult`, `registerBasesView`), kepano/obsidian-skills
-`skills/obsidian-bases`
+**Status:** Design / pre-architecture
+**Date:** 2026-08-14
+**Author:** design discussion (ProfSynapse + Claude)
+**Prompted by:** review of `kepano/obsidian-skills` (`skills/obsidian-bases`)
 
-## Gap
+## 1. Goal
 
-Nexus has no `.base` support of any kind — no reads, no writes, no awareness.
-Bases are Obsidian's native database view, and they're exactly the artifact an
-agent should be able to produce after organising a set of notes: "give me a
-table of every note tagged `task` with days-until-due" is a one-file answer today
-and we can't produce it.
+Give Nexus first-class support for **Obsidian Bases** — the `.base` file, which is
+a saved database-style query over the vault rendered as a table, cards, list or
+map view.
 
-`.canvas` has an agent. `.base` is the other first-class non-Markdown Obsidian
-file type and it doesn't.
+Two capabilities, not one:
 
-## Tools
+1. **Author** bases — read, create and modify `.base` files, with validation that
+   rejects a broken file *before* it reaches disk.
+2. **Execute** bases — return the actual rows a user would see when they open the
+   base, with filters applied and formulas evaluated.
 
-New always-on agent, CLI slug `base`, no credentials, cross-platform.
+`.canvas` has had an agent since v1. `.base` is the other first-class
+non-Markdown Obsidian file type and we have no awareness of it at all: a model
+that has just organised fifty notes cannot produce the one artifact that makes
+them navigable.
 
-| Tool | Behaviour |
-|------|-----------|
-| `read` | Parse a `.base` and return its sections (the file's *config*) |
-| `write` | Create a NEW `.base`; fails if it exists |
-| `update` | Modify an EXISTING `.base`; fails if it does not exist |
-| `list` | List `.base` files with view/formula counts (mirrors canvas node/edge counts) |
-| `analyze` | Execute the base and return the **rows the user would see** |
+## 2. Mental model (the important part)
 
-There is deliberately **no `validate` tool**. Validation is not a thing a caller
-should have to remember to do — `write` and `update` validate before touching
-disk and reject with the specific reasons on failure. A separate validate tool
-would be a footgun (a model can skip it) and redundant (a rejected write is
-already a dry run that tells you exactly what's wrong). Errors come back as a
-structured list, not a single string, so a model can fix each one.
+> **A `.base` is a saved query. We own the file; Obsidian owns the engine.**
 
-`update` replaces only the top-level sections supplied (`filters`, `formulas`,
-`properties`, `summaries`, `views`) rather than rewriting the file, so a model
-editing one view doesn't silently drop the user's others. This differs from
-`canvas update`, which replaces whole arrays; the divergence is deliberate and
-belongs in the tool description.
+This split decides every question below.
 
-### Registration (two touchpoints, per CLAUDE.md)
+The **file** is YAML with a documented, *typed* shape — Obsidian's public API
+exports `BasesConfigFile` — so authoring it is ordinary structured file work of
+the kind `CanvasManagerAgent` already does for `.canvas`.
 
-1. `initializeBasesManager()` in `src/services/agent/AgentInitializationService.ts`
-   (mirror `initializeCanvasManager`, :126–132).
-2. `this.safeInitialize('basesManager', …)` alongside the `canvasManager` entry
-   in `src/services/agent/AgentRegistrationService.ts:176`.
+The **query language** (filters, formulas, durations, summaries) is a real
+expression language with its own evaluator inside Obsidian. We must never
+reimplement it. Where we need results, we ask Obsidian to run the query and read
+out what it computed (§7).
 
-## Schema: use Obsidian's own types, don't hand-roll
+Consequences:
 
-Obsidian's public typings (verified in `obsidian@1.13.1`) ship the serialized
-`.base` format:
+| Property | Decision | Why |
+|---|---|---|
+| Schema source | **Re-export Obsidian's types** | `BasesConfigFile` is public API; hand-rolling it guarantees drift |
+| Validation | **Structural + reference integrity only** | We can prove `formula.x` is undefined; we cannot prove an expression is semantically right without the evaluator |
+| Results | **Obsidian's engine via `BasesQueryResult`** | Filters and formulas already evaluated; zero language surface owned by us |
+| Availability | **Agent absent when Bases is off** (§3) | A tool that always fails is worse than a tool that isn't offered |
+| View types | **Open set** | `BasesConfigFileView.type` is `string` because plugins register their own |
+
+## 3. Availability gating — no Bases, no tools
+
+If the vault has Bases disabled, the `base` tools must not merely fail when
+called: **they must not be discoverable at all**. `getTools` is how a model
+learns what exists, and advertising a tool that can only return "not available"
+wastes a discovery round-trip and invites retry loops.
+
+**Probe.** `Plugin.registerBasesView(viewId, registration)` returns `false` when
+Bases is not enabled in the vault (documented in the API, `@since 1.10.0`). That
+single call is both the probe and the registration we need for `analyze` — so at
+init we attempt to register the headless view (§7) and use the boolean result to
+decide whether to register the agent at all:
+
+```ts
+// AgentInitializationService — mirrors initializeCanvasManager (:126-132)
+initializeBasesManager(): boolean {
+  // Below 1.10.0 the method does not exist; above it, false = Bases disabled.
+  if (typeof this.plugin.registerBasesView !== 'function') return false;
+  const registered = this.plugin.registerBasesView(NEXUS_ANALYZE_VIEW_ID, analyzeViewRegistration);
+  if (!registered) return false;
+  this.agentManager.registerAgent(new BasesManagerAgent(this.app, this.plugin));
+  return true;
+}
+```
+
+and in `AgentRegistrationService.doInitializeAllAgents()`, alongside the
+`canvasManager` entry in PHASE 1 (`:176`). `safeInitialize` already swallows and
+logs failures, so a `false` return simply means no agent — the same shape as the
+existing `enableSearchModes` / `enableLLMModes` capability flags at `:244-251`.
+
+**Runtime toggling is explicitly out of scope.** If the user enables Bases after
+startup, the tools appear on the next reload. Adding/removing an agent at runtime
+would make `AppManager` no longer the only dynamic registrar and would trip
+exactly the design limit recorded in issue #174 (the `syncToolManagerAgent`
+callback-wrap bridge "does not compose for a second one"). Building a second
+dynamic registrar to save a plugin reload is not a trade worth making; if this
+becomes a real complaint, the fix is the event-based refactor in #174, not a
+workaround here.
+
+## 4. Tool surface
+
+Agent `basesManager`, CLI slug `base`. Five tools, four of which mirror
+`canvas` 1:1 so there is nothing new to learn.
+
+| Tool | CLI | Purpose |
+|---|---|---|
+| `read` | `base read --path Notes/Tasks.base` | Return the file's config |
+| `write` | `base write --path X.base --config '<yaml/json>'` | Create NEW; fails if exists |
+| `update` | `base update --path X.base --views '[…]'` | Modify EXISTING; fails if absent |
+| `list` | `base list [--path Folder]` | List `.base` files with view/formula counts |
+| `analyze` | `base analyze --path X.base [--view "Active"] [--limit 50]` | Execute and return rows |
+
+### There is no `validate` tool — deliberately
+
+Validation is not something a caller should have to remember. `write` and
+`update` validate before touching disk and **reject with the reasons**; a
+rejected write is already a dry run that says exactly what is wrong. A separate
+`validate` tool would be redundant *and* a footgun — an optional correctness step
+is one a model will skip. Errors are returned as a structured array so each can
+be fixed independently:
+
+```json
+{
+  "success": false,
+  "error": "Base config is invalid (2 errors)",
+  "errors": [
+    { "path": "views[0].order[3]", "code": "unknown-formula",
+      "message": "order references formula.days_left, which is not defined in formulas" },
+    { "path": "filters", "code": "filter-arity",
+      "message": "filter object has 2 keys (and, or); exactly one of and|or|not is allowed" }
+  ],
+  "warnings": [
+    { "path": "formulas.age", "code": "duration-arithmetic",
+      "message": "(now() - file.ctime).round(0) — Duration has no .round(); access .days first" }
+  ]
+}
+```
+
+### `update` merges top-level sections
+
+`update` replaces only the sections supplied (`filters`, `formulas`,
+`properties`, `summaries`, `views`) and leaves the rest untouched, so a model
+editing one view cannot silently drop the user's others. This differs from
+`canvas update`, which replaces whole arrays; the divergence is deliberate,
+because a `.base` is a small hand-tuned document a user edits directly, while a
+canvas is bulk generated geometry. The tool description must say so.
+
+### Example returns
+
+`base list`:
+
+```json
+{ "success": true, "bases": [
+  { "path": "Notes/Tasks.base", "views": 2, "formulas": 3, "hasGlobalFilters": true }
+]}
+```
+
+`base analyze --path Notes/Tasks.base --view "Active Tasks" --limit 2`:
+
+```json
+{ "success": true,
+  "view": { "name": "Active Tasks", "type": "table" },
+  "properties": ["file.name", "status", "formula.days_until_due"],
+  "rowCount": 47, "returned": 2, "truncated": true,
+  "groups": [ { "key": "in-progress", "rows": [
+      { "file.name": "Ship v6", "status": "in-progress", "formula.days_until_due": 3 },
+      { "file.name": "Write docs", "status": "in-progress", "formula.days_until_due": 11 }
+  ]}],
+  "summaries": { "formula.days_until_due": { "Average": 7.2 } }
+}
+```
+
+## 5. Schema — re-export, don't hand-roll
+
+Verified against `obsidian@1.13.1` typings:
 
 - `BasesConfigFile` — `filters?`, `formulas?`, `properties?`, `summaries?`, `views?`
-- `BasesConfigFileFilter` — `string | { and: … } | { or: … } | { not: … }`
-- `BasesConfigFileView` — `{ type, name, filters?, groupBy?, order?, summaries?, limit? }`
+- `BasesConfigFileFilter` — `string | { and: F[] } | { or: F[] } | { not: F[] }`
+- `BasesConfigFileView` — `{ type: string, name: string, filters?, groupBy?, order?, summaries? }`
 
-So our `types.ts` should re-export those rather than duplicate them, and the
-schema tracks Obsidian automatically. kepano's skill is still the best reference
-for *semantics* — the function catalogue, property namespaces (`file.*`,
-`formula.*`, bare frontmatter), and the documented pitfalls — but the structural
-shape is typed for us.
+`types.ts` re-exports these rather than duplicating them, so the schema tracks
+Obsidian automatically across app updates.
 
-YAML via Obsidian's `parseYaml` / `stringifyYaml`, **not** the `yaml` npm package
-(desktop-only per CLAUDE.md; `SkillValidator` set this precedent). Always
-serialise through `stringifyYaml` rather than string templates: it handles the
-quoting rules that are the largest single source of broken bases.
+kepano's `obsidian-bases` skill remains the reference for **semantics** — the
+function catalogue (`references/FUNCTIONS_REFERENCE.md`), the three property
+namespaces (bare/`note.*` frontmatter, `file.*` metadata, `formula.*` computed),
+the `this` keyword, and the authoring pitfalls that inform §6.
 
-## Validation rules (run automatically on write/update)
+**YAML via Obsidian's `parseYaml` / `stringifyYaml`**, never the `yaml` npm
+package — it is on the CLAUDE.md desktop-only list, and `SkillValidator`
+(`src/agents/apps/skills/services/SkillValidator.ts`) already set this
+precedent. Always serialise through `stringifyYaml` rather than string templates:
+quoting is the largest single source of broken bases, and the serialiser handles
+it for free.
 
-Errors — reject the write:
+## 6. Validation (automatic, on every write)
 
-1. Parses as YAML; no unknown top-level keys.
-2. Every filter object has **exactly one** key, and it is `and`/`or`/`not`.
-3. `groupBy.direction` is `ASC`/`DESC`.
-4. Every `formula.X` referenced from `order`, `properties` or `summaries` exists
-   in top-level `formulas`.
-5. Every value in a view's `summaries` is a built-in summary name (Average, Min,
-   Max, Sum, Range, Median, Stddev, Earliest, Latest, Checked, Unchecked, Empty,
-   Filled, Unique) or a key in top-level `summaries`.
+**Errors — reject the write:**
 
-Warnings — write proceeds, warnings returned:
+| Code | Rule |
+|---|---|
+| `yaml-parse` | File parses as YAML |
+| `unknown-key` | No unknown top-level keys |
+| `filter-arity` | Every filter object has exactly one key, and it is `and`/`or`/`not` |
+| `group-direction` | `groupBy.direction` is `ASC` or `DESC` |
+| `unknown-formula` | Every `formula.X` in `order`/`properties`/`summaries` exists in `formulas` |
+| `unknown-summary` | Each view summary value is a built-in name or a key in top-level `summaries` |
 
-6. `views[].type` outside `table|cards|list|map`. Note `BasesConfigFileView.type`
-   is typed as `string`, not an enum, precisely because plugins register custom
-   view types via `registerBasesView` — so an unknown type is suspicious, not
-   invalid, and must not be a hard reject.
-7. **Duration lint.** Date subtraction yields a Duration, which has no
-   `.round()`/`.floor()`/`.ceil()`. Flag `(a - b).round(` with no intervening
-   `.days`/`.hours`/`.minutes`/`.seconds`. kepano documents this as the
-   number-one authoring error.
-8. `order` references a frontmatter property that appears in no note — usually a
-   typo, but legitimately can precede the notes that will have it.
+Built-in summary names: Average, Min, Max, Sum, Range, Median, Stddev, Earliest,
+Latest, Checked, Unchecked, Empty, Filled, Unique.
 
-## `analyze` — returning the data the user would see
+**Warnings — write proceeds:**
 
-This is feasible **without reimplementing anything**, because Obsidian's own
-query engine is exposed. `BasesQueryResult` (public since 1.10.0) carries:
+| Code | Rule |
+|---|---|
+| `unknown-view-type` | `type` outside `table\|cards\|list\|map` — see below |
+| `duration-arithmetic` | `(a - b).round(` with no intervening `.days`/`.hours`/`.minutes`/`.seconds` |
+| `unused-property` | `order` references a frontmatter property no note currently has |
 
-- `data: BasesEntry[]` — filtered, sorted, limited, **formulas already evaluated**
-- `groupedData: BasesEntryGroup[]` — grouped per `groupBy`
-- `properties: BasesPropertyId[]` — the user's visible columns
-- `getSummaryValue(controller, entries, prop, summaryKey)` — footer aggregates
+`unknown-view-type` **must not be an error.** `BasesConfigFileView.type` is typed
+as `string`, not a union, precisely because plugins register their own view types
+via `registerBasesView` — our own `nexus-analyze` is one. Rejecting unknown types
+would make us reject files that Obsidian renders fine, including files we wrote.
 
-and `BasesEntry.getValue(propertyId): Value | null` reads a cell.
+`duration-arithmetic` is a warning rather than an error because we are pattern
+matching on an expression language we do not parse; it is kepano's documented
+number-one authoring error, so it earns a flag but not a veto.
 
-The catch: `QueryController` is an opaque exported class with no public members.
-You cannot construct one and ask it to run a config. The only supported way to
-receive one is `Plugin.registerBasesView(viewId, { name, icon, factory })` —
-Obsidian calls the factory with a live controller when it renders a base using
-that view type.
+## 7. `analyze` — executing the query
 
-### Mechanism
+Obsidian exposes the whole result set as public API (`@since 1.10.0`):
 
-1. At init, register a headless view type (`nexus-analyze`) whose `BasesView`
-   subclass renders nothing and simply resolves a promise inside
-   `onDataUpdated()` with a snapshot of `data`.
-2. On `analyze`, copy the target `.base` to a scratch path under our storage
-   root and append a view of type `nexus-analyze` that clones the requested
-   view's `filters`/`order`/`groupBy`/`limit`.
-3. Render `![[<scratch>.base#__nexus_analyze]]` through `MarkdownRenderer.render`
-   into a **detached** container element — embeds support a `#View Name` selector,
-   so this executes the query with no leaf, no tab and no visible flicker.
-4. Harvest rows via `entry.getValue(prop)`, plus summaries via `getSummaryValue`.
-5. Detach the component, delete the scratch file.
+- `BasesQueryResult.data: BasesEntry[]` — filtered, sorted, limited, **formulas
+  already evaluated**
+- `.groupedData: BasesEntryGroup[]` — grouped per the view's `groupBy`
+- `.properties: BasesPropertyId[]` — the user's visible columns
+- `.getSummaryValue(controller, entries, prop, key): Value` — footer aggregates
+- `BasesEntry.getValue(propertyId): Value | null` — one cell
 
-Serialise `Value` objects to plain JSON via `toString()`, with `LinkValue`
-preserved as a wikilink so results stay actionable.
+**The obstacle:** `QueryController` is an exported class with *no public members*.
+It cannot be constructed, and nothing accepts a `BasesConfigFile` and returns
+results. The only supported way to receive a live controller is
+`registerBasesView(viewId, { name, icon, factory })` — Obsidian calls the factory
+when it renders a base **using that view type**.
 
-### Prerequisites and risks
+**Mechanism:**
 
-- `registerBasesView` exists only from **1.10.0** and returns `false` when Bases
-  is disabled in the vault. Our `minAppVersion` is 1.8.7, so guard with a
-  `typeof plugin.registerBasesView === 'function'` capability check and have
-  `analyze` report the reason rather than throw. `read`/`write`/`update`/`list`
-  are plain file operations and stay available regardless.
-- Step 3 is the part to prototype first — if detached rendering doesn't kick off
-  a query, fall back to a background leaf and accept a brief flicker.
-- `this` in a base resolves to the base file itself, so a scratch copy changes
-  what `this` means. Document it; if it bites, inject the temporary view into
-  the original file and restore it in a `finally`.
-- The harvesting layer must be separate from how the controller was obtained, so
-  that if Obsidian later exposes a "run this config" entry point the scaffolding
-  collapses to one call.
-- Cap rows returned and paginate — a base over a large vault can be thousands of
-  entries and this output goes into a model's context.
+1. At init (§3), register `nexus-analyze`: a `BasesView` subclass that renders
+   nothing and resolves a pending promise inside `onDataUpdated()` with a
+   snapshot of `data`.
+2. On `analyze`, copy the target `.base` to a scratch path under the resolved
+   storage root, appending a view of type `nexus-analyze` that clones the
+   requested view's `filters`/`order`/`groupBy`/`limit`.
+3. Render `![[<scratch>.base#__nexus_analyze]]` via `MarkdownRenderer.render`
+   into a **detached** container element. Base embeds accept a `#View Name`
+   selector, so this executes the query with no leaf, no tab, no flicker.
+4. Harvest rows through `entry.getValue(prop)`; summaries through
+   `getSummaryValue`.
+5. Unload the `Component`, delete the scratch file in a `finally`.
 
-## Non-goals for v1
+**Serialisation.** `Value` subclasses (`StringValue`, `NumberValue`, `DateValue`,
+`ListValue`, `LinkValue`, …) go to plain JSON via `toString()`, with `LinkValue`
+preserved as a wikilink so results stay actionable — a returned row should be
+something the model can immediately `content read`.
 
-- Map-view specific settings (needs the Maps community plugin).
-- Generating bases from task boards / workspaces. Attractive follow-up.
-- Writing our own filter/formula evaluator. If `analyze` can't use Obsidian's
+**Bounding.** A base over a large vault is thousands of entries and this output
+lands in a model's context. Default `limit`, always report `rowCount` vs
+`returned` and a `truncated` flag; never silently drop rows.
+
+**Layering.** The harvesting code must not know how the controller was obtained.
+If Obsidian later exposes a "run this config" entry point, steps 2–3 and 5
+collapse to one call and nothing else changes.
+
+## 8. Mobile / desktop split
+
+All five tools are cross-platform in principle: YAML through Obsidian helpers,
+files through the vault API, and the Bases engine ships with the app on both
+platforms. Bases availability, not platform, is the gate (§3).
+
+`analyze` needs verification on mobile — detached `MarkdownRenderer` rendering is
+the uncertain part, and the mobile adapter has surprised us before (the
+`adapter.list('')` vs `'/'` vault-root discovery issue in the Skills app). If it
+proves unreliable there, gate `analyze` alone rather than the agent.
+
+## 9. Phasing
+
+| Phase | Content | Gate |
+|---|---|---|
+| 0 | **Spike `analyze` step 3** — does detached embed rendering execute the query? | Decides §7; do this first |
+| 1 | Agent scaffold + availability probe (§3) + `read`/`list` | Tools appear only when Bases is on |
+| 2 | `BaseValidator` (§6) + `write`/`update` with automatic validation | kepano fixtures validate clean |
+| 3 | `analyze` (§7) | Rows match what the app shows for the same base |
+| 4 | Docs: CLAUDE.md agent list + tool counts, `cli-first-tool-schemas.json` | `shippedGuidanceCommands.test.ts` green |
+
+Phase 0 first is the point of the phasing: it is the only part that can fail
+outright, and everything else is ordinary file work that does not depend on the
+answer.
+
+## 10. Open questions
+
+1. **Does detached rendering kick off a query?** If not, fall back to a
+   background leaf and accept a brief flicker, or inject the temporary view into
+   the original file and restore it in a `finally`.
+2. **`this` semantics under a scratch copy.** `this` resolves to the base file
+   itself, so a copy at a different path changes what `this` means. Affects only
+   bases that use `this`; detect and fall back to in-place injection.
+3. **Do `storage list` / file-facing tools filter to `.md`?** If so a model can
+   create a base and then not find it. Check before shipping.
+4. **Should `analyze` accept an inline config** (execute without a file)? Would
+   make bases a general query interface. Attractive, out of v1 scope.
+
+## 11. Implementation reuse map (DRY)
+
+| Need | Reuse |
+|---|---|
+| Agent + lazy tool registration | `src/agents/canvasManager/canvasManager.ts` (registerLazyTool shape) |
+| Read/write/update/list tool shapes | `src/agents/canvasManager/tools/*` |
+| Registration touchpoints | `AgentInitializationService.ts:126-132`, `AgentRegistrationService.ts:176` |
+| Capability-flag registration | `enableSearchModes` / `enableLLMModes`, `AgentRegistrationService.ts:244-251` |
+| YAML parse/serialise | Obsidian `parseYaml`/`stringifyYaml`, as in `SkillValidator` |
+| Collected-errors validator shape | `SkillValidator.validate()` (collects all errors, no short-circuit) |
+| Scratch paths under storage root | `resolveVaultRoot(settings, { configDir })` |
+| Structured tool results | `BaseTool.prepareResult` |
+
+## 12. Non-goals
+
+- Writing our own filter/formula evaluator. If `analyze` cannot use Obsidian's
   engine, the answer is to fix the mechanism, not to reimplement the language.
+- Map-view-specific settings (needs the Maps community plugin).
+- Generating bases from task boards or workspaces — attractive follow-up, but it
+  presumes the file tools are proven.
+- Runtime enable/disable of the agent (§3).
 
-## Tests
+## 13. Tests
 
-- Validator unit tests per rule, both directions.
-- Round-trip: `parseYaml` → mutate → `stringifyYaml` → reparse is stable.
-- Fixtures: the two complete examples from kepano's skill (Task Tracker,
-  Reading List) must validate clean — a useful external conformance check.
-- `analyze` can only be covered end-to-end in a running app; it's a natural first
-  customer for the Obsidian CLI smoke lane (see
-  `docs/plans/obsidian-cli-verification-plan.md`).
+- Validator unit tests per rule code, both directions.
+- Round-trip stability: `parseYaml` → mutate → `stringifyYaml` → reparse.
+- Fixtures: the two complete examples from kepano's skill (Task Tracker, Reading
+  List) must validate clean — an external conformance check we didn't author.
+- `analyze` is only truly testable in a running app; it is the natural first
+  customer for the Obsidian CLI smoke lane
+  (`docs/plans/obsidian-cli-verification-plan.md`).
 - `tests/unit/shippedGuidanceCommands.test.ts` gates shipped docs against real
-  tool slugs, so the CLAUDE.md agent list and tool count need updating in the
-  same change (13 → 14 agents, 74 → 79 tools).
-
-## Open question
-
-Whether `storage list` and other file-facing tools currently filter to `.md` and
-would hide `.base` files. Worth checking before shipping, so a model that creates
-a base can then find it.
+  tool slugs, so the CLAUDE.md agent inventory and tool counts must move in the
+  same change.

--- a/docs/plans/bases-manager-agent-plan.md
+++ b/docs/plans/bases-manager-agent-plan.md
@@ -1,0 +1,132 @@
+# BasesManager agent (`.base` files) — plan
+
+Status: **proposed**
+Date: 2026-08-14
+Related: `src/agents/canvasManager/` (shape to mirror), kepano/obsidian-skills
+`skills/obsidian-bases`
+
+## Gap
+
+Nexus has no `.base` support of any kind — no reads, no writes, no awareness.
+Bases are Obsidian's native database view (YAML files with filters, formulas and
+views), and they are exactly the artifact an agent should be able to build after
+it has organised a set of notes: "make me a table of every note tagged `task`
+with days-until-due" is a one-file answer today and we can't produce it.
+
+`.canvas` has an agent. `.base` is the other first-class non-Markdown Obsidian
+file type and it doesn't.
+
+## Shape: mirror CanvasManager exactly
+
+New always-on agent, CLI slug `base`, no credentials, cross-platform.
+
+```
+src/agents/basesManager/
+  basesManager.ts            # BaseAgent subclass, lazy-registered tools
+  tools/{read,write,update,list,validate}.ts
+  services/BaseValidator.ts  # pure, dependency-free
+  types.ts
+```
+
+Tools (first four match `canvas` 1:1, so there is nothing new to learn):
+
+| Tool | Behaviour |
+|------|-----------|
+| `read` | Parse a `.base` and return its sections + a normalised summary |
+| `write` | Create a NEW `.base`; fails if it exists |
+| `update` | Modify an EXISTING `.base`; fails if it does not exist |
+| `list` | List `.base` files with view/formula counts (mirrors canvas node/edge counts) |
+| `validate` | Validate without writing — the pre-flight for a model-authored base |
+
+`update` should replace only the top-level sections the caller supplies
+(`filters`/`formulas`/`properties`/`summaries`/`views`) rather than rewriting the
+file, so a model editing one view doesn't silently drop the user's other views.
+Note this differs from `canvas update`, which replaces whole arrays — the
+divergence is deliberate and should be called out in the tool description.
+
+### Registration (two touchpoints, per CLAUDE.md)
+
+1. `initializeBasesManager()` in `src/services/agent/AgentInitializationService.ts`
+   (mirror `initializeCanvasManager`, :126–132).
+2. `this.safeInitialize('basesManager', …)` alongside the `canvasManager` entry
+   in `src/services/agent/AgentRegistrationService.ts:176`.
+
+No factory class, no ServiceDefinitions entry.
+
+## YAML handling
+
+Use Obsidian's `parseYaml` / `stringifyYaml`, **not** the `yaml` npm package —
+that package is on the CLAUDE.md desktop-only list, and `SkillValidator` already
+set this precedent. Always serialise through `stringifyYaml` rather than string
+templates: it handles the quoting rules that are the single largest source of
+broken bases (expressions containing `"`, values containing `:`/`{`/`}`).
+
+## Schema to model
+
+```yaml
+filters:      # filter node: a string, OR an object with exactly one of and|or|not
+formulas:     # name -> expression string
+properties:   # property key -> { displayName }
+summaries:    # name -> aggregation expression
+views:
+  - type: table | cards | list | map
+    name: string
+    limit: number?
+    groupBy: { property, direction: ASC|DESC }?
+    filters: <filter node>?
+    order: string[]?          # file.x | property | formula.x
+    summaries: { property: SummaryName }?
+```
+
+Property namespaces: bare/`note.x` (frontmatter), `file.x` (name, basename, path,
+folder, ext, size, ctime, mtime, tags, links, backlinks, embeds, properties),
+`formula.x` (computed).
+
+Built-in summary names: Average, Min, Max, Sum, Range, Median, Stddev, Earliest,
+Latest, Checked, Unchecked, Empty, Filled, Unique.
+
+## Validator rules
+
+These are the documented real-world failure modes, not invented strictness:
+
+1. File parses as YAML; unknown top-level keys rejected.
+2. Every filter object has **exactly one** key, and it is `and`/`or`/`not`.
+3. `views[].type` is in the enum; `groupBy.direction` is `ASC`/`DESC`.
+4. Every `formula.X` referenced from `order`, `properties` or `summaries` exists
+   in the top-level `formulas`.
+5. Every value in a view's `summaries` is either a built-in name or a key in
+   top-level `summaries`.
+6. **Duration lint (warning).** Date subtraction yields a Duration, which has no
+   `.round()`/`.floor()`/`.ceil()`. Flag `(a - b).round(` with no intervening
+   `.days`/`.hours`/`.minutes`/`.seconds` field access. kepano documents this as
+   the number-one pitfall.
+7. Warn when `order` references a frontmatter property that appears in no note
+   in the vault — usually a typo, so warn rather than reject.
+
+Rules 1–5 are errors, 6–7 warnings. `write`/`update` run the validator and refuse
+on errors; `validate` returns both lists.
+
+## Non-goals for v1
+
+- **Evaluating** filters/formulas against the vault. That is Obsidian's query
+  engine and reimplementing it is a project, not a tool. If a model wants
+  results rather than a view, `search query-notes` already exists.
+- Map-view specific settings (needs the Maps community plugin).
+- Generating bases from task boards / workspaces. Attractive follow-up, out of
+  scope until the file-level tools are proven.
+
+## Tests
+
+- Validator unit tests per rule, both directions.
+- Round-trip: `parseYaml` → mutate → `stringifyYaml` → reparse is stable.
+- Fixtures: the two complete examples from kepano's skill (Task Tracker,
+  Reading List) must validate clean — a useful external conformance check.
+- `tests/unit/shippedGuidanceCommands.test.ts` gates shipped docs against real
+  tool slugs, so the CLAUDE.md agent list and tool count need updating in the
+  same change (13 → 14 agents, 74 → 79 tools).
+
+## Open question
+
+Whether `storage list` and other file-facing tools currently filter to `.md` and
+would hide `.base` files. Worth checking before shipping, so a model that creates
+a base can then find it.

--- a/docs/plans/obsidian-cli-verification-plan.md
+++ b/docs/plans/obsidian-cli-verification-plan.md
@@ -58,14 +58,17 @@ pattern from "our CLI against a real vault" to "our plugin inside the real app":
 use `obsidian eval` to invoke a Nexus tool in-app and assert on the result, then
 `dev:errors` to prove nothing threw.
 
-Highest-value first targets, all currently unautomatable:
+The selection criterion is narrow on purpose: **only things that cannot be
+observed outside the running app**. Anything a unit test can reach should stay a
+unit test. That points at plugin lifecycle (does it load clean on a real vault),
+rendering (does the chat bubble actually paint what the pipeline produced — the
+reasoning-render gap flowed through every layer and was only caught by eye), and
+cold-cache behaviour (the class of race behind the task-board empty-board bug,
+where hydration order decided the result).
 
-- MCP socket connect on an installed build (an open item in the 5.11.1 manual
-  test plan).
-- Secure key storage round-trip (same).
-- Chat view renders a streamed response — the reasoning-render gap shipped
-  through every layer and was only caught by eye.
-- Task board cold-start (the `waitForQueryReady` hydration race behind #267).
+The first scenario should be whichever of those is currently costing the most
+manual checking — worth confirming against what's actually open before writing
+it, rather than picking from an older test plan.
 
 ### 3. A `/nexus-verify` skill
 
@@ -104,5 +107,6 @@ green `dev:mobile` run be read as "mobile-safe".
 
 1. Confirm the local Obsidian is ≥ 1.12.4 and `obsidian help` responds.
 2. Land `verify-in-obsidian.mjs` + npm script; run it by hand once.
-3. Add the smoke test lane with one scenario (MCP socket connect).
+3. Add the smoke test lane with one scenario — pick the check currently costing
+   the most manual effort.
 4. Add `/nexus-verify`; then wire into `/nexus-release`.

--- a/docs/plans/obsidian-cli-verification-plan.md
+++ b/docs/plans/obsidian-cli-verification-plan.md
@@ -1,25 +1,25 @@
-# Closing the manual-verification gap with the Obsidian CLI
+# In-App Verification via the Obsidian CLI — Design Plan
 
-Status: **proposed**
-Date: 2026-08-14
-Related: `tests/debug/*-live-smoke.test.ts`, `/nexus-release`, kepano/obsidian-skills
-`skills/obsidian-cli`
+**Status:** Design / pre-architecture
+**Date:** 2026-08-14
+**Author:** design discussion (ProfSynapse + Claude)
+**Prompted by:** review of `kepano/obsidian-skills` (`skills/obsidian-cli`)
 
-## The gap this closes
+## 1. Goal
 
-Almost every recent entry in CLAUDE.md ends the same way: *"verified by unit
-tests + build only — NOT yet manually tested in Obsidian"*, plus a standing
-"do not commit until the user manually tests" constraint. The suite can be green
-and the plugin still be broken in the app, and only a human at a keyboard can
-currently tell the difference. Three shipped defects (v5.16.2 search ranking)
-went past a green suite for exactly this reason.
+Make "does this actually work in Obsidian?" a question a script can answer.
 
-Obsidian shipped an official CLI — early access in 1.12.0, generally available
-in **1.12.4** (Feb 2026) — that drives a *running* Obsidian instance, including
-developer commands. That turns "reload the plugin and check for errors" into
-something a script (or an agent) can do unattended.
+Today it is answerable only by a human opening the app, which is why so much
+work in this repo sits in a state described as *verified by unit tests and build
+only*, and why "don't commit until manually tested" is a standing constraint.
+The suite can be green while the plugin is broken in the app, and nothing
+automated can tell the difference.
 
-Relevant commands:
+## 2. What changed
+
+Obsidian shipped an official CLI that drives a **running** instance: early
+access in 1.12.0, generally available in **1.12.4** (Feb 2026). It includes
+developer commands, which is the part that matters here:
 
 ```bash
 obsidian plugin:reload id=nexus          # pick up a fresh build
@@ -28,85 +28,126 @@ obsidian dev:console level=error         # console output
 obsidian dev:screenshot path=shot.png    # visual check
 obsidian dev:dom selector=".x" text      # assert rendered DOM
 obsidian dev:css selector=".x" prop=color
-obsidian dev:mobile on                   # mobile emulation
+obsidian dev:mobile on                   # mobile emulation (see §6)
 obsidian eval code="app.plugins.plugins.nexus…"   # run JS in app context
 ```
 
-Our plugin id is `nexus` (manifest.json:2).
+Our plugin id is `nexus` (`manifest.json:2`). The app must be running; the first
+command launches it if not.
 
-## Deliverables
+## 3. Mental model
 
-### 1. `scripts/verify-in-obsidian.mjs` + `npm run verify:obsidian`
+> **We already accepted this argument once.**
 
-The core loop, exiting non-zero on failure so it can gate anything:
+`tests/debug/search-ranking-live-smoke.test.ts` exists because three ranking
+defects (#309, #313, #314) shipped past a green unit suite, and every one was
+caught by searching a real vault. Its header states the reason plainly: the unit
+suite can only prove the tiers are ordered consistently with a *mocked* scorer.
+
+That test drives **our CLI against a real vault**. The Obsidian CLI extends the
+same idea one layer out — **our plugin inside the real app** — and closes the
+same class of gap: everything that only exists once the plugin is loaded,
+rendered and hydrated.
+
+## 4. Deliverables
+
+### 4.1 `scripts/verify-in-obsidian.mjs` + `npm run verify:obsidian`
+
+The core loop, exiting non-zero on failure so anything can gate on it:
 
 1. `npm run build`
 2. `obsidian plugin:reload id=nexus`
 3. `obsidian dev:errors` → fail if non-empty
 4. `obsidian dev:screenshot path=test-artifacts/verify-<ts>.png`
 
-Preconditions to detect and report clearly rather than crash: `obsidian` on
-PATH, Obsidian ≥ 1.12.4, an instance running, desktop only. Skip cleanly (exit
-0 with a notice) when unavailable, so CI is unaffected.
+Preconditions are detected and reported, never crashed on: `obsidian` on PATH,
+version ≥ 1.12.4, an instance running, desktop only. When unavailable it exits 0
+with a notice, so CI is unaffected. Sits alongside the existing `scripts/*.mjs`
+conventions (`build-cli.mjs`, `smoke-google-live.mjs`).
 
-### 2. `tests/debug/obsidian-live-smoke.test.ts`, gated `RUN_OBSIDIAN_SMOKE=1`
+### 4.2 `tests/debug/obsidian-live-smoke.test.ts`, gated `RUN_OBSIDIAN_SMOKE=1`
 
-We already have this exact pattern: `search-ranking-live-smoke.test.ts` runs
-under `RUN_SEARCH_SMOKE=1` and drives a real vault through the `nexus` CLI,
-because mocked search hid three real ranking bugs. The Obsidian CLI extends the
-pattern from "our CLI against a real vault" to "our plugin inside the real app":
-use `obsidian eval` to invoke a Nexus tool in-app and assert on the result, then
+Mirrors the existing live-smoke lane exactly: env-gated, `--runInBand`, scratch
+folder it cleans up, a header explaining why mocks cannot cover it. Uses
+`obsidian eval` to invoke a Nexus tool in-app and assert on the result, then
 `dev:errors` to prove nothing threw.
 
-The selection criterion is narrow on purpose: **only things that cannot be
-observed outside the running app**. Anything a unit test can reach should stay a
-unit test. That points at plugin lifecycle (does it load clean on a real vault),
-rendering (does the chat bubble actually paint what the pipeline produced — the
-reasoning-render gap flowed through every layer and was only caught by eye), and
-cold-cache behaviour (the class of race behind the task-board empty-board bug,
-where hydration order decided the result).
+**Scenario selection criterion — the narrow part.** Only things that *cannot* be
+observed outside the running app earn a scenario here. Anything a unit test can
+reach stays a unit test. That points at three families:
 
-The first scenario should be whichever of those is currently costing the most
-manual checking — worth confirming against what's actually open before writing
-it, rather than picking from an older test plan.
+| Family | Why only in-app | Example failure this catches |
+|---|---|---|
+| Lifecycle | Needs a real vault and a real load | Plugin fails to initialise on an installed build |
+| Rendering | The pipeline can be right and the paint wrong | Reasoning flowed through every layer and never rendered; caught by eye |
+| Cold cache / hydration | Ordering only exists at real startup | A board reading before its data source was ready |
 
-### 3. A `/nexus-verify` skill
+The first scenario should be whichever of these is currently costing the most
+manual checking — worth confirming against what is actually open at build time
+rather than picking from an older test plan.
 
-Wraps the loop so an agent can self-verify: build → reload → errors → screenshot
-→ report. This is what makes the "don't commit until tested" constraint
-something an agent can satisfy rather than block on.
+### 4.3 A `/nexus-verify` skill
 
-### 4. Pre-release gate in `/nexus-release`
+Wraps the loop (build → reload → errors → screenshot → report) so an **agent**
+can self-verify. This is the deliverable that changes the working agreement:
+"don't commit until tested" becomes something an agent can satisfy rather than
+block on. Lives beside the existing `.claude/skills/nexus-*` skills.
+
+### 4.4 Pre-release gate in `/nexus-release`
 
 Run `verify:obsidian` against the built artifact before tagging. Cheap, and it
-would have caught the class of bug that shipped in 5.8.12/5.8.13.
+covers the class of defect that has shipped before — a build that passes tests
+and then misbehaves on a real vault at startup.
 
-## Honest limitation: this does NOT cover mobile crashes
+## 5. Phasing
 
-`dev:mobile on` emulates the mobile *environment* — `Platform.isMobile`, touch,
-layout. It does not remove Node built-ins from Electron. The mobile failure mode
-CLAUDE.md warns about (a top-level `import ... from 'fs'` or an npm package with
-Node transitive deps killing plugin init) will **not** reproduce under emulation,
-because `require('fs')` still resolves there.
+| Phase | Content | Gate |
+|---|---|---|
+| 0 | Confirm local Obsidian ≥ 1.12.4 and `obsidian help` responds | Prerequisite; everything else is blocked on it |
+| 1 | `verify-in-obsidian.mjs` + npm script, run by hand once | Reload + errors + screenshot work end to end |
+| 2 | Smoke lane with one scenario | Fails when deliberately broken, passes when fixed |
+| 3 | `/nexus-verify` skill | An agent completes the loop unattended |
+| 4 | Wire into `/nexus-release` | Release blocked on a clean in-app load |
 
-So: use `dev:mobile` for UI and platform-branch coverage, and keep the static
-import-guard lint (issue #221) as the actual mobile-compat defence. Do not let a
-green `dev:mobile` run be read as "mobile-safe".
+Phase 2's gate matters more than it sounds: a smoke test that has never failed
+has not been shown to work.
 
-## Other caveats
+## 6. Honest limitation — this does NOT cover mobile crashes
 
-- Desktop-only, requires a running instance, and the user's real vault — this is
-  a local developer loop, not CI.
-- `obsidian eval` runs arbitrary JS in the app against the user's live vault.
-  Smoke tests must target a scratch vault (`vault=<name>` targets a specific
-  one), never the primary one, and must not write outside a fixture folder.
-- Cannot be validated from a remote container — there is no Obsidian here. All
-  of this needs a first run on the user's machine.
+`dev:mobile on` emulates the mobile *environment*: `Platform.isMobile`, touch,
+layout. It does **not** remove Node built-ins from Electron. The specific mobile
+failure CLAUDE.md warns about — a top-level `import … from 'fs'`, or an npm
+package with Node transitive deps, killing plugin init — will **not** reproduce
+under emulation, because `require('fs')` still resolves there.
 
-## Steps
+Use `dev:mobile` for UI and platform-branch coverage. Keep the static
+import-guard lint (issue #221) as the actual mobile-compat defence, and do not
+let a green `dev:mobile` run be read as "mobile-safe".
 
-1. Confirm the local Obsidian is ≥ 1.12.4 and `obsidian help` responds.
-2. Land `verify-in-obsidian.mjs` + npm script; run it by hand once.
-3. Add the smoke test lane with one scenario — pick the check currently costing
-   the most manual effort.
-4. Add `/nexus-verify`; then wire into `/nexus-release`.
+## 7. Risks and constraints
+
+| Risk | Mitigation |
+|---|---|
+| `obsidian eval` runs arbitrary JS against the user's live vault | Target a scratch vault via `vault=<name>`; confine writes to a fixture folder; clean up in `finally`, as the search smoke test does |
+| Local-only — needs a running desktop instance | Env-gated and skip-clean, exactly like the existing live-smoke lanes; never a CI dependency |
+| Screenshot diffing invites flakiness | Screenshots are **artifacts for a human**, not assertions. Assert via `dev:dom`/`dev:errors` only |
+| CLI output format changes between Obsidian versions | Parse defensively; treat unparseable output as "unknown", not "pass" |
+| A stale build reloading silently | Reload only after a successful build in the same script run |
+
+## 8. Open questions
+
+1. Which scenario is worth automating first (§4.2)?
+2. Should `/nexus-verify` run the full build or an incremental `npm run dev`
+   output? Full build is slower but is what release actually ships.
+3. Is a dedicated test vault worth checking in as a fixture, or does that drift
+   from real-vault conditions — the very thing this lane exists to test?
+
+## 9. Implementation reuse map (DRY)
+
+| Need | Reuse |
+|---|---|
+| Env-gated live lane, scratch-and-clean discipline | `tests/debug/search-ranking-live-smoke.test.ts` |
+| Node script conventions | `scripts/smoke-google-live.mjs`, `scripts/build-cli.mjs` |
+| Skill layout | `.claude/skills/nexus-*` |
+| Release gating | `/nexus-release` skill |
+| Plugin id | `manifest.json:2` (`nexus`) |

--- a/docs/plans/obsidian-cli-verification-plan.md
+++ b/docs/plans/obsidian-cli-verification-plan.md
@@ -1,0 +1,108 @@
+# Closing the manual-verification gap with the Obsidian CLI
+
+Status: **proposed**
+Date: 2026-08-14
+Related: `tests/debug/*-live-smoke.test.ts`, `/nexus-release`, kepano/obsidian-skills
+`skills/obsidian-cli`
+
+## The gap this closes
+
+Almost every recent entry in CLAUDE.md ends the same way: *"verified by unit
+tests + build only — NOT yet manually tested in Obsidian"*, plus a standing
+"do not commit until the user manually tests" constraint. The suite can be green
+and the plugin still be broken in the app, and only a human at a keyboard can
+currently tell the difference. Three shipped defects (v5.16.2 search ranking)
+went past a green suite for exactly this reason.
+
+Obsidian shipped an official CLI — early access in 1.12.0, generally available
+in **1.12.4** (Feb 2026) — that drives a *running* Obsidian instance, including
+developer commands. That turns "reload the plugin and check for errors" into
+something a script (or an agent) can do unattended.
+
+Relevant commands:
+
+```bash
+obsidian plugin:reload id=nexus          # pick up a fresh build
+obsidian dev:errors                      # errors since load
+obsidian dev:console level=error         # console output
+obsidian dev:screenshot path=shot.png    # visual check
+obsidian dev:dom selector=".x" text      # assert rendered DOM
+obsidian dev:css selector=".x" prop=color
+obsidian dev:mobile on                   # mobile emulation
+obsidian eval code="app.plugins.plugins.nexus…"   # run JS in app context
+```
+
+Our plugin id is `nexus` (manifest.json:2).
+
+## Deliverables
+
+### 1. `scripts/verify-in-obsidian.mjs` + `npm run verify:obsidian`
+
+The core loop, exiting non-zero on failure so it can gate anything:
+
+1. `npm run build`
+2. `obsidian plugin:reload id=nexus`
+3. `obsidian dev:errors` → fail if non-empty
+4. `obsidian dev:screenshot path=test-artifacts/verify-<ts>.png`
+
+Preconditions to detect and report clearly rather than crash: `obsidian` on
+PATH, Obsidian ≥ 1.12.4, an instance running, desktop only. Skip cleanly (exit
+0 with a notice) when unavailable, so CI is unaffected.
+
+### 2. `tests/debug/obsidian-live-smoke.test.ts`, gated `RUN_OBSIDIAN_SMOKE=1`
+
+We already have this exact pattern: `search-ranking-live-smoke.test.ts` runs
+under `RUN_SEARCH_SMOKE=1` and drives a real vault through the `nexus` CLI,
+because mocked search hid three real ranking bugs. The Obsidian CLI extends the
+pattern from "our CLI against a real vault" to "our plugin inside the real app":
+use `obsidian eval` to invoke a Nexus tool in-app and assert on the result, then
+`dev:errors` to prove nothing threw.
+
+Highest-value first targets, all currently unautomatable:
+
+- MCP socket connect on an installed build (an open item in the 5.11.1 manual
+  test plan).
+- Secure key storage round-trip (same).
+- Chat view renders a streamed response — the reasoning-render gap shipped
+  through every layer and was only caught by eye.
+- Task board cold-start (the `waitForQueryReady` hydration race behind #267).
+
+### 3. A `/nexus-verify` skill
+
+Wraps the loop so an agent can self-verify: build → reload → errors → screenshot
+→ report. This is what makes the "don't commit until tested" constraint
+something an agent can satisfy rather than block on.
+
+### 4. Pre-release gate in `/nexus-release`
+
+Run `verify:obsidian` against the built artifact before tagging. Cheap, and it
+would have caught the class of bug that shipped in 5.8.12/5.8.13.
+
+## Honest limitation: this does NOT cover mobile crashes
+
+`dev:mobile on` emulates the mobile *environment* — `Platform.isMobile`, touch,
+layout. It does not remove Node built-ins from Electron. The mobile failure mode
+CLAUDE.md warns about (a top-level `import ... from 'fs'` or an npm package with
+Node transitive deps killing plugin init) will **not** reproduce under emulation,
+because `require('fs')` still resolves there.
+
+So: use `dev:mobile` for UI and platform-branch coverage, and keep the static
+import-guard lint (issue #221) as the actual mobile-compat defence. Do not let a
+green `dev:mobile` run be read as "mobile-safe".
+
+## Other caveats
+
+- Desktop-only, requires a running instance, and the user's real vault — this is
+  a local developer loop, not CI.
+- `obsidian eval` runs arbitrary JS in the app against the user's live vault.
+  Smoke tests must target a scratch vault (`vault=<name>` targets a specific
+  one), never the primary one, and must not write outside a fixture folder.
+- Cannot be validated from a remote container — there is no Obsidian here. All
+  of this needs a first run on the user's machine.
+
+## Steps
+
+1. Confirm the local Obsidian is ≥ 1.12.4 and `obsidian help` responds.
+2. Land `verify-in-obsidian.mjs` + npm script; run it by hand once.
+3. Add the smoke test lane with one scenario (MCP socket connect).
+4. Add `/nexus-verify`; then wire into `/nexus-release`.

--- a/docs/plans/web-capture-defuddle-plan.md
+++ b/docs/plans/web-capture-defuddle-plan.md
@@ -1,0 +1,127 @@
+# Web capture via Defuddle — investigation + plan
+
+Status: **proposed** (investigation complete, no code written)
+Date: 2026-08-14
+Related: `src/agents/apps/webTools/`, kepano/obsidian-skills `skills/defuddle`
+
+## Why look at this
+
+`web capture-markdown` does not extract anything itself. It drives Obsidian's
+Web Viewer:
+
+- `captureToMarkdown.ts` opens a Web Viewer leaf (`openWebViewerUrl`), waits for
+  it to settle, then invokes the core-plugin command
+  `webviewer:save-to-vault` (`utils/webViewer.ts:31`) and *hunts the filesystem*
+  for whatever file that command produced (`findCreatedMarkdownFile`,
+  `utils/webViewer.ts:175`).
+- It is gated on `hasWebViewerSaveCommand(app)` (`utils/webViewer.ts:215`), so
+  it silently does nothing useful if the user has the Web Viewer core plugin
+  disabled.
+- The whole `webTools` app is desktop + Electron only.
+
+Consequences: mobile can't capture at all, a core plugin is a hard dependency,
+the workspace is mutated (a tab opens) as a side effect of a data operation, the
+output format is whatever Obsidian decided, and we get no page metadata back.
+
+Defuddle is the extraction library behind Obsidian Web Clipper, so adopting it
+directly gives us the same extraction quality without renting Obsidian's UI.
+
+## What Defuddle actually is (verified against the published tarball)
+
+`defuddle@0.19.2`, MIT. Measured from `npm pack defuddle@0.19.2`:
+
+| Entry | Size (unminified) | Contents |
+|-------|------------------|----------|
+| `defuddle` (`.`) | 324,454 B | Extraction only — returns cleaned **HTML** |
+| `defuddle/full` | 750,156 B | Adds Turndown + mathml-to-latex → **Markdown** |
+| `defuddle/node` | 3,212 B | Requires `linkedom`/`jsdom` — not for us |
+
+Dependency shape: one runtime dep (`commander`, used only by the CLI);
+`turndown`, `temml`, `linkedom`, `mathml-to-latex` are **optional** deps and are
+pre-bundled into the `full` entry.
+
+**Mobile safety — the decisive check.** Node built-ins appear in exactly two
+files in `dist/`: `fetch.js` and `cli.js`. Neither is reachable from `.` or
+`/full` (`grep -c "node:http" dist/index.js` → `0`; same for `require("path")`).
+So the browser entries violate none of the CLAUDE.md mobile rules. We should
+still `await import()` them lazily inside the tool rather than top-level, per
+rule 2.
+
+**Detached-document safety.** Defuddle uses `getComputedStyle` (hidden-element
+and small-image removal), but every call goes through a guard:
+
+```js
+const w = getWindow(el.ownerDocument);
+return w && typeof w.getComputedStyle === 'function' ? w.getComputedStyle(el) : null;
+```
+
+and call sites use optional chaining on the result. A document produced by
+`new DOMParser().parseFromString(html, 'text/html')` has `defaultView === null`,
+so those passes degrade to no-ops instead of throwing. Extraction still works;
+CSS-hidden clutter survives. That is an acceptable trade for the fetch path and
+a non-issue for the live-DOM path (below).
+
+**Return shape.** `parse()` yields `content` plus `title`, `author`,
+`description`, `domain`, `favicon`, `image`, `language`, `published`, `site`,
+`metaTags`, `schemaOrgData`, `wordCount`, `parseTime` — i.e. ready-made
+frontmatter, which the current implementation cannot give us at all.
+
+## Proposal
+
+Two extraction paths behind the existing tool, plus a deletion.
+
+### A. Fetch path (new capability — works on mobile)
+
+`requestUrl(url)` → `DOMParser` → `new Defuddle(doc, { url, markdown: true }).parse()`
+→ write the file ourselves with Defuddle's metadata as frontmatter.
+
+No browser leaf, no core plugin, no workspace mutation, no CORS problem
+(`requestUrl` bypasses it), deterministic output path. This is the first
+`webTools` capability that could run on mobile — note the agent is currently
+registered desktop-only, so exposing it means gating per-tool instead of
+per-agent.
+
+Limits: no JS execution (SPA shells come back empty) and no session cookies
+(paywalled/logged-in pages).
+
+### B. Live-DOM path (desktop, replaces the save-command dependency)
+
+We already hold the Web Viewer's `webContents` (`getWebViewerContents`,
+`utils/webViewer.ts:146`). Pull `document.documentElement.outerHTML` via
+`executeJavaScript`, then run the same Defuddle call over it.
+
+This keeps everything the current implementation is good at — JS-rendered pages,
+authenticated sessions — while dropping `webviewer:save-to-vault`, the
+`hasWebViewerSaveCommand` gate, and `findCreatedMarkdownFile` entirely. It also
+runs Defuddle against a *live* document, so `getComputedStyle` works and
+clutter removal is at full strength.
+
+### C. Selection + removal
+
+`capture-markdown` tries A first; falls back to B on desktop when the fetch is
+non-2xx, the content type isn't HTML, or `wordCount` comes back under a
+threshold (the SPA-shell signal). Keep the old save-to-vault route behind a
+setting for one release, then delete it along with the three helpers above.
+
+## Costs and risks
+
+- **Bundle.** Obsidian plugins ship one `main.js`, so a lazy `import()` still
+  inlines `defuddle/full` (750 KB unminified) into the bundle. Minified cost
+  needs measuring before committing — if it lands badly, the fallback is the
+  core entry (324 KB) plus our own HTML→Markdown, which means reimplementing
+  Turndown and is not worth it. Measure first.
+- **0.x API.** Pre-1.0; pin the exact version and keep the call behind our own
+  wrapper so a breaking change touches one file.
+- **Quality regression risk.** Web Viewer's save may be tuned beyond stock
+  Defuddle. Compare outputs on ~10 real pages (article, docs, blog, SPA,
+  paywalled) before deleting path C.
+
+## Steps
+
+1. Measure minified bundle delta with `defuddle/full` added.
+2. `WebContentExtractor` service wrapping Defuddle (one call site).
+3. Path A + frontmatter from metadata + unit tests over saved HTML fixtures.
+4. Path B via `executeJavaScript`; drop the save-command dependency.
+5. Auto-selection + settings flag for the legacy route.
+6. Side-by-side quality comparison, then delete legacy + helpers.
+7. Decide per-tool mobile gating for the fetch path.

--- a/docs/plans/web-capture-defuddle-plan.md
+++ b/docs/plans/web-capture-defuddle-plan.md
@@ -1,127 +1,196 @@
-# Web capture via Defuddle — investigation + plan
+# Web Capture via Defuddle — Design Plan
 
-Status: **proposed** (investigation complete, no code written)
-Date: 2026-08-14
-Related: `src/agents/apps/webTools/`, kepano/obsidian-skills `skills/defuddle`
+**Status:** Design / pre-architecture
+**Date:** 2026-08-14
+**Author:** design discussion (ProfSynapse + Claude)
+**Prompted by:** review of `kepano/obsidian-skills` (`skills/defuddle`)
 
-## Why look at this
+## 1. Goal
 
-`web capture-markdown` does not extract anything itself. It drives Obsidian's
-Web Viewer:
+Own our web-content extraction instead of renting Obsidian's Web Viewer UI for
+it, and in doing so make web capture work on **mobile**, without the Web Viewer
+core plugin, without opening a tab, and with page metadata attached.
 
-- `captureToMarkdown.ts` opens a Web Viewer leaf (`openWebViewerUrl`), waits for
-  it to settle, then invokes the core-plugin command
-  `webviewer:save-to-vault` (`utils/webViewer.ts:31`) and *hunts the filesystem*
-  for whatever file that command produced (`findCreatedMarkdownFile`,
-  `utils/webViewer.ts:175`).
-- It is gated on `hasWebViewerSaveCommand(app)` (`utils/webViewer.ts:215`), so
-  it silently does nothing useful if the user has the Web Viewer core plugin
-  disabled.
-- The whole `webTools` app is desktop + Electron only.
+## 2. What we do today, and why it hurts
 
-Consequences: mobile can't capture at all, a core plugin is a hard dependency,
-the workspace is mutated (a tab opens) as a side effect of a data operation, the
-output format is whatever Obsidian decided, and we get no page metadata back.
+`web capture-markdown` extracts nothing itself. It drives the Web Viewer:
 
-Defuddle is the extraction library behind Obsidian Web Clipper, so adopting it
-directly gives us the same extraction quality without renting Obsidian's UI.
+1. `openWebViewerUrl` opens a leaf and `waitForWebViewerReady` waits for it
+   (`src/agents/apps/webTools/utils/webViewer.ts`).
+2. It invokes the **core-plugin command** `webviewer:save-to-vault`
+   (`webViewer.ts:31`), gated on `hasWebViewerSaveCommand(app)` (`:215`).
+3. It then **hunts the filesystem** for whatever file that command produced
+   (`findCreatedMarkdownFile`, `:175`).
 
-## What Defuddle actually is (verified against the published tarball)
+| Consequence | Detail |
+|---|---|
+| Mobile: impossible | The whole `webTools` app is desktop + Electron gated |
+| Hard dependency | Silently useless if the user disabled the Web Viewer core plugin |
+| Side effects | A data operation mutates the workspace by opening a tab |
+| No control | Output format and filename are Obsidian's choice; we reverse-engineer the result |
+| No metadata | Title, author, publish date, site — all discarded |
 
-`defuddle@0.19.2`, MIT. Measured from `npm pack defuddle@0.19.2`:
+## 3. Mental model
 
-| Entry | Size (unminified) | Contents |
-|-------|------------------|----------|
-| `defuddle` (`.`) | 324,454 B | Extraction only — returns cleaned **HTML** |
-| `defuddle/full` | 750,156 B | Adds Turndown + mathml-to-latex → **Markdown** |
-| `defuddle/node` | 3,212 B | Requires `linkedom`/`jsdom` — not for us |
+> **Fetch is a transport problem; extraction is a parsing problem. Today we
+> conflate them by borrowing a browser to do both.**
 
-Dependency shape: one runtime dep (`commander`, used only by the CLI);
-`turndown`, `temml`, `linkedom`, `mathml-to-latex` are **optional** deps and are
-pre-bundled into the `full` entry.
+Separating them gives two independent transports (HTTP fetch, live browser DOM)
+feeding one extraction pipeline. Most pages need only the cheap transport.
 
-**Mobile safety — the decisive check.** Node built-ins appear in exactly two
-files in `dist/`: `fetch.js` and `cli.js`. Neither is reachable from `.` or
-`/full` (`grep -c "node:http" dist/index.js` → `0`; same for `require("path")`).
-So the browser entries violate none of the CLAUDE.md mobile rules. We should
-still `await import()` them lazily inside the tool rather than top-level, per
-rule 2.
+## 4. Defuddle — verified properties
 
-**Detached-document safety.** Defuddle uses `getComputedStyle` (hidden-element
-and small-image removal), but every call goes through a guard:
+Everything below was measured against the published tarball
+(`npm pack defuddle@0.19.2`), not the README. Defuddle is the extraction library
+behind Obsidian Web Clipper; MIT licensed; one runtime dep (`commander`, used
+only by its CLI).
+
+### 4.1 Mobile safety — the decisive check
+
+Node built-ins appear in exactly two files in `dist/`: `fetch.js` and `cli.js`.
+Neither is reachable from the `.` or `/full` entries — verified
+`grep -c "node:http" dist/index.js` → `0`, same for `require("path")`.
+
+So the browser entries violate none of the CLAUDE.md mobile rules. We still
+`await import()` them inside the tool rather than at module top level, per rule 2.
+
+### 4.2 Detached-document safety
+
+Defuddle calls `getComputedStyle` for hidden-element and small-image removal,
+but always through a guard:
 
 ```js
 const w = getWindow(el.ownerDocument);
 return w && typeof w.getComputedStyle === 'function' ? w.getComputedStyle(el) : null;
 ```
 
-and call sites use optional chaining on the result. A document produced by
-`new DOMParser().parseFromString(html, 'text/html')` has `defaultView === null`,
-so those passes degrade to no-ops instead of throwing. Extraction still works;
-CSS-hidden clutter survives. That is an acceptable trade for the fetch path and
-a non-issue for the live-DOM path (below).
+with optional chaining on every call site. A `DOMParser` document has
+`defaultView === null`, so those passes degrade to no-ops rather than throwing.
+Extraction works; CSS-hidden clutter survives. Acceptable on the fetch transport,
+irrelevant on the live-DOM transport where a real window exists.
 
-**Return shape.** `parse()` yields `content` plus `title`, `author`,
-`description`, `domain`, `favicon`, `image`, `language`, `published`, `site`,
-`metaTags`, `schemaOrgData`, `wordCount`, `parseTime` — i.e. ready-made
-frontmatter, which the current implementation cannot give us at all.
+### 4.3 Measured bundle cost (esbuild, `--bundle --minify --format=esm`)
 
-## Proposal
+| Entry | Minified | Gzipped | Contents |
+|---|---|---|---|
+| `defuddle` | 316 KB | 92 KB | Extraction → cleaned **HTML** |
+| `defuddle/full` | 745 KB | 213 KB | Adds Turndown + temml + mathml-to-latex → **Markdown** |
+| `defuddle/node` | — | — | Needs `linkedom`/`jsdom`; not for us |
 
-Two extraction paths behind the existing tool, plus a deletion.
+Obsidian plugins ship a single `main.js`, so a lazy `import()` still lands in the
+bundle. 745 KB is a lot to add for the markdown step alone.
 
-### A. Fetch path (new capability — works on mobile)
+### 4.4 Return shape
 
-`requestUrl(url)` → `DOMParser` → `new Defuddle(doc, { url, markdown: true }).parse()`
-→ write the file ourselves with Defuddle's metadata as frontmatter.
+`parse()` yields `content` plus `title`, `author`, `description`, `domain`,
+`favicon`, `image`, `language`, `published`, `site`, `metaTags`, `schemaOrgData`,
+`wordCount`, `parseTime` — ready-made frontmatter we currently cannot produce.
 
-No browser leaf, no core plugin, no workspace mutation, no CORS problem
-(`requestUrl` bypasses it), deterministic output path. This is the first
-`webTools` capability that could run on mobile — note the agent is currently
-registered desktop-only, so exposing it means gating per-tool instead of
-per-agent.
+## 5. Key decision: core entry + Obsidian's own `htmlToMarkdown`
 
-Limits: no JS execution (SPA shells come back empty) and no session cookies
-(paywalled/logged-in pages).
+Obsidian exports `htmlToMarkdown(html: string | HTMLElement | Document | DocumentFragment): string`
+as public API. So the markdown step is already in the app, and we should not
+bundle a second converter to do it:
 
-### B. Live-DOM path (desktop, replaces the save-command dependency)
+> **`requestUrl`/live DOM → Defuddle core (cleaned HTML) → `htmlToMarkdown()`**
+
+| | `defuddle/full` | core + `htmlToMarkdown` |
+|---|---|---|
+| Bundle | 745 KB / 213 KB gz | **316 KB / 92 KB gz** |
+| Markdown conventions | Turndown defaults | **Obsidian's own** — matches paste-as-markdown |
+| Math → LaTeX | Yes (temml, mathml-to-latex) | No |
+
+Saving 429 KB and getting output that matches what Obsidian produces everywhere
+else is worth losing MathML→LaTeX conversion. Defuddle core still standardises
+headings, code blocks and footnotes in the HTML it emits, so most of the
+normalisation survives; only the math conversion step is lost. Revisit only if
+math-heavy captures become a real complaint.
+
+## 6. Two transports, one pipeline
+
+### 6.1 Fetch transport — new capability, mobile-capable
+
+`requestUrl(url)` → `DOMParser.parseFromString(html, 'text/html')` → Defuddle →
+`htmlToMarkdown` → we write the file ourselves with metadata frontmatter.
+
+No leaf, no core plugin, no workspace mutation, no CORS (`requestUrl` bypasses
+it), deterministic output path. This would be the **first `webTools` capability
+that can run on mobile**, which means per-tool rather than per-agent platform
+gating (§8).
+
+Limits: no JS execution (SPA shells come back near-empty) and no session cookies
+(paywalled or logged-in pages).
+
+### 6.2 Live-DOM transport — desktop, drops the save-command dependency
 
 We already hold the Web Viewer's `webContents` (`getWebViewerContents`,
-`utils/webViewer.ts:146`). Pull `document.documentElement.outerHTML` via
-`executeJavaScript`, then run the same Defuddle call over it.
+`webViewer.ts:146`). Pull `document.documentElement.outerHTML` via
+`executeJavaScript`, then run the same pipeline.
 
-This keeps everything the current implementation is good at — JS-rendered pages,
-authenticated sessions — while dropping `webviewer:save-to-vault`, the
-`hasWebViewerSaveCommand` gate, and `findCreatedMarkdownFile` entirely. It also
-runs Defuddle against a *live* document, so `getComputedStyle` works and
-clutter removal is at full strength.
+Keeps what the current implementation is genuinely good at — JS-rendered pages,
+authenticated sessions — while deleting `webviewer:save-to-vault`,
+`hasWebViewerSaveCommand` and `findCreatedMarkdownFile`. It also runs Defuddle
+against a live document, so §4.2's degradation does not apply.
 
-### C. Selection + removal
+### 6.3 Selection
 
-`capture-markdown` tries A first; falls back to B on desktop when the fetch is
-non-2xx, the content type isn't HTML, or `wordCount` comes back under a
-threshold (the SPA-shell signal). Keep the old save-to-vault route behind a
-setting for one release, then delete it along with the three helpers above.
+`capture-markdown` tries 6.1 first, falling back to 6.2 on desktop when: the
+fetch is non-2xx, the content type is not HTML, or `wordCount` comes back under a
+threshold (the SPA-shell signal). Explicit `--transport fetch|browser` overrides.
 
-## Costs and risks
+## 7. Phasing
 
-- **Bundle.** Obsidian plugins ship one `main.js`, so a lazy `import()` still
-  inlines `defuddle/full` (750 KB unminified) into the bundle. Minified cost
-  needs measuring before committing — if it lands badly, the fallback is the
-  core entry (324 KB) plus our own HTML→Markdown, which means reimplementing
-  Turndown and is not worth it. Measure first.
-- **0.x API.** Pre-1.0; pin the exact version and keep the call behind our own
-  wrapper so a breaking change touches one file.
-- **Quality regression risk.** Web Viewer's save may be tuned beyond stock
-  Defuddle. Compare outputs on ~10 real pages (article, docs, blog, SPA,
-  paywalled) before deleting path C.
+| Phase | Content | Gate |
+|---|---|---|
+| 0 | `WebContentExtractor` service — the single Defuddle call site | Unit tests over saved HTML fixtures |
+| 1 | Fetch transport + metadata frontmatter | Captures a static article end to end |
+| 2 | Live-DOM transport via `executeJavaScript` | Matches or beats current output on a JS-heavy page |
+| 3 | Auto-selection + `--transport` override | SPA falls back correctly |
+| 4 | Quality bake-off vs the legacy route (§9), then delete it and its 3 helpers | No regression on the comparison set |
+| 5 | Per-tool mobile gating for the fetch transport | Capture works on mobile |
 
-## Steps
+## 8. Mobile / desktop split
 
-1. Measure minified bundle delta with `defuddle/full` added.
-2. `WebContentExtractor` service wrapping Defuddle (one call site).
-3. Path A + frontmatter from metadata + unit tests over saved HTML fixtures.
-4. Path B via `executeJavaScript`; drop the save-command dependency.
-5. Auto-selection + settings flag for the legacy route.
-6. Side-by-side quality comparison, then delete legacy + helpers.
-7. Decide per-tool mobile gating for the fetch path.
+Today `webTools` is registered desktop+Electron only, which is correct for
+`open`, `capture-png`, `capture-pdf` and `links` (all need a browser). The fetch
+transport needs none of that. Either split the fetch capability into a tool that
+registers on both platforms, or move the platform check from agent registration
+to per-tool guards. The latter is cleaner and matches how `analyze` is gated in
+the Bases plan.
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Quality regression vs Web Viewer's save, which may be tuned beyond stock Defuddle | Bake-off on ~10 real pages (article, docs, blog, SPA, paywalled, math-heavy) **before** deleting the legacy route |
+| 0.x API churn | Pin the exact version; keep the call behind `WebContentExtractor` so a break touches one file |
+| Bundle growth | Measured at +92 KB gzip (§5); re-measure `main.js` before and after and record the delta in the PR |
+| `requestUrl` differs from browser fetch (headers, redirects, encodings) | Fixture tests over real captured responses; fall back to the browser transport on failure |
+| Losing math conversion | Known, accepted (§5); revisit with `/full` behind a setting if it bites |
+
+## 10. Open questions
+
+1. Do we keep the legacy save-to-vault route behind a setting for one release, or
+   delete it once the bake-off passes? (Lean: delete — two code paths for one
+   capability is how `captureToMarkdown` got complicated in the first place.)
+2. Should the extractor also back `ingest`, which has its own HTML handling?
+   Possible consolidation, out of scope until the tool ships.
+3. Does `requestUrl` need a user-agent override for sites that gate on it?
+
+## 11. Implementation reuse map (DRY)
+
+| Need | Reuse |
+|---|---|
+| HTTP fetch | Obsidian `requestUrl` (CLAUDE.md rule: never `fetch()`) |
+| HTML → Markdown | Obsidian `htmlToMarkdown` (§5) |
+| URL safety check | `assertSafeWebUrl` (`webViewer.ts:61`) |
+| Unique output paths | `resolveUniqueMarkdownPath` (`webViewer.ts:187`) |
+| Parent folder creation | `ensureParentFolderExists` (`webViewer.ts:155`) |
+| Live page DOM | `getWebViewerContents` (`webViewer.ts:146`) |
+| Lazy heavy import | `await import()` inside async execute, per CLAUDE.md mobile rule 2 |
+
+## 12. Non-goals
+
+- Rendering/screenshotting — `capture-png`/`capture-pdf` stay browser-bound.
+- A crawler. One URL per call; link following is `web links` plus the caller's own loop.
+- Bundling a second markdown converter (§5).


### PR DESCRIPTION
Docs only — no source changes.

## Three design plans

Written in the house format used by `skills-protocol-integration-plan.md` (numbered sections, mental model, phasing with gates, open questions, implementation reuse map). Each gets a tracking issue.

### `docs/plans/web-capture-defuddle-plan.md`

`web capture-markdown` extracts nothing itself — it opens a Web Viewer leaf, fires the core-plugin command `webviewer:save-to-vault`, then hunts the filesystem for the file that appeared. Desktop-only, silently useless without the core plugin, and it discards all page metadata.

Verified against the published tarball rather than the README:
- Node built-ins appear only in `dist/fetch.js` and `dist/cli.js`, neither reachable from the browser entries — so Defuddle passes the mobile rules.
- `getComputedStyle` is guarded, so it degrades rather than throws on a `DOMParser` document.
- Measured with esbuild: core 316 KB min / 92 KB gz, `defuddle/full` 745 KB / 213 KB.

Because `htmlToMarkdown()` is public Obsidian API, the design is **Defuddle core + Obsidian's own converter** rather than bundling Turndown and temml via `/full` — 429 KB cheaper, and the output matches Obsidian's conventions everywhere else. Cost is MathML→LaTeX, recorded as accepted.

Adds a `requestUrl` fetch transport that works on mobile, and a live-DOM transport over the Web Viewer's `webContents` that drops the save-command dependency entirely.

### `docs/plans/bases-manager-agent-plan.md`

No `.base` support exists today. New always-on `basesManager` agent (`base` slug) mirroring CanvasManager: `read`/`write`/`update`/`list`, plus `analyze`.

- **No `validate` tool.** `write`/`update` validate before touching disk and reject with a structured error list; an optional correctness step is one a model will skip.
- **Not registered at all when Bases is disabled.** `registerBasesView()` returns `false` in that case, so it is both the probe and the registration `analyze` needs. Runtime toggling is explicitly out of scope — a second dynamic registrar would trip the design limit recorded in #174.
- **`analyze` uses Obsidian's engine, not ours.** `BasesQueryResult` (public since 1.10.0) exposes `data`, `groupedData`, `properties` and `getSummaryValue` with formulas already evaluated. Since `QueryController` is opaque, the mechanism is a headless registered view reached by rendering a `#View Name` base embed into a detached element.
- Schema re-exports `BasesConfigFile` from the Obsidian typings instead of hand-rolling YAML types.

### `docs/plans/obsidian-cli-verification-plan.md`

The Obsidian CLI (GA in 1.12.4) drives a running instance, so build → `plugin:reload` → `dev:errors` → screenshot becomes scriptable. Extends the existing `RUN_SEARCH_SMOKE` live-lane pattern from "our CLI against a real vault" to "our plugin inside the real app".

Documents one limitation prominently: `dev:mobile on` does **not** catch the mobile crash class, because `require('fs')` still resolves under Electron. The static import lint (#221) remains the real defence.

## CLAUDE.md audit

Every non-trivial claim verified against the tree. ~39% fewer words (6067 → 3809); line count rises only because 1200-word single-line status dumps are now reflowed and tabulated.

Cut: every "uncommitted on main / DO NOT COMMIT until user tests / not yet PR'd" block — all that code is committed and the tree is clean (`extractError`, `onReasoningUpdate`, the skills app, the agy flags listed as "slice d PENDING", `ContextBudgetService`, the context contract at `useTools.ts:37`). A standing "do not commit" constraint on already-committed code would block a future agent. Durable rules from those paragraphs moved to Architectural Notes. Also cut eval session logs and eight per-release narratives that `docs/changelog.md` already covers.

Corrections: `prompt sub` → `prompt subagent`; five wrong key-file paths; SQLite schema is v13 not v12; `Deprecated payload shape` refs moved to 757/775/808; the 600+ line watch list rebuilt from a fresh `wc -l` sweep (all 13 entries were wrong, one file no longer exists).

PACT hook insertion points and all six marker comments are preserved.

## Verification

Docs only, so no build or test impact. Note that `npm test` could not be run in this environment (no `node_modules`), and the audit worked from a shallow clone — issue numbers below ~#300 are kept in an explicitly labelled UNVERIFIED block rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_