### PR TITLE
docs: strip CLAUDE.md to bare bones, move the specifics into skills

### DIFF
--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -95,26 +95,52 @@ so nothing catches drift in this table. Verify against source before trusting it
 | DataAnalysisAgent (desktop) | `data` | run-python, list-capabilities |
 | SkillsAgent | `skills` | list-skills, load-skill, create-skill, update-skill, archive-skill, sync-skills |
 
+\* The four PromptManager media tools are **credential-gated**, not always-on:
+`generate-image` needs a Google or OpenRouter key; `generate-audio` needs OpenAI,
+Google, Mistral, OpenRouter or the ElevenLabs app; `generate-video` and
+`check-generated-artifact` are registered together behind the video check. They
+are registered/unregistered live from `handleSettingsChange`, so a vault without
+keys simply does not expose them.
+
 Non-obvious contracts:
-- `content read` requires `--start-line`.
-- No delete anywhere the AI can reach it — the model gets `archive` (reversible).
-  Permanent delete is UI-only; there is no `deleteState` MCP tool.
-- Media generation is async: `generate-*` returns a job, poll
-  `check-generated-artifact <jobId>`.
+- `content read` requires `--start-line` (declared `required` in `read.ts` and
+  enforced for CLI commands by the normalizer's missing-required-argument check).
+- `prompt sub` is the CLI form of the `subagent` slug. It is discoverable through
+  `getTools`, but only executes when the chat UI has wired a `SubagentExecutor` —
+  otherwise it returns "Execution context not available".
+- No **delete tool** anywhere the AI can reach — the model gets `archive`
+  (reversible). Permanent delete of states/workspaces is UI-only; there is no
+  `deleteState` MCP tool. Destruction is still reachable indirectly: `storage
+  move`/`copy` and `composer compose` trash an existing target when overwriting,
+  and `content replace` deletes the anchored range.
+- Media generation is mostly synchronous. `generate-image`/`generate-audio` write
+  the file and return. `generate-video` runs inline and returns a `jobId` **only**
+  when it exceeds its timeout (default 600000 ms); that is what
+  `check-generated-artifact --job-id <id>` is for.
 - No session tools — sessions are context fields. `memory run` triggers a workflow
-  (`--workflow-id`/`--workflow-name`).
+  (`--workflow-id` or `--workflow-name`; one of the two is required).
 - TaskManager naming is asymmetric: project tools are suffixed (`create-project`),
   task tools are bare (`create`, `list`).
-- ElevenLabs has no text-to-speech tool; TTS runs through `prompt generate-audio`.
+- ElevenLabs has no registered text-to-speech tool (`TextToSpeechTool` exists in
+  the tree but is never registered); TTS runs through `prompt generate-audio`.
 
 ## MCP server configuration
 
-- The server runs locally via `connector.js`
+- The server runs locally via `connector.js` (generated into the plugin folder; the
+  source is `connector.ts` at the repo root)
 - Configured in Claude Desktop's `claude_desktop_config.json`
-- Server identifier: `claudesidian-mcp-[vault-name]`
-- Multiple vault instances are supported simultaneously
-- Shipped agent-facing guidance lives in `src/utils/cliAssets.ts` (single-sourced to
-  both the product and the docs); traces in
+- Server identifier: **`nexus-[sanitized-vault-name]`** — `getPrimaryServerKey()` in
+  `src/constants/branding.ts`, used by `ConfigModal` and `GetStartedTab` when writing
+  the config. `claudesidian-mcp-[vault-name]` is the **legacy** key: still accepted
+  when discovering an existing entry, never written for a new one.
+- Per-vault IPC socket/pipe: `nexus_mcp_<vault>` — multiple vault instances are
+  supported simultaneously
+- `tools/list` returns exactly two MCP tools, `toolManager_getTools` and
+  `toolManager_useTools` (`src/handlers/strategies/ToolListStrategy.ts`)
+- Shipped agent-facing guidance is authored in `skill/SKILL.md`,
+  `cli/agents-snippet.md` and `skill/playbooks/*.md`, then embedded into
+  `src/utils/cliAssets.ts` by `scripts/generate-cli-content.mjs` — that file is
+  auto-generated, never hand-edit it. Traces:
   `src/services/trace/ToolCallTraceService.ts`
 
 ## Adding a new agent
@@ -125,10 +151,21 @@ Two touchpoints. No factory classes, no ServiceDefinitions entry.
 2. Add `safeInitialize('yourAgent', ...)` to a phase in
    `AgentRegistrationService.doInitializeAllAgents()`
 
-Phase 1 is for agents with no dependencies; phase 2 for dependent ones. Capability
-gating is done by passing a flag (see `enableSearchModes` / `enableLLMModes`) or by
-returning early, so an unavailable agent is simply never registered rather than
-registered-but-broken.
+There are four phases: phase 1 for agents with no dependencies (content, storage,
+canvas), phase 2 for dependent ones (prompt, search, memory, task, ingest), phase 3
+for app agents, phase 4 for ToolManager — which **must** stay last, since it
+snapshots the registry of everything else.
+
+⚠️ Do not copy the existing capability flags as a gating pattern — they do not gate.
+`initializeSearchManager(enableSearchModes, …)` passes the flag into
+`SearchManagerAgent`, where it is the ignored legacy parameter `_enableVectorModes`;
+all four search tools register regardless. `initializePromptManager(enableLLMModes)`
+registers PromptManager either way, falling back to a minimal `LLMProviderManager`
+when LLM modes are off. Real gating happens two other ways: an initializer
+`return`s early when a hard dependency is missing (no prompt storage, no settings),
+and individual tools are registered conditionally inside the agent constructor
+(PromptManager's credential-gated media tools). `safeInitialize` catches and logs
+any throw, so a failed agent is absent rather than half-registered.
 
 ## Structure and base classes
 

--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: nexus-agents
+description: Nexus agent and tool architecture — the agent/tool inventory, the two-tool MCP contract (getTools/useTools), how to add a new agent, and the base classes. Use when adding or changing an agent or tool, when working out which tool does what, when a tool name or CLI form needs verifying, or when touching the ToolManager MCP payload shape.
+---
+
+# Nexus Agents & Tools
+
+The plugin exposes exactly **two** MCP tools. Everything else is an internal agent
+reached through them.
+
+## Two-tool architecture
+
+| Tool | Role |
+|---|---|
+| `getTools` | Discovery — returns tool schemas for requested agents/tools |
+| `useTools` | Execution — unified context-first tool execution |
+
+**Context schema:** `{ workspaceId, sessionId, memory, goal, constraints? }` — all
+required except `constraints`, and **enforced at runtime**, not just declared.
+`ToolCliNormalizer.collectContextContractViolations()` / `validateExecutionContext()`
+run first in `useTools.ts:37` and throw a *recoverable steering error* when
+`memory`/`goal` are empty or placeholder. `workspaceId`/`sessionId` keep silent
+defaults and steer only on present-junk. Discovery is exempt. The eval harness
+imports the same validator — single source, don't fork it.
+
+**Payload shape — CLI-first only.** A `tool` string plus context fields at the top
+level. Optional top-level `strategy: 'serial' | 'parallel'` and `values` map.
+
+```
+"storage list --path Notes, content read --path a.md --start-line 1"
+```
+
+Batch by separating commands with a top-level comma outside quotes. Context fields
+must NOT appear as CLI flags inside the tool string.
+
+⚠️ The legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` shapes
+were removed in v5.9.0 and throw `Deprecated payload shape` at
+`src/agents/toolManager/services/ToolCliNormalizer.ts:757/775/808`. `UseToolParams`
+has no `calls`/`request` fields. There is no compat shim.
+
+**Verbatim / multiline transports** (never flatten multiline content):
+- MCP/chat: top-level `values` map, referenced as `@key` in the tool string.
+  Substituted *after* tokenization with no escape processing, so backslashes,
+  quotes and newlines survive exactly (`C:\temp`, `\alpha`, `\d`). A missing key,
+  or a declared key the command never references, fails loud.
+- Terminal CLI: `--<flag>-stdin` and `--<flag>-file <path>` hydrate *any*
+  value-taking flag. One `-stdin` per command; several `-file` may coexist; a flag
+  must not arrive both directly and via a transport.
+
+**`content replace`** (and `executePrompts.replace`) is pattern-anchored:
+`{path, start, end, content}` where `start`/`end` are TEXT anchors matched as whole
+lines (Unicode-normalized, so straight vs curly quotes compare equal) — never line
+numbers.
+
+## Tool inventory
+
+Names below are the **CLI form** (`agent tool-name`, kebab-case). The source of
+truth is the `slug:` field under `src/agents/**` (camelCase there, kebab-cased for
+CLI). Regenerate the machine-readable export with `npm run schemas:tools`.
+`tests/unit/shippedGuidanceCommands.test.ts` fails when shipped docs name a tool
+that does not exist — verify against source before trusting this table.
+
+**Always-on agents (8):**
+
+| Agent | CLI | Tools |
+|---|---|---|
+| PromptManager | `prompt` | execute, subagent, create, get, list, update, archive, list-models, generate-image, generate-audio, generate-video, check-generated-artifact |
+| ContentManager | `content` | read, write, replace, insert, set-property |
+| StorageManager | `storage` | list, create-folder, move, copy, archive, open |
+| SearchManager | `search` | content, directory, memory, query-notes |
+| MemoryManager | `memory` | create-workspace, list-workspaces, search-workspaces, load-workspace, update-workspace, archive-workspace, create-state, list-states, load-state, update-state, archive-state, run |
+| CanvasManager | `canvas` | read, write, update, list |
+| TaskManager | `task` | create-project, list-projects, update-project, archive-project, create, list, update, move, query, open, link-note |
+| IngestManager | `ingest` | run, capabilities |
+
+**Opt-in app agents (5)** — a vault only exposes the apps it enables:
+
+| Agent | CLI | Tools |
+|---|---|---|
+| WebToolsAgent (desktop) | `web` | open, capture-markdown, capture-png, capture-pdf, links |
+| ComposerAgent | `composer` | compose, list-formats |
+| ElevenLabsAgent | `elevenlabs` | list-voices, sound-effects, generate-music |
+| DataAnalysisAgent (desktop) | `data` | run-python, list-capabilities |
+| SkillsAgent | `skills` | list-skills, load-skill, create-skill, update-skill, archive-skill, sync-skills |
+
+Non-obvious contracts:
+- `content read` requires `--start-line`.
+- No delete anywhere the AI can reach it — the model gets `archive` (reversible).
+  Permanent delete is UI-only; there is no `deleteState` MCP tool.
+- Media generation is async: `generate-*` returns a job, poll
+  `check-generated-artifact <jobId>`.
+- No session tools — sessions are context fields. `memory run` triggers a workflow
+  (`--workflow-id`/`--workflow-name`).
+- TaskManager naming is asymmetric: project tools are suffixed (`create-project`),
+  task tools are bare (`create`, `list`).
+- ElevenLabs has no text-to-speech tool; TTS runs through `prompt generate-audio`.
+
+## MCP server configuration
+
+- The server runs locally via `connector.js`
+- Configured in Claude Desktop's `claude_desktop_config.json`
+- Server identifier: `claudesidian-mcp-[vault-name]`
+- Multiple vault instances are supported simultaneously
+- Shipped agent-facing guidance lives in `src/utils/cliAssets.ts` (single-sourced to
+  both the product and the docs); traces in
+  `src/services/trace/ToolCallTraceService.ts`
+
+## Adding a new agent
+
+Two touchpoints. No factory classes, no ServiceDefinitions entry.
+
+1. Add `initializeYourAgent()` to `src/services/agent/AgentInitializationService.ts`
+2. Add `safeInitialize('yourAgent', ...)` to a phase in
+   `AgentRegistrationService.doInitializeAllAgents()`
+
+Phase 1 is for agents with no dependencies; phase 2 for dependent ones. Capability
+gating is done by passing a flag (see `enableSearchModes` / `enableLLMModes`) or by
+returning early, so an unavailable agent is simply never registered rather than
+registered-but-broken.
+
+## Structure and base classes
+
+```
+agents/[agentName]/
+  [agentName].ts     # extends BaseAgent, registers tools in the constructor
+  tools/[toolName].ts
+  tools/services/    # tool-specific services
+  services/          # agent-level shared services
+  types.ts
+  utils/
+```
+
+- `BaseAgent` — `src/agents/baseAgent.ts`
+- `BaseTool<Params, Result>` — `src/agents/baseTool.ts`; implement `execute()`,
+  `getParameterSchema()`, `getResultSchema()`
+- `IAgent` / `ITool` — `src/agents/interfaces/`
+- App agents also extend `BaseAppAgent` (`src/agents/apps/BaseAppAgent.ts`) and may
+  opt into `AppRuntimeContext` for settings, storage-adapter and session-context
+  access
+- Results: `{ success: true, ...data }` or `{ success: false, error: string }`
+
+**App agents that produce files** must have vault access wired through
+`BaseAppAgent`. Use `vault.createBinary()` for binary output (audio, images) and
+`vault.create()` for text, and always ensure parent directories exist before
+writing.
+
+## Schema validation is documentation only
+
+`getParameterSchema()` is DOCUMENTATION plus CLI-normalizer hints. There is **no**
+ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A
+schema `required`, `oneOf` or `enum` does **not** reject a malformed payload at
+runtime — bad input flows straight to the service.
+
+**Validation guards MUST live in the service/normalizer layer, not the schema.**
+Origin: a `createTask.linkedNotes` oneOf object missing `notePath` silently
+persisted `notePath: undefined` until an explicit guard was added in
+`normalizeLinkedNote` (`src/agents/taskManager/services/TaskService.ts:78`).
+
+## Dynamic registration limit (issue #174)
+
+`AgentRegistrationService.syncToolManagerAgent` (`:85`) plus
+`ToolManagerAgent.registerDynamicAgent/unregisterDynamicAgent`
+(`src/agents/toolManager/toolManager.ts:117`) is a callback-wrap bridge keeping
+`getTools` discovery in sync when `AppManager` installs/uninstalls app agents at
+runtime. It works only because `AppManager` is the **only** dynamic registrar and
+**does not compose** for a second one.
+
+When a second dynamic registrar lands, refactor to events: add
+`onAgentRegistered`/`onAgentUnregistered` to `AgentManager`, subscribe in
+`ToolManagerAgent`'s constructor, delete the bridge and the
+`instanceof ToolManagerAgent` concrete import. Do **not** do this speculatively —
+wait for the triggering consumer. https://github.com/ProfSynapse/nexus/issues/174

--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -202,7 +202,13 @@ writing.
 `getParameterSchema()` is DOCUMENTATION plus CLI-normalizer hints. There is **no**
 ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A
 schema `required`, `oneOf` or `enum` does **not** reject a malformed payload at
-runtime — bad input flows straight to the service.
+runtime — bad input flows straight to the service. (`ajv` is not even a dependency.)
+
+The one place `required` has teeth is the CLI path: `ToolCliNormalizer` derives its
+per-tool argument list from the schema and rejects a parsed command with
+`Missing required argument "<name>"`. That covers commands typed as a `tool` string;
+it does not validate value shape, `oneOf` branches, or `enum` membership, and it
+does nothing for params reaching a tool by any other route.
 
 **Validation guards MUST live in the service/normalizer layer, not the schema.**
 Origin: a `createTask.linkedNotes` oneOf object missing `notePath` silently

--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -171,7 +171,10 @@ any throw, so a failed agent is absent rather than half-registered.
 
 ```
 agents/[agentName]/
-  [agentName].ts     # extends BaseAgent, registers tools in the constructor
+  [agentName].ts     # extends BaseAgent, registers tools in the constructor —
+                     # `registerLazyTool({slug, name, description, version, factory})`
+                     # is the norm; `registerTool(new XTool(...))` for eager ones
+                     # with complex dependencies
   tools/[toolName].ts
   tools/services/    # tool-specific services
   services/          # agent-level shared services
@@ -180,8 +183,9 @@ agents/[agentName]/
 ```
 
 - `BaseAgent` — `src/agents/baseAgent.ts`
-- `BaseTool<Params, Result>` — `src/agents/baseTool.ts`; implement `execute()`,
-  `getParameterSchema()`, `getResultSchema()`
+- `BaseTool<Params, Result>` — `src/agents/baseTool.ts`; `execute()` and
+  `getParameterSchema()` are abstract, `getResultSchema()` has a default (the
+  common result schema) and is override-only
 - `IAgent` / `ITool` — `src/agents/interfaces/`
 - App agents also extend `BaseAppAgent` (`src/agents/apps/BaseAppAgent.ts`) and may
   opt into `AppRuntimeContext` for settings, storage-adapter and session-context

--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -30,8 +30,10 @@ level. Optional top-level `strategy: 'serial' | 'parallel'` and `values` map.
 "storage list --path Notes, content read --path a.md --start-line 1"
 ```
 
-Batch by separating commands with a top-level comma outside quotes. Context fields
-must NOT appear as CLI flags inside the tool string.
+Batch by separating commands with a top-level comma outside quotes. The comma is a
+separator only when followed by whitespace or end of input — a comma glued to the
+next character (`--paths a,b,c`) stays a CSV value inside the current command.
+Context fields must NOT appear as CLI flags inside the tool string.
 
 ⚠️ The legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` shapes
 were removed in v5.9.0 and throw `Deprecated payload shape` at
@@ -55,16 +57,26 @@ numbers.
 ## Tool inventory
 
 Names below are the **CLI form** (`agent tool-name`, kebab-case). The source of
-truth is the `slug:` field under `src/agents/**` (camelCase there, kebab-cased for
-CLI). Regenerate the machine-readable export with `npm run schemas:tools`.
-`tests/unit/shippedGuidanceCommands.test.ts` fails when shipped docs name a tool
-that does not exist — verify against source before trusting this table.
+truth is the `slug:` field under `src/agents/**` — camelCase in most agents
+(`webTools` declares kebab slugs directly). The CLI name is `toKebabCase(slug)`
+(`ToolCliNormalizer.ts`), and the agent alias is `toKebabCase(agentName)`; that
+helper **also strips a trailing `Manager`/`Agent`/`Tools`**, which is why
+`searchManager` → `search`, `webTools` → `web`, and the slug `subagent` →
+`prompt sub`.
+
+Regenerate the machine-readable export with `npm run schemas:tools` — note it
+writes `docs/generated/cli-first-tool-schemas.json` by default; pass
+`--output cli-first-tool-schemas.json` to refresh the repo-root catalog.
+`tests/unit/shippedGuidanceCommands.test.ts` validates that catalog against
+README, `skill/SKILL.md`, `cli/nexus-cli.ts`, `cli/agents-snippet.md`,
+`skill/playbooks/*.md` and `guide/*.md` — it does **not** read `.claude/skills/**`,
+so nothing catches drift in this table. Verify against source before trusting it.
 
 **Always-on agents (8):**
 
 | Agent | CLI | Tools |
 |---|---|---|
-| PromptManager | `prompt` | execute, subagent, create, get, list, update, archive, list-models, generate-image, generate-audio, generate-video, check-generated-artifact |
+| PromptManager | `prompt` | execute, sub, create, get, list, update, archive, list-models, generate-image\*, generate-audio\*, generate-video\*, check-generated-artifact\* |
 | ContentManager | `content` | read, write, replace, insert, set-property |
 | StorageManager | `storage` | list, create-folder, move, copy, archive, open |
 | SearchManager | `search` | content, directory, memory, query-notes |

--- a/.claude/skills/nexus-agents/SKILL.md
+++ b/.claude/skills/nexus-agents/SKILL.md
@@ -1,231 +1,178 @@
 ---
 name: nexus-agents
-description: Nexus agent and tool architecture — the agent/tool inventory, the two-tool MCP contract (getTools/useTools), how to add a new agent, and the base classes. Use when adding or changing an agent or tool, when working out which tool does what, when a tool name or CLI form needs verifying, or when touching the ToolManager MCP payload shape.
+description: How to add, change and verify a Nexus agent or tool, and the contract every tool must satisfy. Use when adding or modifying an agent or tool, when a documented command does not resolve, when wiring registration or capability gating, or when touching the ToolManager payload shape.
 ---
 
-# Nexus Agents & Tools
+# Working on Nexus Agents & Tools
 
-The plugin exposes exactly **two** MCP tools. Everything else is an internal agent
-reached through them.
+## The shape you are working inside
 
-## Two-tool architecture
+MCP exposes exactly **two** tools — `getTools` (discovery) and `useTools`
+(execution). Every other agent is internal and reached through them. Adding an
+agent does not add an MCP tool; it adds something discoverable *through* those two.
 
-| Tool | Role |
-|---|---|
-| `getTools` | Discovery — returns tool schemas for requested agents/tools |
-| `useTools` | Execution — unified context-first tool execution |
+Four invariants your change must not break:
 
-**Context schema:** `{ workspaceId, sessionId, memory, goal, constraints? }` — all
-required except `constraints`, and **enforced at runtime**, not just declared.
-`ToolCliNormalizer.collectContextContractViolations()` / `validateExecutionContext()`
-run first in `useTools.ts:37` and throw a *recoverable steering error* when
-`memory`/`goal` are empty or placeholder. `workspaceId`/`sessionId` keep silent
-defaults and steer only on present-junk. Discovery is exempt. The eval harness
-imports the same validator — single source, don't fork it.
+1. **Context is enforced, not merely declared.** `useTools` validates
+   `{ workspaceId, sessionId, memory, goal, constraints? }` before dispatch and
+   throws a *recoverable steering error* on empty or placeholder `memory`/`goal`.
+   Discovery is exempt. The eval harness imports the same validator — one source,
+   don't fork it.
+2. **The payload is CLI-first.** A `tool` string plus context fields at the top
+   level. The nested `{context, calls}` and `{request}` shapes are gone with no
+   compat shim; they throw `Deprecated payload shape`.
+3. **The AI gets no delete tool.** Destructive operations are exposed as `archive`,
+   which is reversible. Permanent delete is UI-only. If you are adding a tool that
+   destroys something, that is a design decision to raise, not to make quietly.
+4. **Results are `{ success: true, ...data }` or `{ success: false, error }`.**
 
-**Payload shape — CLI-first only.** A `tool` string plus context fields at the top
-level. Optional top-level `strategy: 'serial' | 'parallel'` and `values` map.
+## Find what exists
 
+Never trust a written inventory, including one in a doc like this. Ask the tree:
+
+```bash
+ls src/agents/ src/agents/apps/                   # agents
+grep -n "slug:" src/agents/<agent>/<agent>.ts     # that agent's tool slugs
 ```
-"storage list --path Notes, content read --path a.md --start-line 1"
+
+For the CLI names a caller actually types, regenerate the catalog rather than
+deriving them by hand:
+
+```bash
+npm run schemas:tools -- --output cli-first-tool-schemas.json
+grep '"command"' cli-first-tool-schemas.json
 ```
 
-Batch by separating commands with a top-level comma outside quotes. The comma is a
-separator only when followed by whitespace or end of input — a comma glued to the
-next character (`--paths a,b,c`) stays a CSV value inside the current command.
-Context fields must NOT appear as CLI flags inside the tool string.
+Slugs are not CLI names. `toKebabCase` (`ToolCliNormalizer`) kebab-cases **and
+strips a trailing `Manager`/`Agent`/`Tools`** — which is why `searchManager` is
+`search`, `webTools` is `web`, and the slug `subagent` is typed `prompt sub`. When
+in doubt, run the transform instead of guessing:
 
-⚠️ The legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` shapes
-were removed in v5.9.0 and throw `Deprecated payload shape` at
-`src/agents/toolManager/services/ToolCliNormalizer.ts:757/775/808`. `UseToolParams`
-has no `calls`/`request` fields. There is no compat shim.
+```bash
+node -e 'const f=v=>v.replace(/Manager$/i,"").replace(/Agent$/i,"").replace(/Tools$/i,"").replace(/([a-z0-9])([A-Z])/g,"$1-$2").replace(/[_\s]+/g,"-").replace(/--+/g,"-").toLowerCase();console.log(f("yourSlug"))'
+```
 
-**Verbatim / multiline transports** (never flatten multiline content):
-- MCP/chat: top-level `values` map, referenced as `@key` in the tool string.
-  Substituted *after* tokenization with no escape processing, so backslashes,
-  quotes and newlines survive exactly (`C:\temp`, `\alpha`, `\d`). A missing key,
-  or a declared key the command never references, fails loud.
-- Terminal CLI: `--<flag>-stdin` and `--<flag>-file <path>` hydrate *any*
-  value-taking flag. One `-stdin` per command; several `-file` may coexist; a flag
-  must not arrive both directly and via a transport.
+## Add a tool to an existing agent
 
-**`content replace`** (and `executePrompts.replace`) is pattern-anchored:
-`{path, start, end, content}` where `start`/`end` are TEXT anchors matched as whole
-lines (Unicode-normalized, so straight vs curly quotes compare equal) — never line
-numbers.
+1. Create `tools/<toolName>.ts` extending `BaseTool<Params, Result>`. `execute()`
+   and `getParameterSchema()` are abstract; `getResultSchema()` has a default and
+   is override-only.
+2. Register it in the agent constructor. `registerLazyTool({slug, name,
+   description, version, factory})` is the norm — use eager `registerTool(new X())`
+   only when construction needs dependencies the factory cannot reach.
+3. **Put your validation in `execute()` or the service, not the schema** (see
+   Gotchas). Guard every field you will persist or pass to the filesystem.
+4. If the tool must only exist under some condition (a credential, a platform),
+   register it conditionally in the constructor rather than registering a tool that
+   always fails.
 
-## Tool inventory
+**Verify:**
 
-Names below are the **CLI form** (`agent tool-name`, kebab-case). The source of
-truth is the `slug:` field under `src/agents/**` — camelCase in most agents
-(`webTools` declares kebab slugs directly). The CLI name is `toKebabCase(slug)`
-(`ToolCliNormalizer.ts`), and the agent alias is `toKebabCase(agentName)`; that
-helper **also strips a trailing `Manager`/`Agent`/`Tools`**, which is why
-`searchManager` → `search`, `webTools` → `web`, and the slug `subagent` →
-`prompt sub`.
+```bash
+npm run build                                     # typecheck + bundle
+npm run schemas:tools -- --output cli-first-tool-schemas.json
+grep '"command"' cli-first-tool-schemas.json | grep <your-tool>
+```
 
-Regenerate the machine-readable export with `npm run schemas:tools` — note it
-writes `docs/generated/cli-first-tool-schemas.json` by default; pass
-`--output cli-first-tool-schemas.json` to refresh the repo-root catalog.
-`tests/unit/shippedGuidanceCommands.test.ts` validates that catalog against
-README, `skill/SKILL.md`, `cli/nexus-cli.ts`, `cli/agents-snippet.md`,
-`skill/playbooks/*.md` and `guide/*.md` — it does **not** read `.claude/skills/**`,
-so nothing catches drift in this table. Verify against source before trusting it.
+The command string in that catalog is what a caller must type. If it is not what
+you expected, the kebab transform changed it. Then exercise it for real — through
+`getTools` to confirm discovery, and `useTools` to confirm execution, since
+registration and executability are separate failures.
 
-**Always-on agents (8):**
-
-| Agent | CLI | Tools |
-|---|---|---|
-| PromptManager | `prompt` | execute, sub, create, get, list, update, archive, list-models, generate-image\*, generate-audio\*, generate-video\*, check-generated-artifact\* |
-| ContentManager | `content` | read, write, replace, insert, set-property |
-| StorageManager | `storage` | list, create-folder, move, copy, archive, open |
-| SearchManager | `search` | content, directory, memory, query-notes |
-| MemoryManager | `memory` | create-workspace, list-workspaces, search-workspaces, load-workspace, update-workspace, archive-workspace, create-state, list-states, load-state, update-state, archive-state, run |
-| CanvasManager | `canvas` | read, write, update, list |
-| TaskManager | `task` | create-project, list-projects, update-project, archive-project, create, list, update, move, query, open, link-note |
-| IngestManager | `ingest` | run, capabilities |
-
-**Opt-in app agents (5)** — a vault only exposes the apps it enables:
-
-| Agent | CLI | Tools |
-|---|---|---|
-| WebToolsAgent (desktop) | `web` | open, capture-markdown, capture-png, capture-pdf, links |
-| ComposerAgent | `composer` | compose, list-formats |
-| ElevenLabsAgent | `elevenlabs` | list-voices, sound-effects, generate-music |
-| DataAnalysisAgent (desktop) | `data` | run-python, list-capabilities |
-| SkillsAgent | `skills` | list-skills, load-skill, create-skill, update-skill, archive-skill, sync-skills |
-
-\* The four PromptManager media tools are **credential-gated**, not always-on:
-`generate-image` needs a Google or OpenRouter key; `generate-audio` needs OpenAI,
-Google, Mistral, OpenRouter or the ElevenLabs app; `generate-video` and
-`check-generated-artifact` are registered together behind the video check. They
-are registered/unregistered live from `handleSettingsChange`, so a vault without
-keys simply does not expose them.
-
-Non-obvious contracts:
-- `content read` requires `--start-line` (declared `required` in `read.ts` and
-  enforced for CLI commands by the normalizer's missing-required-argument check).
-- `prompt sub` is the CLI form of the `subagent` slug. It is discoverable through
-  `getTools`, but only executes when the chat UI has wired a `SubagentExecutor` —
-  otherwise it returns "Execution context not available".
-- No **delete tool** anywhere the AI can reach — the model gets `archive`
-  (reversible). Permanent delete of states/workspaces is UI-only; there is no
-  `deleteState` MCP tool. Destruction is still reachable indirectly: `storage
-  move`/`copy` and `composer compose` trash an existing target when overwriting,
-  and `content replace` deletes the anchored range.
-- Media generation is mostly synchronous. `generate-image`/`generate-audio` write
-  the file and return. `generate-video` runs inline and returns a `jobId` **only**
-  when it exceeds its timeout (default 600000 ms); that is what
-  `check-generated-artifact --job-id <id>` is for.
-- No session tools — sessions are context fields. `memory run` triggers a workflow
-  (`--workflow-id` or `--workflow-name`; one of the two is required).
-- TaskManager naming is asymmetric: project tools are suffixed (`create-project`),
-  task tools are bare (`create`, `list`).
-- ElevenLabs has no registered text-to-speech tool (`TextToSpeechTool` exists in
-  the tree but is never registered); TTS runs through `prompt generate-audio`.
-
-## MCP server configuration
-
-- The server runs locally via `connector.js` (generated into the plugin folder; the
-  source is `connector.ts` at the repo root)
-- Configured in Claude Desktop's `claude_desktop_config.json`
-- Server identifier: **`nexus-[sanitized-vault-name]`** — `getPrimaryServerKey()` in
-  `src/constants/branding.ts`, used by `ConfigModal` and `GetStartedTab` when writing
-  the config. `claudesidian-mcp-[vault-name]` is the **legacy** key: still accepted
-  when discovering an existing entry, never written for a new one.
-- Per-vault IPC socket/pipe: `nexus_mcp_<vault>` — multiple vault instances are
-  supported simultaneously
-- `tools/list` returns exactly two MCP tools, `toolManager_getTools` and
-  `toolManager_useTools` (`src/handlers/strategies/ToolListStrategy.ts`)
-- Shipped agent-facing guidance is authored in `skill/SKILL.md`,
-  `cli/agents-snippet.md` and `skill/playbooks/*.md`, then embedded into
-  `src/utils/cliAssets.ts` by `scripts/generate-cli-content.mjs` — that file is
-  auto-generated, never hand-edit it. Traces:
-  `src/services/trace/ToolCallTraceService.ts`
-
-## Adding a new agent
+## Add a new agent
 
 Two touchpoints. No factory classes, no ServiceDefinitions entry.
 
-1. Add `initializeYourAgent()` to `src/services/agent/AgentInitializationService.ts`
-2. Add `safeInitialize('yourAgent', ...)` to a phase in
+1. `initializeYourAgent()` in `src/services/agent/AgentInitializationService.ts`
+2. `safeInitialize('yourAgent', ...)` in a phase of
    `AgentRegistrationService.doInitializeAllAgents()`
 
-There are four phases: phase 1 for agents with no dependencies (content, storage,
-canvas), phase 2 for dependent ones (prompt, search, memory, task, ingest), phase 3
-for app agents, phase 4 for ToolManager — which **must** stay last, since it
+Phase 1 is for agents with no dependencies, phase 2 for dependent ones, phase 3 for
+app agents, and phase 4 is ToolManager — which **must stay last**, because it
 snapshots the registry of everything else.
 
-⚠️ Do not copy the existing capability flags as a gating pattern — they do not gate.
-`initializeSearchManager(enableSearchModes, …)` passes the flag into
-`SearchManagerAgent`, where it is the ignored legacy parameter `_enableVectorModes`;
-all four search tools register regardless. `initializePromptManager(enableLLMModes)`
-registers PromptManager either way, falling back to a minimal `LLMProviderManager`
-when LLM modes are off. Real gating happens two other ways: an initializer
-`return`s early when a hard dependency is missing (no prompt storage, no settings),
-and individual tools are registered conditionally inside the agent constructor
-(PromptManager's credential-gated media tools). `safeInitialize` catches and logs
-any throw, so a failed agent is absent rather than half-registered.
+To make an agent conditional, `return` early from the initializer when a hard
+dependency is missing. `safeInitialize` catches and logs any throw, so a failed
+agent is absent rather than half-registered — absent is the correct outcome, since
+a tool that can only answer "unavailable" wastes a discovery round-trip.
 
-## Structure and base classes
+**Verify:** build, then confirm the agent appears in `getTools` discovery and that
+one of its tools executes through `useTools`.
 
-```
-agents/[agentName]/
-  [agentName].ts     # extends BaseAgent, registers tools in the constructor —
-                     # `registerLazyTool({slug, name, description, version, factory})`
-                     # is the norm; `registerTool(new XTool(...))` for eager ones
-                     # with complex dependencies
-  tools/[toolName].ts
-  tools/services/    # tool-specific services
-  services/          # agent-level shared services
-  types.ts
-  utils/
-```
+## Gotchas
 
-- `BaseAgent` — `src/agents/baseAgent.ts`
-- `BaseTool<Params, Result>` — `src/agents/baseTool.ts`; `execute()` and
-  `getParameterSchema()` are abstract, `getResultSchema()` has a default (the
-  common result schema) and is override-only
-- `IAgent` / `ITool` — `src/agents/interfaces/`
-- App agents also extend `BaseAppAgent` (`src/agents/apps/BaseAppAgent.ts`) and may
-  opt into `AppRuntimeContext` for settings, storage-adapter and session-context
-  access
-- Results: `{ success: true, ...data }` or `{ success: false, error: string }`
+Each of these has bitten. They are listed by the symptom you will actually see.
 
-**App agents that produce files** must have vault access wired through
-`BaseAppAgent`. Use `vault.createBinary()` for binary output (audio, images) and
-`vault.create()` for text, and always ensure parent directories exist before
-writing.
+**"My documented command returns nothing / unknown tool."** The CLI name is not the
+slug — `toKebabCase` strips a trailing `Manager`/`Agent`/`Tools`. A tool whose slug
+ends in `Agent` advertises without it. Check the generated catalog, not the source.
 
-## Schema validation is documentation only
+**"Malformed params reached my service and persisted garbage."** `getParameterSchema()`
+is documentation plus CLI-normalizer hints. There is no ajv behind
+`ToolBatchExecutionService.execute()` — `required`, `oneOf` and `enum` do **not**
+reject anything at runtime. The one place `required` has teeth is a command typed
+as a `tool` string, where the normalizer raises `Missing required argument`; it
+still does not check value shape or `enum` membership. Guards belong in the
+service/normalizer layer. Origin: a `linkedNotes` object missing `notePath`
+silently persisted `notePath: undefined` until `normalizeLinkedNote` guarded it.
 
-`getParameterSchema()` is DOCUMENTATION plus CLI-normalizer hints. There is **no**
-ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A
-schema `required`, `oneOf` or `enum` does **not** reject a malformed payload at
-runtime — bad input flows straight to the service. (`ajv` is not even a dependency.)
+**"My comma-separated argument got split into two commands."** A top-level comma
+outside quotes separates batched commands — but only when followed by whitespace or
+end of input. `--paths a,b,c` stays one CSV value; `--paths a, b` does not.
 
-The one place `required` has teeth is the CLI path: `ToolCliNormalizer` derives its
-per-tool argument list from the schema and rejects a parsed command with
-`Missing required argument "<name>"`. That covers commands typed as a `tool` string;
-it does not validate value shape, `oneOf` branches, or `enum` membership, and it
-does nothing for params reaching a tool by any other route.
+**"Deprecated payload shape."** Something is still sending `calls`, `request`, or a
+nested `context` object. Context fields go at the top level, and must not appear as
+CLI flags inside the tool string either.
 
-**Validation guards MUST live in the service/normalizer layer, not the schema.**
-Origin: a `createTask.linkedNotes` oneOf object missing `notePath` silently
-persisted `notePath: undefined` until an explicit guard was added in
-`normalizeLinkedNote` (`src/agents/taskManager/services/TaskService.ts:78`).
+**"My multiline content arrived flattened or mangled."** Use the verbatim
+transports rather than inlining: the top-level `values` map referenced as `@key`
+(substituted after tokenization, no escape processing, so backslashes and newlines
+survive), or `--<flag>-stdin` / `--<flag>-file <path>` on the terminal CLI. One
+`-stdin` per command, and a flag must not arrive both directly and via a transport.
 
-## Dynamic registration limit (issue #174)
+**"I passed a capability flag and the agent registered anyway."** The existing
+`enableSearchModes` / `enableLLMModes` flags are **not** a gating pattern to copy.
+The search flag lands on an ignored legacy parameter and all its tools register
+regardless; PromptManager registers either way behind a fallback provider manager.
+Gate by returning early, or by conditional per-tool registration.
 
-`AgentRegistrationService.syncToolManagerAgent` (`:85`) plus
-`ToolManagerAgent.registerDynamicAgent/unregisterDynamicAgent`
-(`src/agents/toolManager/toolManager.ts:117`) is a callback-wrap bridge keeping
-`getTools` discovery in sync when `AppManager` installs/uninstalls app agents at
-runtime. It works only because `AppManager` is the **only** dynamic registrar and
-**does not compose** for a second one.
+**"My tool is discoverable but returns 'Execution context not available'."**
+Discovery and executability are separate. Some tools need a runtime collaborator
+wired by the chat UI; registration alone does not make them callable.
 
-When a second dynamic registrar lands, refactor to events: add
-`onAgentRegistered`/`onAgentUnregistered` to `AgentManager`, subscribe in
-`ToolManagerAgent`'s constructor, delete the bridge and the
-`instanceof ToolManagerAgent` concrete import. Do **not** do this speculatively —
-wait for the triggering consumer. https://github.com/ProfSynapse/nexus/issues/174
+**"I edited `cliAssets.ts` and my change vanished."** It is generated by
+`scripts/generate-cli-content.mjs` during the build from `skill/SKILL.md`,
+`cli/agents-snippet.md` and `skill/playbooks/*.md`. Edit the sources.
+
+**"`npm run schemas:tools` did not fix the shipped-docs test failure."** It writes
+`docs/generated/cli-first-tool-schemas.json` by default, while
+`tests/unit/shippedGuidanceCommands.test.ts` validates against the **repo-root**
+catalog. Pass `--output cli-first-tool-schemas.json` to refresh the one the gate
+reads.
+
+**"A doc named a tool that does not exist and nothing caught it."** That gate reads
+README, `skill/SKILL.md`, `cli/nexus-cli.ts`, `cli/agents-snippet.md`,
+`skill/playbooks/*.md` and `guide/*.md` — it does **not** read `.claude/skills/**`.
+Anything you write in a skill file is unguarded, which is why this file names
+commands to run rather than listing tools.
+
+**"My new dynamic registrar broke `getTools` discovery."** The
+`syncToolManagerAgent` bridge keeps discovery in sync when `AppManager` installs
+app agents at runtime, and works only because `AppManager` is the *only* dynamic
+registrar. It does not compose for a second one. When one lands, refactor to
+events (`onAgentRegistered`/`onAgentUnregistered` on `AgentManager`, subscribed in
+`ToolManagerAgent`) rather than adding a second bridge — see
+https://github.com/ProfSynapse/nexus/issues/174. Do not do it speculatively.
+
+## Where the details live
+
+- Agent and tool base classes: `src/agents/baseAgent.ts`, `src/agents/baseTool.ts`,
+  interfaces in `src/agents/interfaces/`
+- App agents: `src/agents/apps/BaseAppAgent.ts`, plus `AppRuntimeContext` for
+  settings, storage-adapter and session-context access. App agents that write files
+  use `vault.createBinary()` for binary output and `vault.create()` for text, and
+  must ensure parent directories exist first.
+- Payload normalization and the kebab transform: `ToolCliNormalizer`
+- MCP surface: `src/handlers/strategies/ToolListStrategy.ts` returns the two tools;
+  the server key comes from `getPrimaryServerKey()` in `src/constants/branding.ts`
+- Traces: `src/services/trace/ToolCallTraceService.ts`

--- a/.claude/skills/nexus-llm-adapters/SKILL.md
+++ b/.claude/skills/nexus-llm-adapters/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: nexus-llm-adapters
+description: Nexus LLM provider adapter invariants — streaming, in-stream error frames, reasoning/thinking rendering, local-model quirks (LM Studio, Ollama), CLI-backed providers, and shared transcription. Use when adding or debugging a provider adapter, working on streaming or reasoning display, or touching chat message/branch plumbing.
+---
+
+# Nexus LLM Adapters
+
+Providers talk direct HTTP via `ProviderHttpClient` — the vendor SDKs were removed
+deliberately. Adapters live in `src/services/llm/adapters/{provider}/`, over
+`BaseAdapter`.
+
+## Streaming: in-stream error frames
+
+Some providers (notably LM Studio) return `{"error":{...}}` frames **over HTTP
+200**. Without handling, the stream simply ends empty and the user sees a blank
+bubble with no error.
+
+`SSEStreamOptions.extractError` + `processNodeStream` in `BaseAdapter.ts` turn those
+frames into `LLMProviderError(..., 'PROVIDER_STREAM_ERROR')`.
+
+**Any new streaming adapter should wire `extractError`.** An empty stream is not an
+acceptable failure mode.
+
+## Reasoning / thinking rendering
+
+The path is: `chunk.reasoning` → `onReasoningUpdate(messageId, text, isComplete)` on
+`StreamHandlerEvents`/`MessageManagerEvents` → a collapsible
+`<details class="message-reasoning">` block that auto-expands while streaming and
+collapses on completion.
+
+**Do NOT reintroduce a synthetic `reasoning`-type tool call.** That was the previous
+mechanism; the tool coordinator never rendered it, so reasoning flowed correctly
+through every layer and silently vanished at the final paint.
+
+## Local models
+
+**LM Studio speculative decoding.** A `draft_model` against a batched-MLX target
+fails. `LMStudioAdapter` detects the failure (HTTP *or* in-stream) before any real
+output, marks the draft incompatible, drops `draft_model`, and retries — so chat
+always produces output. Batched MLX bans speculative decoding outright and vision
+MLX never supports it; GGUF targets have no such restriction, paired with a
+same-family GGUF draft for matching vocab.
+
+**`ensureModelLoaded` never compares `flash_attention`.** It is passed through, but
+comparing it caused infinite model reloads: it is llama.cpp-only, and MLX no-ops it
+without reporting it back, so the comparison never converged. Keep `parallel: 1` in
+the load body — LM Studio honours it despite its absence from the public REST docs,
+and MLX speculative needs a non-batched instance.
+
+**Reasoning level for local models is deliberately not wired.** `renderReasoningControls`
+gates on `staticModelsService.findModel`, which has no `lmstudio`/`ollama` case;
+adapters don't send a level (`OllamaAdapter` sends `think:<boolean>`, LM Studio sends
+no `reasoning_effort`); `ThinkingEffortMapper` has no entries for either. **Decision:
+users set reasoning effort in LM Studio's own UI.** Do not build this speculatively.
+
+## CLI-backed providers: Antigravity (`agy`)
+
+The `google-gemini-cli` provider id is unchanged for settings compatibility, but the
+runtime is `agy`, not the deprecated `gemini` CLI. Contract:
+
+- Emits **plain text** — no JSON output mode
+- Reports **no token usage**
+- `--model` takes human labels and **fails open** on an unknown slug, so
+  `geminiCliModelNormalize.ts` is a **fail-closed allowlist** — keep it that way
+- Ignores `GEMINI_CLI_SYSTEM_SETTINGS_PATH`
+
+Security constraints, non-negotiable: the auth probe is a **boolean-only** presence
+check over `~/.gemini/oauth_creds.json` — never read, log, or return the token; no
+persistent `~/.gemini` writes; no `--dangerously-skip-permissions`.
+
+## Shared transcription
+
+Shared service: `src/services/llm/TranscriptionService.ts`. Types:
+`src/services/llm/types/VoiceTypes.ts`.
+
+Providers with word-level timestamps: **OpenAI** (`verbose_json`), **Groq**,
+**Mistral** (+diarization), **Deepgram** (+utterances, diarization, keyword
+biasing), **AssemblyAI** (+speaker labels).
+
+⚠️ The ingest shim at
+`src/agents/ingestManager/tools/services/TranscriptionService.ts` **strips
+word-level data**. Callers needing word timings must use the shared service
+directly.
+
+**Drag-drop paths:** browser `File.name` is a basename only — recover the
+vault-relative path with `vault.getFiles().find(f => f.name === file.name)` in
+`handleIngestFiles`.
+
+## Chat branches
+
+A branch **is** a conversation with parent metadata:
+
+- `metadata.parentConversationId` — parent conversation
+- `metadata.parentMessageId` — the message it attaches to
+- `metadata.branchType` — `'alternative' | 'subagent'`
+
+Key files: `src/services/chat/BranchService.ts` (facade over ConversationService),
+`src/ui/chat/controllers/SubagentController.ts`,
+`src/ui/chat/services/ContextTracker.ts` (token/cost tracking).
+
+Subagents: branch → stream via LLMService → save result. `chunk.toolCalls` are
+display-only.
+
+## Chat UI touchpoints
+
+Chat view is `src/ui/chat/ChatView.ts` — conversations, branching, streaming, tool
+accordion. Suggesters live in `src/ui/chat/components/suggesters/` (TextArea and
+ContentEditable variants, wired in `initializeSuggesters.ts`):
+
+| Trigger | Purpose |
+|---|---|
+| `/` | Tool hints |
+| `@` | Custom agents / prompts |
+| `[[` | Note links |
+| `#` | Workspace data |
+
+Prompt assembly: `src/ui/chat/services/MessageEnhancer.ts` and
+`SystemPromptBuilder.ts`.
+
+**WebLLM / Nexus Quark** (in-browser model, 4B, 4K context, `<tool_call>` format):
+multi-turn tool continuations may crash on Apple Silicon via WebGPU. If startup
+hangs on "loading cache", clear site data.
+
+## Model definitions
+
+Adding or changing model metadata (ids, pricing, context windows, capabilities,
+defaults) is the `nexus-model-updates` skill, which includes the live provider
+smoke test. Grading models on tool use is `nexus-model-eval`.

--- a/.claude/skills/nexus-llm-adapters/SKILL.md
+++ b/.claude/skills/nexus-llm-adapters/SKILL.md
@@ -43,10 +43,12 @@ through every layer and silently vanished at the final paint.
 
 **LM Studio speculative decoding.** A `draft_model` against a batched-MLX target
 fails. `LMStudioAdapter` detects the failure (HTTP *or* in-stream) before any real
-output, marks the draft incompatible, drops `draft_model`, and retries — so chat
-always produces output. Batched MLX bans speculative decoding outright and vision
-MLX never supports it; GGUF targets have no such restriction, paired with a
-same-family GGUF draft for matching vocab.
+output (`producedRealOutput` gate), marks the draft incompatible (per `target::draft`
+pair, with a one-time Notice), drops `draft_model`, and retries — so chat always
+produces output. The two rejection causes the code distinguishes: the engine/mode
+doesn't support speculative decoding (batched MLX, vision MLX) or the draft's
+tokenizer doesn't match. Field guidance, not enforced by code: pair a GGUF target
+with a same-family GGUF draft for matching vocab.
 
 **`ensureModelLoaded` never compares `flash_attention`.** It is passed through when
 configured, but comparing it caused infinite model reloads: it is llama.cpp-only, and

--- a/.claude/skills/nexus-llm-adapters/SKILL.md
+++ b/.claude/skills/nexus-llm-adapters/SKILL.md
@@ -1,189 +1,135 @@
 ---
 name: nexus-llm-adapters
-description: Nexus LLM provider adapter invariants — streaming, in-stream error frames, reasoning/thinking rendering, local-model quirks (LM Studio, Ollama), CLI-backed providers, and shared transcription. Use when adding or debugging a provider adapter, working on streaming or reasoning display, or touching chat message/branch plumbing.
+description: How to add or debug a Nexus LLM provider adapter — what every adapter must wire, how to verify it against a live provider, and the failure modes that produce a silently blank chat. Use when adding or changing a provider adapter, debugging streaming or reasoning display, working with local or CLI-backed models, or touching chat branch plumbing.
 ---
 
-# Nexus LLM Adapters
+# Working on LLM Adapters
 
-Providers talk direct HTTP via `ProviderHttpClient`
-(`src/services/llm/adapters/shared/ProviderHttpClient.ts`, reached through
-`BaseAdapter.request()` / `requestStream()`) — there are no vendor LLM SDKs in
-`package.json`. Adapters live in `src/services/llm/adapters/{provider}/`, over
-`BaseAdapter`.
+Providers talk direct HTTP through `ProviderHttpClient`, reached via
+`BaseAdapter.request()` / `requestStream()`. There are no vendor LLM SDKs in
+`package.json` and adding one is a decision to raise, not to make. Adapters live in
+`src/services/llm/adapters/{provider}/` over `BaseAdapter`.
 
-## Streaming: in-stream error frames
+## What every streaming adapter must wire
 
-Some providers (notably LM Studio) return `{"error":{...}}` frames **over HTTP
-200**. Without handling, the stream simply ends empty and the user sees a blank
-bubble with no error.
+**`extractError` on `SSEStreamOptions`.** Some providers return `{"error":{...}}`
+frames **over HTTP 200**. Without an extractor the stream simply ends, the user gets
+a blank bubble, and nothing is logged — the worst failure shape available. With it,
+`processNodeStream` records the message, drains the pump and throws a
+`LLMProviderError` with a stream-error code, so no bogus "complete" chunk is emitted.
 
-`SSEStreamOptions.extractError` (`src/services/llm/streaming/SSEStreamProcessor.ts`)
-+ `BaseAdapter.processNodeStream` turn those frames into
-`LLMProviderError(..., 'PROVIDER_STREAM_ERROR')` — the message is recorded, the pump
-is drained, then the error is thrown (so no bogus "complete" chunk is emitted).
+An empty stream is never an acceptable outcome. If you cannot map a provider's error
+frame, fail loudly rather than returning nothing.
 
-**Any new streaming adapter should wire `extractError`.** An empty stream is not an
-acceptable failure mode.
+**Reasoning goes through the event, not a fake tool call.** Emit `chunk.reasoning`
+and let the existing chain carry it: `onReasoningUpdate(messageId, text, isComplete)`
+on the stream/message events → `ChatView` → `MessageDisplay` → `MessageBubble`,
+which renders a collapsible block that auto-expands while streaming. Do **not**
+reintroduce a synthetic `reasoning`-type tool call — that was the previous mechanism
+and the tool coordinator never rendered it, so reasoning flowed correctly through
+every layer and vanished at the final paint.
 
-## Reasoning / thinking rendering
+## Verify a new or changed adapter
 
-The path is: `chunk.reasoning` → `onReasoningUpdate(messageId, reasoningText, isComplete)`
-on `StreamHandlerEvents`/`MessageManagerEvents` → `ChatView` →
-`MessageDisplay.updateMessageReasoning` → `MessageBubble.updateReasoning` /
-`syncReasoningBlock`, which renders a collapsible
-`<details class="message-reasoning">` block (summary `.message-reasoning-summary`
-"Thinking", body `.message-reasoning-content`) that auto-expands while streaming and
-collapses on completion.
+Unit tests cannot tell you whether a provider actually accepts your request shape.
+The lanes that can:
 
-**Do NOT reintroduce a synthetic `reasoning`-type tool call.** That was the previous
-mechanism; the tool coordinator never rendered it, so reasoning flowed correctly
-through every layer and silently vanished at the final paint.
+- `tests/debug/provider-model-live-smoke.test.ts` — drives real model ids against
+  the real endpoint. Use it when adding a provider or changing model metadata; the
+  `nexus-model-updates` skill wraps this.
+- For a local server, curl it directly before blaming the adapter. Local runtimes
+  return in-stream errors and undocumented behaviours that no fixture will predict.
+
+Check three things explicitly, because they fail independently: the non-streaming
+path, the streaming path, and the streaming **error** path (send something the
+provider will reject mid-stream and confirm you get an error rather than silence).
 
 ## Local models
 
-**LM Studio speculative decoding.** A `draft_model` against a batched-MLX target
-fails. `LMStudioAdapter` detects the failure (HTTP *or* in-stream) before any real
-output (`producedRealOutput` gate), marks the draft incompatible (per `target::draft`
-pair, with a one-time Notice), drops `draft_model`, and retries — so chat always
-produces output. The two rejection causes the code distinguishes: the engine/mode
-doesn't support speculative decoding (batched MLX, vision MLX) or the draft's
-tokenizer doesn't match. Field guidance, not enforced by code: pair a GGUF target
-with a same-family GGUF draft for matching vocab.
+Local runtimes are where the undocumented behaviour lives.
 
-**`ensureModelLoaded` never compares `flash_attention`.** It is passed through when
-configured, but comparing it caused infinite model reloads: it is llama.cpp-only, and
-MLX no-ops it without reporting it back, so the comparison never converged. The
-loaded-instance scan matches on `context_length` only (plus `parallel === 1` when a
-draft is configured). `parallel: 1` goes in the load body **when a draft model is
-configured** — LM Studio honours it despite its absence from the public REST docs,
-and MLX speculative needs a non-batched instance. (The whole pre-load is skipped
-unless a context length is configured; failures fall back to JIT loading.)
+**Speculative decoding can fail per-backend.** A draft model against a batched MLX
+target is rejected — and the rejection may arrive as an in-stream frame rather than
+an HTTP error. `LMStudioAdapter` handles this by detecting the failure before any
+real output, marking the draft incompatible, dropping it and retrying, so chat
+always produces something. Preserve that fallback shape if you touch it. GGUF
+targets have no such restriction; pair one with a same-family GGUF draft so the
+vocab matches.
 
-**Reasoning level for local models is deliberately not wired.** `renderReasoningControls`
-(`src/components/shared/ChatSettingsRenderer.ts`) bails unless
-`staticModelsService.findModel(provider, model)?.capabilities?.supportsThinking` is
-true, and `StaticModelsService.getModelsForProvider` has no `lmstudio`/`ollama` case
-(falls through to `[]`), so the control never renders for local providers. Adapters
-don't send a level either: `OllamaAdapter` sends a top-level `think: <boolean>`
-(`shouldEnableThinking` = explicit `options.enableThinking` ?? `isThinkingModelName`)
-and `LMStudioAdapter` sends no `reasoning_effort` at all;
-`ThinkingEffortMapper` (`src/services/llm/utils/ThinkingEffortMapper.ts`) has entries
-only for anthropic / openai / google / groq / deepseek. **Decision: users set
-reasoning effort in LM Studio's own UI.** Do not build this speculatively.
+**Do not compare `flash_attention` when deciding whether a loaded model is
+reusable.** It is llama.cpp-only, MLX silently no-ops it and does not report it
+back, so the comparison never converges and the adapter reloads the model forever.
+Pass it through; never diff it. The loaded-instance scan matches on context length,
+plus a non-batched instance when a draft is configured.
 
-## CLI-backed providers: Antigravity (`agy`)
+**Reasoning *level* is deliberately not wired for local providers.** The control
+only renders for models whose static metadata advertises thinking support, local
+providers have no such entry, and neither local adapter sends an effort parameter.
+This is a decision, not a gap: users set reasoning effort in LM Studio's own UI. Do
+not build it speculatively.
 
-The `google-gemini-cli` provider id is unchanged for settings compatibility
-(`GoogleGeminiCliAdapter.name`), but the runtime binary resolved on PATH is `agy`
-(`resolveGeminiCliRuntime` in `src/utils/geminiCli.ts`), not the deprecated `gemini`
-CLI. Contract:
+## CLI-backed providers
 
-- Emits **plain text** — `parseAgyOutput` is `stdout.trim()`; no JSON output mode
-- Reports **no token usage** (usage omitted, defaults to zero)
-- Text-completion only — no tool/function calling through this provider
-- `--model` takes human labels and **fails open** on an unknown slug, so
-  `geminiCliModelNormalize.ts` is a **fail-closed allowlist**: it composes
-  `"<Base label> (<Effort>)"` from a known base slug + the effort slider and throws
-  `LLMProviderError` on anything outside `BASE_MODELS` / `KNOWN_AGY_LABELS`. Keep it
-  that way. (Only two bases: Gemini 3.5 Flash — Low/Medium/High; Gemini 3.1 Pro —
-  Low/High, so a requested Medium clamps *up* to High.)
-- Nexus never sets `GEMINI_CLI_SYSTEM_SETTINGS_PATH`; the old temp-settings-file
-  mechanism is gone and a test asserts it is absent from the child env
+One provider shells out to a CLI (`agy`, under the historical `google-gemini-cli`
+provider id, which stays unchanged for settings compatibility). Its contract is
+narrower than an HTTP provider's: plain-text output, no token usage, text completion
+only — no tool calling.
 
-Invocation is `--print --model <label> --print-timeout 60s` with the prompt on stdin,
-plus `--sandbox` **only on macOS** (`shouldUseSandbox()` — the sandbox backend is
-verified only there; it is additive defense-in-depth, not the floor).
-`--print-timeout` takes a Go duration string (`60s`), not milliseconds, and is the
-security-load-bearing kill-switch for a headless tool-permission block (nothing can
-approve a prompt in print mode). Note the adapter's own comment claiming it is the
-*only* bound is now stale: `runCliProcess` also applies a 120s inactivity watchdog
-(`DEFAULT_CLI_IDLE_TIMEOUT_MS`) to every CLI child, agy included.
+**Security constraints, non-negotiable:**
 
-Security constraints, non-negotiable: the auth probe (`GeminiCliAuthService.runAuthProbe`)
-is a **boolean-only** presence check over `~/.gemini/oauth_creds.json` — it reads the
-file to test for a non-empty `access_token` (tolerant: whole-file parse → per-line
-parse → structural regex) and returns only an exitCode; the token value is **never
-captured, logged, or returned**. No persistent `~/.gemini` writes; no
-`--dangerously-skip-permissions`. `buildGeminiCliEnv` also strips
-`GEMINI_API_KEY`/`GOOGLE_*`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY` from the child env so
-agy can only use its own file-based OAuth.
+- The auth probe is **boolean-only**. It may read the credentials file to test for a
+  non-empty token, and must return only a boolean or exit code. The token value is
+  never captured, logged, or returned.
+- No persistent writes into the user's provider config directory.
+- No permission-skipping flags.
+- Model selection is a **fail-closed allowlist**. The CLI fails *open* on an unknown
+  model — it will happily run something you did not intend — so Nexus must reject
+  anything outside the known set. Keep that direction if you touch the normalizer.
+- Provider API keys are stripped from the child environment so the CLI can only use
+  its own file-based auth.
 
-## Shared transcription
-
-Shared service: `src/services/llm/TranscriptionService.ts`. Types:
-`src/services/llm/types/VoiceTypes.ts`.
-
-Five providers are wired, each with its own adapter under
-`src/services/llm/adapters/{provider}/`:
-
-- **OpenAI** — word timestamps on `whisper-1` only (`verbose_json` +
-  `timestamp_granularities[]=word`). `gpt-4o-transcribe-diarize` uses
-  `diarized_json` (speaker labels, segment timing, **no** word detail); the
-  `gpt-transcribe` generation returns plain JSON with no timing and rejects
-  `verbose_json`.
-- **Groq** — `verbose_json`, word timestamps on request
-- **Mistral** — word timestamps (`timestamp_granularities=word`) + opt-in `diarize`
-- **Deepgram** — `utterances` always on, words parsed, opt-in `diarize`
-- **AssemblyAI** — words parsed, opt-in `speaker_labels`
-
-⚠️ The ingest shim at
-`src/agents/ingestManager/tools/services/TranscriptionService.ts` **strips
-word-level data** — it maps each segment down to `{startSeconds, endSeconds, text}`
-even though it requests word timestamps. Callers needing word timings must use the
-shared service directly.
+Anything shelling out inherits the shared CLI process runner and its idle watchdog;
+do not assume a provider-specific timeout flag is the only bound on a hung process.
 
 ## Chat branches
 
-A branch **is** a conversation with parent metadata:
+A branch **is** a conversation with parent metadata — `parentConversationId`,
+`parentMessageId`, `branchType`.
 
-- `metadata.parentConversationId` — parent conversation
-- `metadata.parentMessageId` — the message it attaches to
-- `metadata.branchType` — stored as `'alternative' | 'subagent'`
-  (`src/types/chat/ChatTypes.ts`, `src/types/storage/StorageTypes.ts`)
+⚠️ **Two vocabularies, don't conflate them.** The *stored* branch type and the
+*view-layer* union are different sets, and the conversion collapses anything that
+is not a subagent into the view's generic value. So a value you stored may not be
+the value the UI reports. Read both the storage types and the view types before
+assuming a mismatch is a bug — it is a layer boundary.
 
-⚠️ **Two vocabularies, don't conflate them.** The *stored* metadata value is
-`'alternative' | 'subagent'`, but the *view-layer* union
-`BranchType` (`src/types/branch/BranchTypes.ts`) is `'human' | 'subagent'`.
-`BranchService.conversationToBranch` (~line 226) collapses the two: anything that
-isn't `'subagent'` becomes `'human'` on the `ConversationBranch.type` it returns —
-so a stored `'alternative'` surfaces as `'human'` in the UI. The same mapping is in
-`ConversationTypeConverters.ts` and `ChatBranchViewCoordinator.ts`. Neither name is
-wrong; they belong to different layers.
+**Subagent tool calls are already executed.** The `chunk.toolCalls` a subagent
+executor sees carry their results; the ping-pong ran inside `LLMService`. Consume
+them for display and status only — re-executing them runs the side effects twice.
 
-Key files: `src/services/chat/BranchService.ts` (facade over ConversationService),
-`src/ui/chat/controllers/SubagentController.ts`,
-`src/ui/chat/services/ContextTracker.ts` (token/cost tracking).
+## Gotchas
 
-Subagents: branch → stream via LLMService → save result
-(`src/services/chat/SubagentExecutor.ts`). The `chunk.toolCalls` the executor sees
-are **already-executed** calls carrying their results (the ping-pong ran inside
-LLMService) — consume them for display/status only, never re-execute them.
+**"The chat bubble is blank and nothing was logged."** The stream ended without
+emitting. Almost always a provider error frame over HTTP 200 with no `extractError`
+wired.
 
-## Chat UI touchpoints
+**"Reasoning is in the payload but never appears in the UI."** Something is emitting
+a synthetic reasoning tool call instead of `onReasoningUpdate`. The tool coordinator
+does not render it.
 
-Chat view is `src/ui/chat/ChatView.ts` — conversations, branching, streaming, tool
-accordion. Suggesters live in `src/ui/chat/components/suggesters/` (a `BaseSuggester`
-with `TextArea*` and ContentEditable variants; `initializeSuggesters.ts` wires the
-four `TextArea*` ones):
+**"The model reloads on every single message."** A load-parameter comparison that
+can never match — check `flash_attention` first.
 
-| Trigger | Regex | Purpose |
-|---|---|---|
-| `/` | `/^\/(\w*)$/` — start of input only | Tool hints (MCP tools) |
-| `@` | `/@(\w*)$/` | Custom prompts |
-| `[[` | `/\[\[([^\]]*?)$/` | Note links |
-| `#` | `/#(\w*)$/` | Workspaces |
+**"Chat produces no output only when speculative decoding is on."** The draft model
+is incompatible with the target backend and the error arrived in-stream. The retry
+path exists; confirm it was not bypassed.
 
-Prompt assembly: `src/ui/chat/services/MessageEnhancer.ts` and
-`src/ui/chat/services/SystemPromptBuilder.ts`.
+**"A tool ran twice."** Something re-executed `chunk.toolCalls` in a subagent path.
 
-**WebLLM / Nexus Quark** (in-browser model — `nexus-quark-q3.0.5`, Qwen3-1.7B,
-4096-token context, native `<tool_call>` format; the adapter also parses
-`[TOOL_CALLS]`): multi-turn tool continuations may crash on Apple Silicon via WebGPU
-(documented at `src/utils/platform.ts` `supportsWebLLM` and in the `WebLLMAdapter`
-header).
+**"The CLI provider accepted a model name I never configured."** The CLI fails open;
+the allowlist is what closes it. Do not relax it into a warning.
 
-## Model definitions
+## Related skills
 
-Adding or changing model metadata (ids, pricing, context windows, capabilities,
-defaults) is the `nexus-model-updates` skill, which includes the live provider
-smoke test. Grading models on tool use is `nexus-model-eval`.
+Model metadata (ids, pricing, context windows, capabilities, defaults) and the live
+provider smoke test: `nexus-model-updates`. Grading models on tool use:
+`nexus-model-eval`.

--- a/.claude/skills/nexus-llm-adapters/SKILL.md
+++ b/.claude/skills/nexus-llm-adapters/SKILL.md
@@ -5,8 +5,10 @@ description: Nexus LLM provider adapter invariants — streaming, in-stream erro
 
 # Nexus LLM Adapters
 
-Providers talk direct HTTP via `ProviderHttpClient` — the vendor SDKs were removed
-deliberately. Adapters live in `src/services/llm/adapters/{provider}/`, over
+Providers talk direct HTTP via `ProviderHttpClient`
+(`src/services/llm/adapters/shared/ProviderHttpClient.ts`, reached through
+`BaseAdapter.request()` / `requestStream()`) — there are no vendor LLM SDKs in
+`package.json`. Adapters live in `src/services/llm/adapters/{provider}/`, over
 `BaseAdapter`.
 
 ## Streaming: in-stream error frames
@@ -15,17 +17,22 @@ Some providers (notably LM Studio) return `{"error":{...}}` frames **over HTTP
 200**. Without handling, the stream simply ends empty and the user sees a blank
 bubble with no error.
 
-`SSEStreamOptions.extractError` + `processNodeStream` in `BaseAdapter.ts` turn those
-frames into `LLMProviderError(..., 'PROVIDER_STREAM_ERROR')`.
+`SSEStreamOptions.extractError` (`src/services/llm/streaming/SSEStreamProcessor.ts`)
++ `BaseAdapter.processNodeStream` turn those frames into
+`LLMProviderError(..., 'PROVIDER_STREAM_ERROR')` — the message is recorded, the pump
+is drained, then the error is thrown (so no bogus "complete" chunk is emitted).
 
 **Any new streaming adapter should wire `extractError`.** An empty stream is not an
 acceptable failure mode.
 
 ## Reasoning / thinking rendering
 
-The path is: `chunk.reasoning` → `onReasoningUpdate(messageId, text, isComplete)` on
-`StreamHandlerEvents`/`MessageManagerEvents` → a collapsible
-`<details class="message-reasoning">` block that auto-expands while streaming and
+The path is: `chunk.reasoning` → `onReasoningUpdate(messageId, reasoningText, isComplete)`
+on `StreamHandlerEvents`/`MessageManagerEvents` → `ChatView` →
+`MessageDisplay.updateMessageReasoning` → `MessageBubble.updateReasoning` /
+`syncReasoningBlock`, which renders a collapsible
+`<details class="message-reasoning">` block (summary `.message-reasoning-summary`
+"Thinking", body `.message-reasoning-content`) that auto-expands while streaming and
 collapses on completion.
 
 **Do NOT reintroduce a synthetic `reasoning`-type tool call.** That was the previous
@@ -41,50 +48,87 @@ always produces output. Batched MLX bans speculative decoding outright and visio
 MLX never supports it; GGUF targets have no such restriction, paired with a
 same-family GGUF draft for matching vocab.
 
-**`ensureModelLoaded` never compares `flash_attention`.** It is passed through, but
-comparing it caused infinite model reloads: it is llama.cpp-only, and MLX no-ops it
-without reporting it back, so the comparison never converged. Keep `parallel: 1` in
-the load body — LM Studio honours it despite its absence from the public REST docs,
-and MLX speculative needs a non-batched instance.
+**`ensureModelLoaded` never compares `flash_attention`.** It is passed through when
+configured, but comparing it caused infinite model reloads: it is llama.cpp-only, and
+MLX no-ops it without reporting it back, so the comparison never converged. The
+loaded-instance scan matches on `context_length` only (plus `parallel === 1` when a
+draft is configured). `parallel: 1` goes in the load body **when a draft model is
+configured** — LM Studio honours it despite its absence from the public REST docs,
+and MLX speculative needs a non-batched instance. (The whole pre-load is skipped
+unless a context length is configured; failures fall back to JIT loading.)
 
 **Reasoning level for local models is deliberately not wired.** `renderReasoningControls`
-gates on `staticModelsService.findModel`, which has no `lmstudio`/`ollama` case;
-adapters don't send a level (`OllamaAdapter` sends `think:<boolean>`, LM Studio sends
-no `reasoning_effort`); `ThinkingEffortMapper` has no entries for either. **Decision:
-users set reasoning effort in LM Studio's own UI.** Do not build this speculatively.
+(`src/components/shared/ChatSettingsRenderer.ts`) bails unless
+`staticModelsService.findModel(provider, model)?.capabilities?.supportsThinking` is
+true, and `StaticModelsService.getModelsForProvider` has no `lmstudio`/`ollama` case
+(falls through to `[]`), so the control never renders for local providers. Adapters
+don't send a level either: `OllamaAdapter` sends a top-level `think: <boolean>`
+(`shouldEnableThinking` = explicit `options.enableThinking` ?? `isThinkingModelName`)
+and `LMStudioAdapter` sends no `reasoning_effort` at all;
+`ThinkingEffortMapper` (`src/services/llm/utils/ThinkingEffortMapper.ts`) has entries
+only for anthropic / openai / google / groq / deepseek. **Decision: users set
+reasoning effort in LM Studio's own UI.** Do not build this speculatively.
 
 ## CLI-backed providers: Antigravity (`agy`)
 
-The `google-gemini-cli` provider id is unchanged for settings compatibility, but the
-runtime is `agy`, not the deprecated `gemini` CLI. Contract:
+The `google-gemini-cli` provider id is unchanged for settings compatibility
+(`GoogleGeminiCliAdapter.name`), but the runtime binary resolved on PATH is `agy`
+(`resolveGeminiCliRuntime` in `src/utils/geminiCli.ts`), not the deprecated `gemini`
+CLI. Contract:
 
-- Emits **plain text** — no JSON output mode
-- Reports **no token usage**
+- Emits **plain text** — `parseAgyOutput` is `stdout.trim()`; no JSON output mode
+- Reports **no token usage** (usage omitted, defaults to zero)
+- Text-completion only — no tool/function calling through this provider
 - `--model` takes human labels and **fails open** on an unknown slug, so
-  `geminiCliModelNormalize.ts` is a **fail-closed allowlist** — keep it that way
-- Ignores `GEMINI_CLI_SYSTEM_SETTINGS_PATH`
+  `geminiCliModelNormalize.ts` is a **fail-closed allowlist**: it composes
+  `"<Base label> (<Effort>)"` from a known base slug + the effort slider and throws
+  `LLMProviderError` on anything outside `BASE_MODELS` / `KNOWN_AGY_LABELS`. Keep it
+  that way. (Only two bases: Gemini 3.5 Flash — Low/Medium/High; Gemini 3.1 Pro —
+  Low/High, so a requested Medium clamps *up* to High.)
+- Nexus never sets `GEMINI_CLI_SYSTEM_SETTINGS_PATH`; the old temp-settings-file
+  mechanism is gone and a test asserts it is absent from the child env
 
-Security constraints, non-negotiable: the auth probe is a **boolean-only** presence
-check over `~/.gemini/oauth_creds.json` — never read, log, or return the token; no
-persistent `~/.gemini` writes; no `--dangerously-skip-permissions`.
+Invocation is `--print --model <label> --print-timeout 60s` with the prompt on stdin,
+plus `--sandbox` **only on macOS** (`shouldUseSandbox()` — the sandbox backend is
+verified only there; it is additive defense-in-depth, not the floor).
+`--print-timeout` takes a Go duration string (`60s`), not milliseconds, and is the
+security-load-bearing kill-switch for a headless tool-permission block (nothing can
+approve a prompt in print mode). Note the adapter's own comment claiming it is the
+*only* bound is now stale: `runCliProcess` also applies a 120s inactivity watchdog
+(`DEFAULT_CLI_IDLE_TIMEOUT_MS`) to every CLI child, agy included.
+
+Security constraints, non-negotiable: the auth probe (`GeminiCliAuthService.runAuthProbe`)
+is a **boolean-only** presence check over `~/.gemini/oauth_creds.json` — it reads the
+file to test for a non-empty `access_token` (tolerant: whole-file parse → per-line
+parse → structural regex) and returns only an exitCode; the token value is **never
+captured, logged, or returned**. No persistent `~/.gemini` writes; no
+`--dangerously-skip-permissions`. `buildGeminiCliEnv` also strips
+`GEMINI_API_KEY`/`GOOGLE_*`/`ANTHROPIC_API_KEY`/`OPENAI_API_KEY` from the child env so
+agy can only use its own file-based OAuth.
 
 ## Shared transcription
 
 Shared service: `src/services/llm/TranscriptionService.ts`. Types:
 `src/services/llm/types/VoiceTypes.ts`.
 
-Providers with word-level timestamps: **OpenAI** (`verbose_json`), **Groq**,
-**Mistral** (+diarization), **Deepgram** (+utterances, diarization, keyword
-biasing), **AssemblyAI** (+speaker labels).
+Five providers are wired, each with its own adapter under
+`src/services/llm/adapters/{provider}/`:
+
+- **OpenAI** — word timestamps on `whisper-1` only (`verbose_json` +
+  `timestamp_granularities[]=word`). `gpt-4o-transcribe-diarize` uses
+  `diarized_json` (speaker labels, segment timing, **no** word detail); the
+  `gpt-transcribe` generation returns plain JSON with no timing and rejects
+  `verbose_json`.
+- **Groq** — `verbose_json`, word timestamps on request
+- **Mistral** — word timestamps (`timestamp_granularities=word`) + opt-in `diarize`
+- **Deepgram** — `utterances` always on, words parsed, opt-in `diarize`
+- **AssemblyAI** — words parsed, opt-in `speaker_labels`
 
 ⚠️ The ingest shim at
 `src/agents/ingestManager/tools/services/TranscriptionService.ts` **strips
-word-level data**. Callers needing word timings must use the shared service
-directly.
-
-**Drag-drop paths:** browser `File.name` is a basename only — recover the
-vault-relative path with `vault.getFiles().find(f => f.name === file.name)` in
-`handleIngestFiles`.
+word-level data** — it maps each segment down to `{startSeconds, endSeconds, text}`
+even though it requests word timestamps. Callers needing word timings must use the
+shared service directly.
 
 ## Chat branches
 
@@ -92,34 +136,49 @@ A branch **is** a conversation with parent metadata:
 
 - `metadata.parentConversationId` — parent conversation
 - `metadata.parentMessageId` — the message it attaches to
-- `metadata.branchType` — `'alternative' | 'subagent'`
+- `metadata.branchType` — stored as `'alternative' | 'subagent'`
+  (`src/types/chat/ChatTypes.ts`, `src/types/storage/StorageTypes.ts`)
+
+⚠️ **Two vocabularies, don't conflate them.** The *stored* metadata value is
+`'alternative' | 'subagent'`, but the *view-layer* union
+`BranchType` (`src/types/branch/BranchTypes.ts`) is `'human' | 'subagent'`.
+`BranchService.conversationToBranch` (~line 226) collapses the two: anything that
+isn't `'subagent'` becomes `'human'` on the `ConversationBranch.type` it returns —
+so a stored `'alternative'` surfaces as `'human'` in the UI. The same mapping is in
+`ConversationTypeConverters.ts` and `ChatBranchViewCoordinator.ts`. Neither name is
+wrong; they belong to different layers.
 
 Key files: `src/services/chat/BranchService.ts` (facade over ConversationService),
 `src/ui/chat/controllers/SubagentController.ts`,
 `src/ui/chat/services/ContextTracker.ts` (token/cost tracking).
 
-Subagents: branch → stream via LLMService → save result. `chunk.toolCalls` are
-display-only.
+Subagents: branch → stream via LLMService → save result
+(`src/services/chat/SubagentExecutor.ts`). The `chunk.toolCalls` the executor sees
+are **already-executed** calls carrying their results (the ping-pong ran inside
+LLMService) — consume them for display/status only, never re-execute them.
 
 ## Chat UI touchpoints
 
 Chat view is `src/ui/chat/ChatView.ts` — conversations, branching, streaming, tool
-accordion. Suggesters live in `src/ui/chat/components/suggesters/` (TextArea and
-ContentEditable variants, wired in `initializeSuggesters.ts`):
+accordion. Suggesters live in `src/ui/chat/components/suggesters/` (a `BaseSuggester`
+with `TextArea*` and ContentEditable variants; `initializeSuggesters.ts` wires the
+four `TextArea*` ones):
 
-| Trigger | Purpose |
-|---|---|
-| `/` | Tool hints |
-| `@` | Custom agents / prompts |
-| `[[` | Note links |
-| `#` | Workspace data |
+| Trigger | Regex | Purpose |
+|---|---|---|
+| `/` | `/^\/(\w*)$/` — start of input only | Tool hints (MCP tools) |
+| `@` | `/@(\w*)$/` | Custom prompts |
+| `[[` | `/\[\[([^\]]*?)$/` | Note links |
+| `#` | `/#(\w*)$/` | Workspaces |
 
 Prompt assembly: `src/ui/chat/services/MessageEnhancer.ts` and
-`SystemPromptBuilder.ts`.
+`src/ui/chat/services/SystemPromptBuilder.ts`.
 
-**WebLLM / Nexus Quark** (in-browser model, 4B, 4K context, `<tool_call>` format):
-multi-turn tool continuations may crash on Apple Silicon via WebGPU. If startup
-hangs on "loading cache", clear site data.
+**WebLLM / Nexus Quark** (in-browser model — `nexus-quark-q3.0.5`, Qwen3-1.7B,
+4096-token context, native `<tool_call>` format; the adapter also parses
+`[TOOL_CALLS]`): multi-turn tool continuations may crash on Apple Silicon via WebGPU
+(documented at `src/utils/platform.ts` `supportsWebLLM` and in the `WebLLMAdapter`
+header).
 
 ## Model definitions
 

--- a/.claude/skills/nexus-mobile-compat/SKILL.md
+++ b/.claude/skills/nexus-mobile-compat/SKILL.md
@@ -1,99 +1,41 @@
 ---
 name: nexus-mobile-compat
-description: Obsidian plugin store rules and mobile compatibility for Nexus — which imports crash on mobile, desktopRequire, path confinement, DOM and styling constraints. Use before adding any npm dependency or Node import, when touching plugin lifecycle or DOM code, when writing to vault paths, or when a feature is desktop-only.
+description: How to keep Nexus loading on mobile and compliant with Obsidian plugin store rules — vetting a dependency, importing safely, confining vault paths, and verifying none of it regressed. Use before adding any npm package or Node import, when writing to vault paths, when a feature is desktop-only, or when the plugin fails to load on a phone.
 ---
 
-# Nexus Plugin Rules & Mobile Compatibility
+# Mobile Safety & Plugin Rules
 
 Full guidelines: `docs/obsidian-plugin-guidelines.md`. This skill is the part that
-bites in practice.
+bites.
 
-## Non-negotiable plugin rules
+## The rule, and why a guard cannot save you
 
-- All styles in `styles.css` — never inline
-- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`.
-  Only two forms are sanctioned: `el.innerHTML = ''` to clear, and *reading*
-  already-escaped content (`docs/obsidian-plugin-guidelines.md` §Security)
-- `registerDomEvent` for all DOM events, never `addEventListener` — it leaks. The
-  exception is a target Obsidian's `Component` API cannot bind (`Worker`,
-  `AbortSignal`, `window.visualViewport`); where a renderer has no `Component`,
-  the codebase uses a `component ? registerDomEvent : addEventListener` fallback
-- `requestUrl()` not `fetch()` for HTTP; `normalizePath()` for paths
-- `vault.adapter` is acceptable for direct storage-path access; normalize paths and
-  resolve storage roots from settings rather than hardcoding `.nexus` or `Nexus`
-- **`normalizePath()` does NOT strip `..`.** It collapses separators only, so a
-  `..`-bearing path handed to `vault.create()` / `adapter.write()` resolves through
-  Node's `path.join` on desktop and escapes the vault. Confinement is therefore
-  explicit, in two layers:
-  - `src/core/vaultPath.ts` — the vault-wide boundary. A branded `VaultPath` type
-    that is *only* constructible through this module: `resolveVaultPath` /
-    `tryResolveVaultPath` for untrusted caller-supplied paths (they REJECT
-    traversal, absolute and home-expansion paths), `vaultPathFromTrusted` for
-    code-controlled paths (canonicalizes, never rejects). The traversal check is
-    segment-based, not `includes('..')`, so `notes/a..b.md` still passes. Mobile-safe
-    — no Node built-ins, only `normalizePath`.
-  - `src/agents/apps/skills/services/skillPaths.ts` — the Skills-app layer:
-    `resolveVaultPath` / `assertInside` / `isSafePathSegment` (+ `SkillPathError`),
-    applied at every write/copy/remove boundary in the Skills app. ⚠️ Its
-    `resolveVaultPath` is a *different* function from the `core/vaultPath.ts` one
-    of the same name — it folds `..` rather than rejecting it. Check your import.
-- Plugin store compliance: `isDesktopOnly: false` is correct. `VaultOperations`
-  (`src/core/VaultOperations.ts`) uses `app.fileManager.trashFile()` and its
-  constructor takes `App` first
-
-## Mobile compatibility — the critical part
-
-**`isDesktopOnly: false`** — this plugin runs on mobile, where Node.js built-ins
+`isDesktopOnly: false` — this plugin runs on mobile, where Node.js built-ins
 (`fs`, `path`, `http`, `crypto`, `events`, `stream`, `net`, `os`, `url`, `process`,
-`buffer`) **do not exist**.
+`buffer`) do not exist.
 
-**Top-level imports execute during module init, BEFORE any `Platform.isDesktop`
-guard can run.** A guard below a top-level import is decoration.
+**Top-level imports execute during module init, before any `Platform.isDesktop`
+check can run.** A platform guard below a top-level import is decoration — the
+import already crashed the plugin. This is why the rule is about *where* you import,
+not whether you check the platform.
 
 | Pattern | Result on mobile |
 |---|---|
-| `import mammoth from 'mammoth'` (top level) | **Crashes plugin** — depends on `stream`, `fs` |
-| `import { EventEmitter } from 'events'` (top level) | **Crashes plugin** — null on mobile |
-| `const mammoth = await import('mammoth')` (inside async fn) | **Safe** — loads only when called |
-| `const fs = desktopRequire<typeof import('node:fs')>('node:fs')` (inside fn) | **Safe** — lazy |
+| `import x from 'node-dependent-pkg'` (top level) | **Crashes plugin at init** |
+| `import { EventEmitter } from 'events'` (top level) | **Crashes plugin at init** |
+| `const x = await import('node-dependent-pkg')` (inside async fn) | Safe — loads when called |
+| `const fs = desktopRequire<typeof import('node:fs')>('node:fs')` (inside fn) | Safe — lazy |
 
-**Rules for new code:**
+So: never top-level import a Node built-in — use `desktopRequire()` from
+`src/utils/desktopRequire.ts`. Never top-level import an npm package with Node
+transitive deps — `await import()` it inside an async function. Use Obsidian's
+`Events` class instead of `EventEmitter`. For YAML use Obsidian's
+`parseYaml`/`stringifyYaml`, which are cross-platform and what the codebase uses
+throughout.
 
-1. **Never** top-level import Node built-ins — use `desktopRequire()` from
-   `src/utils/desktopRequire.ts`
-2. **Never** top-level import npm packages with Node transitive deps — use dynamic
-   `await import()` inside an async function
-3. **Replace** `EventEmitter` with Obsidian's `Events` class (cross-platform)
-4. **Node-dependent features** (ingestion, OAuth, CLI bridge, MCP transports, data
-   analysis, web tools): ensure every Node-dependent import is lazy. Only `data`
-   (data analysis) is gated out of the app registry on mobile
-   (`AppManager.getBuiltInAppRegistry`); `web-tools` registers everywhere but each
-   tool returns "desktop-only" behind an `isDesktop() && isElectron()` runtime
-   guard. Composer is *not* desktop-only — it is cross-platform and ships no
-   Node-dependent import.
+## Before adding a dependency
 
-**Desktop-only npm packages in this repo:** `mammoth` and `jszip` — both runtime
-dependencies, both correctly loaded via `await import()` inside an async function
-(`DocxExtractionService.ts:29`, `PptxExtractionService.ts:36`). JSZip also has a
-static `import type JSZip` — type-only, erased at compile, harmless.
-
-For YAML, use Obsidian's `parseYaml`/`stringifyYaml`; they are cross-platform and
-already available, and are what the codebase uses throughout. The `yaml` npm
-package is a devDependency only and is imported nowhere in `src/`. `xlsx` is not a
-dependency of this project at all.
-
-**Current baseline:** `src/` has *zero* top-level Node built-in imports. Every
-runtime Node access goes through `desktopRequire()` inside a function body.
-`connector.ts` and `cli/*.ts` do import Node built-ins statically — that is correct;
-they are separate Node-targeted builds (`tsconfig.connector.json`,
-`scripts/build-cli.mjs`) and never enter `main.js`. `src/utils/connectorContent.ts`
-and `src/utils/cliAssets.ts` contain `require("net")`-style text, but only inside
-generated template-literal string constants — nothing executes.
-
-### Vetting a new dependency
-
-Before adding one, check whether its browser entry pulls Node built-ins. Do it
-against the published package, not the README:
+Check the published package, not the README:
 
 ```bash
 npm pack <pkg>@<version> && tar xzf <pkg>-<version>.tgz
@@ -101,56 +43,117 @@ grep -rlE "require\(['\"](node:)?(fs|path|http|stream|os|crypto)['\"]\)" package
 ```
 
 If the hits are confined to a CLI or Node-specific entry that the browser entry
-never imports, the browser entry is safe to bundle — still import it lazily per
-rule 2. Bundle cost is worth measuring at the same time:
+never imports, the browser entry is safe to bundle — still import it lazily.
+
+Measure the cost while you are there:
 
 ```bash
 npx esbuild entry.mjs --bundle --minify --format=esm --platform=browser --outfile=out.js
 ```
 
 Obsidian plugins ship a single `main.js`, so a lazy `import()` still lands in the
-bundle — lazy loading protects mobile *init*, it does not reduce bundle size.
+bundle. **Lazy loading protects mobile init; it does not reduce bundle size.** Those
+are two separate problems and you may need to solve both.
 
-## Emulation does not prove mobile safety
+## Verify mobile safety
 
-`obsidian dev:mobile on` emulates `Platform.isMobile`, touch and layout. It does
-**not** remove Node built-ins from Electron, so `require('fs')` still resolves
-there and the crash class above will **not** reproduce. Use it for UI and
-platform-branch coverage only — never read a green `dev:mobile` run as
-"mobile-safe". See `docs/plans/obsidian-cli-verification-plan.md` §6.
+The check that matters is **reachability**, not grep. A top-level Node import is
+harmless in a module nothing loads at startup, and fatal in one that does.
+
+```bash
+# top-level Node built-in imports anywhere in src/
+grep -rnE "^import .*(from )?['\"](node:)?(fs|path|http|stream|os|crypto|events|net|buffer|child_process)['\"]" src/
+```
+
+Two things that will show up and are **correct**: `connector.ts` and `cli/*.ts`
+import Node built-ins statically, but they are separate Node-targeted builds that
+never enter `main.js`; and some generated asset files contain `require("net")`-style
+text inside string constants, which never executes.
+
+The real hazard is subtler. Some modules do top-level import Node-dependent packages
+and are safe **only because they are not statically reachable from `src/main.ts`**.
+That safety is a property of the current import graph, not of the code: one
+innocuous top-level import from a startup-reachable file pulls them into init and
+breaks launch on mobile, with a diff that looks unrelated and nothing in CI to catch
+it. If you are adding an import to anything on the startup path, trace what it drags
+in. A reachability lint is tracked in
+[#221](https://github.com/ProfSynapse/nexus/issues/221).
+
+**Emulation does not prove mobile safety.** `obsidian dev:mobile on` emulates
+`Platform.isMobile`, touch and layout, but does not remove Node built-ins from
+Electron — `require('fs')` still resolves, so this crash class will not reproduce.
+Use it for UI and platform-branch coverage only, and never read a green
+`dev:mobile` run as "mobile-safe".
+
+## Confining vault paths
+
+**`normalizePath()` does not strip `..`.** It collapses separators only, so a
+`..`-bearing path handed to `vault.create()` or `adapter.write()` resolves through
+Node's path join on desktop and escapes the vault. Confinement is therefore
+explicit.
+
+The vault-wide boundary is `src/core/vaultPath.ts`: a branded `VaultPath` type
+constructible only through that module. Use `resolveVaultPath` /
+`tryResolveVaultPath` for **untrusted, caller-supplied** paths — they reject
+traversal, absolute and home-expansion paths — and `vaultPathFromTrusted` for
+code-controlled paths, which canonicalizes and never rejects. The traversal check is
+segment-based rather than `includes('..')`, so a legitimate `notes/a..b.md` still
+passes. It is mobile-safe: no Node built-ins.
+
+⚠️ **`resolveVaultPath` exists in two modules with opposite semantics.** The
+`src/core/vaultPath.ts` one *rejects* traversal; the Skills-app one in
+`src/agents/apps/skills/services/skillPaths.ts` *folds* it. Check your import — the
+wrong one silently weakens a security boundary rather than failing.
+
+## Plugin store rules
+
+- All styles in `styles.css`, never inline
+- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`.
+  Only clearing (`el.innerHTML = ''`) and reading already-escaped content are
+  sanctioned
+- `registerDomEvent` for DOM events, never `addEventListener` — it leaks. The
+  exception is a target Obsidian's `Component` API cannot bind (`Worker`,
+  `AbortSignal`, `visualViewport`); where a renderer has no `Component`, the
+  codebase falls back deliberately
+- `requestUrl()` not `fetch()`; `normalizePath()` for paths
+- `vault.adapter` is fine for direct storage-path access — normalize, and resolve
+  roots from settings rather than hardcoding
+- Deletion goes through `app.fileManager.trashFile()`
 
 ## pdfjs-dist in Obsidian/Electron
 
-PDF.js 5 treats the Electron renderer as a browser and expects a configured
-`workerSrc`. The worker cannot be bundled or shipped as a release asset — Obsidian
-community releases may only ship `main.js` / `manifest.json` / `styles.css` — so the
-loader points `workerSrc` at a CDN copy pinned to the installed version, and
-memoizes the module promise:
+PDF.js treats the Electron renderer as a browser and expects a configured
+`workerSrc`. The worker **cannot** be bundled or shipped as a release asset —
+Obsidian community releases may only ship `main.js` / `manifest.json` /
+`styles.css` — so the loader points `workerSrc` at a CDN copy pinned to the
+installed version and memoizes the module promise.
 
-```typescript
-// src/agents/ingestManager/tools/services/PdfJsLoader.ts
-async function initializePdfJs(): Promise<PdfJsModule> {
-  const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
-
-  if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
-    pdfjsLib.GlobalWorkerOptions.workerSrc =
-      `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/legacy/build/pdf.worker.mjs`;
-  }
-
-  return pdfjsLib;
-}
-```
-
-Use `loadPdfJs()` from `PdfJsLoader.ts` in both `PdfTextExtractor.ts` and
-`PdfPageRenderer.ts` — both already do. Always the `legacy/build/pdf.mjs` entry, and
-always via the shared loader, so `workerSrc` is configured exactly once.
+Always go through `loadPdfJs()` in
+`src/agents/ingestManager/tools/services/PdfJsLoader.ts`, and always the
+`legacy/build/pdf.mjs` entry, so `workerSrc` is configured exactly once. Do not
+import `pdfjs-dist` directly — the main entry fails in Electron without a worker URL.
 
 ## Line endings
 
-`.gitattributes` sets `* text=auto eol=lf` and then declares LF explicitly across
-`.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.jsx`/`.json`/`.yml`/`.yaml`/`.toml`/`.xml`/
-`.md`/`.txt`/`.html`/`.css`/`.scss`/`.svg`/`.sh`/`.ps1`/`.bat`, with `binary`
-markers for images and `.pdf`. CRLF in the tree is a local-editor bug —
-fix the editor, don't chase it with tool normalization. If hundreds of files show
-modified with a tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF:
-`git add --renormalize .` on that subset, and don't let it land.
+`.gitattributes` sets `* text=auto eol=lf` plus explicit declarations per extension.
+CRLF in the tree is a local-editor bug — fix the editor, don't chase it with tool
+normalization. If hundreds of files show modified with a tiny `--ignore-cr-at-eol`
+delta, someone's editor wrote CRLF: `git add --renormalize .` on that subset, and
+don't let it land.
+
+## Gotchas
+
+**"The plugin won't load on my phone and the diff looks unrelated."** Something on
+the startup path gained an import that transitively reaches a Node-dependent module.
+Trace reachability from `src/main.ts`, not just your own file.
+
+**"I added a `Platform.isDesktop` guard and it still crashes."** The guard runs after
+module init. Move the import inside a function.
+
+**"`dev:mobile` was green."** It cannot catch this class. See above.
+
+**"My path validation passed but the write escaped the vault."** You used the
+folding `resolveVaultPath`, not the rejecting one, or relied on `normalizePath()`.
+
+**"I lazy-imported the package and `main.js` grew anyway."** Expected — one bundle.
+Lazy import is about init safety, not size.

--- a/.claude/skills/nexus-mobile-compat/SKILL.md
+++ b/.claude/skills/nexus-mobile-compat/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: nexus-mobile-compat
+description: Obsidian plugin store rules and mobile compatibility for Nexus — which imports crash on mobile, desktopRequire, path confinement, DOM and styling constraints. Use before adding any npm dependency or Node import, when touching plugin lifecycle or DOM code, when writing to vault paths, or when a feature is desktop-only.
+---
+
+# Nexus Plugin Rules & Mobile Compatibility
+
+Full guidelines: `docs/obsidian-plugin-guidelines.md`. This skill is the part that
+bites in practice.
+
+## Non-negotiable plugin rules
+
+- All styles in `styles.css` — never inline
+- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`
+- `registerDomEvent` for all DOM events, never `addEventListener` — it leaks
+- `requestUrl()` not `fetch()` for HTTP; `normalizePath()` for paths
+- `vault.adapter` is acceptable for direct storage-path access; normalize paths and
+  resolve storage roots from settings rather than hardcoding `.nexus` or `Nexus`
+- **`normalizePath()` does NOT strip `..`.** Path confinement needs an explicit
+  `assertInside`-style guard at every write/copy/remove boundary. See
+  `src/agents/apps/skills/services/skillPaths.ts` for the pattern
+  (`resolveVaultPath` / `assertInside` / `isSafePathSegment`)
+- Plugin store compliance: `isDesktopOnly: false` is correct. `VaultOperations`
+  uses `app.fileManager.trashFile()` (constructor takes `App` first)
+
+## Mobile compatibility — the critical part
+
+**`isDesktopOnly: false`** — this plugin runs on mobile, where Node.js built-ins
+(`fs`, `path`, `http`, `crypto`, `events`, `stream`, `net`, `os`, `url`, `process`,
+`buffer`) **do not exist**.
+
+**Top-level imports execute during module init, BEFORE any `Platform.isDesktop`
+guard can run.** A guard below a top-level import is decoration.
+
+| Pattern | Result on mobile |
+|---|---|
+| `import mammoth from 'mammoth'` (top level) | **Crashes plugin** — depends on `stream`, `fs` |
+| `import { EventEmitter } from 'events'` (top level) | **Crashes plugin** — null on mobile |
+| `const mammoth = await import('mammoth')` (inside async fn) | **Safe** — loads only when called |
+| `const fs = desktopRequire<typeof import('node:fs')>('node:fs')` (inside fn) | **Safe** — lazy |
+
+**Rules for new code:**
+
+1. **Never** top-level import Node built-ins — use `desktopRequire()` from
+   `src/utils/desktopRequire.ts`
+2. **Never** top-level import npm packages with Node transitive deps — use dynamic
+   `await import()` inside an async function
+3. **Replace** `EventEmitter` with Obsidian's `Events` class (cross-platform)
+4. **Desktop-only features** (ingestion, composer, OAuth, CLI, MCP transports, data
+   analysis, web tools): ensure every Node-dependent import is lazy
+
+**Known desktop-only npm packages:** mammoth, jszip, xlsx, yaml — all have Node
+transitive deps. For YAML specifically, use Obsidian's `parseYaml`/`stringifyYaml`
+instead; they are cross-platform and already available.
+
+### Vetting a new dependency
+
+Before adding one, check whether its browser entry pulls Node built-ins. Do it
+against the published package, not the README:
+
+```bash
+npm pack <pkg>@<version> && tar xzf <pkg>-<version>.tgz
+grep -rlE "require\(['\"](node:)?(fs|path|http|stream|os|crypto)['\"]\)" package/dist
+```
+
+If the hits are confined to a CLI or Node-specific entry that the browser entry
+never imports, the browser entry is safe to bundle — still import it lazily per
+rule 2. Bundle cost is worth measuring at the same time:
+
+```bash
+npx esbuild entry.mjs --bundle --minify --format=esm --platform=browser --outfile=out.js
+```
+
+Obsidian plugins ship a single `main.js`, so a lazy `import()` still lands in the
+bundle — lazy loading protects mobile *init*, it does not reduce bundle size.
+
+## Emulation does not prove mobile safety
+
+`obsidian dev:mobile on` emulates `Platform.isMobile`, touch and layout. It does
+**not** remove Node built-ins from Electron, so `require('fs')` still resolves
+there and the crash class above will **not** reproduce. Use it for UI and
+platform-branch coverage only.
+
+## pdfjs-dist in Obsidian/Electron
+
+PDF.js 5 expects a configured `workerSrc` in the Electron renderer. Use the legacy
+build with the shared loader that seeds `globalThis.pdfjsWorker`:
+
+```typescript
+// src/agents/ingestManager/tools/services/PdfJsLoader.ts
+const [pdfjsLib, pdfjsWorker] = await Promise.all([
+  import('pdfjs-dist/legacy/build/pdf.mjs'),
+  import('pdfjs-dist/legacy/build/pdf.worker.mjs'),
+]);
+if (!globalThis.pdfjsWorker) globalThis.pdfjsWorker = pdfjsWorker;
+```
+
+Use `loadPdfJs()` from `PdfJsLoader.ts` in both `PdfTextExtractor.ts` and
+`PdfPageRenderer.ts`. Do NOT `import('pdfjs-dist')` directly — the main entry fails
+in Electron without a worker URL.
+
+## Line endings
+
+`.gitattributes` declares LF canonical across `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/
+`.json`/`.md`/`.css`/`.html`/`.yml`/`.sh`. CRLF in the tree is a local-editor bug —
+fix the editor, don't chase it with tool normalization. If hundreds of files show
+modified with a tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF:
+`git add --renormalize .` on that subset, and don't let it land.

--- a/.claude/skills/nexus-mobile-compat/SKILL.md
+++ b/.claude/skills/nexus-mobile-compat/SKILL.md
@@ -11,17 +11,35 @@ bites in practice.
 ## Non-negotiable plugin rules
 
 - All styles in `styles.css` — never inline
-- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`
-- `registerDomEvent` for all DOM events, never `addEventListener` — it leaks
+- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`.
+  Only two forms are sanctioned: `el.innerHTML = ''` to clear, and *reading*
+  already-escaped content (`docs/obsidian-plugin-guidelines.md` §Security)
+- `registerDomEvent` for all DOM events, never `addEventListener` — it leaks. The
+  exception is a target Obsidian's `Component` API cannot bind (`Worker`,
+  `AbortSignal`, `window.visualViewport`); where a renderer has no `Component`,
+  the codebase uses a `component ? registerDomEvent : addEventListener` fallback
 - `requestUrl()` not `fetch()` for HTTP; `normalizePath()` for paths
 - `vault.adapter` is acceptable for direct storage-path access; normalize paths and
   resolve storage roots from settings rather than hardcoding `.nexus` or `Nexus`
-- **`normalizePath()` does NOT strip `..`.** Path confinement needs an explicit
-  `assertInside`-style guard at every write/copy/remove boundary. See
-  `src/agents/apps/skills/services/skillPaths.ts` for the pattern
-  (`resolveVaultPath` / `assertInside` / `isSafePathSegment`)
+- **`normalizePath()` does NOT strip `..`.** It collapses separators only, so a
+  `..`-bearing path handed to `vault.create()` / `adapter.write()` resolves through
+  Node's `path.join` on desktop and escapes the vault. Confinement is therefore
+  explicit, in two layers:
+  - `src/core/vaultPath.ts` — the vault-wide boundary. A branded `VaultPath` type
+    that is *only* constructible through this module: `resolveVaultPath` /
+    `tryResolveVaultPath` for untrusted caller-supplied paths (they REJECT
+    traversal, absolute and home-expansion paths), `vaultPathFromTrusted` for
+    code-controlled paths (canonicalizes, never rejects). The traversal check is
+    segment-based, not `includes('..')`, so `notes/a..b.md` still passes. Mobile-safe
+    — no Node built-ins, only `normalizePath`.
+  - `src/agents/apps/skills/services/skillPaths.ts` — the Skills-app layer:
+    `resolveVaultPath` / `assertInside` / `isSafePathSegment` (+ `SkillPathError`),
+    applied at every write/copy/remove boundary in the Skills app. ⚠️ Its
+    `resolveVaultPath` is a *different* function from the `core/vaultPath.ts` one
+    of the same name — it folds `..` rather than rejecting it. Check your import.
 - Plugin store compliance: `isDesktopOnly: false` is correct. `VaultOperations`
-  uses `app.fileManager.trashFile()` (constructor takes `App` first)
+  (`src/core/VaultOperations.ts`) uses `app.fileManager.trashFile()` and its
+  constructor takes `App` first
 
 ## Mobile compatibility — the critical part
 
@@ -46,12 +64,31 @@ guard can run.** A guard below a top-level import is decoration.
 2. **Never** top-level import npm packages with Node transitive deps — use dynamic
    `await import()` inside an async function
 3. **Replace** `EventEmitter` with Obsidian's `Events` class (cross-platform)
-4. **Desktop-only features** (ingestion, composer, OAuth, CLI, MCP transports, data
-   analysis, web tools): ensure every Node-dependent import is lazy
+4. **Node-dependent features** (ingestion, OAuth, CLI bridge, MCP transports, data
+   analysis, web tools): ensure every Node-dependent import is lazy. Only `data`
+   (data analysis) is gated out of the app registry on mobile
+   (`AppManager.getBuiltInAppRegistry`); `web-tools` registers everywhere but each
+   tool returns "desktop-only" behind an `isDesktop() && isElectron()` runtime
+   guard. Composer is *not* desktop-only — it is cross-platform and ships no
+   Node-dependent import.
 
-**Known desktop-only npm packages:** mammoth, jszip, xlsx, yaml — all have Node
-transitive deps. For YAML specifically, use Obsidian's `parseYaml`/`stringifyYaml`
-instead; they are cross-platform and already available.
+**Desktop-only npm packages in this repo:** `mammoth` and `jszip` — both runtime
+dependencies, both correctly loaded via `await import()` inside an async function
+(`DocxExtractionService.ts:29`, `PptxExtractionService.ts:36`). JSZip also has a
+static `import type JSZip` — type-only, erased at compile, harmless.
+
+For YAML, use Obsidian's `parseYaml`/`stringifyYaml`; they are cross-platform and
+already available, and are what the codebase uses throughout. The `yaml` npm
+package is a devDependency only and is imported nowhere in `src/`. `xlsx` is not a
+dependency of this project at all.
+
+**Current baseline:** `src/` has *zero* top-level Node built-in imports. Every
+runtime Node access goes through `desktopRequire()` inside a function body.
+`connector.ts` and `cli/*.ts` do import Node built-ins statically — that is correct;
+they are separate Node-targeted builds (`tsconfig.connector.json`,
+`scripts/build-cli.mjs`) and never enter `main.js`. `src/utils/connectorContent.ts`
+and `src/utils/cliAssets.ts` contain `require("net")`-style text, but only inside
+generated template-literal string constants — nothing executes.
 
 ### Vetting a new dependency
 
@@ -79,30 +116,41 @@ bundle — lazy loading protects mobile *init*, it does not reduce bundle size.
 `obsidian dev:mobile on` emulates `Platform.isMobile`, touch and layout. It does
 **not** remove Node built-ins from Electron, so `require('fs')` still resolves
 there and the crash class above will **not** reproduce. Use it for UI and
-platform-branch coverage only.
+platform-branch coverage only — never read a green `dev:mobile` run as
+"mobile-safe". See `docs/plans/obsidian-cli-verification-plan.md` §6.
 
 ## pdfjs-dist in Obsidian/Electron
 
-PDF.js 5 expects a configured `workerSrc` in the Electron renderer. Use the legacy
-build with the shared loader that seeds `globalThis.pdfjsWorker`:
+PDF.js 5 treats the Electron renderer as a browser and expects a configured
+`workerSrc`. The worker cannot be bundled or shipped as a release asset — Obsidian
+community releases may only ship `main.js` / `manifest.json` / `styles.css` — so the
+loader points `workerSrc` at a CDN copy pinned to the installed version, and
+memoizes the module promise:
 
 ```typescript
 // src/agents/ingestManager/tools/services/PdfJsLoader.ts
-const [pdfjsLib, pdfjsWorker] = await Promise.all([
-  import('pdfjs-dist/legacy/build/pdf.mjs'),
-  import('pdfjs-dist/legacy/build/pdf.worker.mjs'),
-]);
-if (!globalThis.pdfjsWorker) globalThis.pdfjsWorker = pdfjsWorker;
+async function initializePdfJs(): Promise<PdfJsModule> {
+  const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+
+  if (!pdfjsLib.GlobalWorkerOptions.workerSrc) {
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/legacy/build/pdf.worker.mjs`;
+  }
+
+  return pdfjsLib;
+}
 ```
 
 Use `loadPdfJs()` from `PdfJsLoader.ts` in both `PdfTextExtractor.ts` and
-`PdfPageRenderer.ts`. Do NOT `import('pdfjs-dist')` directly — the main entry fails
-in Electron without a worker URL.
+`PdfPageRenderer.ts` — both already do. Always the `legacy/build/pdf.mjs` entry, and
+always via the shared loader, so `workerSrc` is configured exactly once.
 
 ## Line endings
 
-`.gitattributes` declares LF canonical across `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/
-`.json`/`.md`/`.css`/`.html`/`.yml`/`.sh`. CRLF in the tree is a local-editor bug —
+`.gitattributes` sets `* text=auto eol=lf` and then declares LF explicitly across
+`.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.jsx`/`.json`/`.yml`/`.yaml`/`.toml`/`.xml`/
+`.md`/`.txt`/`.html`/`.css`/`.scss`/`.svg`/`.sh`/`.ps1`/`.bat`, with `binary`
+markers for images and `.pdf`. CRLF in the tree is a local-editor bug —
 fix the editor, don't chase it with tool normalization. If hundreds of files show
 modified with a tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF:
 `git add --renormalize .` on that subset, and don't let it land.

--- a/.claude/skills/nexus-storage/SKILL.md
+++ b/.claude/skills/nexus-storage/SKILL.md
@@ -19,32 +19,48 @@ reconstructible from JSONL — never treat it as authoritative.
 
 | Path | Contents |
 |---|---|
-| `conversations/<conversationId>/shard-*.jsonl` | conversation events |
-| `workspaces/<workspaceId>/shard-*.jsonl` | workspace/session/state/trace events |
-| `tasks/<workspaceId>/shard-*.jsonl` | task/project events |
-| `_meta/` | storage and migration manifests |
+| `conversations/conv_<conversationId>/shard-*.jsonl` | conversation events |
+| `workspaces/ws_<workspaceId>/shard-*.jsonl` | workspace/session/state/trace events |
+| `tasks/tasks_<workspaceId>/shard-*.jsonl` | task/project events |
+| `_meta/` | `storage-manifest.json`, `migration-manifest.json`, `migration-report.json` |
 
-**Legacy read paths** — read/migration fallback only, never a write target:
-`.obsidian/plugins/<plugin-folder>/data/`, compatibility plugin folders (`nexus`,
-`claudesidian-mcp`), legacy `.nexus/`, and `storage.previousRootPaths`.
+Note the stream-directory **prefixes** (`conv_`, `ws_`, `tasks_`) — repositories
+build the logical path (e.g. `ConversationRepository`, `WorkspaceRepository`,
+`TaskRepository`), and `VaultEventStore` turns each logical `<category>/<id>.jsonl`
+into a directory of `shard-NNNNNN.jsonl` files. Only three categories exist:
+`conversations | workspaces | tasks` (`EventStreamUtilities.ts`).
+
+**Legacy read paths** — read/migration fallback only, never a write target.
+`PluginScopedStorageCoordinator.prepareStoragePlan` assembles them as:
+`<configDir>/plugins/<active-plugin-folder>/data/`, compatibility plugin folders
+(`nexus`, `claudesidian-mcp`), legacy `.nexus/`, and each entry of
+`storage.previousRootPaths` suffixed with `/data`.
 
 **Local-only cache** — auto-rebuilt from JSONL, never synced:
 
 - **Desktop:** IndexedDB via `IndexedDBCacheBlobStore` — cloud-sync-immune. A
-  first-launch migration FSM upgrades existing `cache.db` installs.
+  first-launch, foreground-blocking migration FSM
+  (`CacheBackendMigration`: DETECT → READ_LEGACY → WRITE_IDB → VERIFY →
+  MARK_VERIFIED → DONE, plus a fire-and-forget janitor) upgrades existing
+  `cache.db` installs. Mobile short-circuits it (`mobile_bypass`).
 - **Mobile:** `vault.adapter` file backend via `VaultAdapterCacheBlobStore`.
-- Chosen by `src/database/storage/CacheBlobStoreFactory.ts`.
+- Chosen by `createCacheBlobStore` in
+  `src/database/storage/CacheBlobStoreFactory.ts`, on `isDesktop()`.
 
-The cloud-sync immunity is the point: a synced `cache.db` was the cause of boot
-hangs and revert incidents on Google Drive and Dropbox. Do not move cache data back
-under a synced path.
+The cloud-sync immunity is the point. The documented trigger incident
+(`docs/architecture/cloud-sync-cache-backend.md`) was a 162 MB `cache.db` inside a
+Google Drive Shared Drive conflict-copying mid-write, timing out
+`waitForQueryReady` at 60 s; the reconcile work
+(`docs/plans/sync-safe-storage-reconcile-plan.md`, `ReconcilePipeline`) handles the
+related silent-overwrite/revert pattern. Do not move cache data back under a synced
+path.
 
 ## Path resolution — never hardcode
 
 - `resolveVaultRoot(settings, { configDir })`
   (`src/database/storage/VaultRootResolver.ts:133`) for the configured synced event
   root. Never hardcode `Nexus` except as `DEFAULT_STORAGE_SETTINGS.rootPath`.
-- `resolvePluginStorageRoot()`
+- `resolvePluginStorageRoot(app, plugin)`
   (`src/database/storage/PluginStoragePathResolver.ts:26`) for plugin-scoped
   compatibility/cache paths. Never hardcode `.nexus` for new writes.
 
@@ -53,29 +69,52 @@ under a synced path.
 `CURRENT_SCHEMA_VERSION` lives in `src/database/schema/SchemaMigrator.ts:76`.
 Currently **13**.
 
+The `MIGRATIONS` array in the same file is the authority. v1→v2 and v3→v4 have no
+migration entry (v2 matched v1; v4's branch tables were fresh-install-only and are
+dropped by v5), so the array starts at v3:
+
 | Version | Added |
 |---|---|
-| v9 | 4 task tables |
-| v10 | workflow columns |
-| v11 | archive flag |
-| v12 | `shard_cursors` |
-| v13 | `skills` table |
+| v3 | `alternativesJson` + `activeAlternativeIndex` on `messages` (branching) |
+| v5 | **drops** `branches` / `branch_messages` — branches ARE conversations |
+| v6 | `dedicatedAgentId` on `workspaces` + `custom_prompts` table |
+| v7 | conversation embedding tables + denormalized `workspaceId`/`sessionId` on `conversations` |
+| v8 | `referencedNotes` on `conversation_embedding_metadata` |
+| v9 | 4 task tables: `projects`, `tasks`, `task_dependencies`, `task_note_links` |
+| v10 | workflow run columns on `conversations` (`workflowId`, `runTrigger`, `scheduledFor`, `runKey`) + a `migrationFn` backfill from `metadataJson` |
+| v11 | `isArchived` on `workspaces` |
+| v12 | `shard_cursors` table (per-file reconcile fast-path) |
+| v13 | `skills` table, `UNIQUE(provider, name)` |
 
-Adding a table means bumping `CURRENT_SCHEMA_VERSION` and adding the migration —
-the cache is rebuildable, so migrations may drop and repopulate rather than
-transform in place.
+Adding a table is the 3-step procedure documented at the top of `SchemaMigrator.ts`:
+bump `CURRENT_SCHEMA_VERSION`, append a `MIGRATIONS` entry, **and** update
+`SCHEMA_SQL` in `src/database/schema/schema.ts` so fresh installs get it too.
+Migrations are **additive and idempotent** — `CREATE TABLE IF NOT EXISTS`,
+`CREATE INDEX IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN` (the migrator skips an
+ADD COLUMN whose column already exists). Never edit an existing migration; drops,
+renames and type changes are not supported. A migration that needs data reshaped
+in JS uses the optional `migrationFn` hook (see v10).
 
-Other properties: true database pagination with OFFSET/LIMIT; workspace-scoped
-sessions and traces; searchable via the MemoryManager and SearchManager agents.
+Other properties: true database pagination with `LIMIT ? OFFSET ?`
+(`BaseRepository.queryPaginated`, `SQLiteCacheManager`); workspace-scoped sessions
+and traces (both `SessionRepository` and `TraceRepository` write the same
+`workspaces/ws_<workspaceId>` stream); searchable via the MemoryManager and
+SearchManager agents (`searchManager/tools/searchMemory.ts`).
 
 ## Migration and recovery
 
 On startup, legacy JSONL sources are read and migrated into the configured
-vault-root event store **without deleting the originals**. Two user-facing
-commands:
+vault-root event store **without deleting the originals**
+(`VaultRootMigrationService`, fed `legacyReadBasePaths` by
+`PluginScopedStorageCoordinator`). Two user-facing commands, both registered in
+`src/core/commands/MaintenanceCommandManager.ts`:
 
-- **Nexus: Refresh synced data** — for mobile users whose vault syncs after init
-- **Nexus: Rebuild cache** — recovers from a corrupted cache
+- **Nexus: Refresh synced data** (id `refresh-synced-data`) — calls
+  `adapter.sync()`; for mobile users whose vault syncs after init
+- **Nexus: Rebuild cache** (id `rebuild-cache`) — confirm-modal gated, then
+  `StorageMaintenanceService.rebuildCache`: stop autosave → close cache → remove
+  the cache blob → reinitialize → `syncCoordinator.fullRebuild()` from JSONL.
+  The synced JSONL event store is never touched.
 
 ## Traps
 
@@ -84,9 +123,17 @@ commands:
   bug came from exactly this. If a filter needs a field, denormalize it into the
   metadata rather than skipping the fetch.
 - **Hydration gates.** Reads that race startup must await the adapter's readiness
-  (`waitForQueryReady()`) or they return empty on a cold cache and render as "no
-  data" rather than "not ready".
+  (`waitForQueryReady()` — optional on `IStorageAdapter`, implemented by
+  `HybridStorageAdapter`, waiters resolved by `StartupHydrationController`) or they
+  return empty on a cold cache and render as "no data" rather than "not ready".
+  Existing gates: `TaskBoardDataController`, `TaskService`, `DualBackendExecutor`,
+  `ProjectsManagerView`.
 - **Conflict-copy patterns.** `CONFLICT_COPY_PATTERNS`
   (`src/database/migration/CacheBackendMigration.ts:12`) does not match the Dropbox
-  `cache (User's conflicted copy YYYY-MM-DD).db` form — the closing paren before
-  `.db` breaks the anchor.
+  `cache (User's conflicted copy YYYY-MM-DD).db` form. The entry is
+  `/^cache.*conflicted copy \d{4}-\d{2}-\d{2}\.db$/i`, which requires `.db`
+  immediately after the date — the closing paren breaks the anchor. Verified: the
+  full pattern list returns `false` for
+  `cache (User's conflicted copy 2026-01-01).db`, and for the very example in that
+  line's own trailing comment. The unparenthesised
+  `cache conflicted copy 2026-01-01.db` does match.

--- a/.claude/skills/nexus-storage/SKILL.md
+++ b/.claude/skills/nexus-storage/SKILL.md
@@ -1,139 +1,134 @@
 ---
 name: nexus-storage
-description: Nexus storage and memory architecture — the JSONL event store, the rebuildable SQLite cache, path resolution, cache backends, and schema migrations. Use when reading or writing persisted data, resolving a vault or plugin storage path, adding a SQLite table or migration, or debugging sync, hydration, or cache-rebuild problems.
+description: How to read, write, migrate and recover Nexus persisted data safely. Use when adding a SQLite table or column, resolving a vault or plugin storage path, writing anything that must survive a restart, or debugging sync, hydration, cold-cache or rebuild problems.
 ---
 
-# Nexus Storage & Memory
+# Working on Nexus Storage
 
-## Model
+## The model, and what it forbids
 
-**Hybrid JSONL + SQLite.** The sharded JSONL event store is the source of truth;
-SQLite is a rebuildable fast query/vector cache. Anything in SQLite must be
-reconstructible from JSONL — never treat it as authoritative.
+**The sharded JSONL event store is the source of truth. SQLite is a rebuildable
+query/vector cache.** Everything in SQLite must be reconstructible from JSONL,
+because "Nexus: Rebuild cache" deletes the cache and replays the event store.
 
-## Where data lives
+Three consequences that constrain what you may write:
 
-**Primary synced event store** — settings-derived vault root,
-`settings.storage.rootPath` (default `Nexus`), with managed data under
-`<rootPath>/data/`:
+1. **Never treat SQLite as authoritative.** A write that lands only in the cache is
+   a write that disappears on the next rebuild.
+2. **Never hardcode a storage root.** Resolve it — the root is a user setting, and
+   the plugin folder name varies by install.
+3. **Never assume the cache is warm.** On a cold start the cache is empty while the
+   event store is fine; a read that does not wait reports "no data" for data that
+   exists.
 
-| Path | Contents |
-|---|---|
-| `conversations/conv_<conversationId>/shard-*.jsonl` | conversation events |
-| `workspaces/ws_<workspaceId>/shard-*.jsonl` | workspace/session/state/trace events |
-| `tasks/tasks_<workspaceId>/shard-*.jsonl` | task/project events |
-| `_meta/` | `storage-manifest.json`, `migration-manifest.json`, `migration-report.json` |
+## Find where data actually lives
 
-Note the stream-directory **prefixes** (`conv_`, `ws_`, `tasks_`) — repositories
-build the logical path (e.g. `ConversationRepository`, `WorkspaceRepository`,
-`TaskRepository`), and `VaultEventStore` turns each logical `<category>/<id>.jsonl`
-into a directory of `shard-NNNNNN.jsonl` files. Only three categories exist:
-`conversations | workspaces | tasks` (`EventStreamUtilities.ts`).
+Ask the tree rather than trusting a path written down anywhere:
 
-**Legacy read paths** — read/migration fallback only, never a write target.
-`PluginScopedStorageCoordinator.prepareStoragePlan` assembles them as:
-`<configDir>/plugins/<active-plugin-folder>/data/`, compatibility plugin folders
-(`nexus`, `claudesidian-mcp`), legacy `.nexus/`, and each entry of
-`storage.previousRootPaths` suffixed with `/data`.
+```bash
+grep -rn "resolveVaultRoot\|resolvePluginStorageRoot" src/database/storage/
+grep -rn "streamPath\|<category>" src/database/storage/EventStreamUtilities.ts
+```
 
-**Local-only cache** — auto-rebuilt from JSONL, never synced:
+Stream directories are **prefixed** — the logical id is not the directory name.
+Repositories build a logical `<category>/<id>` path and the event store turns it
+into a directory of shard files. If a glob finds nothing, check the prefix before
+concluding the data is missing.
 
-- **Desktop:** IndexedDB via `IndexedDBCacheBlobStore` — cloud-sync-immune. A
-  first-launch, foreground-blocking migration FSM
-  (`CacheBackendMigration`: DETECT → READ_LEGACY → WRITE_IDB → VERIFY →
-  MARK_VERIFIED → DONE, plus a fire-and-forget janitor) upgrades existing
-  `cache.db` installs. Mobile short-circuits it (`mobile_bypass`).
-- **Mobile:** `vault.adapter` file backend via `VaultAdapterCacheBlobStore`.
-- Chosen by `createCacheBlobStore` in
-  `src/database/storage/CacheBlobStoreFactory.ts`, on `isDesktop()`.
+Path resolution has exactly two entry points, and which you want depends on the
+data: `resolveVaultRoot(settings, { configDir })` for the configured synced event
+root, `resolvePluginStorageRoot(app, plugin)` for plugin-scoped compatibility and
+cache paths. Legacy locations are read/migration fallbacks only and must never be a
+write target.
 
-The cloud-sync immunity is the point. The documented trigger incident
-(`docs/architecture/cloud-sync-cache-backend.md`) was a 162 MB `cache.db` inside a
-Google Drive Shared Drive conflict-copying mid-write, timing out
-`waitForQueryReady` at 60 s; the reconcile work
-(`docs/plans/sync-safe-storage-reconcile-plan.md`, `ReconcilePipeline`) handles the
-related silent-overwrite/revert pattern. Do not move cache data back under a synced
-path.
+## Add a SQLite table or column
 
-## Path resolution — never hardcode
+This is the procedure most likely to cause real damage if done from memory. The
+authoritative rules are in the header comment at the top of `SchemaMigrator.ts` —
+read it before writing a migration.
 
-- `resolveVaultRoot(settings, { configDir })`
-  (`src/database/storage/VaultRootResolver.ts:133`) for the configured synced event
-  root. Never hardcode `Nexus` except as `DEFAULT_STORAGE_SETTINGS.rootPath`.
-- `resolvePluginStorageRoot(app, plugin)`
-  (`src/database/storage/PluginStoragePathResolver.ts:26`) for plugin-scoped
-  compatibility/cache paths. Never hardcode `.nexus` for new writes.
+**Three steps, not two:**
 
-## SQLite schema
+1. Bump `CURRENT_SCHEMA_VERSION` in `SchemaMigrator.ts`
+2. Append an entry to the `MIGRATIONS` array in the same file
+3. **Update `SCHEMA_SQL` in `src/database/schema/schema.ts`** so fresh installs get
+   it too
 
-`CURRENT_SCHEMA_VERSION` lives in `src/database/schema/SchemaMigrator.ts:76`.
-Currently **13**.
+**Migrations are additive and idempotent.** `CREATE TABLE IF NOT EXISTS`,
+`CREATE INDEX IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN` (the migrator skips an ADD
+COLUMN whose column already exists). **Never edit an existing migration.** Drops,
+renames and type changes are not supported — if you need data reshaped in JS, use
+the optional `migrationFn` hook rather than reaching for DDL that destroys.
 
-The `MIGRATIONS` array in the same file is the authority. v1→v2 and v3→v4 have no
-migration entry (v2 matched v1; v4's branch tables were fresh-install-only and are
-dropped by v5), so the array starts at v3:
+**Verify both paths, because they fail independently:**
 
-| Version | Added |
-|---|---|
-| v3 | `alternativesJson` + `activeAlternativeIndex` on `messages` (branching) |
-| v5 | **drops** `branches` / `branch_messages` — branches ARE conversations |
-| v6 | `dedicatedAgentId` on `workspaces` + `custom_prompts` table |
-| v7 | conversation embedding tables + denormalized `workspaceId`/`sessionId` on `conversations` |
-| v8 | `referencedNotes` on `conversation_embedding_metadata` |
-| v9 | 4 task tables: `projects`, `tasks`, `task_dependencies`, `task_note_links` |
-| v10 | workflow run columns on `conversations` (`workflowId`, `runTrigger`, `scheduledFor`, `runKey`) + a `migrationFn` backfill from `metadataJson` |
-| v11 | `isArchived` on `workspaces` |
-| v12 | `shard_cursors` table (per-file reconcile fast-path) |
-| v13 | `skills` table, `UNIQUE(provider, name)` |
+- **Upgrade:** open an existing vault and confirm the migration ran and the column
+  or table is present.
+- **Fresh install:** delete the cache (or use a clean vault), let it build from
+  `SCHEMA_SQL`, and confirm the same shape.
 
-Adding a table is the 3-step procedure documented at the top of `SchemaMigrator.ts`:
-bump `CURRENT_SCHEMA_VERSION`, append a `MIGRATIONS` entry, **and** update
-`SCHEMA_SQL` in `src/database/schema/schema.ts` so fresh installs get it too.
-Migrations are **additive and idempotent** — `CREATE TABLE IF NOT EXISTS`,
-`CREATE INDEX IF NOT EXISTS`, `ALTER TABLE … ADD COLUMN` (the migrator skips an
-ADD COLUMN whose column already exists). Never edit an existing migration; drops,
-renames and type changes are not supported. A migration that needs data reshaped
-in JS uses the optional `migrationFn` hook (see v10).
+Skipping step 3 is invisible on any dev machine that already has a cache — the
+upgrade path works, and only new users get a broken schema.
 
-Other properties: true database pagination with `LIMIT ? OFFSET ?`
-(`BaseRepository.queryPaginated`, `SQLiteCacheManager`); workspace-scoped sessions
-and traces (both `SessionRepository` and `TraceRepository` write the same
-`workspaces/ws_<workspaceId>` stream); searchable via the MemoryManager and
-SearchManager agents (`searchManager/tools/searchMemory.ts`).
+## Recover and rebuild
 
-## Migration and recovery
-
-On startup, legacy JSONL sources are read and migrated into the configured
-vault-root event store **without deleting the originals**
-(`VaultRootMigrationService`, fed `legacyReadBasePaths` by
-`PluginScopedStorageCoordinator`). Two user-facing commands, both registered in
+Two user-facing commands, both registered in
 `src/core/commands/MaintenanceCommandManager.ts`:
 
-- **Nexus: Refresh synced data** (id `refresh-synced-data`) — calls
-  `adapter.sync()`; for mobile users whose vault syncs after init
-- **Nexus: Rebuild cache** (id `rebuild-cache`) — confirm-modal gated, then
-  `StorageMaintenanceService.rebuildCache`: stop autosave → close cache → remove
-  the cache blob → reinitialize → `syncCoordinator.fullRebuild()` from JSONL.
-  The synced JSONL event store is never touched.
+- **Nexus: Refresh synced data** — re-reads the event store; for vaults that sync
+  after init
+- **Nexus: Rebuild cache** — stops autosave, closes and removes the cache blob,
+  reinitializes, and replays from JSONL. The synced event store is never touched.
 
-## Traps
+Rebuild is the correct answer to a corrupted or suspect cache, and it is safe by
+design. If rebuilding loses something, that something was only ever in the cache —
+which is the bug.
 
-- **Denormalize before you shortcut.** A metadata fast-path that skips the JSONL
-  content fetch will miss fields that live only in content — an archive-visibility
-  bug came from exactly this. If a filter needs a field, denormalize it into the
-  metadata rather than skipping the fetch.
-- **Hydration gates.** Reads that race startup must await the adapter's readiness
-  (`waitForQueryReady()` — optional on `IStorageAdapter`, implemented by
-  `HybridStorageAdapter`, waiters resolved by `StartupHydrationController`) or they
-  return empty on a cold cache and render as "no data" rather than "not ready".
-  Existing gates: `TaskBoardDataController`, `TaskService`, `DualBackendExecutor`,
-  `ProjectsManagerView`.
-- **Conflict-copy patterns.** `CONFLICT_COPY_PATTERNS`
-  (`src/database/migration/CacheBackendMigration.ts:12`) does not match the Dropbox
-  `cache (User's conflicted copy YYYY-MM-DD).db` form. The entry is
-  `/^cache.*conflicted copy \d{4}-\d{2}-\d{2}\.db$/i`, which requires `.db`
-  immediately after the date — the closing paren breaks the anchor. Verified: the
-  full pattern list returns `false` for
-  `cache (User's conflicted copy 2026-01-01).db`, and for the very example in that
-  line's own trailing comment. The unparenthesised
-  `cache conflicted copy 2026-01-01.db` does match.
+## Gotchas
+
+**"The migration works on my machine but new installs are broken."** You updated
+`MIGRATIONS` and forgot `SCHEMA_SQL`. Upgraders get the table, fresh installs never
+do, and no dev machine with an existing cache will show it.
+
+**"I need to drop a column / change a type."** Not supported. Migrations are
+additive; reshape in JS via `migrationFn`, or add a new column and leave the old one
+alone.
+
+**"My data came back after a rebuild / vanished after a rebuild."** Something is
+writing to SQLite without a corresponding event, or reading a field that only exists
+in the cache. Write through the repository, not the cache.
+
+**"The view says 'no tasks' but the data is there."** A read raced startup. Await
+the adapter's readiness (`waitForQueryReady()` — optional on `IStorageAdapter`,
+implemented by `HybridStorageAdapter`) before querying, as
+`TaskBoardDataController`, `TaskService`, `DualBackendExecutor` and
+`ProjectsManagerView` do. Without it a cold cache renders as "no data" rather than
+"not ready".
+
+**"A filter silently misses records that obviously match."** A metadata fast-path
+skipped the JSONL content fetch, and the field being filtered on lives only in
+content. An archive-visibility bug came from exactly this. If a filter needs a
+field, denormalize it into the metadata — do not skip the fetch.
+
+**"My glob over the event store finds nothing."** Stream directories carry a
+category prefix; the bare id is not the directory name. Check
+`EventStreamUtilities.ts`.
+
+**"Boot hangs, or the cache keeps getting corrupted."** The cache must never live
+under a cloud-synced path — that is the entire reason desktop uses IndexedDB and
+mobile uses the vault adapter, chosen by `createCacheBlobStore`. The documented
+trigger was a large `cache.db` inside a Google Drive Shared Drive conflict-copying
+mid-write and timing out hydration. See
+`docs/architecture/cloud-sync-cache-backend.md`. Do not move cache data back under a
+synced path.
+
+**"A conflict copy was not recognised."** `CONFLICT_COPY_PATTERNS` in
+`CacheBackendMigration.ts` does not match the parenthesised Dropbox form — tracked
+in [#334](https://github.com/ProfSynapse/nexus/issues/334). If you touch that list,
+verify by *running* the patterns against real filenames; the example in one
+pattern's own trailing comment does not match the pattern it annotates, which is how
+the gap survived review.
+
+**"I hardcoded the storage root and it works fine."** It works on your vault. The
+root is a user setting with a default, and legacy installs use different plugin
+folder names. Use the resolvers.

--- a/.claude/skills/nexus-storage/SKILL.md
+++ b/.claude/skills/nexus-storage/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: nexus-storage
+description: Nexus storage and memory architecture — the JSONL event store, the rebuildable SQLite cache, path resolution, cache backends, and schema migrations. Use when reading or writing persisted data, resolving a vault or plugin storage path, adding a SQLite table or migration, or debugging sync, hydration, or cache-rebuild problems.
+---
+
+# Nexus Storage & Memory
+
+## Model
+
+**Hybrid JSONL + SQLite.** The sharded JSONL event store is the source of truth;
+SQLite is a rebuildable fast query/vector cache. Anything in SQLite must be
+reconstructible from JSONL — never treat it as authoritative.
+
+## Where data lives
+
+**Primary synced event store** — settings-derived vault root,
+`settings.storage.rootPath` (default `Nexus`), with managed data under
+`<rootPath>/data/`:
+
+| Path | Contents |
+|---|---|
+| `conversations/<conversationId>/shard-*.jsonl` | conversation events |
+| `workspaces/<workspaceId>/shard-*.jsonl` | workspace/session/state/trace events |
+| `tasks/<workspaceId>/shard-*.jsonl` | task/project events |
+| `_meta/` | storage and migration manifests |
+
+**Legacy read paths** — read/migration fallback only, never a write target:
+`.obsidian/plugins/<plugin-folder>/data/`, compatibility plugin folders (`nexus`,
+`claudesidian-mcp`), legacy `.nexus/`, and `storage.previousRootPaths`.
+
+**Local-only cache** — auto-rebuilt from JSONL, never synced:
+
+- **Desktop:** IndexedDB via `IndexedDBCacheBlobStore` — cloud-sync-immune. A
+  first-launch migration FSM upgrades existing `cache.db` installs.
+- **Mobile:** `vault.adapter` file backend via `VaultAdapterCacheBlobStore`.
+- Chosen by `src/database/storage/CacheBlobStoreFactory.ts`.
+
+The cloud-sync immunity is the point: a synced `cache.db` was the cause of boot
+hangs and revert incidents on Google Drive and Dropbox. Do not move cache data back
+under a synced path.
+
+## Path resolution — never hardcode
+
+- `resolveVaultRoot(settings, { configDir })`
+  (`src/database/storage/VaultRootResolver.ts:133`) for the configured synced event
+  root. Never hardcode `Nexus` except as `DEFAULT_STORAGE_SETTINGS.rootPath`.
+- `resolvePluginStorageRoot()`
+  (`src/database/storage/PluginStoragePathResolver.ts:26`) for plugin-scoped
+  compatibility/cache paths. Never hardcode `.nexus` for new writes.
+
+## SQLite schema
+
+`CURRENT_SCHEMA_VERSION` lives in `src/database/schema/SchemaMigrator.ts:76`.
+Currently **13**.
+
+| Version | Added |
+|---|---|
+| v9 | 4 task tables |
+| v10 | workflow columns |
+| v11 | archive flag |
+| v12 | `shard_cursors` |
+| v13 | `skills` table |
+
+Adding a table means bumping `CURRENT_SCHEMA_VERSION` and adding the migration —
+the cache is rebuildable, so migrations may drop and repopulate rather than
+transform in place.
+
+Other properties: true database pagination with OFFSET/LIMIT; workspace-scoped
+sessions and traces; searchable via the MemoryManager and SearchManager agents.
+
+## Migration and recovery
+
+On startup, legacy JSONL sources are read and migrated into the configured
+vault-root event store **without deleting the originals**. Two user-facing
+commands:
+
+- **Nexus: Refresh synced data** — for mobile users whose vault syncs after init
+- **Nexus: Rebuild cache** — recovers from a corrupted cache
+
+## Traps
+
+- **Denormalize before you shortcut.** A metadata fast-path that skips the JSONL
+  content fetch will miss fields that live only in content — an archive-visibility
+  bug came from exactly this. If a filter needs a field, denormalize it into the
+  metadata rather than skipping the fetch.
+- **Hydration gates.** Reads that race startup must await the adapter's readiness
+  (`waitForQueryReady()`) or they return empty on a cold cache and render as "no
+  data" rather than "not ready".
+- **Conflict-copy patterns.** `CONFLICT_COPY_PATTERNS`
+  (`src/database/migration/CacheBackendMigration.ts:12`) does not match the Dropbox
+  `cache (User's conflicted copy YYYY-MM-DD).db` form — the closing paren before
+  `.db` breaks the anchor.

--- a/.claude/skills/nexus-testing/SKILL.md
+++ b/.claude/skills/nexus-testing/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: nexus-testing
+description: How Nexus is tested — Jest unit lanes, env-gated live smoke tests against a real vault, and the methodology rules that came out of defects which shipped past a green suite. Use when adding tests, when a change touches search ranking or tool discovery, when a mock might be hiding a real behaviour, or when deciding whether a unit test can actually prove something.
+---
+
+# Nexus Testing
+
+## Lanes
+
+| Lane | How | Scope |
+|---|---|---|
+| Unit | `npm run test` (Jest, ~346 files under `tests/`) | Core logic and services |
+| Live smoke | env-gated, `--runInBand` | Real vault through the real `nexus` CLI |
+| LLM eval | `RUN_EVAL=1`, skills `nexus-model-eval` / `nexus-eval-harness` | Grades two-tool MCP usage |
+| Integration | Manual in Obsidian | Anything only observable in the running app |
+
+## The core lesson: a green suite is not proof
+
+Three search-ranking defects (#309, #313, #314) shipped past a green unit suite.
+Every one was caught by searching a real vault. The suite could only prove the tiers
+were ordered consistently *with a mocked scorer* — it could not know whether real
+filenames look like the fixtures, or whether real Obsidian scores the way the mock
+does.
+
+Two habits follow.
+
+### Ask what the mock is deciding
+
+If a mock supplies the values the assertion depends on, the test proves the mock is
+self-consistent and nothing more. Two live examples worth knowing:
+
+- **`prepareFuzzySearch` mock** (`tests/mocks/obsidian/core.ts`) charges a small
+  per-discontiguity penalty **capped at 8**. That cap reproduces the reason the
+  original bug existed. **Do not make it proportional** — the tests go vacuous.
+- **The scripted `getTools` mock in the eval harness is selector-insensitive** — it
+  returns the same blob for every call. A scenario exposing only some agents makes a
+  model conclude discovery is broken and loop `getTools` forever at temperature 0.
+  Expose every agent a scenario could plausibly need.
+
+### Prove the ordering isn't accidental
+
+`tests/unit/SearchContentTool.test.ts` runs every ranking assertion **twice**, with
+the vault enumerated in both orders, and fails loudly if the order decides the
+result. A tie is not a ranking rule. Apply the same treatment anywhere enumeration
+order could masquerade as ranking.
+
+## Live smoke lanes
+
+Pattern to copy — `tests/debug/search-ranking-live-smoke.test.ts`:
+
+```
+RUN_SEARCH_SMOKE=1 npx jest tests/debug/search-ranking-live-smoke.test.ts --runInBand --no-coverage
+```
+
+Conventions: env-gated so the lane is inert by default and never a CI dependency;
+`--runInBand`; a header explaining what the mocks cannot cover; writes confined to a
+dedicated scratch folder and cleaned up afterwards; never touches anything else in
+the vault.
+
+Other live lanes live beside it in `tests/debug/` (provider model smoke, video
+generation, codex ping-pong).
+
+## Search ranking invariant
+
+`src/agents/searchManager/tools/searchContent.ts` is a **single-scale tier ladder**:
+
+```
+TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8
+> PARTIAL_MATCH_FLOOR 0.3 > FUZZY_ONLY_CEILING 0.25
+```
+
+**Never reintroduce a second scale.** Filename fuzzy used to be normalized to
+`1 + score/100` (~0.92–0.95), an incommensurable scale that let a coincidental
+filename beat a verbatim body match. `foldSeparators()` folds `-`/`_` to spaces on
+both sides so a kebab filename matches a spaced query. Results carry
+`matchType: 'content' | 'path' | 'semantic'`.
+
+## Eval harness knobs
+
+`tests/eval/`, plan at `docs/plans/llm-eval-harness-plan.md`.
+
+| Knob | Effect |
+|---|---|
+| `EVAL_SCENARIO_NAMES=a,b,c` | Targeted retest |
+| `EVAL_CONCURRENCY` | **Defaults to serial=1** — local single-slot servers 500-storm under fan-out |
+| `EVAL_TEMP` | Overrides default temperature (per-scenario `temperature:` still wins) |
+| `EVAL_TEST_TIMEOUT_MS` | Jest timeout; scales with serial lane count |
+| `EVAL_ENFORCE_CONTEXT=1` | Enforces the context contract |
+
+Per-case progress streams to `test-artifacts/eval-progress-<ts>.log`, and reports
+save incrementally so a mid-run timeout still produces JSON + MD. Scenarios with
+known fixture bugs can set `excludeFromBoard: true` to run without scoring.
+
+## Shipped-docs gate
+
+`tests/unit/shippedGuidanceCommands.test.ts` fails when shipped guidance names a
+tool that does not exist. If you rename or remove a tool slug, that test is where it
+surfaces — update the shipped guidance in `src/utils/cliAssets.ts` and regenerate
+schemas with `npm run schemas:tools`.

--- a/.claude/skills/nexus-testing/SKILL.md
+++ b/.claude/skills/nexus-testing/SKILL.md
@@ -9,10 +9,19 @@ description: How Nexus is tested — Jest unit lanes, env-gated live smoke tests
 
 | Lane | How | Scope |
 |---|---|---|
-| Unit | `npm run test` (Jest, ~346 files under `tests/`) | Core logic and services |
+| Unit | `npm run test` (Jest) — `tests/unit/` holds 315 of the 346 `*.test.ts` files | Core logic and services |
 | Live smoke | env-gated, `--runInBand` | Real vault through the real `nexus` CLI |
 | LLM eval | `RUN_EVAL=1`, skills `nexus-model-eval` / `nexus-eval-harness` | Grades two-tool MCP usage |
-| Integration | Manual in Obsidian | Anything only observable in the running app |
+| Integration | `tests/integration/` (Jest, some live-gated) | Cache backend, migrations, tool continuation |
+| Manual | `tests/manual/*.md` — scripts, not Jest | Anything only observable in the running Obsidian app |
+
+Jest config is `roots: ['<rootDir>/tests']` + `testMatch: ['**/*.test.ts']`, so
+`npm run test` picks up **every** lane; the live smoke tests make themselves inert
+with `describe.skip` and `eval.test.ts` degrades to a single "skips — no API keys
+configured" case unless the gate is set. Other directories under `tests/`:
+`integration` (11), `debug` (5), `eval` (3, of which the executor-recovery and
+`headless/` smoke tests always run), `core` (2), `agents/*` (7), `services/*` (2),
+`perf` (1). `npm run test:coverage` runs Jest with a global 80% threshold.
 
 ## The core lesson: a green suite is not proof
 
@@ -32,17 +41,24 @@ self-consistent and nothing more. Two live examples worth knowing:
 - **`prepareFuzzySearch` mock** (`tests/mocks/obsidian/core.ts`) charges a small
   per-discontiguity penalty **capped at 8**. That cap reproduces the reason the
   original bug existed. **Do not make it proportional** — the tests go vacuous.
-- **The scripted `getTools` mock in the eval harness is selector-insensitive** — it
-  returns the same blob for every call. A scenario exposing only some agents makes a
-  model conclude discovery is broken and loop `getTools` forever at temperature 0.
-  Expose every agent a scenario could plausibly need.
+- **A scenario-scripted `getTools` mock is selector-insensitive** — a scenario's
+  `mockResponses` entry becomes a handler built by `registerStaticResponse`
+  (`tests/eval/EvalToolExecutor.ts`), whose body ignores its `_args` and returns the
+  same blob for every call. A scenario exposing only some agents makes a model
+  conclude discovery is broken and loop `getTools` forever at temperature 0. Expose
+  every agent a scenario could plausibly need. (Only the scripted path is blind: with
+  no scripted mock, `handleGetTools` auto-generates schemas and *does* filter
+  `domainTools` by the requested selectors.)
 
 ### Prove the ordering isn't accidental
 
-`tests/unit/SearchContentTool.test.ts` runs every ranking assertion **twice**, with
-the vault enumerated in both orders, and fails loudly if the order decides the
-result. A tie is not a ranking rule. Apply the same treatment anywhere enumeration
-order could masquerade as ranking.
+`tests/unit/SearchContentTool.test.ts` routes every ranking assertion through a
+`rank()` helper that executes the tool **twice** — once with the fixtures forwards,
+once with `[...files].reverse()` — and throws if the two result orders differ. A tie
+is not a ranking rule. The helper is the only way the tests obtain results, so the
+guarantee cannot be bypassed by adding a case; a self-test at the bottom of the file
+asserts the helper actually rejects a tie (`/decided by enumeration order/`). Apply
+the same treatment anywhere enumeration order could masquerade as ranking.
 
 ## Live smoke lanes
 
@@ -52,13 +68,24 @@ Pattern to copy — `tests/debug/search-ranking-live-smoke.test.ts`:
 RUN_SEARCH_SMOKE=1 npx jest tests/debug/search-ranking-live-smoke.test.ts --runInBand --no-coverage
 ```
 
-Conventions: env-gated so the lane is inert by default and never a CI dependency;
-`--runInBand`; a header explaining what the mocks cannot cover; writes confined to a
-dedicated scratch folder and cleaned up afterwards; never touches anything else in
-the vault.
+Conventions: env-gated (`describe.skip` unless `RUN_SEARCH_SMOKE === '1'`) so the
+lane is inert by default and never a CI dependency; `--runInBand`; a header
+explaining what the mocks cannot cover; writes confined to a dedicated scratch folder
+(`_search-ranking-smoke`) which `afterAll` clears with `storage archive` — archive,
+not delete, because the AI surface has no delete by design; never touches anything
+else in the vault. `SEARCH_SMOKE_VAULT=<name>` picks a vault, otherwise the CLI
+default is used.
 
-Other live lanes live beside it in `tests/debug/` (provider model smoke, video
-generation, codex ping-pong).
+Other live lanes and their gates:
+
+| Test | Gate |
+|---|---|
+| `tests/debug/provider-model-live-smoke.test.ts` | `RUN_MODEL_SMOKE=1` |
+| `tests/debug/video-generation-live-smoke.test.ts` | `RUN_LIVE_VIDEO_SMOKE=1` (+ `RUN_PAID_VIDEO_SMOKE=1` for paid calls) |
+| `tests/debug/codex-live-tool-pingpong.test.ts` | `RUN_CODEX_LIVE_TOOL_PINGPONG=1` + live tokens |
+| `tests/debug/intelligence-curse-repro.test.ts` | presence of a JSONL fixture (`DEBUG_REPRO_JSONL`) |
+| `tests/integration/transcription-live.test.ts` | `RUN_LIVE_TRANSCRIPTION_TESTS=1` + per-provider API keys |
+| `tests/integration/tool-continuation-live.test.ts` | `OPENROUTER_API_KEY` present |
 
 ## Search ranking invariant
 
@@ -71,9 +98,13 @@ TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8
 
 **Never reintroduce a second scale.** Filename fuzzy used to be normalized to
 `1 + score/100` (~0.92–0.95), an incommensurable scale that let a coincidental
-filename beat a verbatim body match. `foldSeparators()` folds `-`/`_` to spaces on
-both sides so a kebab filename matches a spaced query. Results carry
-`matchType: 'content' | 'path' | 'semantic'`.
+filename beat a verbatim body match. `foldSeparators()` lowercases and folds runs of
+`-`/`_` to single spaces, and is applied to **both sides of the filename comparison**
+(the query and the filename) so a kebab filename matches a spaced query — never to
+note bodies, which stay byte-exact so the snippet offsets keep pointing at real text.
+Results carry `matchType`, whose type is
+`export type SearchMatchType = 'content' | 'path' | 'semantic'`; the tool assigns
+`content` when the body scored above zero, otherwise `path`.
 
 ## Eval harness knobs
 
@@ -81,19 +112,39 @@ both sides so a kebab filename matches a spaced query. Results carry
 
 | Knob | Effect |
 |---|---|
-| `EVAL_SCENARIO_NAMES=a,b,c` | Targeted retest |
-| `EVAL_CONCURRENCY` | **Defaults to serial=1** — local single-slot servers 500-storm under fan-out |
-| `EVAL_TEMP` | Overrides default temperature (per-scenario `temperature:` still wins) |
-| `EVAL_TEST_TIMEOUT_MS` | Jest timeout; scales with serial lane count |
-| `EVAL_ENFORCE_CONTEXT=1` | Enforces the context contract |
+| `RUN_EVAL=1` | Required to run at all — and at least one provider must have its key env var set, or the suite still skips |
+| `EVAL_SCENARIO_NAMES=a,b,c` | Targeted retest (comma-separated, overrides `config.scenarioNames`) |
+| `EVAL_CONCURRENCY=N` | Override the dispatch width. **The default is per-matrix, not a flat 1**: `resolveConcurrency` returns `1` only when a local provider (`ollama`, `lmstudio`) is in the matrix, otherwise `Infinity`. Local single-slot servers 500-storm under fan-out |
+| `EVAL_TEMP` | Overrides `defaults.temperature` (per-scenario `temperature:` still wins) |
+| `EVAL_TEST_TIMEOUT_MS` | Jest timeout; the computed default scales the per-case budget by the estimated serial lane count |
+| `EVAL_ENFORCE_CONTEXT=1` | Enforces the context contract globally (a scenario can also opt in with `enforceContextContract: true`) |
 
-Per-case progress streams to `test-artifacts/eval-progress-<ts>.log`, and reports
-save incrementally so a mid-run timeout still produces JSON + MD. Scenarios with
-known fixture bugs can set `excludeFromBoard: true` to run without scoring.
+Per-case progress streams to `<artifactsDir>/eval-progress-<ISO-timestamp>.log`
+(`artifactsDir` defaults to `test-artifacts/`) — `tail -f`-able during a slow local
+run. Results are pushed into `allResults` incrementally as each scenario finishes,
+and `afterAll` saves whatever is there, so a mid-run timeout still produces JSON + MD.
+Scenarios with known fixture bugs can set `excludeFromBoard: true`; the runner stamps
+`excludedFromBoard` on the result and `ReportGenerator` runs and reports them but
+skips them when scoring the board.
 
 ## Shipped-docs gate
 
-`tests/unit/shippedGuidanceCommands.test.ts` fails when shipped guidance names a
-tool that does not exist. If you rename or remove a tool slug, that test is where it
-surfaces — update the shipped guidance in `src/utils/cliAssets.ts` and regenerate
-schemas with `npm run schemas:tools`.
+`tests/unit/shippedGuidanceCommands.test.ts` validates every tool command we ship as
+guidance against the generated catalog `cli-first-tool-schemas.json` (repo root). It
+reads `README.md`, `skill/SKILL.md`, `cli/nexus-cli.ts`, `cli/agents-snippet.md`,
+`skill/playbooks/*.md` and `guide/*.md`, and fails on: an unknown agent, tool or
+flag; a playbook `tools:` selector that resolves to nothing; a tool named in the
+`guide/apps.md` Apps table that matches no `slug:` declared under `src/agents/**`
+(apps are opt-in, so those are checked against source rather than the catalog
+snapshot); a missing required argument in a *complete*
+copy-pasteable `nexus use … -- <cmd>` example; a broken relative doc link; and an
+embedded `--prompts` payload that violates the `executePrompts` item contract.
+
+So if you rename or remove a tool slug, fix the **source** guidance files above —
+`src/utils/cliAssets.ts` is generated from `skill/SKILL.md`, `cli/agents-snippet.md`
+and the playbooks by `scripts/generate-cli-content.mjs` during `npm run build`, and
+must never be hand-edited. Refreshing the catalog needs a running vault (the
+`/nexus-tool-schemas` skill); note `npm run schemas:tools` writes to
+`docs/generated/cli-first-tool-schemas.json` by default, not the repo-root file this
+test reads — pass `--output cli-first-tool-schemas.json` to update that one. A stale
+catalog also surfaces as a drift failure in `tests/unit/ToolManagerCliSyntax.test.ts`.

--- a/.claude/skills/nexus-testing/SKILL.md
+++ b/.claude/skills/nexus-testing/SKILL.md
@@ -1,150 +1,140 @@
 ---
 name: nexus-testing
-description: How Nexus is tested — Jest unit lanes, env-gated live smoke tests against a real vault, and the methodology rules that came out of defects which shipped past a green suite. Use when adding tests, when a change touches search ranking or tool discovery, when a mock might be hiding a real behaviour, or when deciding whether a unit test can actually prove something.
+description: How to write a Nexus test that can actually fail, pick the right lane, run the live and eval lanes, and fix a shipped-docs drift failure. Use when adding tests, when a mock might be deciding the outcome, when a change touches search ranking or tool discovery, or when the guidance gate fails.
 ---
 
-# Nexus Testing
+# Testing Nexus
 
-## Lanes
+## Pick the lane
 
-| Lane | How | Scope |
+| Lane | Where | For |
 |---|---|---|
-| Unit | `npm run test` (Jest) — `tests/unit/` holds 315 of the 346 `*.test.ts` files | Core logic and services |
-| Live smoke | env-gated, `--runInBand` | Real vault through the real `nexus` CLI |
-| LLM eval | `RUN_EVAL=1`, skills `nexus-model-eval` / `nexus-eval-harness` | Grades two-tool MCP usage |
-| Integration | `tests/integration/` (Jest, some live-gated) | Cache backend, migrations, tool continuation |
-| Manual | `tests/manual/*.md` — scripts, not Jest | Anything only observable in the running Obsidian app |
+| Unit | `tests/unit/` | Logic that can be proven with fakes |
+| Integration | `tests/integration/` | Cache backend, migrations, tool continuation |
+| Live smoke | `tests/debug/` | Behaviour only the real dependency exhibits |
+| LLM eval | `tests/eval/` | How well a model drives the two-tool protocol |
+| Manual | `tests/manual/*.md` | Scripts for what only the running app shows |
 
-Jest config is `roots: ['<rootDir>/tests']` + `testMatch: ['**/*.test.ts']`, so
-`npm run test` picks up **every** lane; the live smoke tests make themselves inert
-with `describe.skip` and `eval.test.ts` degrades to a single "skips — no API keys
-configured" case unless the gate is set. Other directories under `tests/`:
-`integration` (11), `debug` (5), `eval` (3, of which the executor-recovery and
-`headless/` smoke tests always run), `core` (2), `agents/*` (7), `services/*` (2),
-`perf` (1). `npm run test:coverage` runs Jest with a global 80% threshold.
+Jest is configured with `roots: ['<rootDir>/tests']` and `testMatch: ['**/*.test.ts']`,
+so `npm run test` picks up **every** lane. The live and eval lanes make themselves
+inert when their gate is unset — that is a property of each test file, not of the
+runner, so a new live test must opt out explicitly or it will run in CI.
 
-## The core lesson: a green suite is not proof
+## Write a test that can actually fail
 
-Three search-ranking defects (#309, #313, #314) shipped past a green unit suite.
-Every one was caught by searching a real vault. The suite could only prove the tiers
-were ordered consistently *with a mocked scorer* — it could not know whether real
-filenames look like the fixtures, or whether real Obsidian scores the way the mock
-does.
+Three ranking defects shipped past a green suite. Every one was caught by searching
+a real vault. The suite could only prove the tiers were ordered consistently *with a
+mocked scorer* — it could not know whether real data looks like the fixtures.
 
 Two habits follow.
 
-### Ask what the mock is deciding
+**Ask what the mock is deciding.** If the mock supplies the values your assertion
+depends on, the test proves the mock is self-consistent and nothing more. Before
+writing the assertion, ask: if the real dependency behaved differently, would this
+test notice? If not, the test belongs in a live lane, or the mock needs to reproduce
+the *shape* of the real behaviour — including the part that caused the bug.
 
-If a mock supplies the values the assertion depends on, the test proves the mock is
-self-consistent and nothing more. Two live examples worth knowing:
+**Prove the ordering is not accidental.** Anywhere enumeration order could
+masquerade as ranking, run the assertion twice with the input order reversed and
+fail if the two results differ. `tests/unit/SearchContentTool.test.ts` does this
+through a `rank()` helper that is the only way the tests obtain results, so the
+guarantee cannot be bypassed by adding a case — and a self-test at the bottom
+asserts the helper really does reject a tie. Copy that structure rather than
+remembering to reverse by hand.
 
-- **`prepareFuzzySearch` mock** (`tests/mocks/obsidian/core.ts`) charges a small
-  per-discontiguity penalty **capped at 8**. That cap reproduces the reason the
-  original bug existed. **Do not make it proportional** — the tests go vacuous.
-- **A scenario-scripted `getTools` mock is selector-insensitive** — a scenario's
-  `mockResponses` entry becomes a handler built by `registerStaticResponse`
-  (`tests/eval/EvalToolExecutor.ts`), whose body ignores its `_args` and returns the
-  same blob for every call. A scenario exposing only some agents makes a model
-  conclude discovery is broken and loop `getTools` forever at temperature 0. Expose
-  every agent a scenario could plausibly need. (Only the scripted path is blind: with
-  no scripted mock, `handleGetTools` auto-generates schemas and *does* filter
-  `domainTools` by the requested selectors.)
+## Add a live smoke lane
 
-### Prove the ordering isn't accidental
+Copy `tests/debug/search-ranking-live-smoke.test.ts`. The conventions exist because
+a live lane touches a real vault:
 
-`tests/unit/SearchContentTool.test.ts` routes every ranking assertion through a
-`rank()` helper that executes the tool **twice** — once with the fixtures forwards,
-once with `[...files].reverse()` — and throws if the two result orders differ. A tie
-is not a ranking rule. The helper is the only way the tests obtain results, so the
-guarantee cannot be bypassed by adding a case; a self-test at the bottom of the file
-asserts the helper actually rejects a tie (`/decided by enumeration order/`). Apply
-the same treatment anywhere enumeration order could masquerade as ranking.
+1. **Gate it** — `describe.skip` unless its env var is set, so it is inert by
+   default and never a CI dependency
+2. **`--runInBand`** — live lanes are not safe to parallelise
+3. **Header comment** stating what the mocks cannot cover, so the next person knows
+   why the lane exists
+4. **Confine writes** to a dedicated scratch folder and clean up in `afterAll` —
+   note the existing lane clears its folder with `storage archive`, not delete,
+   because the AI surface has no delete by design
+5. **Touch nothing else in the vault**
 
-## Live smoke lanes
+Run it explicitly:
 
-Pattern to copy — `tests/debug/search-ranking-live-smoke.test.ts`:
-
-```
+```bash
 RUN_SEARCH_SMOKE=1 npx jest tests/debug/search-ranking-live-smoke.test.ts --runInBand --no-coverage
 ```
 
-Conventions: env-gated (`describe.skip` unless `RUN_SEARCH_SMOKE === '1'`) so the
-lane is inert by default and never a CI dependency; `--runInBand`; a header
-explaining what the mocks cannot cover; writes confined to a dedicated scratch folder
-(`_search-ranking-smoke`) which `afterAll` clears with `storage archive` — archive,
-not delete, because the AI surface has no delete by design; never touches anything
-else in the vault. `SEARCH_SMOKE_VAULT=<name>` picks a vault, otherwise the CLI
-default is used.
+Each live lane has its own gate variable — read the file's header rather than
+assuming; several also need provider keys or a fixture path.
 
-Other live lanes and their gates:
+## Run the eval harness
 
-| Test | Gate |
-|---|---|
-| `tests/debug/provider-model-live-smoke.test.ts` | `RUN_MODEL_SMOKE=1` |
-| `tests/debug/video-generation-live-smoke.test.ts` | `RUN_LIVE_VIDEO_SMOKE=1` (+ `RUN_PAID_VIDEO_SMOKE=1` for paid calls) |
-| `tests/debug/codex-live-tool-pingpong.test.ts` | `RUN_CODEX_LIVE_TOOL_PINGPONG=1` + live tokens |
-| `tests/debug/intelligence-curse-repro.test.ts` | presence of a JSONL fixture (`DEBUG_REPRO_JSONL`) |
-| `tests/integration/transcription-live.test.ts` | `RUN_LIVE_TRANSCRIPTION_TESTS=1` + per-provider API keys |
-| `tests/integration/tool-continuation-live.test.ts` | `OPENROUTER_API_KEY` present |
+`RUN_EVAL=1`, plus at least one provider key, or the suite skips. Full guidance is
+in the `nexus-model-eval` and `nexus-eval-harness` skills; the knobs that change
+behaviour rather than scope are `EVAL_SCENARIO_NAMES` (targeted retest),
+`EVAL_CONCURRENCY`, `EVAL_TEMP`, `EVAL_TEST_TIMEOUT_MS` and `EVAL_ENFORCE_CONTEXT`.
 
-## Search ranking invariant
+**Concurrency is per-matrix, not a flat serial.** `resolveConcurrency` returns 1
+only when a local provider (`ollama`, `lmstudio`) is in the matrix; every other
+matrix fans out fully. Local single-slot servers 500-storm under fan-out, which is
+what that special case exists to prevent — so do not "fix" a slow cloud run by
+forcing serial, and do not expect a local run to behave like a cloud one.
 
-`src/agents/searchManager/tools/searchContent.ts` is a **single-scale tier ladder**:
+Results are pushed in as each scenario finishes and `afterAll` saves whatever is
+there, so a mid-run timeout still produces reports. Per-case progress streams to a
+log under the artifacts dir — `tail -f` it during a slow local run rather than
+waiting for the summary.
 
-```
-TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8
-> PARTIAL_MATCH_FLOOR 0.3 > FUZZY_ONLY_CEILING 0.25
-```
+## Fix a shipped-docs drift failure
 
-**Never reintroduce a second scale.** Filename fuzzy used to be normalized to
-`1 + score/100` (~0.92–0.95), an incommensurable scale that let a coincidental
-filename beat a verbatim body match. `foldSeparators()` lowercases and folds runs of
-`-`/`_` to single spaces, and is applied to **both sides of the filename comparison**
-(the query and the filename) so a kebab filename matches a spaced query — never to
-note bodies, which stay byte-exact so the snippet offsets keep pointing at real text.
-Results carry `matchType`, whose type is
-`export type SearchMatchType = 'content' | 'path' | 'semantic'`; the tool assigns
-`content` when the body scored above zero, otherwise `path`.
+`tests/unit/shippedGuidanceCommands.test.ts` validates every tool command in shipped
+guidance against the repo-root `cli-first-tool-schemas.json`. It fails on an unknown
+agent/tool/flag, a playbook selector resolving to nothing, a missing required
+argument in a complete copy-pasteable example, a broken relative doc link, and an
+embedded `--prompts` payload violating the item contract.
 
-## Eval harness knobs
+When it fails, the fix is in one of two places and it matters which:
 
-`tests/eval/`, plan at `docs/plans/llm-eval-harness-plan.md`.
+- **The docs are wrong** → edit the *source* guidance (`skill/SKILL.md`,
+  `cli/agents-snippet.md`, `skill/playbooks/*.md`, README, `guide/*.md`). Never edit
+  `src/utils/cliAssets.ts` — it is generated from those sources during the build.
+- **The catalog is stale** → refresh it. Regenerating needs a running vault (the
+  `nexus-tool-schemas` skill). `npm run schemas:tools` writes
+  `docs/generated/cli-first-tool-schemas.json` by default, **not** the repo-root file
+  this test reads — pass `--output cli-first-tool-schemas.json`.
 
-| Knob | Effect |
-|---|---|
-| `RUN_EVAL=1` | Required to run at all — and at least one provider must have its key env var set, or the suite still skips |
-| `EVAL_SCENARIO_NAMES=a,b,c` | Targeted retest (comma-separated, overrides `config.scenarioNames`) |
-| `EVAL_CONCURRENCY=N` | Override the dispatch width. **The default is per-matrix, not a flat 1**: `resolveConcurrency` returns `1` only when a local provider (`ollama`, `lmstudio`) is in the matrix, otherwise `Infinity`. Local single-slot servers 500-storm under fan-out |
-| `EVAL_TEMP` | Overrides `defaults.temperature` (per-scenario `temperature:` still wins) |
-| `EVAL_TEST_TIMEOUT_MS` | Jest timeout; the computed default scales the per-case budget by the estimated serial lane count |
-| `EVAL_ENFORCE_CONTEXT=1` | Enforces the context contract globally (a scenario can also opt in with `enforceContextContract: true`) |
+A stale catalog also surfaces as a drift failure in
+`tests/unit/ToolManagerCliSyntax.test.ts`, so two failures with one cause is the
+expected signature.
 
-Per-case progress streams to `<artifactsDir>/eval-progress-<ISO-timestamp>.log`
-(`artifactsDir` defaults to `test-artifacts/`) — `tail -f`-able during a slow local
-run. Results are pushed into `allResults` incrementally as each scenario finishes,
-and `afterAll` saves whatever is there, so a mid-run timeout still produces JSON + MD.
-Scenarios with known fixture bugs can set `excludeFromBoard: true`; the runner stamps
-`excludedFromBoard` on the result and `ReportGenerator` runs and reports them but
-skips them when scoring the board.
+## Gotchas
 
-## Shipped-docs gate
+**"I fixed the docs and the gate still fails."** You regenerated to
+`docs/generated/`. The gate reads the repo-root catalog.
 
-`tests/unit/shippedGuidanceCommands.test.ts` validates every tool command we ship as
-guidance against the generated catalog `cli-first-tool-schemas.json` (repo root). It
-reads `README.md`, `skill/SKILL.md`, `cli/nexus-cli.ts`, `cli/agents-snippet.md`,
-`skill/playbooks/*.md` and `guide/*.md`, and fails on: an unknown agent, tool or
-flag; a playbook `tools:` selector that resolves to nothing; a tool named in the
-`guide/apps.md` Apps table that matches no `slug:` declared under `src/agents/**`
-(apps are opt-in, so those are checked against source rather than the catalog
-snapshot); a missing required argument in a *complete*
-copy-pasteable `nexus use … -- <cmd>` example; a broken relative doc link; and an
-embedded `--prompts` payload that violates the `executePrompts` item contract.
+**"My change to `cliAssets.ts` disappeared."** It is generated during the build.
 
-So if you rename or remove a tool slug, fix the **source** guidance files above —
-`src/utils/cliAssets.ts` is generated from `skill/SKILL.md`, `cli/agents-snippet.md`
-and the playbooks by `scripts/generate-cli-content.mjs` during `npm run build`, and
-must never be hand-edited. Refreshing the catalog needs a running vault (the
-`/nexus-tool-schemas` skill); note `npm run schemas:tools` writes to
-`docs/generated/cli-first-tool-schemas.json` by default, not the repo-root file this
-test reads — pass `--output cli-first-tool-schemas.json` to update that one. A stale
-catalog also surfaces as a drift failure in `tests/unit/ToolManagerCliSyntax.test.ts`.
+**"The eval model looped `getTools` forever."** A *scenario-scripted* mock is
+selector-insensitive: `registerStaticResponse` builds a handler that discards its
+args and returns the same blob for every call. A scenario exposing only some agents
+makes the model conclude discovery is broken. Expose every agent the scenario could
+plausibly need. Only the scripted path is blind — with no scripted mock, discovery
+does filter by the requested selectors, so do not misdiagnose the auto-generated
+path this way.
+
+**"Ranking looks right locally and wrong in the vault."** The fuzzy-search mock
+charges a bounded per-discontiguity penalty, and the bound is what reproduces the
+original bug. Do not make it proportional — the tests go vacuous and stop
+distinguishing the tiers.
+
+**"I added a scoring rule and everything still passes."** Read the tier constants in
+`src/agents/searchManager/tools/searchContent.ts` before adding one. The ladder is a
+**single scale**; the original defect was a second, incommensurable scale for
+filename fuzzy that let a coincidental filename outrank a verbatim body match. Any
+new score must be placed on the existing ladder.
+
+**"My filename normalisation broke snippet offsets."** Separator folding applies to
+both sides of the *filename* comparison only. Note bodies stay byte-exact so snippet
+offsets keep pointing at real text.
+
+**"The live test ran in CI."** Its gate is missing or inverted. Live lanes must be
+inert without their env var.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,522 +1,83 @@
-<!-- PACT_MANAGED_START: Managed by pact-plugin - do not edit this block -->
-# PACT Framework and Managed Project Memory
+# Nexus
 
-<!-- SESSION_START -->
-## Current Session
-<!-- Auto-managed by session_init hook. Overwritten each session. -->
-<!-- SESSION_END -->
+Obsidian community plugin (`claudesidian-mcp`, manifest id `nexus`) that exposes the
+vault to AI agents over MCP. TypeScript, esbuild, Obsidian Plugin API, MCP SDK.
+`isDesktopOnly: false` — **this plugin runs on mobile.**
 
-<!-- PACT_MEMORY_START -->
-## Retrieved Context
+## Hard rules
 
-## Pinned Context
+- **Never top-level import Node built-ins or npm packages with Node deps** — mobile
+  has no `fs`/`path`/`stream`/`events`. Top-level imports run before any
+  `Platform.isDesktop` guard. Use `desktopRequire()` or `await import()` inside a
+  function.
+- **Styles in `styles.css`**, never inline. No `innerHTML` with dynamic content.
+  `registerDomEvent`, never `addEventListener`.
+- **`requestUrl()`, not `fetch()`.** `normalizePath()` for paths — and note it does
+  **not** strip `..`, so confinement needs an explicit guard.
+- **Never hardcode storage roots** (`Nexus`, `.nexus`) — resolve from settings.
+- **Tool parameter schemas are documentation, not validation.** There is no ajv
+  behind them; guards belong in the service/normalizer layer.
 
-<!-- pinned: 2026-06-02 -->
-### Tool-schema `required`/`oneOf`/`enum` is NOT runtime-validated (no ajv)
-Agent tool param schemas (`getParameterSchema`) are DOCUMENTATION + CLI-normalizer hints only — there is NO ajv/JSON-schema validation behind `ToolBatchExecutionService.execute(params)`. A schema `required: [...]`, `oneOf`, or `enum` does NOT reject a malformed payload at runtime; bad input flows straight to the service. **Validation guards MUST live in the service/normalizer layer, not the schema.** Origin: a `createTask.linkedNotes` oneOf object missing `notePath` silently persisted `notePath:undefined` until an explicit guard was added in `normalizeLinkedNote` (`src/agents/taskManager/services/TaskService.ts:78`). Rule: when a tool accepts structured input, add explicit field guards in the service/normalizer — never rely on the schema to enforce.
+## Layout
 
-<!-- pinned: 2026-04-20 -->
-### Line endings: LF canonical via `.gitattributes`
-`.gitattributes` declares LF canonical across `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`/`.json`/`.md`/`.css`/`.html`/`.yml`/`.sh` + binary markers for images/audio/fonts/pdfs. If you see CRLF in the tree, it's a local-editor bug — fix the editor, don't chase it with tool normalization. If 500+ files show modified with a tiny `--ignore-cr-at-eol` delta, someone's editor wrote CRLF — re-run `git add --renormalize .` on that subset, don't let it land.
+| Path | Contents |
+|---|---|
+| `src/agents/` | Agents and their tools (`apps/` = opt-in app agents) |
+| `src/services/` | LLM providers, memory, conversations, chat, agent registration |
+| `src/database/` | Storage adapters, SQLite cache, migrations |
+| `src/ui/`, `src/components/`, `src/settings/` | Chat view, modals, settings tabs |
+| `src/main.ts`, `src/connector.ts` | Plugin entry point; MCP connector |
+| `docs/plans/` | Design plans — the format to follow for new ones |
+| `docs/changelog.md` | Release history |
 
-<!-- pinned: 2026-04-23 -->
-### Dynamic ToolManager sync: deferred refactor (issue #174)
-`AgentRegistrationService.syncToolManagerAgent` (`src/services/agent/AgentRegistrationService.ts:85`) + `ToolManagerAgent.registerDynamicAgent/unregisterDynamicAgent` (`src/agents/toolManager/toolManager.ts:117`) is a callback-wrap bridge that keeps `getTools` discovery in sync when `AppManager` installs/uninstalls app agents at runtime. Works today because `AppManager` is the only dynamic registrar. **Does not compose** for a second one. When a remote-MCP loader / plugin-extension agent / other dynamic registrar lands, refactor to event-based: add `onAgentRegistered`/`onAgentUnregistered` to `AgentManager`, have `ToolManagerAgent` subscribe in its constructor, delete the bridge + the `instanceof ToolManagerAgent` concrete import. Do NOT do this refactor speculatively — wait for the triggering consumer. Tracking: https://github.com/ProfSynapse/nexus/issues/174.
+## Architecture in five lines
 
-<!-- pinned: 2026-04-20, updated 2026-08-14 -->
-### ToolManager MCP contract: CLI-first only
-`useTools`/`getTools` accept ONLY the top-level CLI shape: a `tool` string plus context fields (`workspaceId`, `sessionId`, `memory`, `goal`, `constraints?`) at the top level. Optional top-level `strategy: 'serial' | 'parallel'` and `values: Record<string, string>` (see below). Legacy nested `{context: {...}, calls: [...]}` and `{request: [...]}` throw `Deprecated payload shape` at `src/agents/toolManager/services/ToolCliNormalizer.ts:757/775/808`. `UseToolParams` has no `calls`/`request` fields.
+- **Agent-Tool pattern.** Agents extend `BaseAgent` and register tools extending
+  `BaseTool<Params, Result>`. Results are `{ success, ...data }` or
+  `{ success: false, error }`.
+- **MCP exposes exactly two tools** — `getTools` (discovery) and `useTools`
+  (execution). Every other agent is internal.
+- **Storage is hybrid**: sharded JSONL event store is the source of truth, SQLite is
+  a rebuildable cache.
+- **Services** are singletons with constructor injection.
+- **The AI never gets a destructive delete** — it gets `archive`, which is
+  reversible. Permanent delete is UI-only.
 
-`content replace` and `executePrompts.replace` use the 4-field pattern-anchored shape `{path, start, end, content}` — `start`/`end` are TEXT anchors matched as whole lines (Unicode-normalized, so straight vs curly quotes compare equal), never line numbers. The pre-v5.9.0 `{oldContent, newContent, startLine, endLine}` shape gets a clean validation error, no compat shim. In `executePrompts`, `append`/`prepend` route to `insert`; `position < 1` is rejected. The CLI parser decodes `\uXXXX` in quoted strings.
+## Commands
 
-**Context contract is now ENFORCED** (not just declared): `ToolCliNormalizer.collectContextContractViolations()` / `validateExecutionContext()` are called first in `useTools.ts:37` and throw a *recoverable steering error* when `memory`/`goal` are empty or placeholder. `workspaceId`/`sessionId` keep silent defaults and only steer on present-junk; `constraints` is optional. getTools/discovery is exempt. The eval harness imports the same validator (single source).
-
-**Verbatim / multiline value transports** (do not flatten multiline content):
-- MCP/chat: top-level `values` map, referenced from the tool string as `@key`. Substituted *after* tokenization with NO escape processing, so backslashes, quotes, and newlines survive exactly (`C:\temp`, LaTeX `\alpha`, regex `\d`). Quoting the token (`"@key"`) passes the literal text. A missing key, or a declared key the command never references, fails loud.
-- Terminal CLI: `--<flag>-stdin` and `--<flag>-file <path>` hydrate *any* value-taking flag, not just `--content`. One `-stdin` per command (stdin reads once); several `-file` transports may coexist; a flag must not arrive both directly and via a transport.
-
-<!-- pinned: 2026-03-29 -->
-### pdfjs-dist in Obsidian/Electron (legacy build + shared loader)
-PDF.js 5 expects a configured `workerSrc` in the Electron renderer. Use the legacy build with a shared loader that seeds `globalThis.pdfjsWorker`:
-```typescript
-// src/agents/ingestManager/tools/services/PdfJsLoader.ts
-const [pdfjsLib, pdfjsWorker] = await Promise.all([
-  import('pdfjs-dist/legacy/build/pdf.mjs'),
-  import('pdfjs-dist/legacy/build/pdf.worker.mjs'),
-]);
-if (!globalThis.pdfjsWorker) globalThis.pdfjsWorker = pdfjsWorker;
-```
-Use `loadPdfJs()` from `PdfJsLoader.ts` in both `PdfTextExtractor.ts` and `PdfPageRenderer.ts`. Do NOT use `import('pdfjs-dist')` directly — the main entry fails in Electron without a worker URL.
-
-<!-- pinned: 2026-04-05 -->
-### Shared Transcription Infrastructure
-Shared service at `src/services/llm/TranscriptionService.ts`; adapters at `src/services/llm/adapters/{provider}/`; types at `src/services/llm/types/VoiceTypes.ts`. Providers with word-level timestamps: **OpenAI** (`verbose_json`), **Groq**, **Mistral** (+diarization), **Deepgram** (+utterances, diarization, keyword biasing), **AssemblyAI** (+speaker labels).
-
-⚠️ The ingest shim at `src/agents/ingestManager/tools/services/TranscriptionService.ts` strips word-level data — callers that need word timings must use the shared service directly.
-
-**Drag-drop file path**: browser `File.name` is basename only — use `vault.getFiles().find(f => f.name === file.name)` to recover the vault-relative path in `handleIngestFiles`.
-
-## Working Memory
-<!-- Auto-managed by pact-memory skill. Last 3 memories shown. Full history searchable via pact-memory skill. -->
-
-<!-- PACT_MEMORY_END -->
-<!-- PACT_MANAGED_END -->
-
-# Claude Code Context Document
-Last Updated: 2026-08-14
-
-## Project Overview
-- **Name**: Nexus (package: `claudesidian-mcp`, manifest id `nexus`)
-- **Version**: 5.16.4
-- **Type**: Obsidian Community Plugin (`isDesktopOnly: false`, minAppVersion 1.8.7)
-- **Purpose**: MCP integration for Obsidian with AI-powered vault operations
-- **Architecture**: Agent-Tool pattern with domain-driven design
-- **Stack**: TypeScript, Node.js, Obsidian Plugin API, MCP SDK
-
-## Obsidian Plugin Development Guidelines
-
-Full guidelines: `docs/obsidian-plugin-guidelines.md`
-
-**Non-negotiable rules:**
-- All styles in `styles.css`, never inline
-- `innerHTML` forbidden with dynamic content — use `createEl()` / `.textContent`
-- `registerDomEvent` for all DOM events (not `addEventListener` — causes memory leaks)
-- Use `requestUrl()` not `fetch()` for HTTP; `normalizePath()` for paths
-- `vault.adapter` is acceptable for direct storage-path access when needed; normalize paths and resolve Nexus storage roots from settings instead of hardcoding `.nexus` or `Nexus`
-- `normalizePath()` does NOT strip `..` — path confinement needs an explicit `assertInside`-style guard at every write/copy/remove boundary
-
-### Mobile Compatibility (Critical)
-
-**`isDesktopOnly: false`** — this plugin runs on mobile. Node.js built-ins (`fs`, `path`, `http`, `crypto`, `events`, `stream`, `net`, `os`, `url`, `process`, `buffer`) do NOT exist on Obsidian mobile.
-
-**Top-level imports execute during module init, BEFORE any `Platform.isDesktop` guard can run.** This means:
-
-| Pattern | Result on Mobile |
-|---------|-----------------|
-| `import mammoth from 'mammoth'` (top-level) | **Crashes plugin** — mammoth depends on `stream`, `fs` |
-| `import { EventEmitter } from 'events'` (top-level) | **Crashes plugin** — null on mobile |
-| `const mammoth = await import('mammoth')` (inside async fn) | **Safe** — only loads when called |
-| `const fs = desktopRequire<typeof import('node:fs')>('node:fs')` (inside fn) | **Safe** — lazy load |
-
-**Rules for new code:**
-1. **Never** top-level import Node.js built-ins — use `desktopRequire()` from `src/utils/desktopRequire.ts`
-2. **Never** top-level import npm packages that depend on Node.js built-ins (mammoth, jszip, xlsx, yaml, etc.) — use dynamic `await import()` inside async functions
-3. **Replace** `EventEmitter` with Obsidian's `Events` class (cross-platform)
-4. **Desktop-only features** (ingestion, composer, OAuth, CLI, MCP transports, data analysis): ensure all Node.js-dependent imports are lazy
-
-**Known desktop-only npm packages**: mammoth, jszip, xlsx, yaml (all have Node.js transitive deps)
-
-## Recent Changes
-
-**Current version**: 5.16.4. Full changelog: `docs/changelog.md` — that file is the changelog; do not retell releases here. Only entries with a live, forward-looking consequence belong below.
-
-- **v5.16.4** — multiline/verbatim value transports (`values` map, `--<flag>-stdin`/`--<flag>-file`) and honest CLI PATH reporting. The transport contract is pinned above; it is load-bearing for anything that passes content through a tool.
-- **v5.16.2** — search ranking is a **single-scale tier ladder** in `src/agents/searchManager/tools/searchContent.ts`: `TITLE_EXACT_SCORE 0.95 > EXACT_PHRASE_SCORE 0.9 > ALL_WORDS_SCORE 0.8 > PARTIAL_MATCH_FLOOR 0.3 > FUZZY_ONLY_CEILING 0.25`. Never reintroduce a second scale (filename fuzzy used to be normalized to `1 + score/100`, which let a coincidental name beat a verbatim body match). `foldSeparators()` folds `-`/`_` to spaces on both sides. Results carry `matchType: 'content' | 'path' | 'semantic'`.
-  **Test methodology rule that came out of it** — three defects shipped past a green suite. `tests/unit/SearchContentTool.test.ts` runs every ranking assertion twice with the vault enumerated in both orders and fails loudly if order decides it (a tie is not a ranking rule). `tests/debug/search-ranking-live-smoke.test.ts` (`RUN_SEARCH_SMOKE=1`) drives a live vault through the `nexus` CLI so the real `prepareFuzzySearch` runs. **The `prepareFuzzySearch` mock in `tests/mocks/obsidian/core.ts` charges a per-discontiguity penalty capped at 8 — do not make it proportional, or the tests go vacuous.**
-
-## Quick Navigation
-
-### Core Directories
-- `/src/agents/` - Agent implementations (see Agent Architecture below)
-- `/src/services/` - Shared services (LLM providers, memory, conversations, chat)
-- `/src/components/`, `/src/ui/`, `/src/settings/` - UI components, chat view, settings tabs
-- `/src/database/` - Storage adapters, SQLite cache, schema migrations
-- `/src/types/`, `/src/utils/` - Type definitions and helpers
-
-### Key Files
-- `src/main.ts` - Plugin entry point and lifecycle management
-- `src/connector.ts` - MCP server connector for Claude Desktop
-- `src/agents/index.ts` - Agent registry
-- `src/services/ConversationService.ts` - Chat conversation management
-- `src/services/llm/core/LLMService.ts` - LLM provider abstraction layer
-- `src/ui/chat/ChatView.ts` - Chat view
-- `src/components/ConfigModal.ts` - Settings modal
-- `src/utils/cliAssets.ts` - Shipped CLI guidance/help text (single-sourced to prod + docs)
-
-## Agent Architecture
-
-### Available Agents
-
-**ToolManager** (`src/agents/toolManager/`) - **MCP Entry Point** (Two-Tool Architecture)
-- `getTools`: Discovery — returns tool schemas for requested agents/tools
-- `useTools`: Execution — unified context-first tool execution
-- *Only these 2 tools are exposed to Claude Desktop. All other agents work internally.*
-
-> Tool names below are the **CLI form** (`agent tool-name`, kebab-case) — what a
-> caller types and what `getTools`/`useTools` resolve. Source of truth is the
-> `slug:` field under `src/agents/**` (camelCase there, kebab-cased for CLI).
-> Regenerate `cli-first-tool-schemas.json` with `npm run schemas:tools`.
-> `tests/unit/shippedGuidanceCommands.test.ts` fails when shipped docs name a
-> tool that does not exist.
-
-**Always-on agents (8, 56 tools):**
-
-1. **PromptManager** (`src/agents/promptManager/`) — custom prompts and LLM integration
-   - `prompt`: execute, subagent, create, get, list, update, archive, list-models,
-     generate-image, generate-audio, generate-video, check-generated-artifact
-   - No delete — the AI gets `archive` (reversible). Media generation is async:
-     `generate-*` returns a job, poll `check-generated-artifact <jobId>`.
-2. **ContentManager** (`src/agents/contentManager/`) — note reading/editing
-   - `content`: read, write, replace, insert, set-property
-   - `read` requires `--start-line`. `replace` is pattern-anchored (see pinned contract).
-3. **StorageManager** (`src/agents/storageManager/`) — file/folder management
-   - `storage`: list, create-folder, move, copy, archive, open
-4. **SearchManager** (`src/agents/searchManager/`) — search
-   - `search`: content, directory, memory, query-notes
-5. **MemoryManager** (`src/agents/memoryManager/`) — workspace/state/workflow management
-   - `memory`: create-workspace, list-workspaces, search-workspaces, load-workspace,
-     update-workspace, archive-workspace, create-state, list-states, load-state,
-     update-state, archive-state, run
-   - No session tools — sessions are context fields, not tools. `memory run`
-     triggers a workflow (`--workflow-id`/`--workflow-name`). AI gets archive-only
-     for states (soft, reversible); permanent delete is UI-only, there is no
-     `deleteState` MCP tool.
-6. **CanvasManager** (`src/agents/canvasManager/`) — Obsidian canvas
-   - `canvas`: read, write, update, list
-7. **TaskManager** (`src/agents/taskManager/`) — workspace-scoped projects/tasks with DAG dependencies
-   - `task`: create-project, list-projects, update-project, archive-project,
-     create, list, update, move, query, open, link-note
-   - Note the asymmetry: project tools are suffixed (`create-project`), task tools
-     are bare (`create`, `list`, `update`, `move`, `query`).
-   - Services: TaskService (business facade), DAGService (pure computation).
-     Auto-loads a task summary when a workspace loads.
-8. **IngestManager** (`src/agents/ingestManager/`) — PDF/audio ingestion
-   - `ingest`: run, capabilities
-
-**Opt-in app agents (5, 18 tools)** — a vault only exposes the apps it enables:
-
-9. **WebToolsAgent** (`src/agents/apps/webTools/`) — headless browser (desktop-only)
-   - `web`: open, capture-markdown, capture-png, capture-pdf, links
-10. **ComposerAgent** (`src/agents/apps/composer/`) — multimodal file composition
-    - `composer`: compose, list-formats
-11. **ElevenLabsAgent** (`src/agents/apps/elevenlabs/`) — AI audio
-    - `elevenlabs`: list-voices, sound-effects, generate-music
-    - No text-to-speech tool; TTS runs through `prompt generate-audio`.
-12. **DataAnalysisAgent** (`src/agents/apps/dataAnalysis/`) — Pyodide pandas (desktop-only)
-    - `data`: run-python, list-capabilities
-13. **SkillsAgent** (`src/agents/apps/skills/`) — Skills Protocol
-    - `skills`: list-skills, load-skill, create-skill, update-skill, archive-skill, sync-skills
-    - Design: `docs/plans/skills-protocol-integration-plan.md`. Skills live under
-      `<root>/skills/<provider>/<name>/SKILL.md`, indexed in the SQLite `skills`
-      table; `sync-skills` mirrors to/from vault-root `.{provider}/skills/`
-      (last-writer-wins) and **writes into the user's real provider dotfolders** —
-      confirm scope before changing that behavior. Path confinement lives in
-      `skillPaths.ts` (`resolveVaultPath`/`assertInside`/`isSafePathSegment`).
-
-### Agent Structure Pattern
-```
-agents/
-  [agentName]/
-    [agentName].ts          # Main agent class extending BaseAgent
-    tools/                  # Operation tools
-      [toolName].ts
-      services/             # Tool-specific services
-    services/               # Agent-level shared services
-    types.ts
-    utils/
+```bash
+npm run dev        # esbuild dev build
+npm run build      # full production build (lint → CLI → tsc → esbuild → connector)
+npm run test       # Jest
+npm run lint       # ESLint
+npm run schemas:tools   # regenerate cli-first-tool-schemas.json
 ```
 
-App agents additionally extend `BaseAppAgent` (`src/agents/apps/BaseAppAgent.ts`) and
-may opt into `AppRuntimeContext` (`src/agents/apps/AppRuntimeContext.ts`) for settings,
-storage-adapter, and session-context access.
+Releases go through the `nexus-release` skill.
 
-### Base Classes
-- **BaseAgent** (`src/agents/baseAgent.ts`)
-- **BaseTool** (`src/agents/baseTool.ts`) — generic `BaseTool<Params, Result>`
-- **IAgent** (`src/agents/interfaces/IAgent.ts`), **ITool** (`src/agents/interfaces/ITool.ts`)
+## Where the details live
 
-## Current Work / Open Items
+This file stays short on purpose. Anything specific or procedural is a skill:
 
-No in-flight uncommitted work is tracked here — the working tree is clean at 5.16.4.
-Check `git log` and `docs/plans/` for what is actually in progress.
+| Skill | Covers |
+|---|---|
+| `nexus-agents` | Agent/tool inventory, the two-tool MCP contract, adding an agent |
+| `nexus-mobile-compat` | Plugin store rules, mobile crash classes, vetting a dependency |
+| `nexus-storage` | Event store, SQLite schema and migrations, path resolution, caches |
+| `nexus-llm-adapters` | Streaming, reasoning rendering, local-model and CLI-provider quirks |
+| `nexus-testing` | Test lanes, live smoke pattern, what a mock can and cannot prove |
+| `nexus-release` | Version bump and GitHub release |
+| `nexus-model-updates` | Provider model definitions and live smoke test |
+| `nexus-model-eval`, `nexus-eval-harness` | Grading models on tool use |
+| `nexus-tool-schemas` | Exporting live CLI tool schemas |
+| `nexus-ui-mockups` | Standalone UI mockups before implementation |
 
-**Proposed, planned but not started** (each has a design plan and a tracking issue):
-- **Web capture via Defuddle** — `docs/plans/web-capture-defuddle-plan.md`. Replace the
-  Web Viewer `save-to-vault` dependency in `web capture-markdown` with Defuddle core
-  plus Obsidian's `htmlToMarkdown()`; adds a mobile-capable fetch transport.
-- **BasesManager agent** — `docs/plans/bases-manager-agent-plan.md`. `.base` file
-  read/write/update/list plus `analyze`, which executes the query through Obsidian's
-  own engine. The agent is not registered at all when Bases is disabled.
-- **In-app verification via the Obsidian CLI** — `docs/plans/obsidian-cli-verification-plan.md`.
-  build → `plugin:reload` → `dev:errors` → screenshot, so "works in Obsidian" stops
-  being a human-only check.
+## What does not belong in this file
 
-**Deferred, with a live decision attached:**
-- **Reasoning-LEVEL (low/medium/high) UI for local models — WON'T DO** unless
-  re-requested. The gap is real and 3-part: (1) `ChatSettingsRenderer.renderReasoningControls`
-  gates on `staticModelsService.findModel`, which has no `lmstudio`/`ollama` case;
-  (2) `OllamaAdapter` sends `think:<boolean>` (Ollama accepts `"low"|"medium"|"high"|"max"`
-  for gpt-oss) and `LMStudioAdapter` sends no `reasoning_effort`; (3) `ThinkingEffortMapper`
-  has no Ollama/LM Studio entries. **User decision: users set reasoning effort in
-  LM Studio's own UI where available.** Do not build this speculatively.
-- **getTools loop-breaker — scoped, NOT built.** Plan: `docs/plans/gettools-loop-breaker-plan.md`.
-  (A) a per-exchange getTools tracker in `ToolContinuationService` that steers on
-  ≥3 consecutive or repeated-selector getTools calls; (B) decorate getTools and
-  search/list *results* with "these are schemas/locations — call useTools / content
-  read next". Partial (B) has landed in the system prompt (`SystemPromptBuilder`),
-  `searchWorkspaces`, and shipped CLI guidance, but generic search/list result
-  decoration and the tracker do not exist. Steers must never block; keep
-  `TOOL_ITERATION_LIMIT=15` as the backstop.
-- **Canonical Message Pipeline — Phase 3**: drop the redundant
-  `LLMService.generateResponseStream` remap; accept `ConversationMessage[]` directly.
-  ~3–5h, medium risk. Plan: `docs/plans/canonical-message-pipeline-plan.md`.
-  Phases 1+2 shipped. Phase 4 (single canonical message type) deferred to the
-  next provider add.
+Status. In-flight work, branch names, "uncommitted, do not commit", open PRs,
+per-release narratives, session state. All of it goes stale within days and then
+actively misleads — a stale "do not commit" note once described code that had
+already shipped.
 
-**Open bug follow-ups (deferred, not blocking):**
-- `CONFLICT_COPY_PATTERNS` (`src/database/migration/CacheBackendMigration.ts:12`)
-  does not match the Dropbox `cache (User's conflicted copy YYYY-MM-DD).db` form —
-  the closing paren before `.db` breaks the anchor.
-- `waitForQueryReady` post-migration race — first-boot transient timeout is papered
-  over with a sticky restart Notice; root cause not investigated.
-- `FilePickerRenderer.getRootFolder()` (`src/components/workspace/FilePickerRenderer.ts:191`)
-  passes `/blog-test`-style paths to `getAbstractFileByPath()`, which expects no
-  leading slash. Fix: `normalizePath()` or strip the leading slash.
-- Claude Code `ENAMETOOLONG` (issue #64) — an earlier fix may not have fully
-  resolved it. UNVERIFIED against current code; needs re-investigation.
-
-**UNVERIFIED older items** (predate this clone's history; status unknown — confirm on GitHub before acting):
-- Issue #217 — frontend polish from the states-management UI review: empty-name
-  silent ignore in StateEditModal, no-op save firing a noisy `state_updated`,
-  double-click race on Archive/Restore/Delete, stale-promise stomp on rapid
-  workspace re-render. All Minor.
-- Issue #219 — denormalize `state.isArchived` into SQLite metadata to restore the
-  fast-path read shortcut lost in the archive-visibility fix. ~80–120 LoC + a
-  migration. Not blocking until workspaces hit 100–500+ states.
-- Issue #221 — mobile-compat lint guard.
-- Issue #88 — `CustomPromptStorageService` dual-write desync.
-- Settings UI redesign Waves/PRs 2–4 (row primitives, TaskDetail, WorkflowEditor +
-  mobile breakpoint). Plan: `docs/plans/workspace-tab-redesign-plan.md`.
-
-### Branch Architecture
-
-A branch IS a conversation with parent metadata:
-- `metadata.parentConversationId`: parent conversation
-- `metadata.parentMessageId`: message the branch is attached to
-- `metadata.branchType`: `'alternative' | 'subagent'`
-
-**Key files**: `src/services/chat/BranchService.ts` (facade over ConversationService),
-`src/ui/chat/controllers/SubagentController.ts`, `src/ui/chat/controllers/NexusLoadingController.ts`,
-`src/ui/chat/services/ContextTracker.ts` (token/cost tracking).
-
-### Known Issues
-
-- **Workspace Delete Persistence**: deleted workspaces may reappear on reload.
-  Backend delete logic looks correct; suspect UI cache. UNVERIFIED — long-standing,
-  re-confirm it still reproduces before spending time on it.
-- **WebLLM / Nexus Quark**: multi-turn tool continuations may crash on Apple Silicon
-  (WebGPU). If startup hangs on "loading cache", clear site data.
-
-## Development Notes
-
-### Build Commands
-- `npm run dev` — esbuild dev build
-- `npm run build` — full production build (obsidian lint → CLI build → CLI content gen → `tsc --noEmit` → esbuild → connector tsc → connector content gen)
-- `npm run build:cli` — CLI bundle + generated CLI content only
-- `npm run test` — Jest
-- `npm run lint` — ESLint (alias of `lint:obsidian`)
-- `npm run schemas:tools` — regenerate `cli-first-tool-schemas.json`
-- `npm run sync:agent-context` / `npm run sync:skills` — sync shipped agent context/skills
-- `npm run deploy` — build + PowerShell deploy (Windows)
-- **Release**: use the `/nexus-release` skill. It bumps `package.json`, `manifest.json`,
-  `versions.json`, and the changelog — `versions.json` is guarded by the release
-  workflow, so it is not optional.
-
-### Testing Approach
-- **Unit tests**: Jest, ~346 test files under `tests/`
-- **Integration**: manual testing in Obsidian
-- **MCP**: via Claude Desktop connection
-- **LLM eval harness** (`tests/eval/`, `RUN_EVAL=1`, skill `/nexus-model-eval`):
-  grades two-tool MCP usage. Plan: `docs/plans/llm-eval-harness-plan.md`.
-  Useful knobs: `EVAL_SCENARIO_NAMES=a,b,c` (targeted retest), `EVAL_CONCURRENCY`
-  (**defaults to serial=1** — local single-slot servers 500-storm under fan-out),
-  `EVAL_TEMP`, `EVAL_TEST_TIMEOUT_MS`, `EVAL_ENFORCE_CONTEXT=1`. Per-case progress
-  streams to `test-artifacts/eval-progress-<ts>.log`; reports save incrementally
-  so a mid-run timeout still produces JSON + MD. Scenarios with known fixture bugs
-  can set `excludeFromBoard: true` to run without scoring.
-  **Harness gotcha**: the scripted getTools mock is selector-insensitive — it returns
-  the same blob for every call. A scenario that exposes only some agents will make a
-  model conclude "discovery is broken" and loop getTools forever at temp 0. Expose
-  every agent the scenario could plausibly need.
-
-### Code Patterns
-
-- **Agents**: extend `BaseAgent`, register tools in the constructor
-- **Tools**: extend `BaseTool<Params, Result>`, implement `execute()`, `getParameterSchema()`, `getResultSchema()`
-- **Results**: return `{ success: boolean, ...data }` or `{ success: false, error: string }`
-- **Services**: singletons with constructor dependency injection
-- **Adding a new agent**: (1) add `initializeYourAgent()` to
-  `src/services/agent/AgentInitializationService.ts`, (2) add
-  `safeInitialize('yourAgent', ...)` to a phase in
-  `AgentRegistrationService.doInitializeAllAgents()`. No factory classes, no
-  ServiceDefinitions entry.
-
-### Dependencies
-See `package.json`. Key: MCP SDK, express, winston, uuid. LLM provider SDKs were
-removed — providers talk direct HTTP via `ProviderHttpClient`.
-
-## Code Quality
-
-Large-file punchlist: `docs/plans/large-file-refactor-punchlist.md`.
-
-**600+ line files to watch** (re-measured 2026-08-14 with `wc -l`):
-
-| Lines | File |
-|------:|------|
-| 1426 | `src/utils/cliAssets.ts` |
-| 1247 | `src/components/shared/ChatSettingsRenderer.ts` |
-| 1214 | `src/settings/tabs/GetStartedTab.ts` |
-| 1182 | `src/ui/chat/ChatView.ts` |
-| 1167 | `src/agents/toolManager/services/ToolCliNormalizer.ts` |
-| 1150 | `src/settings/tabs/DefaultsTab.ts` |
-| 1052 | `src/services/ConversationService.ts` |
-| 1019 | `src/database/adapters/HybridStorageAdapter.ts` |
-|  999 | `src/ui/chat/services/ModelAgentManager.ts` |
-|  941 | `src/agents/taskManager/services/TaskService.ts` |
-|  916 | `src/agents/searchManager/services/MemorySearchProcessor.ts` |
-|  901 | `src/services/cli/LocalCliInstaller.ts` |
-|  890 | `src/settings/tabs/WorkspacesTab.ts` |
-|  880 | `src/services/llm/adapters/openrouter/OpenRouterAdapter.ts` |
-|  871 | `src/services/llm/adapters/BaseAdapter.ts` |
-|  854 | `src/database/interfaces/StorageEvents.ts` |
-|  846 | `src/services/llm/adapters/google/GoogleAdapter.ts` |
-|  839 | `src/services/llm/adapters/lmstudio/LMStudioAdapter.ts` |
-|  829 | `src/services/llm/adapters/webllm/WebLLMEngine.ts` |
-|  784 | `src/services/llm/adapters/openai/OpenAIAdapter.ts` |
-|  774 | `src/services/WorkspaceService.ts` |
-|  770 | `src/connector.ts` |
-|  710 | `src/database/storage/SQLiteCacheManager.ts`, `src/settings/tabs/ProvidersTab.ts` |
-|  673 | `src/services/llm/providers/ProviderManager.ts` |
-
-**Plugin store compliance**: `isDesktopOnly: false` is correct. VaultOperations uses
-`app.fileManager.trashFile()` (constructor takes `App` as its first arg).
-
-## MCP Integration
-
-### Server Configuration
-- Server runs locally via `connector.js`
-- Configured in Claude Desktop's `claude_desktop_config.json`
-- Server identifier: `claudesidian-mcp-[vault-name]`
-- Supports multiple vault instances simultaneously
-
-### Two-Tool Architecture
-
-Instead of 70+ tools, MCP exposes just 2: `getTools` (discovery) and `useTools` (execution).
-
-**Context schema**: `{ workspaceId, sessionId, memory, goal, constraints? }` —
-all required except `constraints`, and **enforced at runtime** (see the pinned
-ToolManager contract for exactly what steers vs. silently defaults).
-
-**Flow**: `getTools` → get schemas → `useTools` with the context fields at the top
-level plus a single `tool` string. Batch by separating commands with a top-level
-comma outside quotes:
-`"storage list --path Notes, content read --path a.md --start-line 1"`.
-
-⚠️ The `calls: [{agent, tool, params}]` array and the nested `context: {...}` object
-were removed in v5.9.0 and are rejected outright (`Deprecated payload shape`).
-Context fields must NOT appear as CLI flags inside the `tool` string either.
-
-**Benefits**: large token reduction vs. exposing every tool schema; works with
-small-context models.
-
-**Key files**: `src/agents/toolManager/` (agent + tools),
-`src/services/trace/ToolCallTraceService.ts`, `src/utils/cliAssets.ts` (shipped guidance).
-
-**Tool count**: 74 tools across 13 agents (excluding the 2 ToolManager meta-tools) —
-56 across the 8 always-on agents, plus 18 across the 5 opt-in apps. The checked-in
-`cli-first-tool-schemas.json` shows 66 tools / 11 agents because it was generated
-from a vault with `skills` and `data` disabled; regenerate with `npm run schemas:tools`.
-
-## Memory & Workspace System
-
-### Storage Location
-
-**Primary synced event store**: settings-derived vault root,
-`settings.storage.rootPath` (default `Nexus`), with managed data under `<rootPath>/data/`:
-- `conversations/<conversationId>/shard-*.jsonl` — sharded append-only conversation events
-- `workspaces/<workspaceId>/shard-*.jsonl` — workspace/session/state/trace events
-- `tasks/<workspaceId>/shard-*.jsonl` — task/project events
-- `_meta/` — storage and migration manifests
-
-**Configured root rules**: resolve with `resolveVaultRoot(settings, { configDir })`
-(`src/database/storage/VaultRootResolver.ts:133`). Never hardcode `Nexus` except as
-`DEFAULT_STORAGE_SETTINGS.rootPath`, and never hardcode `.nexus` for new writes.
-
-**Legacy read paths** (read/migration fallback only, never the write target):
-`.obsidian/plugins/<plugin-folder>/data/`, compatibility plugin folders (`nexus`,
-`claudesidian-mcp`), legacy `.nexus/`, and `storage.previousRootPaths`.
-
-**Local-only cache** (auto-rebuilt from JSONL, never synced):
-- **Desktop**: IndexedDB via `IndexedDBCacheBlobStore` — cloud-sync-immune. A
-  first-launch migration FSM upgrades existing `cache.db` installs.
-- **Mobile**: `vault.adapter` file backend via `VaultAdapterCacheBlobStore`.
-- Chosen by `src/database/storage/CacheBlobStoreFactory.ts`.
-
-**Migration**: on startup, legacy JSONL sources are read/migrated into the configured
-vault-root event store without deleting old files. Mobile users whose vault syncs
-after init can run **Nexus: Refresh synced data**. **Nexus: Rebuild cache** recovers
-from a corrupted cache.
-
-**Path resolution**: `resolveVaultRoot()` for the configured synced event root;
-`resolvePluginStorageRoot()` (`src/database/storage/PluginStoragePathResolver.ts:26`)
-for plugin-scoped compatibility/cache paths.
-
-### Architecture
-- Hybrid JSONL + SQLite: the sharded JSONL event store is the source of truth;
-  SQLite is a rebuildable fast query/vector cache
-- **SQLite schema version 13** (`CURRENT_SCHEMA_VERSION` in
-  `src/database/schema/SchemaMigrator.ts:76`) — v9 added the 4 task tables, v10
-  workflow columns, v11 the archive flag, v12 `shard_cursors`, v13 the `skills` table
-- True database pagination with OFFSET/LIMIT
-- Workspace-scoped sessions and traces
-- Searchable via MemoryManager and SearchManager agents
-
-## UI Components
-
-- **Chat view**: `src/ui/chat/ChatView.ts` — conversations, branching, streaming, tool accordion
-- **Settings**: `src/components/ConfigModal.ts` + `src/settings/tabs/` — tabbed LLM/agent configuration
-
-### Chat Suggesters
-| Trigger | Purpose |
-|---------|---------|
-| `/` | Tool hints |
-| `@` | Custom agents / prompts |
-| `[[` | Note links |
-| `#` | Workspace data |
-
-Key files: `src/ui/chat/components/suggesters/` (`ToolSuggester`, `PromptSuggester`,
-`NoteSuggester`, `WorkspaceSuggester` + TextArea/ContentEditable variants,
-`initializeSuggesters.ts`), `src/ui/chat/services/MessageEnhancer.ts`,
-`src/ui/chat/services/SystemPromptBuilder.ts`.
-
-## Architectural Notes
-
-- **Subagents**: branch → stream via LLMService → save result. `chunk.toolCalls` are display-only.
-- **Reasoning / thinking rendering**: reasoning streams as `chunk.reasoning`, is
-  emitted via `onReasoningUpdate(messageId, text, isComplete)` on
-  `StreamHandlerEvents`/`MessageManagerEvents`, and renders as a collapsible
-  `<details class="message-reasoning">` block. Do NOT reintroduce a synthetic
-  `reasoning`-type tool call — the tool coordinator never rendered it.
-- **In-stream error frames**: some providers (notably LM Studio) return
-  `{"error":{...}}` frames over HTTP 200. `SSEStreamOptions.extractError` +
-  `processNodeStream` in `BaseAdapter.ts` turn those into
-  `LLMProviderError(..., 'PROVIDER_STREAM_ERROR')` instead of an empty stream.
-  Any new streaming adapter should wire `extractError`.
-- **LM Studio speculative decoding**: a `draft_model` against a batched-MLX target
-  fails; `LMStudioAdapter` marks the draft incompatible and retries without it, so
-  chat always produces output. `ensureModelLoaded` passes `flash_attention` through
-  but **never compares it** (llama.cpp-only; MLX no-ops and does not report it —
-  comparing caused infinite model reloads).
-- **Antigravity CLI (`agy`)**: the `google-gemini-cli` provider id is unchanged for
-  settings compat, but the runtime is `agy`, not the deprecated `gemini` CLI. `agy`
-  emits **plain text** (no JSON output mode) and reports **no token usage**;
-  `--model` takes human labels and **fails open** on an unknown slug, so
-  `geminiCliModelNormalize.ts` is a **fail-closed allowlist** — keep it that way.
-  Auth is a boolean-only presence probe over `~/.gemini/oauth_creds.json`; never
-  read, log, or return the token. No `--dangerously-skip-permissions`.
-- **WebLLM / Nexus Quark**: 4B, 4K context, `<tool_call>` format. May crash on Apple Silicon.
-- **Storage**: branches are JSONL events; tool names use the `agent_tool` format.
-- **Apps & vault access**: app agents that produce files must have vault access
-  wired through `BaseAppAgent`. Use `vault.createBinary()` for binary outputs
-  (audio, images) and `vault.create()` for text. Always ensure parent directories
-  exist before writing.
+Current work lives in GitHub issues and `docs/plans/`. Release history lives in
+`docs/changelog.md`. What the code does lives in the code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,9 @@ npm run dev        # esbuild dev build
 npm run build      # full production build (lint → CLI → tsc → esbuild → connector)
 npm run test       # Jest
 npm run lint       # ESLint
-npm run schemas:tools   # regenerate cli-first-tool-schemas.json
+npm run schemas:tools   # regenerate the tool catalog — writes docs/generated/ by
+                        # default; pass --output cli-first-tool-schemas.json for
+                        # the repo-root file the shipped-docs test reads
 ```
 
 Releases go through the `nexus-release` skill.


### PR DESCRIPTION
Docs only. CLAUDE.md goes from **3809 words to 550**.

## What was removed

- **The entire PACT managed block** — session state, retrieved context, working memory, pinned context, and all six marker comments
- Recent-changes narratives, the current-work list, known issues, the 600+ line watch list

Status of any kind goes stale within days and then actively misleads. The file now says that explicitly and points at GitHub issues, `docs/plans/` and `docs/changelog.md` instead.

## What's left

The things that don't change: hard rules, layout, architecture in five lines, commands, and an index of where the details live.

## Five new skills

| Skill | Carries |
|---|---|
| `nexus-agents` | Tool inventory, two-tool MCP contract, adding an agent, MCP server config, why parameter schemas aren't validation, the #174 dynamic-registration limit |
| `nexus-mobile-compat` | Plugin store rules, the mobile crash table, vetting a dependency for Node built-ins, pdfjs loader, line endings |
| `nexus-storage` | Event store layout, path resolution, SQLite schema and migrations, cache backends, hydration and denormalization traps |
| `nexus-llm-adapters` | In-stream error frames, reasoning rendering, LM Studio/Ollama quirks, the `agy` contract and its security constraints, transcription, chat branches and suggesters |
| `nexus-testing` | Test lanes, live-smoke pattern, what a mock can and cannot prove, search ranking invariant, eval harness knobs |

Each has a trigger-phrased `description` so it surfaces on the right task rather than needing to be remembered.

## Nothing durable was dropped silently

I diffed the old file section by section. Everything durable landed in a skill. Three bugs that lived **only** in the deleted status section are now issues #332, #333, #334. The UNVERIFIED issue list turned out to be redundant — #217, #219, #221, #64, #174 and #209 are all open on GitHub already.

## One thing to decide before merging

Removing the PACT block means the pact-plugin's `session_init` hook and `pact-memory` skill no longer have insertion points in this file. If that plugin is still active it may re-add them on the next session, so it likely wants disabling for this repo alongside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_