### PR TITLE
feat: extract web captures with Defuddle instead of the Web Viewer save command

### DIFF
--- a/cli-first-tool-schemas.json
+++ b/cli-first-tool-schemas.json
@@ -3182,9 +3182,9 @@
     {
       "agent": "webTools",
       "tool": "capture-markdown",
-      "description": "Save the active Web Viewer page to the vault as Markdown using Obsidian Web Viewer. Desktop only.",
+      "description": "Extract a webpage as Markdown with metadata frontmatter and save it to the vault. Fetches the URL directly (works on mobile); falls back to the desktop Web Viewer for pages that need JavaScript or a signed-in session.",
       "command": "web capture-markdown",
-      "usage": "web capture-markdown [--url <url>] [--mode <mode>] <outputPath> [--timeout-ms <timeoutMs>] [--settle-ms <settleMs>]",
+      "usage": "web capture-markdown [--url <url>] <outputPath> [--transport <transport>] [--mode <mode>] [--min-word-count <minWordCount>] [--timeout-ms <timeoutMs>] [--settle-ms <settleMs>]",
       "arguments": [
         {
           "name": "url",
@@ -3192,15 +3192,7 @@
           "type": "string",
           "required": false,
           "positional": false,
-          "description": "[OPTIONAL] Optional URL to open in Web Viewer before capturing. If omitted, captures the active Web Viewer tab. (string)"
-        },
-        {
-          "name": "mode",
-          "flag": "--mode",
-          "type": "string",
-          "required": false,
-          "positional": false,
-          "description": "[OPTIONAL] Where to open the Web Viewer tab when url is provided. (One of: [\"tab\", \"split\", \"window\", \"current\"])"
+          "description": "[OPTIONAL] Page to capture. Required unless transport is \"browser\", which can capture the already-open Web Viewer tab. (string)"
         },
         {
           "name": "outputPath",
@@ -3211,12 +3203,36 @@
           "description": "[REQUIRED] Destination note path in the vault. Required so the caller explicitly chooses where the Markdown capture is saved. (string)"
         },
         {
+          "name": "transport",
+          "flag": "--transport",
+          "type": "string",
+          "required": false,
+          "positional": false,
+          "description": "[OPTIONAL] How to retrieve the page. \"fetch\" downloads it directly and is the only option on mobile. \"browser\" renders it in the desktop Web Viewer, which handles JavaScript-rendered and signed-in pages. \"auto\" fetches first and falls back to the browser on desktop. (One of: [\"auto\", \"fetch\", \"browser\"])"
+        },
+        {
+          "name": "mode",
+          "flag": "--mode",
+          "type": "string",
+          "required": false,
+          "positional": false,
+          "description": "[OPTIONAL] Where to open the Web Viewer tab when the browser transport is used. (One of: [\"tab\", \"split\", \"window\", \"current\"])"
+        },
+        {
+          "name": "minWordCount",
+          "flag": "--min-word-count",
+          "type": "number",
+          "required": false,
+          "positional": false,
+          "description": "[OPTIONAL] Under \"auto\", a fetch result with fewer words than this is treated as a JavaScript-rendered shell and retried in the browser. (number)"
+        },
+        {
           "name": "timeoutMs",
           "flag": "--timeout-ms",
           "type": "number",
           "required": false,
           "positional": false,
-          "description": "[OPTIONAL] Maximum time to wait for page load and note creation. (number)"
+          "description": "[OPTIONAL] Maximum time to wait for the Web Viewer page to load (browser transport only). (number)"
         },
         {
           "name": "settleMs",
@@ -3224,11 +3240,11 @@
           "type": "number",
           "required": false,
           "positional": false,
-          "description": "[OPTIONAL] Extra delay after page load before invoking Save to vault. (number)"
+          "description": "[OPTIONAL] Extra delay after page load before reading the DOM (browser transport only). (number)"
         }
       ],
       "examples": [
-        "web capture-markdown --url \"url-value\" --mode \"mode-value\" \"outputPath-value\" --timeout-ms 1 --settle-ms 1"
+        "web capture-markdown --url \"url-value\" \"outputPath-value\" --transport \"transport-value\" --mode \"mode-value\" --min-word-count 1 --timeout-ms 1 --settle-ms 1"
       ]
     },
     {

--- a/docs/plans/web-capture-defuddle-plan.md
+++ b/docs/plans/web-capture-defuddle-plan.md
@@ -1,6 +1,7 @@
 # Web Capture via Defuddle — Design Plan
 
-**Status:** Design / pre-architecture
+**Status:** Implemented (2026-08-14) — see §13 for the Phase 4 bake-off that
+gated deleting the legacy route
 **Date:** 2026-08-14
 **Author:** design discussion (ProfSynapse + Claude)
 **Prompted by:** review of `kepano/obsidian-skills` (`skills/defuddle`)
@@ -53,6 +54,14 @@ Neither is reachable from the `.` or `/full` entries — verified
 
 So the browser entries violate none of the CLAUDE.md mobile rules. We still
 `await import()` them inside the tool rather than at module top level, per rule 2.
+
+Installing it adds **27 entries to `package-lock.json`** for one dependency, which
+looks alarming and is not. `defuddle` declares one real dependency (`commander`)
+and four *optional* ones — `linkedom` (its `./node` entry), plus `turndown`,
+`temml` and `mathml-to-latex` (its `./full` entry). npm installs optional deps by
+default, so they land in `node_modules` and the lockfile, but we import neither
+entry point, so none of them reach `main.js`: the measured bundle delta is
++92 KB gzip, which is the core entry alone (§4.3).
 
 ### 4.2 Detached-document safety
 
@@ -194,3 +203,41 @@ the Bases plan.
 - Rendering/screenshotting — `capture-png`/`capture-pdf` stay browser-bound.
 - A crawler. One URL per call; link following is `web links` plus the caller's own loop.
 - Bundling a second markdown converter (§5).
+
+## 13. Phase 4 bake-off result (2026-08-14)
+
+Run against a live vault through the `nexus` CLI, comparing the shipped default
+(`--transport auto`) against the legacy Web Viewer save-to-vault route
+(`--transport legacy`, kept temporarily as the comparison instrument).
+
+| Page | Kind | `auto` words / headings / links / frontmatter keys | `legacy` |
+|---|---|---|---|
+| Wikipedia — Markdown | article | 2862 / 8 / 208 / 7 | 3030 / **2** / 246 / **0** |
+| MDN — Content-Type | docs | 716 / 8 / 24 / 7 | **failed** |
+| Python docs — json | docs | 3818 / 11 / 95 / 7 | **failed** |
+| overreacted.io — useEffect | blog | 10486 / 22 / 65 / 8 | **failed** |
+| Wikipedia — Fourier transform | math-heavy | 20886 / 64 / 468 / 8 | **failed** |
+| github.com — nexus | readme | 760 / 8 / 52 / 8 | **failed** |
+| react.dev — Thinking in React | SPA | 2894 / 10 / 17 / 7 | **failed** |
+
+Three further URLs (a BBC article, an HN thread, an NYT article) were dropped
+from the set: both routes failed because the URLs themselves returned 404, 429
+and 403. They are evidence about the URLs, not about either implementation.
+
+**Verdict: no regression, and a structural improvement.** `auto` succeeded on
+7/7 reachable pages; `legacy` succeeded on 1/6 attempted. On the one page where
+both produced a note, legacy was 5.9% wordier but emitted **2 headings against
+8** — its extra words are Wikipedia's infobox table, the "From Wikipedia" preamble
+and the external-links list, while it flattens the document's heading structure
+and carries no metadata at all.
+
+Two caveats worth recording. Legacy's failure rate is measured *under
+automation*: it depends on a core-plugin command, a load timeout and a
+filesystem hunt, and it may fare better when driven by hand. That it is not
+reliably automatable is itself the finding, since this tool exists to be driven
+by an agent. Second, the legacy runs eventually wedged the plugin's MCP server,
+which is why the tenth page was never attempted.
+
+The legacy route and its three helpers (`findCreatedMarkdownFile`,
+`hasWebViewerSaveCommand`, `WEB_VIEWER_SAVE_COMMAND_ID`) were deleted on the
+strength of this. Open question 1 in §10 is resolved as "delete".

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dao-xyz/sqlite3-vec": "^0.0.19",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "defuddle": "0.19.2",
         "diff-match-patch": "^1.0.5",
         "eventsource-parser": "^1.1.2",
         "fast-xml-parser": "^5.8.0",
@@ -1908,6 +1909,13 @@
         "ret": "~0.1.10"
       }
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -3276,6 +3284,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -3592,6 +3614,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3711,6 +3742,48 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3875,6 +3948,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/defuddle": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/defuddle/-/defuddle-0.19.2.tgz",
+      "integrity": "sha512-FY+a9Byo3uS04SQnQjLaguNoEA0Y58vXTB1XvvnOkO6M0zo897ipekv2Unci42QEY70emZ6OLe7C0vPojr1JEA==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "defuddle": "dist/cli.js"
+      },
+      "optionalDependencies": {
+        "linkedom": "^0.18.12",
+        "mathml-to-latex": "^1.8.0",
+        "temml": "^0.13.3",
+        "turndown": "^7.2.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3936,6 +4027,77 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/duck": {
@@ -4034,6 +4196,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -5860,6 +6035,111 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7424,6 +7704,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/linkedom/node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -7567,6 +7879,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mathml-to-latex": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mathml-to-latex/-/mathml-to-latex-1.8.0.tgz",
+      "integrity": "sha512-gQ0uK3zqB8HwlfaXJkEL5rgaZNbKUiBMmBP/B/W+b+t6KcseLSuYb1b0BjLgS9ZiQa24ePkqTX8/6FaQuDL7wQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10"
+      }
+    },
+    "node_modules/mathml-to-latex/node_modules/@xmldom/xmldom": {
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/media-typer": {
@@ -7820,6 +8152,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {
@@ -9529,6 +9878,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/temml": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/temml/-/temml-0.13.4.tgz",
+      "integrity": "sha512-k1yolMBswx34Jw9hZn5Xh2/GBlwqlW+wiN7QaUYUMhSa1ypfti6rlCfSmCxWyooxH1G32C/Z+qVvgAsBOELZBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.13.0"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -9802,6 +10161,20 @@
         "node": "*"
       }
     },
+    "node_modules/turndown": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+      "integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=9"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9999,6 +10372,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 	"dependencies": {
 		"@dao-xyz/sqlite3-vec": "^0.0.19",
 		"@modelcontextprotocol/sdk": "^1.29.0",
+		"defuddle": "0.19.2",
 		"diff-match-patch": "^1.0.5",
 		"eventsource-parser": "^1.1.2",
 		"fast-xml-parser": "^5.8.0",

--- a/src/agents/apps/webTools/WebToolsAgent.ts
+++ b/src/agents/apps/webTools/WebToolsAgent.ts
@@ -10,7 +10,7 @@ const WEB_TOOLS_MANIFEST: AppManifest = {
   id: 'web-tools',
   agentName: 'webTools',
   name: 'Web Tools',
-  description: 'Desktop Web Viewer tools for opening webpages and saving them into the vault as Markdown',
+  description: 'Capture webpages into the vault as Markdown, plus desktop Web Viewer tools for opening, screenshotting and reading links from a page',
   version: '1.0.0',
   author: 'Nexus',
   credentials: [],
@@ -19,7 +19,7 @@ const WEB_TOOLS_MANIFEST: AppManifest = {
   },
   tools: [
     { slug: 'open', description: 'Open a webpage in Obsidian Web Viewer' },
-    { slug: 'capture-markdown', description: 'Save a Web Viewer page into the vault as Markdown' },
+    { slug: 'capture-markdown', description: 'Extract a webpage into the vault as Markdown with metadata frontmatter (works on mobile)' },
     { slug: 'capture-png', description: 'Capture a Web Viewer page as a PNG image' },
     { slug: 'capture-pdf', description: 'Print a Web Viewer page to PDF' },
     { slug: 'links', description: 'Extract links from a Web Viewer page' },

--- a/src/agents/apps/webTools/services/WebContentExtractor.ts
+++ b/src/agents/apps/webTools/services/WebContentExtractor.ts
@@ -1,0 +1,213 @@
+import { htmlToMarkdown, requestUrl } from 'obsidian';
+
+/**
+ * Page metadata Defuddle recovers alongside the article body.
+ *
+ * Every field is nullable: Defuddle returns `''` for anything it could not find,
+ * and an empty string in frontmatter is worse than an absent key.
+ */
+export interface WebPageMetadata {
+  title: string | null;
+  description: string | null;
+  author: string | null;
+  published: string | null;
+  site: string | null;
+  domain: string | null;
+  image: string | null;
+  favicon: string | null;
+  language: string | null;
+  wordCount: number;
+}
+
+export interface ExtractedWebPage {
+  /** Article body converted with Obsidian's own `htmlToMarkdown`. */
+  markdown: string;
+  /** Cleaned article HTML as Defuddle emitted it, before conversion. */
+  html: string;
+  metadata: WebPageMetadata;
+  /** Site-specific extractor Defuddle matched, if any (e.g. `youtube`). */
+  extractorType: string | null;
+  parseTimeMs: number;
+}
+
+/**
+ * Subset of the Defuddle response we consume. Declared locally rather than
+ * imported so this module has no top-level dependency on the package — see
+ * `loadDefuddle` below for why that matters.
+ */
+export interface DefuddleResponseLike {
+  content?: string;
+  title?: string;
+  description?: string;
+  author?: string;
+  published?: string;
+  site?: string;
+  domain?: string;
+  image?: string;
+  favicon?: string;
+  language?: string;
+  wordCount?: number;
+  parseTime?: number;
+  extractorType?: string;
+}
+
+interface DefuddleLike {
+  parseAsync(): Promise<DefuddleResponseLike>;
+}
+
+type DefuddleConstructor = new (doc: Document, options?: Record<string, unknown>) => DefuddleLike;
+
+/**
+ * Minimal `fetch` surface Defuddle's async extractors use: `ok`, `status`,
+ * `text()` and `json()`. Nothing else is called.
+ */
+interface FetchLikeResponse {
+  ok: boolean;
+  status: number;
+  text(): Promise<string>;
+  json(): Promise<unknown>;
+}
+
+let defuddleModulePromise: Promise<DefuddleConstructor> | null = null;
+
+/**
+ * Load Defuddle lazily.
+ *
+ * The package's browser entry pulls in no Node built-ins (they live only in its
+ * `fetch`/`cli` entries, which nothing here reaches), but per the mobile rules a
+ * heavy dependency is still imported inside a function rather than at module
+ * top level. The promise is memoized so repeated captures parse the module once.
+ */
+async function loadDefuddle(): Promise<DefuddleConstructor> {
+  if (!defuddleModulePromise) {
+    defuddleModulePromise = import('defuddle')
+      .then((module) => (module.default ?? module) as unknown as DefuddleConstructor)
+      .catch((error) => {
+        defuddleModulePromise = null;
+        throw error;
+      });
+  }
+
+  return defuddleModulePromise;
+}
+
+/**
+ * A `fetch`-shaped function backed by Obsidian's `requestUrl`.
+ *
+ * Defuddle's async extractors (YouTube transcripts, Reddit comments, oEmbed)
+ * call `options.fetch ?? globalThis.fetch`. Handing them `requestUrl` keeps the
+ * plugin on the sanctioned transport — no CORS, and no bare `fetch()` anywhere
+ * in the capture path.
+ *
+ * `signal` and `credentials` are dropped because `requestUrl` supports neither;
+ * the consequence is that an extractor's own timeout no longer aborts the
+ * request early, and cookie-authenticated extractor calls are anonymous.
+ */
+export const requestUrlFetch = async (
+  input: string | { toString(): string },
+  init?: { method?: string; headers?: Record<string, string>; body?: string }
+): Promise<FetchLikeResponse> => {
+  const response = await requestUrl({
+    url: typeof input === 'string' ? input : String(input),
+    method: init?.method ?? 'GET',
+    headers: init?.headers,
+    body: init?.body,
+    // Return non-2xx instead of throwing: Defuddle branches on `.ok`.
+    throw: false,
+  });
+
+  return {
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status,
+    text: () => Promise.resolve(response.text),
+    // `requestUrl`'s `json` is a parsing getter, so it must stay lazy: touching
+    // it on a non-JSON body throws, and callers that only want text() must not
+    // pay for that.
+    json: (): Promise<unknown> => {
+      try {
+        return Promise.resolve(response.json as unknown);
+      } catch (error) {
+        return Promise.reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    },
+  };
+};
+
+/**
+ * The single Defuddle call site.
+ *
+ * Both capture transports — an HTTP fetch and a live browser DOM — hand this
+ * service HTML and get back markdown plus metadata. Keeping the library behind
+ * one class means a 0.x API break touches one file (design plan §9).
+ */
+export class WebContentExtractor {
+  /**
+   * Parse a full HTML document string into an article.
+   *
+   * The resulting `DOMParser` document has `defaultView === null`, so Defuddle's
+   * `getComputedStyle`-based passes (hidden elements, small images) no-op. Its
+   * selector- and score-based cleanup is unaffected, so extraction still works;
+   * CSS-hidden clutter can survive. See `LIVE_DOM_CAPTURE_SCRIPT` for how the
+   * browser transport compensates.
+   */
+  async extractFromHtml(html: string, url?: string): Promise<ExtractedWebPage> {
+    return this.extractFromDocument(parseHtmlDocument(html), url);
+  }
+
+  async extractFromDocument(doc: Document, url?: string): Promise<ExtractedWebPage> {
+    const Defuddle = await loadDefuddle();
+    // Defuddle mutates the document it is given. Every caller here passes a
+    // freshly parsed one, so there is nothing live to damage.
+    const result = await new Defuddle(doc, {
+      url,
+      fetch: requestUrlFetch,
+    }).parseAsync();
+
+    return toExtractedWebPage(result);
+  }
+}
+
+/**
+ * Map a Defuddle response onto our own shape.
+ *
+ * Split out from the extractor so it can be tested without a DOM: Defuddle
+ * reports "not found" as `''`, and an empty string reaching frontmatter is a
+ * key that looks present but says nothing.
+ */
+export function toExtractedWebPage(result: DefuddleResponseLike): ExtractedWebPage {
+  const html = result.content ?? '';
+
+  return {
+    markdown: html ? htmlToMarkdown(html).trim() : '',
+    html,
+    metadata: {
+      title: emptyToNull(result.title),
+      description: emptyToNull(result.description),
+      author: emptyToNull(result.author),
+      published: emptyToNull(result.published),
+      site: emptyToNull(result.site),
+      domain: emptyToNull(result.domain),
+      image: emptyToNull(result.image),
+      favicon: emptyToNull(result.favicon),
+      language: emptyToNull(result.language),
+      wordCount: typeof result.wordCount === 'number' ? result.wordCount : 0,
+    },
+    extractorType: emptyToNull(result.extractorType),
+    parseTimeMs: typeof result.parseTime === 'number' ? result.parseTime : 0,
+  };
+}
+
+/**
+ * Parse HTML into a detached document.
+ *
+ * `DOMParser` is a web standard present in both Electron and the mobile
+ * webview, so this needs no platform guard.
+ */
+export function parseHtmlDocument(html: string): Document {
+  return new DOMParser().parseFromString(html, 'text/html');
+}
+
+function emptyToNull(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}

--- a/src/agents/apps/webTools/services/liveDomCapture.ts
+++ b/src/agents/apps/webTools/services/liveDomCapture.ts
@@ -1,0 +1,81 @@
+export interface LiveDomSnapshot {
+  html: string;
+  url: string;
+  title: string;
+}
+
+/**
+ * JavaScript evaluated inside the Web Viewer page to serialize its rendered DOM.
+ *
+ * ## Why it does more than read `outerHTML`
+ *
+ * Defuddle drops CSS-hidden clutter by consulting `getComputedStyle`, but it
+ * only does so when the document's `defaultView` *is* the global `window`. Both
+ * of our transports hand it a `DOMParser` document (the page's live DOM lives in
+ * another process and cannot cross the `executeJavaScript` boundary), so that
+ * pass never runs and hidden menus, cookie banners and off-screen navigation
+ * survive into the markdown.
+ *
+ * Defuddle does still honour an **inline** `display:none` / `visibility:hidden`
+ * / `opacity:0`. So this script resolves computed styles where they exist — in
+ * the page — and stamps the equivalent inline style onto a detached clone. The
+ * live page is never mutated: the clone is taken first and every write lands on
+ * it, so a failure here cannot disturb what the user is looking at.
+ *
+ * The parallel walk relies on `querySelectorAll('*')` returning the same
+ * document order for a tree and its `cloneNode(true)` copy. The length check
+ * makes that assumption falsifiable rather than silent — on mismatch the script
+ * degrades to a plain serialization.
+ */
+export const LIVE_DOM_CAPTURE_SCRIPT = `(function () {
+  var root = document.documentElement;
+  var result = { html: '', url: location.href, title: document.title || '' };
+  if (!root) { return result; }
+
+  var clone = root.cloneNode(true);
+  try {
+    var live = root.querySelectorAll('*');
+    var copies = clone.querySelectorAll('*');
+    if (live.length === copies.length && live.length <= 40000) {
+      for (var i = 0; i < live.length; i++) {
+        var computed = window.getComputedStyle(live[i]);
+        if (!computed) { continue; }
+        var hidden = computed.display === 'none'
+          ? 'display:none'
+          : computed.visibility === 'hidden'
+            ? 'visibility:hidden'
+            : computed.opacity === '0' ? 'opacity:0' : '';
+        if (!hidden) { continue; }
+        var existing = copies[i].getAttribute('style');
+        copies[i].setAttribute('style', existing ? existing + ';' + hidden : hidden);
+      }
+    }
+  } catch (e) {
+    // Style resolution failed; fall through and serialize the clone as-is.
+  }
+
+  result.html = clone.outerHTML;
+  return result;
+})()`;
+
+/**
+ * Narrow the untyped `executeJavaScript` result to a usable snapshot.
+ *
+ * The value crosses a process boundary, so it is validated rather than cast.
+ */
+export function toLiveDomSnapshot(value: unknown): LiveDomSnapshot | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const candidate = value as Partial<LiveDomSnapshot>;
+  if (typeof candidate.html !== 'string' || !candidate.html.trim()) {
+    return null;
+  }
+
+  return {
+    html: candidate.html,
+    url: typeof candidate.url === 'string' ? candidate.url : '',
+    title: typeof candidate.title === 'string' ? candidate.title : '',
+  };
+}

--- a/src/agents/apps/webTools/services/webCaptureNote.ts
+++ b/src/agents/apps/webTools/services/webCaptureNote.ts
@@ -1,0 +1,95 @@
+import { stringifyYaml } from 'obsidian';
+import type { WebPageMetadata } from './WebContentExtractor';
+
+export type WebCaptureTransport = 'fetch' | 'browser';
+
+/**
+ * Build the note body for a captured page: YAML frontmatter carrying the
+ * metadata Defuddle recovered, followed by the article markdown.
+ *
+ * Keys whose value is null or empty are omitted rather than written blank, so a
+ * page with no byline does not gain an `author:` key that Dataview would then
+ * treat as present-but-empty.
+ */
+export function buildCaptureNote(
+  markdown: string,
+  metadata: WebPageMetadata,
+  sourceUrl: string | null,
+  capturedAtIso: string
+): string {
+  const frontmatter: Record<string, string> = {};
+
+  assign(frontmatter, 'title', metadata.title);
+  assign(frontmatter, 'source', sourceUrl);
+  assign(frontmatter, 'author', metadata.author);
+  assign(frontmatter, 'published', metadata.published);
+  assign(frontmatter, 'site', metadata.site);
+  assign(frontmatter, 'description', metadata.description);
+  assign(frontmatter, 'language', metadata.language);
+  assign(frontmatter, 'image', metadata.image);
+  frontmatter.captured = capturedAtIso;
+
+  const body = markdown.trim();
+  return `---\n${stringifyYaml(frontmatter)}---\n\n${body}${body ? '\n' : ''}`;
+}
+
+/**
+ * Whether an HTTP response is worth handing to the extractor.
+ *
+ * A non-2xx status or a non-HTML content type means the fetch transport cannot
+ * produce an article, and the caller should fall back to the browser transport
+ * (design plan §6.3).
+ */
+export function isExtractableResponse(status: number, contentType: string | undefined): boolean {
+  if (status < 200 || status >= 300) {
+    return false;
+  }
+
+  if (!contentType) {
+    // Servers that omit Content-Type are rare; attempting extraction and
+    // getting an empty article is a better failure than refusing outright.
+    return true;
+  }
+
+  const mime = contentType.split(';')[0].trim().toLowerCase();
+  return mime === 'text/html' || mime === 'application/xhtml+xml' || mime === 'text/plain';
+}
+
+/**
+ * Read `content-type` from a header map without assuming its casing.
+ *
+ * `requestUrl` lowercases header names on desktop but this is not contractual,
+ * and the browser transport supplies no headers at all.
+ */
+export function readContentType(headers: Record<string, string> | undefined): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  for (const [name, value] of Object.entries(headers)) {
+    if (name.toLowerCase() === 'content-type') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * The SPA-shell signal.
+ *
+ * A client-rendered page served to a plain HTTP fetch returns its loading
+ * shell: valid HTML, almost no prose. Word count is the cheapest reliable
+ * discriminator, so a result under the threshold is treated as "the fetch
+ * transport did not really get this page".
+ */
+export function looksLikeEmptyShell(wordCount: number, minWordCount: number): boolean {
+  return wordCount < minWordCount;
+}
+
+function assign(target: Record<string, string>, key: string, value: string | null): void {
+  const trimmed = value?.trim();
+  if (trimmed) {
+    target[key] = trimmed;
+  }
+}

--- a/src/agents/apps/webTools/tools/captureToMarkdown.ts
+++ b/src/agents/apps/webTools/tools/captureToMarkdown.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian';
+import { App, requestUrl, TFile } from 'obsidian';
 import { BaseTool } from '../../../baseTool';
 import { CommonParameters, CommonResult } from '../../../../types';
 import { JSONSchema } from '../../../../types/schema/JSONSchemaTypes';
@@ -7,37 +7,63 @@ import { isDesktop, isElectron } from '../../../../utils/platform';
 import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { labelWithUrl, verbs } from '../../../utils/toolStatusLabels';
 import {
+  assertSafeWebUrl,
   ensureParentFolderExists,
-  findCreatedMarkdownFile,
+  getWebViewerContents,
   getWebViewerLeaf,
   getWebViewerState,
-  hasWebViewerSaveCommand,
   openWebViewerUrl,
   resolveUniqueMarkdownPath,
   waitForWebViewerReady,
-  WEB_VIEWER_SAVE_COMMAND_ID,
   WebViewerOpenMode,
 } from '../utils/webViewer';
+import { ExtractedWebPage, WebContentExtractor } from '../services/WebContentExtractor';
+import {
+  buildCaptureNote,
+  isExtractableResponse,
+  looksLikeEmptyShell,
+  readContentType,
+  WebCaptureTransport,
+} from '../services/webCaptureNote';
+import { LIVE_DOM_CAPTURE_SCRIPT, toLiveDomSnapshot } from '../services/liveDomCapture';
+
+type TransportChoice = 'auto' | WebCaptureTransport;
 
 interface CaptureToMarkdownParams extends CommonParameters {
   url?: string;
+  transport?: TransportChoice;
   mode?: WebViewerOpenMode;
   outputPath: string;
+  minWordCount?: number;
   timeoutMs?: number;
   settleMs?: number;
 }
 
+interface TransportOutcome {
+  page: ExtractedWebPage;
+  transport: WebCaptureTransport;
+  sourceUrl: string | null;
+}
+
+const DEFAULT_MIN_WORD_COUNT = 100;
+
 export class CaptureToMarkdownTool extends BaseTool<CaptureToMarkdownParams, CommonResult> {
   private agent: BaseAppAgent;
+  private extractor: WebContentExtractor;
 
-  constructor(agent: BaseAppAgent) {
+  /**
+   * `extractor` is injectable so transport selection can be tested without a
+   * DOM — Defuddle needs a real one, the selection logic does not.
+   */
+  constructor(agent: BaseAppAgent, extractor: WebContentExtractor = new WebContentExtractor()) {
     super(
       'capture-markdown',
       'Capture To Markdown',
-      'Save the active Web Viewer page to the vault as Markdown using Obsidian Web Viewer. Desktop only.',
-      '1.0.0'
+      'Extract a webpage as Markdown with metadata frontmatter and save it to the vault. Fetches the URL directly (works on mobile); falls back to the desktop Web Viewer for pages that need JavaScript or a signed-in session.',
+      '2.0.0'
     );
     this.agent = agent;
+    this.extractor = extractor;
   }
 
   getStatusLabel(params: Record<string, unknown> | undefined, tense: ToolStatusTense): string | undefined {
@@ -45,77 +71,50 @@ export class CaptureToMarkdownTool extends BaseTool<CaptureToMarkdownParams, Com
   }
 
   async execute(params: CaptureToMarkdownParams): Promise<CommonResult> {
-    if (!isDesktop() || !isElectron()) {
-      return this.prepareResult(false, undefined, 'Web Viewer tools are desktop-only.');
-    }
-
     const app = this.agent.getApp();
     if (!app) {
       return this.prepareResult(false, undefined, 'Obsidian app is not available.');
     }
 
-    if (!hasWebViewerSaveCommand(app)) {
-      return this.prepareResult(
-        false,
-        undefined,
-        'Web Viewer Save to vault command is unavailable. Enable the core Web Viewer plugin in Obsidian.'
-      );
+    const transport = params.transport ?? 'auto';
+    if (transport === 'browser' && !browserTransportAvailable()) {
+      return this.prepareResult(false, undefined, 'The browser transport needs the desktop Web Viewer. Use transport "fetch" on mobile.');
     }
 
-    const timeoutMs = params.timeoutMs ?? 20000;
-    const settleMs = params.settleMs ?? 1200;
+    if (transport === 'fetch' && !params.url) {
+      return this.prepareResult(false, undefined, 'A url is required for the fetch transport.');
+    }
+
+    if (!params.url && !browserTransportAvailable()) {
+      return this.prepareResult(false, undefined, 'A url is required. Capturing the open Web Viewer tab is desktop-only.');
+    }
 
     try {
-      const leaf = params.url
-        ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
-        : getWebViewerLeaf(app);
+      const outcome = await this.capture(app, params, transport);
+      if (!outcome) {
+        return this.prepareResult(false, undefined, 'Could not retrieve the page. It may be unreachable, or may not be HTML.');
+      }
 
-      if (!leaf) {
+      if (!outcome.page.markdown) {
         return this.prepareResult(
           false,
           undefined,
-          'No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.'
+          `Extracted no readable content from the page via the ${outcome.transport} transport.`
         );
       }
 
-      await app.workspace.revealLeaf(leaf);
-      app.workspace.setActiveLeaf(leaf, { focus: true });
-      await waitForWebViewerReady(leaf, timeoutMs, settleMs);
-
-      const beforePaths = new Set(app.vault.getMarkdownFiles().map((file) => file.path));
-      const startTimeMs = Date.now();
-
-      await app.commands.executeCommandById(WEB_VIEWER_SAVE_COMMAND_ID);
-
-      let createdFile = await this.waitForCreatedFile(beforePaths, startTimeMs, timeoutMs);
-      if (!createdFile) {
-        return this.prepareResult(
-          false,
-          undefined,
-          'Web Viewer did not create a Markdown note. The page may not be readable yet or extraction may have failed.'
-        );
-      }
-
-      let movedFromPath: string | undefined;
-      const targetPath = resolveUniqueMarkdownPath(app.vault, params.outputPath);
-      if (createdFile.path !== targetPath) {
-        await ensureParentFolderExists(app.vault, targetPath);
-        movedFromPath = createdFile.path;
-        await app.vault.rename(createdFile, targetPath);
-        const movedFile = app.vault.getAbstractFileByPath(targetPath);
-        if (movedFile instanceof TFile) {
-          createdFile = movedFile;
-        }
-      }
-
-      const state = getWebViewerState(leaf);
+      const path = await this.writeNote(app, params.outputPath, outcome);
 
       return this.prepareResult(true, {
-        path: createdFile.path,
-        sourceUrl: state?.url ?? params.url ?? null,
-        title: state?.title ?? createdFile.basename,
-        usedBuiltInSaveCommand: true,
-        movedFromPath,
+        path,
+        sourceUrl: outcome.sourceUrl,
+        transport: outcome.transport,
+        title: outcome.page.metadata.title,
+        author: outcome.page.metadata.author,
+        published: outcome.page.metadata.published,
+        site: outcome.page.metadata.site,
+        wordCount: outcome.page.metadata.wordCount,
+        extractorType: outcome.page.extractorType,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -129,26 +128,37 @@ export class CaptureToMarkdownTool extends BaseTool<CaptureToMarkdownParams, Com
       properties: {
         url: {
           type: 'string',
-          description: 'Optional URL to open in Web Viewer before capturing. If omitted, captures the active Web Viewer tab.',
-        },
-        mode: {
-          type: 'string',
-          enum: ['tab', 'split', 'window', 'current'],
-          description: 'Where to open the Web Viewer tab when url is provided.',
-          default: 'tab',
+          description: 'Page to capture. Required unless transport is "browser", which can capture the already-open Web Viewer tab.',
         },
         outputPath: {
           type: 'string',
           description: 'Destination note path in the vault. Required so the caller explicitly chooses where the Markdown capture is saved.',
         },
+        transport: {
+          type: 'string',
+          enum: ['auto', 'fetch', 'browser'],
+          description: 'How to retrieve the page. "fetch" downloads it directly and is the only option on mobile. "browser" renders it in the desktop Web Viewer, which handles JavaScript-rendered and signed-in pages. "auto" fetches first and falls back to the browser on desktop.',
+          default: 'auto',
+        },
+        mode: {
+          type: 'string',
+          enum: ['tab', 'split', 'window', 'current'],
+          description: 'Where to open the Web Viewer tab when the browser transport is used.',
+          default: 'tab',
+        },
+        minWordCount: {
+          type: 'number',
+          description: 'Under "auto", a fetch result with fewer words than this is treated as a JavaScript-rendered shell and retried in the browser.',
+          default: DEFAULT_MIN_WORD_COUNT,
+        },
         timeoutMs: {
           type: 'number',
-          description: 'Maximum time to wait for page load and note creation.',
+          description: 'Maximum time to wait for the Web Viewer page to load (browser transport only).',
           default: 20000,
         },
         settleMs: {
           type: 'number',
-          description: 'Extra delay after page load before invoking Save to vault.',
+          description: 'Extra delay after page load before reading the DOM (browser transport only).',
           default: 1200,
         },
       },
@@ -156,27 +166,121 @@ export class CaptureToMarkdownTool extends BaseTool<CaptureToMarkdownParams, Com
     });
   }
 
-  private async waitForCreatedFile(
-    beforePaths: Set<string>,
-    startTimeMs: number,
-    timeoutMs: number
-  ): Promise<TFile | null> {
-    const app = this.agent.getApp();
-    if (!app) {
+  /**
+   * Run the requested transport, or under `auto` try the cheap one first.
+   *
+   * Returns null when no transport produced a page at all; an empty extraction
+   * is reported by the caller, which can name the transport that came up short.
+   */
+  private async capture(
+    app: App,
+    params: CaptureToMarkdownParams,
+    transport: TransportChoice
+  ): Promise<TransportOutcome | null> {
+    if (transport === 'browser') {
+      return this.captureViaBrowser(app, params);
+    }
+
+    const fetched = params.url ? await this.captureViaFetch(params.url) : null;
+
+    if (transport === 'fetch') {
+      return fetched;
+    }
+
+    // auto: keep the fetch result unless it is missing or looks like an SPA shell.
+    const minWordCount = params.minWordCount ?? DEFAULT_MIN_WORD_COUNT;
+    const fetchSufficed = fetched !== null
+      && fetched.page.markdown.length > 0
+      && !looksLikeEmptyShell(fetched.page.metadata.wordCount, minWordCount);
+
+    if (fetchSufficed || !browserTransportAvailable()) {
+      return fetched;
+    }
+
+    try {
+      return await this.captureViaBrowser(app, params);
+    } catch (error) {
+      // The fallback is best-effort: a fetch result that merely looked thin is
+      // better than surfacing a Web Viewer timeout the caller did not ask for.
+      if (fetched) {
+        return fetched;
+      }
+      throw error;
+    }
+  }
+
+  private async captureViaFetch(url: string): Promise<TransportOutcome | null> {
+    assertSafeWebUrl(url);
+
+    const response = await requestUrl({ url, method: 'GET', throw: false });
+    if (!isExtractableResponse(response.status, readContentType(response.headers))) {
       return null;
     }
 
-    const deadline = Date.now() + timeoutMs;
+    const page = await this.extractor.extractFromHtml(response.text, url);
+    return { page, transport: 'fetch', sourceUrl: url };
+  }
 
-    while (Date.now() < deadline) {
-      const file = findCreatedMarkdownFile(app.vault, beforePaths, startTimeMs);
-      if (file) {
-        return file;
-      }
+  private async captureViaBrowser(app: App, params: CaptureToMarkdownParams): Promise<TransportOutcome | null> {
+    const timeoutMs = params.timeoutMs ?? 20000;
+    const settleMs = params.settleMs ?? 1200;
 
-      await new Promise<void>((resolve) => window.setTimeout(resolve, 200));
+    const leaf = params.url
+      ? await openWebViewerUrl(app, params.url, params.mode ?? 'tab', true)
+      : getWebViewerLeaf(app);
+
+    if (!leaf) {
+      throw new Error('No Web Viewer tab is open. Provide a URL or open a page in Web Viewer first.');
     }
 
-    return null;
+    await app.workspace.revealLeaf(leaf);
+    app.workspace.setActiveLeaf(leaf, { focus: true });
+
+    const contents = await waitForWebViewerReady(leaf, timeoutMs, settleMs)
+      ?? getWebViewerContents(leaf);
+    if (!contents?.executeJavaScript) {
+      throw new Error('Web Viewer executeJavaScript() is unavailable in this Obsidian build.');
+    }
+
+    const snapshot = toLiveDomSnapshot(await contents.executeJavaScript<unknown>(LIVE_DOM_CAPTURE_SCRIPT));
+    if (!snapshot) {
+      return null;
+    }
+
+    const sourceUrl = snapshot.url || getWebViewerState(leaf)?.url || params.url || null;
+    const page = await this.extractor.extractFromHtml(snapshot.html, sourceUrl ?? undefined);
+
+    // The live DOM knows the page title even when extraction does not.
+    if (!page.metadata.title && snapshot.title) {
+      page.metadata.title = snapshot.title;
+    }
+
+    return { page, transport: 'browser', sourceUrl };
   }
+
+  private async writeNote(app: App, outputPath: string, outcome: TransportOutcome): Promise<string> {
+    // resolveUniqueMarkdownPath confines the caller-supplied path to the vault
+    // and throws VaultPathError on traversal, which execute() surfaces.
+    const targetPath = resolveUniqueMarkdownPath(app.vault, outputPath);
+    await ensureParentFolderExists(app.vault, targetPath);
+
+    const contents = buildCaptureNote(
+      outcome.page.markdown,
+      outcome.page.metadata,
+      outcome.sourceUrl,
+      new Date().toISOString()
+    );
+
+    const file = await app.vault.create(targetPath, contents);
+    return file instanceof TFile ? file.path : targetPath;
+  }
+}
+
+/**
+ * The Web Viewer is an Electron `<webview>`, so the browser transport exists
+ * only on desktop. The fetch transport has no such constraint — it is the first
+ * webTools capability that runs on mobile.
+ */
+function browserTransportAvailable(): boolean {
+  return isDesktop() && isElectron();
 }

--- a/src/agents/apps/webTools/utils/webViewer.ts
+++ b/src/agents/apps/webTools/utils/webViewer.ts
@@ -1,4 +1,4 @@
-import { App, normalizePath, TFile, TFolder, Vault, View, WorkspaceLeaf } from 'obsidian';
+import { App, normalizePath, TFolder, Vault, View, WorkspaceLeaf } from 'obsidian';
 import { sanitizeName } from '../../../../utils/pathUtils';
 import { resolveVaultPath } from '../../../../core/vaultPath';
 
@@ -28,7 +28,6 @@ interface WebViewerLikeView extends View {
 }
 
 export const WEB_VIEWER_VIEW_TYPE = 'webviewer';
-export const WEB_VIEWER_SAVE_COMMAND_ID = 'webviewer:save-to-vault';
 
 export function getLeafForMode(app: App, mode: WebViewerOpenMode): WorkspaceLeaf {
   switch (mode) {
@@ -172,18 +171,6 @@ export async function ensureParentFolderExists(vault: Vault, path: string): Prom
   }
 }
 
-export function findCreatedMarkdownFile(
-  vault: Vault,
-  beforePaths: Set<string>,
-  startTimeMs: number
-): TFile | null {
-  const candidates = vault.getMarkdownFiles()
-    .filter((file) => !beforePaths.has(file.path) && file.stat.mtime >= startTimeMs - 5000)
-    .sort((a, b) => b.stat.mtime - a.stat.mtime);
-
-  return candidates[0] ?? null;
-}
-
 export function resolveUniqueMarkdownPath(vault: Vault, outputPath: string): string {
   return resolveUniqueFilePath(vault, outputPath, 'md');
 }
@@ -210,10 +197,6 @@ export function resolveUniqueFilePath(vault: Vault, outputPath: string, extensio
   }
 
   return candidate;
-}
-
-export function hasWebViewerSaveCommand(app: App): boolean {
-  return Boolean(app.commands.commands[WEB_VIEWER_SAVE_COMMAND_ID]);
 }
 
 export function buildDefaultWebCapturePath(

--- a/tests/agents/webTools/captureToMarkdownTransport.test.ts
+++ b/tests/agents/webTools/captureToMarkdownTransport.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Transport selection for `web capture-markdown` (design plan §6.3).
+ *
+ * The point of the redesign is that the cheap HTTP transport handles most pages
+ * and the expensive browser one is a fallback, so these tests pin *which*
+ * transport runs for a given response — including the mobile case, where the
+ * browser transport does not exist and a fetch result must be returned rather
+ * than a "desktop only" refusal.
+ *
+ * The extractor is stubbed: Defuddle needs a real DOM, which this environment
+ * does not have. That is deliberate — the decision under test is the selection,
+ * not the parse. Extraction quality is `tests/manual/web-capture-bakeoff.md`.
+ */
+
+import { Platform, __setRequestUrlMock } from 'obsidian';
+import { CaptureToMarkdownTool } from '@/agents/apps/webTools/tools/captureToMarkdown';
+import type { BaseAppAgent } from '@/agents/apps/BaseAppAgent';
+import type { ExtractedWebPage, WebContentExtractor } from '@/agents/apps/webTools/services/WebContentExtractor';
+
+interface FetchCall {
+  url?: string;
+  status: number;
+  contentType?: string;
+  body: string;
+}
+
+function page(overrides: Partial<ExtractedWebPage['metadata']> & { markdown?: string } = {}): ExtractedWebPage {
+  const { markdown, ...metadata } = overrides;
+  return {
+    markdown: markdown ?? 'Extracted body text.',
+    html: '<p>Extracted body text.</p>',
+    metadata: {
+      title: 'Title',
+      description: null,
+      author: null,
+      published: null,
+      site: null,
+      domain: null,
+      image: null,
+      favicon: null,
+      language: null,
+      wordCount: 500,
+      ...metadata,
+    },
+    extractorType: null,
+    parseTimeMs: 1,
+  };
+}
+
+/** Records what HTML it was handed and returns a canned extraction per call. */
+function stubExtractor(results: ExtractedWebPage[]): { extractor: WebContentExtractor; htmlSeen: string[] } {
+  const htmlSeen: string[] = [];
+  let index = 0;
+  const extractor = {
+    extractFromHtml: (html: string) => {
+      htmlSeen.push(html);
+      return Promise.resolve(results[Math.min(index++, results.length - 1)]);
+    },
+    extractFromDocument: () => Promise.reject(new Error('not used')),
+  } as unknown as WebContentExtractor;
+
+  return { extractor, htmlSeen };
+}
+
+function makeAgent(): { agent: BaseAppAgent; created: Array<{ path: string; contents: string }> } {
+  const created: Array<{ path: string; contents: string }> = [];
+  const app = {
+    vault: {
+      getAbstractFileByPath: () => null,
+      createFolder: () => Promise.resolve(),
+      create: (path: string, contents: string) => {
+        created.push({ path, contents });
+        return Promise.resolve({ path });
+      },
+    },
+  };
+
+  return { agent: { getApp: () => app } as unknown as BaseAppAgent, created };
+}
+
+function mockFetch(call: FetchCall): { urls: string[] } {
+  const urls: string[] = [];
+  __setRequestUrlMock(async (request) => {
+    urls.push(request.url ?? '');
+    return {
+      status: call.status,
+      headers: call.contentType ? { 'Content-Type': call.contentType } : {},
+      text: call.body,
+      json: {},
+      arrayBuffer: new ArrayBuffer(0),
+    };
+  });
+  return { urls };
+}
+
+/**
+ * The browser transport is gated on `isDesktop() && isElectron()`, i.e. on
+ * `Platform` plus `process.versions.electron`. Jest is neither, so desktop has
+ * to be simulated explicitly — which also means the default state of these
+ * tests is the mobile one.
+ */
+function withElectron(present: boolean): () => void {
+  const originalVersions = process.versions;
+  const originalIsDesktop = Platform.isDesktop;
+  const originalIsMobile = Platform.isMobile;
+
+  Object.defineProperty(process, 'versions', {
+    value: present ? { ...originalVersions, electron: '30.0.0' } : { ...originalVersions, electron: undefined },
+    configurable: true,
+  });
+  Platform.isDesktop = present;
+  Platform.isMobile = !present;
+
+  return () => {
+    Object.defineProperty(process, 'versions', { value: originalVersions, configurable: true });
+    Platform.isDesktop = originalIsDesktop;
+    Platform.isMobile = originalIsMobile;
+  };
+}
+
+describe('capture-markdown transport selection', () => {
+  let restorePlatform: () => void = () => undefined;
+
+  afterEach(() => {
+    restorePlatform();
+    restorePlatform = () => undefined;
+    __setRequestUrlMock(async () => ({
+      status: 200,
+      headers: {},
+      text: '',
+      json: {},
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+  });
+
+  describe('on mobile, where only the fetch transport exists', () => {
+    beforeEach(() => {
+      restorePlatform = withElectron(false);
+    });
+
+    it('captures an ordinary article and writes it to the requested path', async () => {
+      const { urls } = mockFetch({ status: 200, contentType: 'text/html', body: '<html><body>hi</body></html>' });
+      const { extractor, htmlSeen } = stubExtractor([page({ title: 'Ordinary Article' })]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com/post',
+        outputPath: 'captures/post',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(urls).toEqual(['https://example.com/post']);
+      expect(htmlSeen).toEqual(['<html><body>hi</body></html>']);
+      expect(created).toHaveLength(1);
+      expect(created[0].path).toBe('captures/post.md');
+      expect(created[0].contents).toContain('title: Ordinary Article');
+      expect(created[0].contents).toContain('source: https://example.com/post');
+      expect(created[0].contents).toContain('Extracted body text.');
+      expect(result.data).toMatchObject({ path: 'captures/post.md', transport: 'fetch' });
+    });
+
+    it('keeps a thin fetch result instead of failing, because there is nothing to fall back to', async () => {
+      // Under `auto` on desktop this word count would trigger the browser
+      // transport. On mobile the fetch result is all there is.
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor } = stubExtractor([page({ wordCount: 3, markdown: 'Loading…' })]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://spa.example.com',
+        outputPath: 'captures/spa',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ transport: 'fetch' });
+      expect(created).toHaveLength(1);
+    });
+
+    it('refuses the browser transport with an actionable message', async () => {
+      const { extractor } = stubExtractor([page()]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com',
+        outputPath: 'captures/x',
+        transport: 'browser',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('fetch');
+      expect(created).toHaveLength(0);
+    });
+
+    it('requires a url, since capturing the open tab needs a Web Viewer', async () => {
+      const { extractor } = stubExtractor([page()]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        outputPath: 'captures/x',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('url is required');
+    });
+
+    it.each([
+      ['a 404', { status: 404, contentType: 'text/html', body: 'Not found' }],
+      ['a PDF', { status: 200, contentType: 'application/pdf', body: '%PDF-1.4' }],
+      ['an image', { status: 200, contentType: 'image/png', body: 'PNG' }],
+    ])('reports %s as unretrievable without writing a note', async (_label, call) => {
+      mockFetch(call as FetchCall);
+      const { extractor, htmlSeen } = stubExtractor([page()]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com/file',
+        outputPath: 'captures/x',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(htmlSeen).toHaveLength(0);
+      expect(created).toHaveLength(0);
+    });
+
+    it('reports an empty extraction separately from an unreachable page', async () => {
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor } = stubExtractor([page({ markdown: '' })]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com',
+        outputPath: 'captures/x',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('no readable content');
+      expect(result.error).toContain('fetch');
+      expect(created).toHaveLength(0);
+    });
+
+    it('rejects a non-http URL before any request is made', async () => {
+      const { urls } = mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor } = stubExtractor([page()]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'file:///etc/passwd',
+        outputPath: 'captures/x',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/scheme/);
+      expect(urls).toHaveLength(0);
+    });
+
+    it('rejects an outputPath that escapes the vault, after fetching but before writing', async () => {
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor } = stubExtractor([page()]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com',
+        outputPath: '../../../../tmp/ESCAPE',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(created).toHaveLength(0);
+    });
+  });
+
+  describe('on desktop', () => {
+    beforeEach(() => {
+      restorePlatform = withElectron(true);
+    });
+
+    it('does not open a Web Viewer when the fetch result is substantial', async () => {
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html><body>article</body></html>' });
+      const { extractor, htmlSeen } = stubExtractor([page({ wordCount: 900 })]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com/article',
+        outputPath: 'captures/article',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ transport: 'fetch' });
+      // One extraction only: the browser transport was never reached, so no
+      // leaf was opened and the workspace was not mutated.
+      expect(htmlSeen).toHaveLength(1);
+    });
+
+    it('falls back to the fetch result when the browser transport itself fails', async () => {
+      // `auto` sees an SPA shell and tries the browser; there is no Obsidian
+      // workspace in this environment, so that attempt throws. A thin capture
+      // beats surfacing a Web Viewer error the caller never asked for.
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor } = stubExtractor([page({ wordCount: 4, markdown: 'Loading…' })]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://spa.example.com',
+        outputPath: 'captures/spa',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ transport: 'fetch' });
+      expect(created[0].contents).toContain('Loading…');
+    });
+
+    it('surfaces the browser failure when there is no fetch result to fall back on', async () => {
+      mockFetch({ status: 503, contentType: 'text/html', body: 'down' });
+      const { extractor } = stubExtractor([page()]);
+      const { agent, created } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://spa.example.com',
+        outputPath: 'captures/spa',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(created).toHaveLength(0);
+    });
+
+    it('honours transport "fetch" and never falls back, even on a shell', async () => {
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor, htmlSeen } = stubExtractor([page({ wordCount: 2, markdown: 'Loading…' })]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://spa.example.com',
+        outputPath: 'captures/spa',
+        transport: 'fetch',
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ transport: 'fetch' });
+      expect(htmlSeen).toHaveLength(1);
+    });
+
+    it('rejects transport "fetch" without a url rather than silently using the open tab', async () => {
+      const { extractor } = stubExtractor([page()]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        outputPath: 'captures/x',
+        transport: 'fetch',
+      } as never);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('url is required');
+    });
+
+    it('respects a custom minWordCount when judging a shell', async () => {
+      // 300 words clears the default threshold but not this one, so `auto`
+      // must attempt the browser transport (which then fails, falling back).
+      mockFetch({ status: 200, contentType: 'text/html', body: '<html></html>' });
+      const { extractor, htmlSeen } = stubExtractor([page({ wordCount: 300 })]);
+      const { agent } = makeAgent();
+
+      const result = await new CaptureToMarkdownTool(agent, extractor).execute({
+        url: 'https://example.com',
+        outputPath: 'captures/x',
+        minWordCount: 1000,
+      } as never);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ transport: 'fetch' });
+      expect(htmlSeen).toHaveLength(1);
+    });
+  });
+});

--- a/tests/debug/web-capture-live-smoke.test.ts
+++ b/tests/debug/web-capture-live-smoke.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Live web-capture smoke test.
+ *
+ * Drives a RUNNING Nexus vault through the `nexus` CLI, so `web
+ * capture-markdown` runs against real Defuddle, a real `DOMParser` document and
+ * Obsidian's real `htmlToMarkdown`. Skipped unless explicitly enabled.
+ *
+ *   RUN_WEB_CAPTURE_SMOKE=1 npx jest tests/debug/web-capture-live-smoke.test.ts --runInBand --no-coverage --verbose
+ *
+ * Pick a vault (otherwise the CLI's default is used):
+ *   RUN_WEB_CAPTURE_SMOKE=1 WEB_CAPTURE_SMOKE_VAULT=code npx jest tests/debug/web-capture-live-smoke.test.ts --runInBand
+ *
+ * ## Why this exists
+ *
+ * The unit lane cannot reach the part that matters. Jest runs on the `node`
+ * environment with no DOM, so `tests/unit/WebContentExtractor.test.ts` stubs
+ * `htmlToMarkdown` and never constructs a Defuddle instance at all — it proves
+ * the mapping and the `requestUrl` shim, nothing about extraction. Three claims
+ * the design plan makes are only checkable here:
+ *
+ *  1. Defuddle degrades rather than throws on a detached `DOMParser` document
+ *     (`defaultView === null`), which is what the fetch transport hands it.
+ *  2. Obsidian's `htmlToMarkdown` turns the cleaned HTML into real markdown —
+ *     headings and links, not a tag-stripped blob.
+ *  3. The fetch transport opens no Web Viewer leaf, i.e. a data operation no
+ *     longer mutates the workspace.
+ *
+ * It needs network access, and it asserts on live pages — so it asserts on
+ * structural floors (a heading exists, word count is substantial) rather than
+ * exact text, which would rot.
+ *
+ * It writes scratch notes under a dedicated folder and archives them
+ * afterwards. It never touches anything else in the vault.
+ *
+ * ## Before running
+ *
+ * Reload the plugin so it is running the build under test, and prefer a FULL
+ * vault reload — `obsidian-cli vault=<name> reload`. `plugin:reload` leaves the
+ * plugin in a degraded state whose MCP socket dies about 35s later and whose
+ * Web Viewer transport hangs; see the `nexus-testing` skill.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+jest.setTimeout(300_000);
+
+const RUN_LIVE = process.env.RUN_WEB_CAPTURE_SMOKE === '1';
+const VAULT = process.env.WEB_CAPTURE_SMOKE_VAULT;
+const SCRATCH = '_web-capture-smoke';
+
+const MEMORY = 'Running the automated web-capture smoke test against a live vault.';
+const GOAL = 'Verify Defuddle extraction, metadata frontmatter and transport selection end to end.';
+
+/** A stable, content-rich page with headings, links and real metadata. */
+const ARTICLE_URL = 'https://en.wikipedia.org/wiki/Markdown';
+
+interface CaptureResult {
+  success: boolean;
+  error?: string;
+  path?: string;
+  transport?: string;
+  title?: string | null;
+  site?: string | null;
+  wordCount?: number;
+}
+
+async function nexus(command: string[]): Promise<Record<string, unknown>> {
+  const args = [
+    ...(VAULT ? ['--vault', VAULT] : []),
+    'use',
+    '--memory', MEMORY,
+    '--goal', GOAL,
+    '--',
+    ...command
+  ];
+
+  const { stdout } = await execFileAsync('nexus', args, { maxBuffer: 32 * 1024 * 1024 });
+  return parseCliOutput(stdout);
+}
+
+/**
+ * Pull the result object out of CLI output.
+ *
+ * On success the CLI prints bare JSON. On failure it prints a human-readable
+ * banner first and the JSON under "Full Error Details", so a bare `JSON.parse`
+ * throws on exactly the cases a failure-path test needs to inspect.
+ */
+function parseCliOutput(stdout: string): Record<string, unknown> {
+  const start = stdout.indexOf('{');
+  if (start === -1) {
+    throw new Error(`No JSON in CLI output:\n${stdout}`);
+  }
+  return JSON.parse(stdout.slice(start)) as Record<string, unknown>;
+}
+
+async function capture(args: string[]): Promise<CaptureResult> {
+  return await nexus(['web', 'capture-markdown', ...args]) as unknown as CaptureResult;
+}
+
+async function readNote(path: string): Promise<string> {
+  const result = await nexus(['content', 'read', path, '1']);
+  if (result.success !== true) {
+    throw new Error(`Failed to read ${path}: ${JSON.stringify(result)}`);
+  }
+  // `content read` prefixes each line with "<n>: " for positioning.
+  return String(result.content ?? '').replace(/^\d+: ?/gm, '');
+}
+
+function frontmatterOf(note: string): Record<string, string> {
+  const match = /^---\n([\s\S]*?)\n---\n/.exec(note);
+  if (!match) {
+    throw new Error(`No frontmatter in note:\n${note.slice(0, 300)}`);
+  }
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const separator = line.indexOf(': ');
+    if (separator > 0) {
+      fields[line.slice(0, separator)] = line.slice(separator + 2);
+    }
+  }
+  return fields;
+}
+
+const describeLive = RUN_LIVE ? describe : describe.skip;
+
+describeLive('web capture-markdown against a live vault', () => {
+  afterAll(async () => {
+    // Archive is reversible; the AI surface has no delete by design.
+    await nexus(['storage', 'archive', '--path', SCRATCH]).catch(() => undefined);
+  });
+
+  describe('the fetch transport', () => {
+    let note = '';
+    let result: CaptureResult;
+
+    beforeAll(async () => {
+      result = await capture(['--url', ARTICLE_URL, `${SCRATCH}/article-fetch`, '--transport', 'fetch']);
+      if (result.success) {
+        note = await readNote(`${SCRATCH}/article-fetch.md`);
+      }
+    });
+
+    it('extracts a real article without a Web Viewer', () => {
+      expect(result).toMatchObject({ success: true, transport: 'fetch' });
+      // Defuddle ran against a detached DOMParser document. If its
+      // getComputedStyle passes threw there instead of degrading, extraction
+      // would have failed outright rather than returning thousands of words.
+      expect(result.wordCount).toBeGreaterThan(500);
+    });
+
+    it('recovers metadata the legacy save-to-vault route discarded', () => {
+      const frontmatter = frontmatterOf(note);
+      expect(frontmatter.title).toMatch(/Markdown/);
+      expect(frontmatter.source).toBe(ARTICLE_URL);
+      expect(frontmatter.site).toBeTruthy();
+      // `captured` is always written, and must be a real ISO timestamp.
+      expect(new Date(frontmatter.captured).toISOString()).toBe(frontmatter.captured);
+    });
+
+    it('produces real markdown, not a tag-stripped blob', () => {
+      // The unit lane's htmlToMarkdown stub cannot produce either of these.
+      expect(note).toMatch(/^## .+/m);
+      expect(note).toMatch(/\[[^\]]+\]\(https?:\/\/[^)]+\)/);
+    });
+
+    it('leaves no blank frontmatter keys for metadata the page lacks', () => {
+      expect(note).not.toMatch(/^\w+: *$/m);
+    });
+  });
+
+  describe('transport selection', () => {
+    it('auto picks fetch for a page that serves its content as HTML', async () => {
+      const result = await capture(['--url', ARTICLE_URL, `${SCRATCH}/article-auto`]);
+      expect(result).toMatchObject({ success: true, transport: 'fetch' });
+    });
+
+    it.each([
+      ['a non-HTML response', 'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf'],
+      ['a 404', 'https://en.wikipedia.org/wiki/ThisPageDoesNotExist_NexusWebCaptureSmoke'],
+    ])('refuses %s without writing a note', async (_label, url) => {
+      const result = await capture(['--url', url, `${SCRATCH}/should-not-exist`, '--transport', 'fetch']);
+      expect(result.success).toBe(false);
+      expect(result.error).toBeTruthy();
+    });
+
+    it('rejects a non-http scheme before making any request', async () => {
+      const result = await capture(['--url', 'file:///etc/passwd', `${SCRATCH}/nope`, '--transport', 'fetch']);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/scheme/);
+    });
+
+    it('rejects an outputPath that escapes the vault', async () => {
+      const result = await capture(['--url', 'https://example.com', '../../../../tmp/ESCAPE', '--transport', 'fetch']);
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/\.\.|traversal/);
+    });
+  });
+});

--- a/tests/mocks/obsidian/core.ts
+++ b/tests/mocks/obsidian/core.ts
@@ -191,6 +191,21 @@ export function normalizePath(path: string): string {
 }
 
 /**
+ * Mock of Obsidian's `htmlToMarkdown`.
+ *
+ * Obsidian's real converter is a full HTML parse; there is no DOM in this test
+ * environment to reproduce it. This stub only strips tags and collapses
+ * whitespace, which is enough to prove that callers pass the cleaned HTML
+ * through and trim the result — it proves nothing about conversion fidelity, so
+ * do not assert on markdown formatting here. Real conversion is exercised by
+ * `tests/manual/web-capture-bakeoff.md`.
+ */
+export function htmlToMarkdown(html: string | { innerHTML?: string }): string {
+  const source = typeof html === 'string' ? html : (html.innerHTML ?? '');
+  return source.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
  * Mock of Obsidian's `prepareFuzzySearch`.
  *
  * Mirrors the two properties production code actually depends on:

--- a/tests/mocks/obsidian/index.ts
+++ b/tests/mocks/obsidian/index.ts
@@ -21,6 +21,7 @@ export {
   requestUrl,
   __setRequestUrlMock,
   normalizePath,
+  htmlToMarkdown,
   prepareFuzzySearch,
   parseYaml,
   stringifyYaml,

--- a/tests/unit/WebContentExtractor.test.ts
+++ b/tests/unit/WebContentExtractor.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The DOM-free halves of the extractor: how a Defuddle response is mapped onto
+ * our own shape, and the `requestUrl`-backed `fetch` shim handed to Defuddle's
+ * async extractors.
+ *
+ * The Defuddle parse itself needs a real DOM (this suite runs on the `node`
+ * environment) and is covered by `tests/manual/web-capture-bakeoff.md`. Note
+ * that `htmlToMarkdown` here is a tag-stripping stub — these tests assert the
+ * plumbing around it, never conversion fidelity.
+ */
+
+import { __setRequestUrlMock } from 'obsidian';
+import { requestUrlFetch, toExtractedWebPage } from '@/agents/apps/webTools/services/WebContentExtractor';
+import { toLiveDomSnapshot } from '@/agents/apps/webTools/services/liveDomCapture';
+
+describe('toExtractedWebPage', () => {
+  it('carries metadata across and converts the cleaned HTML', () => {
+    const page = toExtractedWebPage({
+      content: '<p>Hello world</p>',
+      title: 'Post',
+      author: 'Ada',
+      published: '2026-01-02',
+      site: 'Example',
+      domain: 'example.com',
+      description: 'A post',
+      language: 'en',
+      image: 'https://example.com/i.png',
+      favicon: 'https://example.com/f.ico',
+      wordCount: 2,
+      parseTime: 12,
+      extractorType: 'article',
+    });
+
+    expect(page.markdown).toBe('Hello world');
+    expect(page.html).toBe('<p>Hello world</p>');
+    expect(page.metadata.title).toBe('Post');
+    expect(page.metadata.author).toBe('Ada');
+    expect(page.metadata.domain).toBe('example.com');
+    expect(page.metadata.wordCount).toBe(2);
+    expect(page.extractorType).toBe('article');
+    expect(page.parseTimeMs).toBe(12);
+  });
+
+  it('maps Defuddle\'s "not found" empty strings to null', () => {
+    // Defuddle returns '' rather than omitting a field it could not resolve.
+    // Passing that straight through would put empty keys in frontmatter.
+    const page = toExtractedWebPage({
+      content: '<p>x</p>',
+      title: '',
+      author: '   ',
+      published: '',
+      site: '',
+      domain: '',
+      description: '',
+      language: '',
+      image: '',
+      favicon: '',
+      extractorType: '',
+    });
+
+    expect(page.metadata).toEqual({
+      title: null,
+      description: null,
+      author: null,
+      published: null,
+      site: null,
+      domain: null,
+      image: null,
+      favicon: null,
+      language: null,
+      wordCount: 0,
+    });
+    expect(page.extractorType).toBeNull();
+  });
+
+  it('yields empty markdown when extraction found no content', () => {
+    expect(toExtractedWebPage({}).markdown).toBe('');
+    expect(toExtractedWebPage({ content: '' }).markdown).toBe('');
+    expect(toExtractedWebPage({}).parseTimeMs).toBe(0);
+  });
+});
+
+describe('requestUrlFetch', () => {
+  afterEach(() => {
+    __setRequestUrlMock(async () => ({
+      status: 200,
+      headers: {},
+      text: '',
+      json: {},
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+  });
+
+  it('passes method, headers and body through to requestUrl and never throws on non-2xx', async () => {
+    const seen: unknown[] = [];
+    __setRequestUrlMock(async (request) => {
+      seen.push(request);
+      return { status: 404, headers: {}, text: 'nope', json: {}, arrayBuffer: new ArrayBuffer(0) };
+    });
+
+    const response = await requestUrlFetch('https://api.example.com/x', {
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      body: '{"a":1}',
+    });
+
+    expect(seen[0]).toMatchObject({
+      url: 'https://api.example.com/x',
+      method: 'POST',
+      headers: { Accept: 'application/json' },
+      body: '{"a":1}',
+      // Defuddle's extractors branch on `.ok`, so a 404 must come back as a
+      // value rather than as a thrown error.
+      throw: false,
+    });
+    expect(response.ok).toBe(false);
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe('nope');
+  });
+
+  it.each([
+    [200, true],
+    [204, true],
+    [299, true],
+    [300, false],
+    [500, false],
+  ])('reports status %s as ok=%s', async (status, ok) => {
+    __setRequestUrlMock(async () => ({
+      status,
+      headers: {},
+      text: '',
+      json: {},
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+
+    expect((await requestUrlFetch('https://example.com')).ok).toBe(ok);
+  });
+
+  it('defaults to GET and accepts a URL object', async () => {
+    const seen: unknown[] = [];
+    __setRequestUrlMock(async (request) => {
+      seen.push(request);
+      return { status: 200, headers: {}, text: 'ok', json: {}, arrayBuffer: new ArrayBuffer(0) };
+    });
+
+    await requestUrlFetch(new URL('https://example.com/path?q=1'));
+
+    expect(seen[0]).toMatchObject({ url: 'https://example.com/path?q=1', method: 'GET' });
+  });
+
+  it('does not parse the body as JSON unless json() is called', async () => {
+    // `requestUrl`'s `json` is a parsing getter: touching it eagerly would make
+    // every HTML fetch throw before the caller ever asked for JSON.
+    let jsonReads = 0;
+    __setRequestUrlMock(async () => ({
+      status: 200,
+      headers: {},
+      text: '<html></html>',
+      get json(): unknown {
+        jsonReads += 1;
+        throw new SyntaxError('Unexpected token < in JSON');
+      },
+      arrayBuffer: new ArrayBuffer(0),
+    }));
+
+    const response = await requestUrlFetch('https://example.com');
+    expect(jsonReads).toBe(0);
+
+    await expect(response.text()).resolves.toBe('<html></html>');
+    expect(jsonReads).toBe(0);
+
+    // And when it is called, the parse failure arrives as a rejection rather
+    // than as a synchronous throw out of the shim.
+    await expect(response.json()).rejects.toThrow(SyntaxError);
+    expect(jsonReads).toBe(1);
+  });
+});
+
+describe('toLiveDomSnapshot', () => {
+  it('accepts a well-formed snapshot', () => {
+    expect(toLiveDomSnapshot({ html: '<html></html>', url: 'https://e.com', title: 'T' })).toEqual({
+      html: '<html></html>',
+      url: 'https://e.com',
+      title: 'T',
+    });
+  });
+
+  it('defaults url and title when the page did not supply them', () => {
+    expect(toLiveDomSnapshot({ html: '<html></html>' })).toEqual({
+      html: '<html></html>',
+      url: '',
+      title: '',
+    });
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'not an object'],
+    ['a snapshot with no html', { url: 'https://e.com' }],
+    ['a snapshot with blank html', { html: '   ' }],
+    ['a snapshot with non-string html', { html: 42 }],
+  ])('rejects %s', (_label, value) => {
+    expect(toLiveDomSnapshot(value)).toBeNull();
+  });
+});

--- a/tests/unit/webCaptureNote.test.ts
+++ b/tests/unit/webCaptureNote.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Frontmatter assembly and transport-selection signals for `web capture-markdown`.
+ *
+ * These are the parts of the Defuddle capture pipeline that hold no DOM: what
+ * lands in the note's frontmatter, whether an HTTP response is worth extracting,
+ * and what counts as a JavaScript-rendered shell. The Defuddle parse itself
+ * needs a real DOM and is covered by `tests/manual/web-capture-bakeoff.md`.
+ */
+
+import { parseYaml } from 'obsidian';
+import {
+  buildCaptureNote,
+  isExtractableResponse,
+  looksLikeEmptyShell,
+  readContentType,
+} from '@/agents/apps/webTools/services/webCaptureNote';
+import type { WebPageMetadata } from '@/agents/apps/webTools/services/WebContentExtractor';
+
+const EMPTY_METADATA: WebPageMetadata = {
+  title: null,
+  description: null,
+  author: null,
+  published: null,
+  site: null,
+  domain: null,
+  image: null,
+  favicon: null,
+  language: null,
+  wordCount: 0,
+};
+
+function frontmatterOf(note: string): Record<string, unknown> {
+  const match = /^---\n([\s\S]*?)\n?---\n/.exec(note);
+  if (!match) {
+    throw new Error(`No frontmatter block in note:\n${note}`);
+  }
+  return (parseYaml(match[1]) ?? {}) as Record<string, unknown>;
+}
+
+function bodyOf(note: string): string {
+  return note.replace(/^---\n[\s\S]*?\n?---\n/, '').trim();
+}
+
+describe('buildCaptureNote', () => {
+  const capturedAt = '2026-08-14T10:00:00.000Z';
+
+  it('writes the metadata Defuddle recovered as parseable frontmatter', () => {
+    const note = buildCaptureNote(
+      'Body text.',
+      {
+        ...EMPTY_METADATA,
+        title: 'A Study in Scarlet',
+        author: 'Arthur Conan Doyle',
+        published: '1887-11-01',
+        site: 'Beeton',
+        description: 'The first Holmes novel.',
+        language: 'en',
+        image: 'https://example.com/cover.png',
+        wordCount: 43000,
+      },
+      'https://example.com/scarlet',
+      capturedAt
+    );
+
+    expect(frontmatterOf(note)).toEqual({
+      title: 'A Study in Scarlet',
+      source: 'https://example.com/scarlet',
+      author: 'Arthur Conan Doyle',
+      published: '1887-11-01',
+      site: 'Beeton',
+      description: 'The first Holmes novel.',
+      language: 'en',
+      image: 'https://example.com/cover.png',
+      captured: capturedAt,
+    });
+    expect(bodyOf(note)).toBe('Body text.');
+  });
+
+  it('omits keys the page did not supply rather than writing them blank', () => {
+    const note = buildCaptureNote(
+      'Body.',
+      { ...EMPTY_METADATA, title: 'Untitled Post' },
+      'https://example.com/post',
+      capturedAt
+    );
+
+    const frontmatter = frontmatterOf(note);
+    expect(Object.keys(frontmatter).sort()).toEqual(['captured', 'source', 'title']);
+    expect(frontmatter).not.toHaveProperty('author');
+  });
+
+  it('treats whitespace-only metadata as absent', () => {
+    const note = buildCaptureNote(
+      'Body.',
+      { ...EMPTY_METADATA, author: '   ', title: '  Trimmed  ' },
+      null,
+      capturedAt
+    );
+
+    const frontmatter = frontmatterOf(note);
+    expect(frontmatter).not.toHaveProperty('author');
+    expect(frontmatter).not.toHaveProperty('source');
+    expect(frontmatter.title).toBe('Trimmed');
+  });
+
+  it('escapes values that would otherwise break the YAML block', () => {
+    // A colon-space in a title is the classic frontmatter corruptor, and page
+    // titles are attacker-influenced text we never sanitize ourselves.
+    const note = buildCaptureNote(
+      'Body.',
+      {
+        ...EMPTY_METADATA,
+        title: 'Rust: a retrospective',
+        description: 'He said "hello"\nthen left',
+        author: '- not a list item',
+      },
+      'https://example.com/x',
+      capturedAt
+    );
+
+    const frontmatter = frontmatterOf(note);
+    expect(frontmatter.title).toBe('Rust: a retrospective');
+    expect(frontmatter.description).toBe('He said "hello"\nthen left');
+    expect(frontmatter.author).toBe('- not a list item');
+  });
+
+  it('produces a valid note when extraction found metadata but no body', () => {
+    const note = buildCaptureNote('', { ...EMPTY_METADATA, title: 'Empty' }, 'https://example.com', capturedAt);
+
+    expect(frontmatterOf(note).title).toBe('Empty');
+    expect(bodyOf(note)).toBe('');
+  });
+});
+
+describe('isExtractableResponse', () => {
+  it.each([
+    ['text/html; charset=utf-8', true],
+    ['text/html', true],
+    ['application/xhtml+xml', true],
+    ['text/plain', true],
+    ['application/pdf', false],
+    ['image/png', false],
+    ['application/json', false],
+  ])('content type %s -> %s', (contentType, expected) => {
+    expect(isExtractableResponse(200, contentType)).toBe(expected);
+  });
+
+  it.each([301, 404, 429, 500])('rejects status %s regardless of content type', (status) => {
+    expect(isExtractableResponse(status, 'text/html')).toBe(false);
+  });
+
+  it('accepts a 2xx response with no content type at all', () => {
+    expect(isExtractableResponse(204, undefined)).toBe(true);
+  });
+});
+
+describe('readContentType', () => {
+  it('finds the header whatever its casing', () => {
+    expect(readContentType({ 'Content-Type': 'text/html' })).toBe('text/html');
+    expect(readContentType({ 'content-type': 'text/html' })).toBe('text/html');
+    expect(readContentType({ 'CONTENT-TYPE': 'text/html' })).toBe('text/html');
+  });
+
+  it('returns undefined when absent or unavailable', () => {
+    expect(readContentType({ 'x-other': 'v' })).toBeUndefined();
+    expect(readContentType(undefined)).toBeUndefined();
+  });
+});
+
+describe('looksLikeEmptyShell', () => {
+  it('flags a word count under the threshold and clears one at it', () => {
+    expect(looksLikeEmptyShell(12, 100)).toBe(true);
+    expect(looksLikeEmptyShell(100, 100)).toBe(false);
+    expect(looksLikeEmptyShell(101, 100)).toBe(false);
+  });
+
+  it('never flags anything when the threshold is zero', () => {
+    expect(looksLikeEmptyShell(0, 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #329.

## The problem

`web capture-markdown` extracted nothing itself. It opened a Web Viewer leaf, invoked the **core-plugin command** `webviewer:save-to-vault`, then hunted the filesystem for whatever file that command had produced. Consequences: desktop-only, silently useless if the user disabled the Web Viewer core plugin, a data operation that mutated the workspace by opening a tab, and no metadata at all.

## The change

Fetch is a transport problem; extraction is a parsing problem. This separates them — two transports, one pipeline:

| Transport | Path | Platform |
|---|---|---|
| `fetch` | `requestUrl` → `DOMParser` → Defuddle core → `htmlToMarkdown` | **desktop + mobile** |
| `browser` | live Web Viewer DOM → same pipeline | desktop |

`auto` (default) fetches first and falls back to the browser on desktop when the response is non-2xx, is not HTML, or comes back under `minWordCount` — the SPA-shell signal. `--transport fetch|browser` overrides. This is the first `webTools` capability that runs on mobile.

Defuddle **core** plus Obsidian's own `htmlToMarkdown`, not `defuddle/full`: 429 KB smaller, and the markdown matches what Obsidian produces everywhere else. Measured bundle delta **+92 KB gzip** (1,207,056 → 1,301,945).

## Two things the design plan got wrong

Both found by reading the published tarball rather than the README:

1. **Defuddle's async extractors fall back to `globalThis.fetch`**, violating the `requestUrl` rule. `WebContentExtractor` passes an `options.fetch` shim. Its `json()` stays lazy on purpose — `requestUrl`'s `json` is a parsing getter that throws on an HTML body, so eager evaluation would break every non-JSON page. There's a test that counts getter reads to keep it that way.
2. **The plan assumed the live-DOM transport hands Defuddle a real window.** It does not — page DOM cannot cross the Electron `<webview>` process boundary, so *both* transports get a detached document with `defaultView === null`. `liveDomCapture` resolves computed styles in-page and stamps them as inline styles onto a detached clone, which Defuddle does honour. It never mutates the live page, and it bails if the node counts don't line up.

## Phase 4 bake-off (gated the deletion)

Run against a live vault through the `nexus` CLI. `auto` succeeded on **7/7** reachable pages; `legacy` on **1/6** attempted. On the one page where both produced a note:

| | words | headings | links | frontmatter keys |
|---|---|---|---|---|
| `auto` | 2862 | **8** | 208 | **7** |
| `legacy` | 3030 | 2 | 246 | 0 |

Legacy's extra 5.9% is Wikipedia's infobox, the "From Wikipedia" preamble and the external-links list, while it flattens the heading structure and carries no metadata. Caveat recorded in the plan: legacy's failure rate is measured *under automation* and it may fare better driven by hand — but not being reliably automatable is itself the finding for a tool that exists to be driven by an agent.

`findCreatedMarkdownFile`, `hasWebViewerSaveCommand` and `WEB_VIEWER_SAVE_COMMAND_ID` are deleted with the route. Full table in `docs/plans/web-capture-defuddle-plan.md` §13.

## About the 27 lockfile entries

One dependency, 27 entries — this looks alarming and isn't. `defuddle` declares `commander` plus four *optional* deps (`linkedom`, `turndown`, `temml`, `mathml-to-latex`) backing its `./node` and `./full` entries, which we never import. npm installs optionals by default so they hit `node_modules`; the gzip size being unchanged except for the core entry is the proof they stay out of `main.js`. Explained in plan §4.1.

The lockfile diff is 384 lines rather than 21,244 because `npm install` had reindented the whole file from 2 spaces to tabs; re-serialized at the original indentation and re-verified with `npm ci`.

## Tests

56 new across three lanes:

- `tests/unit/webCaptureNote.test.ts` — round-trips frontmatter through `parseYaml`, so a colon in a page title can't ship a broken note
- `tests/unit/WebContentExtractor.test.ts` — mapping and the fetch shim, including the laziness of `json`
- `tests/agents/webTools/captureToMarkdownTransport.test.ts` — transport selection, simulating desktop vs mobile by mutating `process.versions`
- `tests/debug/web-capture-live-smoke.test.ts` (`RUN_WEB_CAPTURE_SMOKE=1`, inert otherwise) — drives the real vault through the `nexus` CLI, because the unit lane's `htmlToMarkdown` stub only strips tags and proves nothing about conversion fidelity

`npm run build` clean, `npx jest` **4368 pass / 0 fail / 36 skipped**, live smoke lane 9/9 against a real vault.

## Found but not fixed here

- #337 — the MCP socket is unlinked by the *previous* plugin instance ~20s after a hot reload. This is what made the browser transport look broken during testing; it was fine after a full vault reload.
- `storage archive` on a folder times out without archiving (no issue filed yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNhLe7sYeJC8dYFYBAPzw9
