### PR TITLE
fix: release the IPC socket at unload so a reload cannot orphan its successor

### DIFF
--- a/src/connector.ts
+++ b/src/connector.ts
@@ -651,6 +651,20 @@ Keep workspaceId and sessionId values EXACTLY as shown above throughout the conv
     }
     
     /**
+     * Release the IPC socket immediately, without awaiting the full stop.
+     *
+     * Called synchronously from onunload so the socket path is free before the
+     * replacement plugin instance binds it. See #337.
+     */
+    releaseIpcSocket(): void {
+        try {
+            this.connectionManager.getServer()?.releaseIpcSocket();
+        } catch (error) {
+            logger.systemError(error as Error, 'IPC Socket Release');
+        }
+    }
+
+    /**
      * Get the MCP server instance - delegates to MCPConnectionManager
      */
     getServer(): MCPServer | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,13 @@ export default class NexusPlugin extends Plugin {
     }
 
     onunload(): void {
+        // Free the MCP socket path here, synchronously, before anything below
+        // gets a chance to await. unloadPlugin() runs embedding shutdown, a
+        // state save and a SQLite close before it reaches the connector, which
+        // is tens of seconds — and Obsidian loads the replacement instance
+        // immediately, so by the time the old instance closed its listener it
+        // was unlinking the *new* instance's socket. See #337.
+        this.connector?.releaseIpcSocket();
         void this.unloadPlugin();
     }
 

--- a/src/server/MCPServer.ts
+++ b/src/server/MCPServer.ts
@@ -177,6 +177,17 @@ export class MCPServer implements IMCPServer {
     }
 
     /**
+     * Release the IPC socket without waiting for the rest of the shutdown.
+     *
+     * Synchronous on purpose: it has to complete inside the same turn as
+     * onunload(), before Obsidian starts loading the replacement instance.
+     * stop() still does the full teardown afterwards. See #337.
+     */
+    releaseIpcSocket(): void {
+        this.ipcTransportManager.closeListener();
+    }
+
+    /**
      * Check if the server is running
      */
     isRunning(): boolean {

--- a/src/server/transport/IPCTransportManager.ts
+++ b/src/server/transport/IPCTransportManager.ts
@@ -14,6 +14,29 @@ type NetServer = ReturnType<typeof import('net')['createServer']>;
 type Socket = import('net').Socket;
 
 /**
+ * Identity of the socket file this instance created, captured at listen().
+ *
+ * dev+ino identify the file itself rather than its name, which is the whole
+ * point: the IPC path is derived from the vault name, so it is shared by every
+ * instance and cannot tell us whether the file there is still ours.
+ */
+interface OwnedSocket {
+    path: string;
+    dev: number;
+    ino: number;
+}
+
+/**
+ * How long teardown waits on a single client before giving up on it. A client
+ * that has not disconnected cleanly can leave close() pending indefinitely,
+ * which would stall restartServer().
+ */
+const TEARDOWN_TIMEOUT_MS = 3000;
+
+/** How long to wait for a connect() probe before calling a socket dead. */
+const LIVENESS_PROBE_TIMEOUT_MS = 250;
+
+/**
  * Service responsible for IPC transport management
  * Follows SRP by focusing only on IPC transport operations
  */
@@ -24,6 +47,8 @@ export class IPCTransportManager {
     private activeConnections: Set<MCPSDKServer> = new Set();
     /** Track current transport for proactive cleanup */
     private currentTransport: StdioServerTransport | null = null;
+    /** The socket file we created, so teardown never deletes someone else's. */
+    private ownedSocket: OwnedSocket | null = null;
 
     constructor(
         private configuration: ServerConfiguration,
@@ -280,6 +305,13 @@ export class IPCTransportManager {
             } catch (error) {
                 logger.systemError(error as Error, 'Socket Permissions');
             }
+
+            // Record which file we created so teardown can tell it apart from a
+            // successor's socket at the same path. See releaseOwnedSocket().
+            this.ownedSocket = this.readSocketIdentity(ipcPath);
+            if (!this.ownedSocket) {
+                logger.systemLog(`Could not identify the socket at ${ipcPath}; teardown will leave it in place`);
+            }
         }
 
         this.ipcServer = server;
@@ -290,38 +322,39 @@ export class IPCTransportManager {
     }
 
     /**
-     * Stop the IPC transport server and close all active connections
+     * Stop the IPC transport server and close all active connections.
+     *
+     * Order matters here, and it is the whole of issue #337. `server.close()`
+     * unlinks the bound socket file **synchronously, at call time** — not when
+     * the last connection drains — and it unlinks the path it was given rather
+     * than the file it created. Because the IPC path is derived from the vault
+     * name, every instance shares it, so a `close()` deferred behind connection
+     * teardown deletes whichever socket happens to be at that path by then.
+     *
+     * On a hot reload that is the *successor's* socket: the new instance binds
+     * within a second or two, the old instance finishes tearing down twenty-odd
+     * seconds later, and its close() takes the new socket file with it. The new
+     * server keeps its listening fd, so nothing errors and nothing is logged —
+     * the transport simply becomes unreachable.
+     *
+     * So the listening server is closed first, before any await — and callers
+     * that are about to do something slow should call closeListener() earlier
+     * still.
      */
     async stopTransport(): Promise<void> {
-        if (!this.ipcServer) {
+        const hasWork = this.ipcServer !== null
+            || this.ownedSocket !== null
+            || this.currentTransport !== null
+            || this.activeConnections.size > 0;
+        if (!hasWork) {
             return;
         }
 
+        this.closeListener();
+
         try {
-            // Close all per-connection servers
-            const closePromises = Array.from(this.activeConnections).map(server =>
-                server.close().catch((err: Error) => {
-                    logger.systemError(err, 'Per-Connection Server Close on Stop');
-                })
-            );
-            this.activeConnections.clear();
-            await Promise.all(closePromises);
-
-            // Close active single-client transport before stopping server
-            if (this.currentTransport) {
-                try {
-                    await this.currentTransport.close();
-                } catch (err) {
-                    logger.systemError(err as Error, 'Transport Cleanup on Stop');
-                }
-                this.currentTransport = null;
-            }
-
-            this.ipcServer.close();
-            this.ipcServer = null;
-            this.isRunning = false;
-
-            await this.cleanupSocket();
+            await this.closeActiveConnections();
+            await this.releaseOwnedSocket();
 
             logger.systemLog('IPC transport stopped successfully');
         } catch (error) {
@@ -331,22 +364,192 @@ export class IPCTransportManager {
     }
 
     /**
-     * Clean up the socket file
+     * Stop accepting connections and release the socket file — synchronously,
+     * so it can be done in a turn that is not allowed to await.
+     *
+     * Unloading the plugin runs embedding shutdown, a state save and a SQLite
+     * close before it reaches stopTransport(), which is tens of seconds during
+     * which the replacement instance has already bound our path. Whoever knows
+     * a slow shutdown is coming should call this first; stopTransport() then
+     * finishes the teardown whenever it gets there.
+     *
+     * Idempotent.
+     */
+    closeListener(): void {
+        const server = this.ipcServer;
+        if (!server) {
+            return;
+        }
+
+        this.ipcServer = null;
+        this.isRunning = false;
+        server.close();
+        logger.systemLog('IPC listener closed; socket path released');
+    }
+
+    /**
+     * Close every per-connection server and any single-client transport.
+     *
+     * Bounded: the socket file is already released by the time this runs, so a
+     * client that never disconnects can only cost us a leaked object, and
+     * waiting on it would stall restartServer() for as long as it stays wedged.
+     */
+    private async closeActiveConnections(): Promise<void> {
+        const closePromises = Array.from(this.activeConnections).map(server =>
+            server.close().catch((err: Error) => {
+                logger.systemError(err, 'Per-Connection Server Close on Stop');
+            })
+        );
+        this.activeConnections.clear();
+        await this.withTeardownTimeout(Promise.all(closePromises), 'Per-connection server close');
+
+        if (this.currentTransport) {
+            const transport = this.currentTransport;
+            this.currentTransport = null;
+            await this.withTeardownTimeout(
+                transport.close().catch((err: Error) => {
+                    logger.systemError(err, 'Transport Cleanup on Stop');
+                }),
+                'Transport close'
+            );
+        }
+    }
+
+    /**
+     * Give up on teardown work that has not settled, rather than blocking stop.
+     */
+    private async withTeardownTimeout(work: Promise<unknown>, label: string): Promise<void> {
+        let timer: number | undefined;
+        const expiry = new Promise<void>(resolve => {
+            timer = window.setTimeout(() => {
+                logger.systemLog(`${label} did not settle within ${TEARDOWN_TIMEOUT_MS}ms — continuing teardown`);
+                resolve();
+            }, TEARDOWN_TIMEOUT_MS);
+        });
+
+        try {
+            await Promise.race([work.then(() => undefined), expiry]);
+        } finally {
+            if (timer !== undefined) {
+                window.clearTimeout(timer);
+            }
+        }
+    }
+
+    /**
+     * Remove the socket file, but only while it is still the one we created.
+     *
+     * `server.close()` has normally unlinked it already; this is the backstop
+     * for the paths where it has not. It must be identity-checked for the same
+     * reason close() has to happen early — deleting by path alone, on a path
+     * every instance shares, is how a successor's socket gets taken out.
+     */
+    private async releaseOwnedSocket(): Promise<void> {
+        const owned = this.ownedSocket;
+        this.ownedSocket = null;
+
+        if (this.configuration.isWindows() || !owned) {
+            return;
+        }
+
+        const current = this.readSocketIdentity(owned.path);
+        if (!current) {
+            return;
+        }
+
+        if (current.dev !== owned.dev || current.ino !== owned.ino) {
+            logger.systemLog(`Leaving the socket at ${owned.path} alone — it belongs to another instance now`);
+            return;
+        }
+
+        try {
+            // A successor could still rebind between the stat above and this
+            // unlink. There is no unlink-by-inode on POSIX, so the window
+            // cannot be closed entirely — only reduced from tens of seconds to
+            // a single turn, which is what the identity check buys.
+            const fs = desktopRequire<typeof import('fs')>('fs').promises;
+            await fs.unlink(owned.path);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                logger.systemError(error as Error, 'Socket Cleanup');
+            }
+        }
+    }
+
+    /**
+     * Stat the socket file for its identity, or null if it is not there.
+     */
+    private readSocketIdentity(ipcPath: string): OwnedSocket | null {
+        try {
+            const stats = desktopRequire<typeof import('fs')>('fs').statSync(ipcPath);
+            return { path: ipcPath, dev: stats.dev, ino: stats.ino };
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Clear whatever socket file is sitting at our path before we bind.
+     *
+     * Deleting by path is right *here* — the job is to clear a socket a crashed
+     * process left behind, and a stale file has no identity worth preserving.
+     * It is wrong in stopTransport(); see releaseOwnedSocket().
+     *
+     * We take over a live socket too, because within a vault this path is ours,
+     * but we say so first. Two vaults sharing a name would land here, and the
+     * silence is what made #337 cost a day.
      */
     private async cleanupSocket(): Promise<void> {
         if (this.configuration.isWindows()) {
             return;
         }
 
+        const ipcPath = this.configuration.getIPCPath();
+        if (await this.isSocketLive(ipcPath)) {
+            logger.systemLog(`Taking over a live IPC socket at ${ipcPath} — another instance will lose its transport`);
+        }
+
         try {
             const fs = desktopRequire<typeof import('fs')>('fs').promises;
-            await fs.unlink(this.configuration.getIPCPath());
+            await fs.unlink(ipcPath);
         } catch (error) {
             // Ignore if file doesn't exist
             if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
                 logger.systemError(error as Error, 'Socket Cleanup');
             }
         }
+    }
+
+    /**
+     * Is something still accepting connections on this path? A refused connect
+     * means the file is stale. A probe that neither connects nor refuses in
+     * time counts as dead, so an unresponsive socket cannot block startup.
+     */
+    private isSocketLive(ipcPath: string): Promise<boolean> {
+        return new Promise<boolean>(resolve => {
+            let probe: Socket;
+            try {
+                probe = desktopRequire<typeof import('net')>('net').connect(ipcPath);
+            } catch {
+                resolve(false);
+                return;
+            }
+
+            let timer: number | undefined;
+            const settle = (alive: boolean) => {
+                if (timer !== undefined) {
+                    window.clearTimeout(timer);
+                    timer = undefined;
+                }
+                probe.removeAllListeners();
+                probe.destroy();
+                resolve(alive);
+            };
+
+            timer = window.setTimeout(() => settle(false), LIVENESS_PROBE_TIMEOUT_MS);
+            probe.once('connect', () => settle(true));
+            probe.once('error', () => settle(false));
+        });
     }
 
     /**
@@ -437,12 +640,18 @@ export class IPCTransportManager {
     }
 
     /**
-     * Force cleanup socket (for emergency cleanup)
+     * Force cleanup socket (for emergency cleanup).
+     *
+     * By path and unconditional, on purpose — this is the escape hatch for when
+     * the identity-checked path in releaseOwnedSocket() has decided to leave a
+     * file alone and a human disagrees.
      */
     async forceCleanupSocket(): Promise<void> {
         if (this.configuration.isWindows()) {
             return;
         }
+
+        this.ownedSocket = null;
 
         try {
             const fs = desktopRequire<typeof import('fs')>('fs').promises;

--- a/tests/integration/ipcSocketOwnership.test.ts
+++ b/tests/integration/ipcSocketOwnership.test.ts
@@ -1,0 +1,223 @@
+/**
+ * IPC socket ownership across a plugin reload (#337).
+ *
+ * These use the real `net` and `fs` modules on real unix domain sockets,
+ * because the bug lives entirely in behaviour a mock would have to be told
+ * about: `server.close()` unlinks the socket file synchronously at call time,
+ * and it unlinks the *path it was given* rather than the file it created. A
+ * stubbed net server has no reason to do either, so a mocked version of these
+ * tests would pass against the broken code.
+ *
+ * The IPC path is derived from the vault name, so every instance of the plugin
+ * shares it. On a hot reload two instances overlap, and a predecessor tearing
+ * down late used to delete the successor's socket file — silently, because the
+ * successor keeps its listening fd and never learns the file is gone.
+ */
+
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import { IPCTransportManager } from '../../src/server/transport/IPCTransportManager';
+import { StdioTransportManager } from '../../src/server/transport/StdioTransportManager';
+import { ServerConfiguration } from '../../src/server/services/ServerConfiguration';
+
+const describeOnPosix = process.platform === 'win32' ? describe.skip : describe;
+
+let pathCounter = 0;
+const createdPaths: string[] = [];
+/**
+ * Everything that binds a socket is registered here, because a failed
+ * assertion skips the in-test teardown and a leaked listening server keeps
+ * Jest's event loop alive — turning a failure into a hang.
+ */
+const openManagers: IPCTransportManager[] = [];
+const openServers: net.Server[] = [];
+
+function uniqueSocketPath(): string {
+  // Unix socket paths are capped near 104 bytes on macOS, so keep it short.
+  pathCounter += 1;
+  const socketPath = path.join(os.tmpdir(), `nx-ipc-${process.pid}-${pathCounter}.sock`);
+  createdPaths.push(socketPath);
+  return socketPath;
+}
+
+function createConfiguration(ipcPath: string): ServerConfiguration {
+  return {
+    isWindows: () => false,
+    getIPCPath: () => ipcPath,
+    getServerInfo: () => ({ name: 'test', version: '1.0' }),
+    getServerOptions: () => ({}),
+  } as unknown as ServerConfiguration;
+}
+
+function createTransportManager(ipcPath: string): IPCTransportManager {
+  const manager = new IPCTransportManager(
+    createConfiguration(ipcPath),
+    {} as unknown as StdioTransportManager
+  );
+  openManagers.push(manager);
+  return manager;
+}
+
+function inodeOf(target: string): number | null {
+  try {
+    return fs.statSync(target).ino;
+  } catch {
+    return null;
+  }
+}
+
+/** Bind a bare net server, standing in for an unrelated process's socket. */
+function listenDirectly(socketPath: string): Promise<net.Server> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    openServers.push(server);
+    server.once('error', reject);
+    server.listen(socketPath, () => resolve(server));
+  });
+}
+
+function closeDirectly(server: net.Server): Promise<void> {
+  return new Promise(resolve => server.close(() => resolve()));
+}
+
+function canConnect(socketPath: string): Promise<boolean> {
+  return new Promise(resolve => {
+    const socket = net.connect(socketPath);
+    const settle = (ok: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(ok);
+    };
+    socket.once('connect', () => settle(true));
+    socket.once('error', () => settle(false));
+  });
+}
+
+describeOnPosix('IPC socket ownership across a reload', () => {
+  afterEach(async () => {
+    for (const manager of openManagers.splice(0)) {
+      manager.closeListener();
+      await manager.stopTransport().catch(() => undefined);
+    }
+    for (const server of openServers.splice(0)) {
+      await closeDirectly(server);
+    }
+    for (const socketPath of createdPaths.splice(0)) {
+      try {
+        fs.unlinkSync(socketPath);
+      } catch {
+        // Already gone, which is the usual case.
+      }
+    }
+  });
+
+  it('leaves the successor’s socket alone when the predecessor tears down late', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    // The reload sequence, in the order Obsidian actually runs it.
+    const predecessor = createTransportManager(ipcPath);
+    await predecessor.startTransport();
+
+    // onunload: release the listener synchronously, before the slow shutdown.
+    predecessor.closeListener();
+
+    const successor = createTransportManager(ipcPath);
+    await successor.startTransport();
+    const successorInode = inodeOf(ipcPath);
+    expect(successorInode).not.toBeNull();
+
+    // The predecessor's shutdown finally reaches the transport, ~20s later in
+    // the field. Nothing it does may touch the file it no longer owns.
+    await predecessor.stopTransport();
+
+    expect(fs.existsSync(ipcPath)).toBe(true);
+    expect(inodeOf(ipcPath)).toBe(successorInode);
+    await expect(canConnect(ipcPath)).resolves.toBe(true);
+
+    await successor.stopTransport();
+  });
+
+  it('does not unlink a socket file that was replaced underneath it', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    const manager = createTransportManager(ipcPath);
+    await manager.startTransport();
+    const ownInode = inodeOf(ipcPath);
+    manager.closeListener();
+
+    // Someone else takes the path over — same name, different file.
+    fs.rmSync(ipcPath, { force: true });
+    const foreign = await listenDirectly(ipcPath);
+    const foreignInode = inodeOf(ipcPath);
+    expect(foreignInode).not.toBe(ownInode);
+
+    // The identity check has to notice, because the path alone cannot.
+    await manager.stopTransport();
+
+    expect(inodeOf(ipcPath)).toBe(foreignInode);
+    await expect(canConnect(ipcPath)).resolves.toBe(true);
+
+    await closeDirectly(foreign);
+  });
+
+  it('removes its own socket file when nothing has replaced it', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    const manager = createTransportManager(ipcPath);
+    await manager.startTransport();
+    expect(fs.existsSync(ipcPath)).toBe(true);
+
+    await manager.stopTransport();
+
+    expect(fs.existsSync(ipcPath)).toBe(false);
+  });
+
+  it('clears a stale socket file left behind by a crashed process', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    // A crash leaves the file with no listener behind it: connect is refused.
+    const abandoned = await listenDirectly(ipcPath);
+    await new Promise<void>(resolve => {
+      abandoned.close(() => resolve());
+      // close() unlinks, so put an inert file back to stand in for the corpse.
+      fs.writeFileSync(ipcPath, '');
+    });
+    expect(fs.existsSync(ipcPath)).toBe(true);
+
+    const manager = createTransportManager(ipcPath);
+    await manager.startTransport();
+
+    await expect(canConnect(ipcPath)).resolves.toBe(true);
+
+    await manager.stopTransport();
+  });
+
+  it('closeListener is idempotent and still lets stopTransport finish', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    const manager = createTransportManager(ipcPath);
+    await manager.startTransport();
+
+    manager.closeListener();
+    manager.closeListener();
+
+    expect(manager.isTransportRunning()).toBe(false);
+    await expect(manager.stopTransport()).resolves.toBeUndefined();
+    expect(fs.existsSync(ipcPath)).toBe(false);
+  });
+
+  it('a released path can be rebound by the same manager', async () => {
+    const ipcPath = uniqueSocketPath();
+
+    const manager = createTransportManager(ipcPath);
+    await manager.startTransport();
+    await manager.stopTransport();
+
+    await manager.startTransport();
+    await expect(canConnect(ipcPath)).resolves.toBe(true);
+
+    await manager.stopTransport();
+  });
+});


### PR DESCRIPTION
Fixes #337.

## Correcting the issue

I wrote #337 and got the cause wrong. It blamed the unconditional `fs.unlink` in `cleanupSocket()`. Implementing only what that issue suggested would not have fixed anything. Two facts about `net.Server.close()` on a unix domain socket, measured against Node rather than assumed:

- It unlinks the socket file **synchronously, at call time** — not when the last connection drains.
- It unlinks **the path it was given**, not the file it created. Once another process has rebound that path, a late `close()` deletes *their* socket. I confirmed this directly: server A's `close()` removed server B's file.

And the twenty-second delay is not inside the transport at all. `onunload()` fires `unloadPlugin()`, which awaits embedding shutdown, a state save and the SQLite close *before* it reaches the connector. `stopTransport()` is only **entered** around t+20s — by which point the replacement instance bound the path long ago. No amount of reordering inside `stopTransport()` addresses that.

## The fix

Release the socket in `onunload()` itself, synchronously, before anything can await:

```ts
onunload(): void {
    this.connector?.releaseIpcSocket();   // synchronous, same turn
    void this.unloadPlugin();             // everything slow
}
```

- **`IPCTransportManager.closeListener()`** — stops accepting and frees the path in one synchronous step. Idempotent, surfaced through `MCPServer` and `MCPConnector` so `onunload` can reach it without awaiting.
- **`stopTransport()`** closes the listener before its first `await` for callers that don't take the early path, then finishes teardown.
- **Bounded teardown** (3s) on per-connection servers and transports, so a client that never disconnects can't stall `restartServer()`. The socket file is already released by then, so abandoning the wait costs nothing.
- **Identity-checked unlink**: the socket's `dev`+`ino` are recorded at `listen()` and re-stat'ed before removal, so the explicit cleanup can only delete the file this instance created. A shared path cannot tell you that; the inode can. There's a residual stat→unlink window that POSIX gives no way to close (no unlink-by-inode), noted in the comment — but it's one turn instead of twenty seconds.

The pre-listen cleanup in `startTransport()` still deletes **by path**, which is correct — its job is clearing a socket a crashed process left behind, and a corpse has no identity worth preserving. It now probes for a live listener first and logs when it takes one over, so the two-vaults-sharing-a-name case is at least visible. That answers the third open question in the issue.

## Verification

**Live vault**, using the reproduction from #337:

| | t+5s … t+25s | t+30s | t+45s | t+60s |
|---|---|---|---|---|
| before | present / ok | **gone / dead** | gone / dead | gone / dead |
| after | present / ok | present / ok | present / ok | present / ok |

Three consecutive hot reloads, socket alive throughout, and a real `content read` still round-trips. Note the first reload after installing the fix *still* fails — the departing instance is the one that needs the fix, so it only takes effect from the second reload onward.

**Tests**: `tests/integration/ipcSocketOwnership.test.ts`, 6 cases on real `net` and `fs` over real unix sockets. That's deliberate — a stubbed server has no reason to unlink anything, so a mocked version of these tests would pass against the broken code. I checked the teeth by deleting the early release from the reload sequence: the first test then fails on exactly the assertion that matters (`existsSync(ipcPath)` → false).

That check also exposed a flaw in my own test, now fixed: a failed assertion skipped the in-test teardown and leaked a listening server, so the failure presented as a Jest hang. Every socket-binding object is registered for `afterEach` cleanup.

Full suite: **4393 pass / 0 fail / 36 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNhLe7sYeJC8dYFYBAPzw9
