### PR TITLE
fix: scope semantic search in the query, not in its results (#323)

### DIFF
--- a/src/agents/searchManager/tools/searchContent.ts
+++ b/src/agents/searchManager/tools/searchContent.ts
@@ -114,6 +114,62 @@ function foldSeparators(text: string): string {
 }
 
 /**
+ * Reduce one `paths` entry to the longest fixed prefix that every path it can
+ * match must begin with, or `null` when it constrains nothing.
+ *
+ * This exists so a scope can be pushed down into the embedding query, where the
+ * candidate window is taken. A literal path is already a prefix. A glob is
+ * truncated at the last folder boundary before its first metacharacter, so
+ * `_Base/**\/*.md` reduces to `_Base/` while `**\/notes/*.md` reduces to
+ * nothing.
+ *
+ * The reduction is intentionally conservative: a prefix here must never exclude
+ * a path the caller's own pattern would have accepted, since the real matching
+ * is still done by the post-filter afterwards.
+ */
+function pathScopePrefix(path: string): string | null {
+  const normalized = normalizePath(path);
+
+  if (!isGlobPattern(normalized)) {
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  const firstGlob = normalized.search(/[*?[\]{}]/);
+  const lastSeparator = normalized.lastIndexOf('/', firstGlob);
+  if (lastSeparator < 0) {
+    return null;
+  }
+
+  return normalized.slice(0, lastSeparator + 1);
+}
+
+/**
+ * Fixed prefixes covering every entry in `paths`, or `undefined` when the scope
+ * cannot be expressed as prefixes.
+ *
+ * The entries are OR'd, so one unbounded entry (a bare `/`, or a glob with a
+ * wildcard in its first segment) makes the whole union unbounded. Returning
+ * `undefined` in that case leaves the query unscoped and the post-filter in
+ * charge, which is the pre-existing behaviour.
+ */
+function pathScopePrefixes(paths: string[]): string[] | undefined {
+  if (paths.length === 0) {
+    return undefined;
+  }
+
+  const prefixes: string[] = [];
+  for (const path of paths) {
+    const prefix = pathScopePrefix(path);
+    if (prefix === null) {
+      return undefined;
+    }
+    prefixes.push(prefix);
+  }
+
+  return prefixes;
+}
+
+/**
  * Score how well `text` matches the query, using one tier ladder.
  *
  * Filenames and file bodies are both scored through this function so their
@@ -277,10 +333,30 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
     }
 
     try {
-      // Use EmbeddingService.semanticSearch()
-      const semanticResults = await embeddingService.semanticSearch(searchParams.query, searchParams.limit * 2); // Get extra for path filtering
+      // Push the scope down into the vector query. The candidate window there
+      // is global and small, so a scope applied only to its OUTPUT can empty a
+      // perfectly good result set: at limit 10 the query ranked the whole vault
+      // and kept 60 rows, and if none of them were under the requested folder
+      // the caller got zero results and no reason why (#323).
+      //
+      // Not every scope reduces to a prefix, so the post-filter below stays as
+      // the second pass that does the real matching.
+      const scopePrefixes = pathScopePrefixes(searchParams.paths);
+
+      const semanticResults = await embeddingService.semanticSearch(
+        searchParams.query,
+        searchParams.limit * 2, // Get extra for the glob post-filter below
+        scopePrefixes
+      );
 
       if (semanticResults.length === 0) {
+        if (scopePrefixes) {
+          // The query itself was scoped, so an empty candidate set means the
+          // requested folders hold no embedded notes — an honest answer, not a
+          // broken index. Reporting a database fault here would be a false
+          // alarm that only appears once the scope reaches the query.
+          return this.prepareResult(true, { results: [] });
+        }
         return this.prepareResult(false, undefined, 'Semantic search returned no results. This may indicate an issue with the vector database. Please check the console for errors.');
       }
 

--- a/src/agents/searchManager/tools/searchContent.ts
+++ b/src/agents/searchManager/tools/searchContent.ts
@@ -2,7 +2,7 @@ import { Plugin, TFile, prepareFuzzySearch } from 'obsidian';
 import { BaseTool } from '../../baseTool';
 import { getErrorMessage } from '../../../utils/errorUtils';
 import { BRAND_NAME } from '../../../constants/branding';
-import { isGlobPattern, globToRegex, normalizePath } from '../../../utils/pathUtils';
+import { isGlobPattern, globToRegex, normalizePath, isWithinPathScope } from '../../../utils/pathUtils';
 import { EmbeddingService } from '../../../services/embeddings/EmbeddingService';
 import { EmbeddingManager } from '../../../services/embeddings/EmbeddingManager';
 import { CommonParameters } from '../../../types';
@@ -372,11 +372,8 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
           .map(p => normalizePath(p));
 
         filteredResults = semanticResults.filter(result => {
-          const matchesLiteral = literalPaths.some(path => {
-            // Empty path (from "/") matches everything
-            if (path === '') return true;
-            return result.notePath.startsWith(path);
-          });
+          // Anchored to a folder boundary: `_Base` must not admit `_Baseball/`.
+          const matchesLiteral = literalPaths.some(path => isWithinPathScope(result.notePath, path));
           const matchesGlob = globPatterns.some(regex => regex.test(result.notePath));
           return matchesLiteral || matchesGlob;
         });
@@ -441,11 +438,8 @@ export class SearchContentTool extends BaseTool<ContentSearchParams, ContentSear
         .map(p => normalizePath(p));
 
       allFiles = allFiles.filter(file => {
-        const matchesLiteral = literalPaths.some(path => {
-          // Empty path (from "/") matches everything
-          if (path === '') return true;
-          return file.path.startsWith(path);
-        });
+        // Anchored to a folder boundary: `_Base` must not admit `_Baseball/`.
+        const matchesLiteral = literalPaths.some(path => isWithinPathScope(file.path, path));
         const matchesGlob = globPatterns.some(regex => regex.test(file.path));
         return matchesLiteral || matchesGlob;
       });

--- a/src/services/embeddings/EmbeddingService.ts
+++ b/src/services/embeddings/EmbeddingService.ts
@@ -117,9 +117,14 @@ export class EmbeddingService {
     return this.noteService.findSimilarNotes(notePath, limit);
   }
 
-  async semanticSearch(query: string, limit = 10): Promise<SimilarNote[]> {
+  /**
+   * @param pathPrefixes - Optional path prefixes confining the candidate scan.
+   *   Omitted searches the whole vault; see NoteEmbeddingService.semanticSearch
+   *   for why the scope has to reach the query rather than the results.
+   */
+  async semanticSearch(query: string, limit = 10, pathPrefixes?: string[]): Promise<SimilarNote[]> {
     if (!this.isEnabled) return [];
-    return this.noteService.semanticSearch(query, limit);
+    return this.noteService.semanticSearch(query, limit, pathPrefixes);
   }
 
   async removeEmbedding(notePath: string): Promise<void> {

--- a/src/services/embeddings/NoteEmbeddingService.ts
+++ b/src/services/embeddings/NoteEmbeddingService.ts
@@ -54,6 +54,52 @@ export interface SimilarNote {
   distance: number;
 }
 
+/**
+ * Escape character used for the `LIKE` patterns built from caller path scopes.
+ *
+ * Vault folders legitimately contain `%` and `_` (`_Base/` is a real example),
+ * both of which are LIKE wildcards. Without an ESCAPE clause `_Base%` would
+ * also match `xBase/…`, quietly widening the very scope the caller asked to
+ * narrow.
+ */
+const LIKE_ESCAPE = '\\';
+
+function escapeLikeLiteral(value: string): string {
+  return value.replace(/[\\%_]/g, character => LIKE_ESCAPE + character);
+}
+
+/**
+ * Build the optional `WHERE` clause that confines the candidate scan to a set
+ * of path prefixes.
+ *
+ * The clause is deliberately a SUPERSET of what the caller ultimately wants: it
+ * matches on `startsWith` semantics only, so a caller scoping to `_Base` still
+ * sees `_Baseball/` rows here. Anchoring to a folder boundary — and matching
+ * globs that do not reduce to a prefix at all — stays with the caller's own
+ * second pass. The job of this clause is narrower: keep the `ORDER BY distance
+ * LIMIT n` candidate window from being spent entirely on rows that are out of
+ * scope, which is what made a scoped search return nothing.
+ *
+ * An empty prefix means "anywhere in the vault". Because the prefixes are OR'd,
+ * a single unbounded entry makes the whole union unbounded, so scoping is
+ * dropped rather than applied partially.
+ */
+function buildPathPrefixScope(pathPrefixes?: string[]): { where: string; params: string[] } {
+  if (!pathPrefixes || pathPrefixes.length === 0) {
+    return { where: '', params: [] };
+  }
+
+  if (pathPrefixes.some(prefix => prefix.length === 0)) {
+    return { where: '', params: [] };
+  }
+
+  const clauses = pathPrefixes.map(() => `em.notePath LIKE ? ESCAPE '${LIKE_ESCAPE}'`);
+  return {
+    where: `WHERE ${clauses.join(' OR ')}`,
+    params: pathPrefixes.map(prefix => `${escapeLikeLiteral(prefix)}%`)
+  };
+}
+
 export class NoteEmbeddingService {
   private app: App;
   private db: SQLiteCacheManager;
@@ -205,9 +251,12 @@ export class NoteEmbeddingService {
    *
    * @param query - Search query
    * @param limit - Maximum number of results (default: 10)
+   * @param pathPrefixes - Optional path prefixes to confine the candidate scan
+   *   to. Omitted (the default) searches the whole vault, so existing callers
+   *   are unaffected.
    * @returns Array of matching notes with distance scores
    */
-  async semanticSearch(query: string, limit = 10): Promise<SimilarNote[]> {
+  async semanticSearch(query: string, limit = 10, pathPrefixes?: string[]): Promise<SimilarNote[]> {
     try {
       // Generate query embedding, then apply the query-side adapter.
       // Identity adapter returns the vector untouched (zero behavior change).
@@ -219,6 +268,14 @@ export class NoteEmbeddingService {
       // Fetch 3x the limit to allow for re-ranking
       const candidateLimit = limit * 3;
 
+      // The scope has to be IN the query. This window is `ORDER BY distance
+      // LIMIT n` over the whole vault, so filtering its output afterwards is
+      // not a filter at all — it is a filter applied to whatever the global
+      // ranking happened to leave behind. Notes under a requested folder that
+      // rank below the window are simply never seen, and the caller gets an
+      // empty list indistinguishable from "nothing matches" (#323).
+      const scope = buildPathPrefixScope(pathPrefixes);
+
       const candidates = await this.db.query<{ notePath: string; distance: number; updated: number }>(`
         SELECT
           em.notePath,
@@ -226,9 +283,10 @@ export class NoteEmbeddingService {
           vec_distance_l2(ne.embedding, ?) as distance
         FROM note_embeddings ne
         JOIN embedding_metadata em ON em.rowid = ne.rowid
+        ${scope.where}
         ORDER BY distance
         LIMIT ?
-      `, asQueryParams([queryBuffer, candidateLimit]));
+      `, asQueryParams([queryBuffer, ...scope.params, candidateLimit]));
 
       // 2. RE-RANKING LOGIC
       const now = Date.now();

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -205,7 +205,14 @@ export function isValidPath(path: string): boolean {
  * trailing slash on the scope is accepted and means the same thing, and an
  * empty scope (what `"/"` normalizes to) still means the whole vault.
  *
- * @param path Vault-relative path to test
+ * NOT A CONFINEMENT GUARD. This is a string test over paths that are already
+ * resolved — `TFile.path` and `embedding_metadata.notePath`, neither of which
+ * can contain a `..` segment. It does no traversal resolution of its own, so
+ * `isWithinPathScope('A/../B/x.md', 'A')` is `true`. Do not reach for it to
+ * decide whether a caller-supplied path may be read or written; `normalizePath`
+ * does not strip `..` either, so such a caller needs its own explicit check.
+ *
+ * @param path Vault-relative path to test. Must already be resolved.
  * @param scope Vault-relative folder or file path to confine to
  */
 export function isWithinPathScope(path: string, scope: string): boolean {

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -193,6 +193,32 @@ export function isValidPath(path: string): boolean {
 }
 
 /**
+ * Is `path` the scope itself, or inside it?
+ *
+ * A bare `startsWith` is not this test. `"_Baseball/roster.md".startsWith("_Base")`
+ * is true, so scoping a search to `_Base` also dragged in every sibling folder
+ * whose name merely begins the same way — silently, since the extra results
+ * look like ordinary hits.
+ *
+ * The comparison is therefore anchored to a folder boundary: a path matches
+ * when it IS the scope, or when it continues past it with a separator. A
+ * trailing slash on the scope is accepted and means the same thing, and an
+ * empty scope (what `"/"` normalizes to) still means the whole vault.
+ *
+ * @param path Vault-relative path to test
+ * @param scope Vault-relative folder or file path to confine to
+ */
+export function isWithinPathScope(path: string, scope: string): boolean {
+    const trimmedScope = scope.endsWith('/') ? scope.slice(0, -1) : scope;
+
+    if (trimmedScope === '') {
+        return true;
+    }
+
+    return path === trimmedScope || path.startsWith(trimmedScope + '/');
+}
+
+/**
  * Checks if a string contains glob characters
  */
 export function isGlobPattern(pattern: string): boolean {

--- a/tests/unit/SearchContentSemanticScope.test.ts
+++ b/tests/unit/SearchContentSemanticScope.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Regression cover for #323: `search content --semantic` with `paths` applied
+ * the scope to the RESULTS of an unscoped ranked query, so a scoped search
+ * could return zero results while matching notes sat in the requested folder.
+ *
+ * ## Why the fixture is shaped the way it is
+ *
+ * Three cuts stood between the vault and the caller, and every one of them ran
+ * before `paths` was consulted:
+ *
+ *   1. `searchContent` asked the service for `limit * 2` results,
+ *   2. `NoteEmbeddingService` answered by taking `ORDER BY distance LIMIT
+ *      limit * 3` over the WHOLE vault and re-ranking that,
+ *   3. `searchContent` then sliced the survivors back down to `limit`.
+ *
+ * At the default limit of 10 that is a 60-row global window. A test whose
+ * scoped notes happen to land inside that window passes against the broken
+ * code and proves nothing, so the fixture deliberately buries them below it:
+ * `SCOPED_NOTES` rank past position 60 globally, and
+ * `it('buries the scoped notes below the window the pre-fix code could see')`
+ * asserts that property directly rather than trusting the note count.
+ *
+ * ## What is real here and what is faked
+ *
+ * The whole chain under test is the production code — `SearchContentTool`,
+ * `EmbeddingService`, `NoteEmbeddingService`, including their real limits,
+ * re-ranking and post-filter. Only two leaves are faked:
+ *
+ *   - the embedding engine, which maps a note to a one-dimensional vector so
+ *     distances are readable in the fixture, and
+ *   - the SQLite layer, which is a small interpreter for the exact query shape
+ *     the service issues: optional `WHERE … LIKE … ESCAPE`, `ORDER BY
+ *     distance`, `LIMIT`. LIKE wildcards and the escape character are honoured,
+ *     so a scope that reaches the SQL is evaluated the way SQLite would.
+ *
+ * The fake DB decides nothing about the outcome: it applies the WHERE clause it
+ * is given, and the point of the fix is whether it is given one.
+ */
+
+import { Plugin, TFile } from 'obsidian';
+import { SearchContentTool, ContentSearchParams, ContentSearchResult } from '../../src/agents/searchManager/tools/searchContent';
+import { EmbeddingService } from '../../src/services/embeddings/EmbeddingService';
+
+const BASE_CONTEXT = {
+  workspaceId: 'default',
+  sessionId: 'session-1',
+  memory: 'Searching a folder for a concept.',
+  goal: 'Get the notes in that folder, not silence.'
+};
+
+/** The tool's default when the caller does not pass one. */
+const DEFAULT_LIMIT = 10;
+
+/**
+ * Rows the pre-fix pipeline could ever consider: the tool asked for
+ * `limit * 2`, and the service fetched `3x` that as candidates.
+ */
+const PRE_FIX_CANDIDATE_WINDOW = DEFAULT_LIMIT * 2 * 3;
+
+const DAY_MS = 1000 * 60 * 60 * 24;
+
+/** Old enough that the recency boost is inert for every fixture row. */
+const STALE_UPDATED = Date.now() - 400 * DAY_MS;
+
+interface NoteRow {
+  notePath: string;
+  /** One-dimensional embedding; distance to the query is just |position|. */
+  position: number;
+  updated: number;
+}
+
+/**
+ * 80 notes that outrank everything in `_Base/`, so the scoped notes fall past
+ * the 60-row window. Their names share no term with the query, which keeps the
+ * service's title boost out of the ranking.
+ */
+const DECOY_NOTES: NoteRow[] = Array.from({ length: 80 }, (_, index) => ({
+  notePath: `Other/decoy-${String(index).padStart(2, '0')}.md`,
+  position: 1 + index * 0.001,
+  updated: STALE_UPDATED
+}));
+
+/** The notes the caller is actually asking for. */
+const SCOPED_NOTES: NoteRow[] = [
+  { notePath: '_Base/finance-notes.md', position: 5, updated: STALE_UPDATED },
+  { notePath: '_Base/deep/ledger.md', position: 6, updated: STALE_UPDATED },
+  { notePath: '_Base/summary.md', position: 7, updated: STALE_UPDATED }
+];
+
+/**
+ * A folder whose name merely STARTS WITH the scoped folder's name. It outranks
+ * everything under `_Base/`, so anything that leaks it into a `_Base/` scope
+ * shows up at the top rather than at the margin.
+ */
+const NEIGHBOUR_NOTES: NoteRow[] = [
+  { notePath: '_Baseball/roster.md', position: 4, updated: STALE_UPDATED }
+];
+
+const VAULT: NoteRow[] = [...DECOY_NOTES, ...NEIGHBOUR_NOTES, ...SCOPED_NOTES];
+
+/** The query. Its terms appear in no fixture path, so no path boost applies. */
+const QUERY = 'quarterly revenue';
+
+/** Where the query sits on the same one-dimensional line as the notes. */
+const QUERY_POSITION = 0;
+
+/**
+ * Translate a SQL `LIKE` pattern into a regex, honouring `%`, `_` and the
+ * backslash escape the service asks for via `ESCAPE`.
+ *
+ * Without this, `_Base%` would be treated as a literal and the test could not
+ * tell a correctly escaped pattern from a sloppy one — `_` is a single-character
+ * wildcard, and `_Base/` is a real folder name.
+ */
+function likePatternToRegex(pattern: string): RegExp {
+  let source = '';
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index];
+    if (character === '\\' && index + 1 < pattern.length) {
+      index++;
+      source += pattern[index].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    } else if (character === '%') {
+      source += '.*';
+    } else if (character === '_') {
+      source += '.';
+    } else {
+      source += character.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+  }
+  // SQLite's LIKE is case-insensitive for ASCII.
+  return new RegExp(`^${source}$`, 'i');
+}
+
+interface CapturedQuery {
+  sql: string;
+  likePatterns: string[];
+  limit: number;
+}
+
+/**
+ * A SQLite stand-in that answers the candidate query the way the real one
+ * would: apply the WHERE clause if there is one, order by distance, truncate to
+ * LIMIT.
+ */
+function createFakeDb(rows: NoteRow[]) {
+  const captured: CapturedQuery[] = [];
+
+  const query = jest.fn(async (sql: string, params: unknown[]) => {
+    if (!/vec_distance_l2/.test(sql)) {
+      return [];
+    }
+
+    const buffer = params[0] as Buffer;
+    const queryVector = new Float32Array(
+      buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+    );
+    const queryPosition = queryVector[0];
+
+    const limit = params[params.length - 1] as number;
+    const likePatterns = params.slice(1, params.length - 1) as string[];
+    captured.push({ sql, likePatterns, limit });
+
+    const scoped = likePatterns.length === 0
+      ? rows
+      : rows.filter(row => likePatterns.some(pattern => likePatternToRegex(pattern).test(row.notePath)));
+
+    return scoped
+      .map(row => ({
+        notePath: row.notePath,
+        updated: row.updated,
+        distance: Math.abs(row.position - queryPosition)
+      }))
+      .sort((left, right) => left.distance - right.distance)
+      .slice(0, limit);
+  });
+
+  const queryOne = jest.fn(async (sql: string) => {
+    if (/COUNT\(\*\)/i.test(sql) && /embedding_metadata/.test(sql)) {
+      return { count: rows.length };
+    }
+    return { count: 0 };
+  });
+
+  return { db: { query, queryOne, run: jest.fn() }, captured };
+}
+
+function createHarness(rows: NoteRow[] = VAULT) {
+  const { db, captured } = createFakeDb(rows);
+
+  const engine = {
+    initialize: jest.fn(async () => undefined),
+    generateEmbedding: jest.fn(async () => new Float32Array([QUERY_POSITION])),
+    getModelInfo: () => ({ id: 'fixture-model', dimensions: 1 })
+  };
+
+  const embeddingService = new EmbeddingService({} as never, db as never, engine as never);
+
+  const files = new Map(rows.map(row => {
+    const name = row.notePath.split('/').pop() ?? row.notePath;
+    return [row.notePath, new TFile(name, row.notePath)];
+  }));
+
+  const plugin = {
+    app: {
+      vault: {
+        getMarkdownFiles: () => [...files.values()],
+        getAbstractFileByPath: (path: string) => files.get(path) ?? null,
+        read: async () => ''
+      },
+      metadataCache: {
+        getFileCache: () => null
+      }
+    }
+  } as unknown as Plugin;
+
+  const tool = new SearchContentTool(plugin);
+  tool.setEmbeddingService(embeddingService);
+
+  return { tool, captured };
+}
+
+function params(overrides: Partial<ContentSearchParams> = {}): ContentSearchParams {
+  return {
+    context: BASE_CONTEXT,
+    query: QUERY,
+    semantic: true,
+    ...overrides
+  } as ContentSearchParams;
+}
+
+/** `prepareResult` nests the payload under `data`; read through both. */
+function resultsOf(result: ContentSearchResult): ContentSearchResult['results'] {
+  const nested = (result as unknown as { data?: ContentSearchResult }).data;
+  return nested?.results ?? result.results ?? [];
+}
+
+async function search(overrides: Partial<ContentSearchParams> = {}) {
+  const { tool, captured } = createHarness();
+  const raw = await tool.execute(params(overrides));
+  return { raw, results: resultsOf(raw), paths: resultsOf(raw).map(entry => entry.filePath), captured };
+}
+
+/** Global rank (1-based) of a note if the whole vault were ranked by distance. */
+function globalRank(notePath: string): number {
+  const ordered = [...VAULT]
+    .sort((left, right) => Math.abs(left.position - QUERY_POSITION) - Math.abs(right.position - QUERY_POSITION))
+    .map(row => row.notePath);
+  return ordered.indexOf(notePath) + 1;
+}
+
+describe('SearchContentTool — semantic search scoping (#323)', () => {
+  /**
+   * The guard on every other test in this file. If the scoped notes drift into
+   * the window the pre-fix code could see, the regression test below would pass
+   * against the broken implementation and stop meaning anything.
+   */
+  it('buries the scoped notes below the window the pre-fix code could see', () => {
+    for (const note of SCOPED_NOTES) {
+      expect(globalRank(note.notePath)).toBeGreaterThan(PRE_FIX_CANDIDATE_WINDOW);
+    }
+  });
+
+  it('returns notes under a scoped folder that rank below the global window', async () => {
+    const { raw, paths } = await search({ paths: ['_Base/'] });
+
+    // Before the fix this was `[]`: the 60-row candidate window was spent
+    // entirely on `Other/`, and the scope was applied to what survived it.
+    expect(paths).toEqual([
+      '_Base/finance-notes.md',
+      '_Base/deep/ledger.md',
+      '_Base/summary.md'
+    ]);
+    expect(raw.success).toBe(true);
+  });
+
+  it('labels the scoped results as semantic matches', async () => {
+    const { results } = await search({ paths: ['_Base/'] });
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(entry => entry.matchType === 'semantic')).toBe(true);
+  });
+
+  it('pushes the scope into the candidate query rather than filtering after it', async () => {
+    const { captured } = await search({ paths: ['_Base/'] });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].sql).toMatch(/WHERE\s+em\.notePath LIKE \? ESCAPE/);
+    expect(captured[0].likePatterns).toEqual(['\\_Base/%']);
+  });
+
+  /**
+   * `_` is a single-character LIKE wildcard and `_Base/` is a real folder name,
+   * so an unescaped pattern silently widens the scope it was asked to narrow.
+   */
+  it('escapes LIKE wildcards in the scope prefix', async () => {
+    const { captured } = await search({ paths: ['_Base/'] });
+
+    expect(captured[0].likePatterns[0].startsWith('\\_')).toBe(true);
+  });
+
+  it('reduces a glob to its fixed folder prefix', async () => {
+    const { captured, paths } = await search({ paths: ['_Base/**/*.md'] });
+
+    expect(captured[0].likePatterns).toEqual(['\\_Base/%']);
+    expect(paths).toContain('_Base/deep/ledger.md');
+  });
+
+  it('keeps the neighbouring folder out of a trailing-slash scope', async () => {
+    const { paths } = await search({ paths: ['_Base/'] });
+
+    expect(paths).not.toContain('_Baseball/roster.md');
+  });
+
+  /**
+   * Not every scope reduces to a prefix. Those still go out unscoped and lean
+   * on the post-filter, exactly as before — the fix must not turn a pattern
+   * with a leading wildcard into a bogus prefix.
+   */
+  it('leaves the query unscoped for a glob with no fixed prefix', async () => {
+    const { captured, paths } = await search({ paths: ['**/decoy-03.md'] });
+
+    expect(captured[0].likePatterns).toEqual([]);
+    expect(captured[0].sql).not.toMatch(/WHERE/);
+    expect(paths).toEqual(['Other/decoy-03.md']);
+  });
+
+  it('leaves the query unscoped for a whole-vault path', async () => {
+    const { captured } = await search({ paths: ['/'] });
+
+    expect(captured[0].likePatterns).toEqual([]);
+    expect(captured[0].sql).not.toMatch(/WHERE/);
+  });
+
+  /**
+   * One unbounded entry makes the OR'd union unbounded, so the scope cannot be
+   * pushed down at all — pushing only the bounded half would drop results the
+   * caller asked for.
+   */
+  it('leaves the query unscoped when any one path is unbounded', async () => {
+    const { captured } = await search({ paths: ['_Base/', '**/decoy-03.md'] });
+
+    expect(captured[0].likePatterns).toEqual([]);
+  });
+
+  /**
+   * The added parameter is optional, and every existing caller omits it —
+   * `noteSearch.searchNotes` among them. An unscoped search must still issue
+   * exactly the query it always did.
+   */
+  it('issues an unscoped query when no paths are given', async () => {
+    const { captured, paths } = await search();
+
+    expect(captured[0].sql).not.toMatch(/WHERE/);
+    expect(captured[0].likePatterns).toEqual([]);
+    expect(captured[0].limit).toBe(DEFAULT_LIMIT * 2 * 3);
+    expect(paths).toHaveLength(DEFAULT_LIMIT);
+    expect(paths[0]).toBe('Other/decoy-00.md');
+  });
+
+  /**
+   * With the scope in the query, an empty candidate set means the folder holds
+   * no embedded notes. Reporting a vector-database fault there would be a false
+   * alarm introduced by the fix itself.
+   */
+  it('reports an empty scope as an empty result, not a database fault', async () => {
+    const { raw, results } = await search({ paths: ['Nowhere/'] });
+
+    expect(raw.success).toBe(true);
+    expect(results).toEqual([]);
+  });
+});

--- a/tests/unit/SearchContentSemanticScope.test.ts
+++ b/tests/unit/SearchContentSemanticScope.test.ts
@@ -143,7 +143,7 @@ interface CapturedQuery {
  * would: apply the WHERE clause if there is one, order by distance, truncate to
  * LIMIT.
  */
-function createFakeDb(rows: NoteRow[]) {
+function createFakeDb(rows: NoteRow[], options: { vectorTableBroken?: boolean } = {}) {
   const captured: CapturedQuery[] = [];
 
   const query = jest.fn(async (sql: string, params: unknown[]) => {
@@ -160,6 +160,12 @@ function createFakeDb(rows: NoteRow[]) {
     const limit = params[params.length - 1] as number;
     const likePatterns = params.slice(1, params.length - 1) as string[];
     captured.push({ sql, likePatterns, limit });
+
+    // A vec0 table that answers nothing while `embedding_metadata` still counts
+    // rows: the genuine "vector database is broken" case the tool reports on.
+    if (options.vectorTableBroken) {
+      return [];
+    }
 
     const scoped = likePatterns.length === 0
       ? rows
@@ -185,8 +191,8 @@ function createFakeDb(rows: NoteRow[]) {
   return { db: { query, queryOne, run: jest.fn() }, captured };
 }
 
-function createHarness(rows: NoteRow[] = VAULT) {
-  const { db, captured } = createFakeDb(rows);
+function createHarness(rows: NoteRow[] = VAULT, options: { vectorTableBroken?: boolean } = {}) {
+  const { db, captured } = createFakeDb(rows, options);
 
   const engine = {
     initialize: jest.fn(async () => undefined),
@@ -217,7 +223,7 @@ function createHarness(rows: NoteRow[] = VAULT) {
   const tool = new SearchContentTool(plugin);
   tool.setEmbeddingService(embeddingService);
 
-  return { tool, captured };
+  return { tool, captured, embeddingService };
 }
 
 function params(overrides: Partial<ContentSearchParams> = {}): ContentSearchParams {
@@ -368,6 +374,50 @@ describe('SearchContentTool — semantic search scoping (#323)', () => {
 
     expect(raw.success).toBe(true);
     expect(results).toEqual([]);
+  });
+
+  /**
+   * The other half of that trade, and the reason `pathScopePrefix` returns
+   * `null` rather than `''` for a whole-vault path.
+   *
+   * Suppressing the vector-database error is only honest when the query WAS
+   * narrowed. `/` narrows nothing, so an empty answer there still means the
+   * index is broken and must still say so. If `/` were allowed to reduce to an
+   * empty prefix the scope would look present to this branch while the SQL went
+   * out unscoped, and a genuinely broken index would report silent success for
+   * every whole-vault search.
+   */
+  it('still reports a database fault for a whole-vault path, which is not a scope', async () => {
+    const { tool } = createHarness(VAULT, { vectorTableBroken: true });
+
+    const rootScoped = await tool.execute(params({ paths: ['/'] }));
+    const unscoped = await tool.execute(params());
+
+    expect(rootScoped.success).toBe(false);
+    expect((rootScoped as { error?: string }).error).toMatch(/vector database/i);
+    // Identical to passing no `paths` at all, which is what `/` means.
+    expect(rootScoped.success).toBe(unscoped.success);
+  });
+
+  /**
+   * `NoteEmbeddingService.semanticSearch` documents an empty prefix as "anywhere
+   * in the vault", and the prefixes are OR'd, so one empty entry unbounds the
+   * union. Dropping the scope entirely and emitting `LIKE '%'` return the same
+   * rows, but only the former leaves the query the service always issued — this
+   * pins the contract at the service boundary, where `searchContent` is not the
+   * only possible caller.
+   */
+  it('drops the scope entirely when a prefix is empty', async () => {
+    const { embeddingService, captured } = createHarness();
+
+    await embeddingService.semanticSearch(QUERY, 5, ['']);
+    await embeddingService.semanticSearch(QUERY, 5, ['_Base/', '']);
+
+    expect(captured).toHaveLength(2);
+    for (const call of captured) {
+      expect(call.sql).not.toMatch(/WHERE/);
+      expect(call.likePatterns).toEqual([]);
+    }
   });
 });
 

--- a/tests/unit/SearchContentSemanticScope.test.ts
+++ b/tests/unit/SearchContentSemanticScope.test.ts
@@ -40,6 +40,7 @@
 import { Plugin, TFile } from 'obsidian';
 import { SearchContentTool, ContentSearchParams, ContentSearchResult } from '../../src/agents/searchManager/tools/searchContent';
 import { EmbeddingService } from '../../src/services/embeddings/EmbeddingService';
+import { isWithinPathScope } from '../../src/utils/pathUtils';
 
 const BASE_CONTEXT = {
   workspaceId: 'default',
@@ -367,5 +368,54 @@ describe('SearchContentTool — semantic search scoping (#323)', () => {
 
     expect(raw.success).toBe(true);
     expect(results).toEqual([]);
+  });
+});
+
+/**
+ * A separate defect in the same filter: the literal-path branch compared with a
+ * bare `startsWith`, which is not a folder test. Scoping to `_Base` also
+ * admitted `_Baseball/`, and the extra results are indistinguishable from
+ * legitimate hits.
+ *
+ * `_Baseball/roster.md` outranks every note under `_Base/` in the fixture, so a
+ * leak shows up at the top of the list rather than somewhere in the tail.
+ */
+describe('SearchContentTool — literal path scopes are anchored to a folder boundary', () => {
+  it('excludes a sibling folder whose name merely starts with the scope', async () => {
+    const { paths } = await search({ paths: ['_Base'] });
+
+    expect(paths).not.toContain('_Baseball/roster.md');
+    expect(paths).toEqual([
+      '_Base/finance-notes.md',
+      '_Base/deep/ledger.md',
+      '_Base/summary.md'
+    ]);
+  });
+
+  it('accepts the same scope written with a trailing slash', async () => {
+    const withSlash = await search({ paths: ['_Base/'] });
+    const withoutSlash = await search({ paths: ['_Base'] });
+
+    expect(withoutSlash.paths).toEqual(withSlash.paths);
+  });
+
+  it('still admits the neighbouring folder when it is the scope', async () => {
+    const { paths } = await search({ paths: ['_Baseball'] });
+
+    expect(paths).toEqual(['_Baseball/roster.md']);
+  });
+});
+
+describe('isWithinPathScope', () => {
+  it.each([
+    ['_Base/notes.md', '_Base', true],
+    ['_Base/notes.md', '_Base/', true],
+    ['_Base', '_Base', true],
+    ['_Baseball/roster.md', '_Base', false],
+    ['_Basement.md', '_Base', false],
+    ['Other/note.md', '_Base', false],
+    ['anything/at/all.md', '', true]
+  ])('%s within %s -> %s', (path, scope, expected) => {
+    expect(isWithinPathScope(path, scope)).toBe(expected);
   });
 });

--- a/tests/unit/SearchContentTool.test.ts
+++ b/tests/unit/SearchContentTool.test.ts
@@ -311,6 +311,50 @@ describe('SearchContentTool — keyword ranking', () => {
     expect(results).toEqual([]);
   });
 
+  /**
+   * The `paths` filter compared with a bare `startsWith`, which is a string
+   * test rather than a folder test: scoping to `_Base` also pulled in every
+   * sibling folder whose name begins the same way, and the extra results look
+   * exactly like legitimate ones.
+   *
+   * The two fixtures score differently on purpose so `rank()` is asserting the
+   * scope rather than tripping its own tie guard.
+   */
+  describe('literal path scopes are anchored to a folder boundary', () => {
+    const NEIGHBOURS: VaultFile[] = [
+      {
+        path: '_Base/quarterly report.md',
+        content: 'The quarterly revenue figures are attached in full.'
+      },
+      {
+        path: '_Baseball/roster.md',
+        content: 'Revenue from ticket sales was up.'
+      }
+    ];
+
+    it('excludes a sibling folder whose name merely starts with the scope', async () => {
+      const results = await rank(NEIGHBOURS, { query: 'quarterly revenue', paths: ['_Base'] });
+
+      expect(results.map(entry => entry.filePath)).toEqual(['_Base/quarterly report.md']);
+    });
+
+    it('accepts the same scope written with a trailing slash', async () => {
+      const withSlash = await rank(NEIGHBOURS, { query: 'quarterly revenue', paths: ['_Base/'] });
+      const withoutSlash = await rank(NEIGHBOURS, { query: 'quarterly revenue', paths: ['_Base'] });
+
+      expect(withoutSlash.map(entry => entry.filePath)).toEqual(withSlash.map(entry => entry.filePath));
+    });
+
+    it('still searches the whole vault for the root scope', async () => {
+      const results = await rank(NEIGHBOURS, { query: 'quarterly revenue', paths: ['/'] });
+
+      expect(results.map(entry => entry.filePath).sort()).toEqual([
+        '_Base/quarterly report.md',
+        '_Baseball/roster.md'
+      ]);
+    });
+  });
+
   it('documents matchType in the result schema', () => {
     const tool = createTool([]);
 


### PR DESCRIPTION
Closes #323.

## The problem is bigger than the issue says

There are **three** truncations, not one. At the default `limit: 10`:

1. `searchContent.ts` over-fetches `limit * 2`
2. `NoteEmbeddingService.semanticSearch` runs `ORDER BY distance LIMIT limit * 3` with **no `WHERE` clause at all**
3. `ranked.slice(0, limit)`, then the `paths` filter, then another slice

So: 60 global candidates → rerank → 20 → *then* apply scope → 10. If the scoped notes rank below the global top 60, the caller gets zero results and no indication why.

This is also why raising the multiplier never fixed it — the unscoped cut sits underneath.

## The fix

`NoteEmbeddingService.semanticSearch` takes an optional `pathPrefixes` and adds `WHERE em.notePath LIKE ? ESCAPE '\'` (OR'd) to the candidate scan. `EmbeddingService` passes it through. `searchContent` reduces each `paths` entry to its fixed prefix — a glob is cut at the last `/` before the first metacharacter — and an entry that cannot reduce leaves the query unscoped with the post-filter in charge.

The SQL prefix is deliberately a **superset**; the post-filter still decides membership. `%`, `_` and `\` are escaped, which matters here because `_` is a LIKE wildcard and `_Base/` is a real folder name in this vault.

**Second commit:** the literal path match was an unanchored `startsWith`, so scoping to `_Base` also matched `_Baseball/`. New `isWithinPathScope` in `pathUtils.ts`, applied to both the semantic post-filter and the keyword pre-filter.

**One deliberate behaviour change:** a scoped query with no candidates now returns `success: true, results: []` instead of an "issue with the vector database" error, which would otherwise be a false alarm this fix introduced.

## The test has the failing shape

`tests/unit/SearchContentSemanticScope.test.ts` drives the real chain — tool → `EmbeddingService` → `NoteEmbeddingService`, real limits, real re-rank, real post-filter. Only the embedding engine and SQLite are faked, the latter a small interpreter for the exact query issued, honouring LIKE wildcards and the escape character.

80 decoy notes outrank everything scoped, putting the three `_Base/` notes at global ranks **82–84**, past the 60-row window. A guard test asserts that property from the fixture itself, so it cannot silently drift into the window and stop meaning anything. `_Baseball/roster.md` sits closer than every `_Base/` note, so an anchoring leak surfaces at the top.

Verified against pre-fix source (`git checkout <base> -- src/`): **8 failures**, including the headline case returning exactly `[]` — the silent zero from the issue.

## Verification

- `npx jest tests/unit` — 327 suites, 4319 tests passing
- `npm run build` clean (lint, mobile-import gate, tsc, CLI + connector)
- Callers checked: `noteSearch.ts` calls with two arguments and a test pins that an unscoped call still issues a `WHERE`-less query; `NoteEmbeddingQueryAdapter.test.ts` reads the query buffer at param index 0, so the LIKE params were appended before the limit rather than prepended

## Known limitation, pinned by a test rather than papered over

A glob with a wildcard in its **first** segment (`**/ledger.md`) cannot reduce to a prefix and is still subject to the global window. Closing that needs a whole-vault re-rank, which changes ranking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_