### PR TITLE
fix: arm the startup rebuild watchdog on the background branch too (#158)

### DIFF
--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -335,22 +335,27 @@ export class HybridStorageAdapter implements IStorageAdapter {
 
   private async runStartupFullRebuild(isBlockingHydration: boolean): Promise<void> {
     let rejectIdleTimeout: ((error: Error) => void) | undefined;
-    const idleTimeoutPromise = isBlockingHydration
-      ? new Promise<never>((_, reject) => {
-        rejectIdleTimeout = reject;
-      })
-      : undefined;
+    const idleTimeoutPromise = new Promise<never>((_, reject) => {
+      rejectIdleTimeout = reject;
+    });
 
-    const stopWatchdog = isBlockingHydration
-      ? this.hydration.startIdleWatchdog({
-        idleTimeoutMs: this.getStartupRebuildIdleTimeoutMs(),
-        onTimeout: () => {
-          const message = `Local chat index rebuild made no progress for ${this.getStartupRebuildIdleTimeoutMs()} ms`;
-          this.hydration.fail(message);
-          rejectIdleTimeout?.(new Error(message));
-        }
-      })
-      : undefined;
+    // Stall protection is NOT specific to the blocking rebuild. `onProgress`
+    // calls `updateProgress` on both branches, and that moves the phase to
+    // `running`, which is not query-ready. So a *background* rebuild that
+    // reported progress and then stalled leaves `isQueryReady()` false for the
+    // rest of the session with nothing to fail it — the same shape as the
+    // completion bug handled below. The watchdog therefore arms on both
+    // branches; it is inert until the phase actually reaches `running`, so the
+    // background branch that never reports progress (phase stays `idle`, which
+    // is query-ready) is unaffected.
+    const stopWatchdog = this.hydration.startIdleWatchdog({
+      idleTimeoutMs: this.getStartupRebuildIdleTimeoutMs(),
+      onTimeout: () => {
+        const message = `Local chat index rebuild made no progress for ${this.getStartupRebuildIdleTimeoutMs()} ms`;
+        this.hydration.fail(message);
+        rejectIdleTimeout?.(new Error(message));
+      }
+    });
 
     try {
       const rebuildPromise = this.syncCoordinator.fullRebuild({
@@ -358,9 +363,7 @@ export class HybridStorageAdapter implements IStorageAdapter {
           this.hydration.updateProgress(stage, progress, total, isBlockingHydration);
         }
       });
-      const result = idleTimeoutPromise
-        ? await Promise.race([rebuildPromise, idleTimeoutPromise])
-        : await rebuildPromise;
+      const result = await Promise.race([rebuildPromise, idleTimeoutPromise]);
 
       if (!result.success) {
         const summary = result.errors.length > 0 ? result.errors.join('; ') : 'Unknown error';

--- a/tests/unit/HybridStorageAdapter.test.ts
+++ b/tests/unit/HybridStorageAdapter.test.ts
@@ -681,6 +681,74 @@ describe('HybridStorageAdapter', () => {
       // stay inert rather than failing a rebuild that has nothing to stall on.
       expect(adapter.hydration.getState().phase).toBe('idle');
     });
+
+    // Regression (#158 gap 2, found by mutation testing): arming the watchdog on
+    // both branches makes `isBlockingHydration` the ONLY thing left in
+    // `runStartupFullRebuild` that still distinguishes them — it is forwarded as
+    // the 4th argument of `updateProgress`, which sets `state.isBlocking`.
+    // Nothing pinned it, so passing `true` there survived every test. The
+    // consequence is user-visible: `isStartupHydrationBlocking()` reads that
+    // flag, and ChatView holds the chat behind a modal loading overlay for as
+    // long as it is true (src/ui/chat/ChatView.ts) — minutes on a real vault.
+    it('never reports a background startup fullRebuild as blocking hydration', async () => {
+      const adapter = makeHarness();
+      const blockingDuringProgress: boolean[] = [];
+      adapter.syncCoordinator.fullRebuild.mockImplementation(({ onProgress }) => {
+        onProgress('Processing workspaces', 0, 2);
+        blockingDuringProgress.push((adapter as unknown as HybridStorageAdapter).isStartupHydrationBlocking());
+        onProgress('Processing conversations', 1, 2);
+        blockingDuringProgress.push((adapter as unknown as HybridStorageAdapter).isStartupHydrationBlocking());
+        return Promise.resolve(successfulRebuild);
+      });
+
+      await runStartupFullRebuild(adapter, false);
+
+      // Sampled mid-rebuild, while the phase is `running` — the only window in
+      // which `isBlocking()` can ever return true.
+      expect(blockingDuringProgress).toEqual([false, false]);
+    });
+
+    it('reports a blocking startup fullRebuild as blocking hydration', async () => {
+      const adapter = makeHarness();
+      adapter.hydration.startBlocking();
+      const blockingDuringProgress: boolean[] = [];
+      adapter.syncCoordinator.fullRebuild.mockImplementation(({ onProgress }) => {
+        onProgress('Processing workspaces', 0, 2);
+        blockingDuringProgress.push((adapter as unknown as HybridStorageAdapter).isStartupHydrationBlocking());
+        return Promise.resolve(successfulRebuild);
+      });
+
+      await runStartupFullRebuild(adapter, true);
+
+      // The counterpart assertion: without this, hardcoding `false` at the same
+      // argument would pass the test above.
+      expect(blockingDuringProgress).toEqual([true]);
+    });
+
+    // Regression (#158 gap 3, found by mutation testing): a background rebuild
+    // that succeeds WITHOUT ever reporting progress leaves the phase at `idle`,
+    // so the `phase === 'running'` guard skips `complete()` — and `complete()`
+    // is what would otherwise stop the watchdog. Only the `finally`'s
+    // `stopWatchdog?.()` disarms it on that path. Without it the controller
+    // keeps a live watchdog registration with no timer, which re-arms against a
+    // stale `onTimeout` the next time anything moves the phase to `running`.
+    it('disarms the watchdog after a background rebuild that finished without progress', async () => {
+      jest.useFakeTimers();
+      const adapter = makeHarness();
+      adapter.syncCoordinator.fullRebuild.mockResolvedValue(successfulRebuild);
+
+      await runStartupFullRebuild(adapter, false);
+      expect(adapter.hydration.getState().phase).toBe('idle');
+
+      // Moving the phase to `running` must not resurrect the finished rebuild's
+      // watchdog: 50 ms is its full idle timeout.
+      adapter.hydration.startBlocking();
+      await jest.advanceTimersByTimeAsync(50);
+
+      const state = adapter.hydration.getState();
+      expect(state.phase).toBe('running');
+      expect(state.error).toBeUndefined();
+    });
   });
 
   describe('reconcileMissingConversations', () => {

--- a/tests/unit/HybridStorageAdapter.test.ts
+++ b/tests/unit/HybridStorageAdapter.test.ts
@@ -607,6 +607,80 @@ describe('HybridStorageAdapter', () => {
       await expect(gate).resolves.toBe(true);
       expect((adapter as unknown as HybridStorageAdapter).isQueryReady()).toBe(true);
     });
+
+    // Regression (#158 gap 1): the idle watchdog used to be armed only when
+    // `isBlockingHydration` was true. But `updateProgress` moves the phase to
+    // `running` on BOTH branches, and `running` is not query-ready — so a
+    // background rebuild that reported progress and then stalled left
+    // `isQueryReady()` false indefinitely with nothing to fail it. Every
+    // `waitForQueryReady()` caller then burned its full idle timeout, and the
+    // rebuild promise never settled at all.
+    it('fails hydration when a background startup fullRebuild stalls after progress', async () => {
+      jest.useFakeTimers();
+      const adapter = makeHarness();
+      adapter.syncCoordinator.fullRebuild.mockImplementation(({ onProgress }) => {
+        onProgress('Processing workspaces', 0, 2);
+        // Never resolves and never reports progress again.
+        return new Promise(() => undefined);
+      });
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        const pending = runStartupFullRebuild(adapter, false);
+        const rejection = expect(pending).rejects.toThrow('made no progress');
+
+        await jest.advanceTimersByTimeAsync(50);
+        await rejection;
+
+        const state = adapter.hydration.getState();
+        expect(state.phase).toBe('error');
+        expect(state.error).toContain('made no progress');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('settles background-rebuild query-ready waiters as failed when the rebuild stalls', async () => {
+      jest.useFakeTimers();
+      const adapter = makeHarness();
+      adapter.syncCoordinator.fullRebuild.mockImplementation(({ onProgress }) => {
+        onProgress('Processing workspaces', 0, 2);
+        return new Promise(() => undefined);
+      });
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        void adapter.initLifecycle.run(() => runStartupFullRebuild(adapter, false), { blocking: false });
+        // The notes index registers this gate while the rebuild is mid-flight.
+        const gate = (adapter as unknown as HybridStorageAdapter).waitForQueryReady(10_000);
+
+        // Only the watchdog's idle timeout elapses — far short of the gate's
+        // own 10 s budget, so a `true`/late resolution here means the watchdog
+        // never armed.
+        await jest.advanceTimersByTimeAsync(50);
+
+        await expect(gate).resolves.toBe(false);
+        await expect((adapter as unknown as HybridStorageAdapter).waitForReady()).resolves.toBe(false);
+        expect((adapter as unknown as HybridStorageAdapter).isQueryReady()).toBe(false);
+        expect((adapter as unknown as HybridStorageAdapter).getInitError()?.message).toContain('made no progress');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('still leaves a background rebuild that never reports progress query-ready while it runs', async () => {
+      jest.useFakeTimers();
+      const adapter = makeHarness();
+      adapter.syncCoordinator.fullRebuild.mockReturnValue(new Promise(() => undefined));
+
+      void adapter.initLifecycle.run(() => runStartupFullRebuild(adapter, false), { blocking: false });
+
+      await jest.advanceTimersByTimeAsync(200);
+
+      // Phase never left `idle`, which is query-ready, so the watchdog must
+      // stay inert rather than failing a rebuild that has nothing to stall on.
+      expect(adapter.hydration.getState().phase).toBe('idle');
+    });
   });
 
   describe('reconcileMissingConversations', () => {


### PR DESCRIPTION
Addresses gap 1 of #158.

## The gap

`startIdleWatchdog` was gated on `isBlockingHydration`. But `updateProgress()` sets `phase: 'running'` on **both** branches, and `running` is not query-ready — so a stalled *background* rebuild left `isQueryReady()` false indefinitely with nothing to fail it.

This is the same shape as the bug fixed earlier today: phase *completion* was corrected for both branches, while stall protection still covered only the blocking one.

## The fix

Both the watchdog and the `Promise.race` now arm on either branch.

`armIdleWatchdog()` stays inert until the phase is actually `running`, so a background rebuild that never reports progress at all — phase `idle`, which *is* query-ready — is unaffected. That distinction is the reason this can't just be a flag flip.

## Tests

Three, and the third exists to stop the fix over-correcting:

1. The rebuild promise rejects with `made no progress` on the non-blocking branch
2. A mid-flight `waitForQueryReady(10_000)` settles `false` at the injected 50 ms watchdog timeout rather than burning its own budget
3. The inert-while-`idle` case stays inert

Pre-fix, both stall tests **hang to a Jest timeout** — the promise never settles, which is the defect stated as a test.

## Live verification

Exercised against the real shipped bundle in headless Obsidian 1.13.7 with a 1000 ms injected timeout: rejected at 1001 ms, phase `error`, and the gate resolved `false` against a 30 s budget. State restored and plugin reloaded afterwards; `dev:errors` clean.

## Still open on #158

Gap 2 — `ChatView.waitForStartupHydration` writes the error into the overlay and returns early *without hiding it*, leaving no retry affordance. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_