### PR TITLE
fix: make corrupt-cache recovery say so instead of swallowing it

### DIFF
--- a/src/database/storage/SQLitePersistenceService.ts
+++ b/src/database/storage/SQLitePersistenceService.ts
@@ -66,9 +66,14 @@ export class SQLitePersistenceService {
    * re-hide the event. A `Notice` is not raised here: this runs during cache
    * open, well before the workspace is ready, and this class is pure
    * persistence with no Obsidian dependency. `console.error` is what the
-   * Obsidian developer console and `obsidian-cli dev:errors` both read, which
-   * is where a bug report gets written from. If a user-facing surface is ever
-   * wanted, it belongs to a caller that already owns UI, not here.
+   * Obsidian developer console and `obsidian-cli dev:console` read, which is
+   * where a bug report gets written from. Note it does NOT reach
+   * `obsidian-cli dev:errors`: that surface reports uncaught exceptions, not
+   * `console.error` calls - verified live on 2026-08-24 by corrupting a real
+   * cache, where this line appeared in `dev:console` while `dev:errors` stayed
+   * empty. So the release verification gate does not fail on this line; it is
+   * discoverable, not alarming. If a user-facing surface is ever wanted, it
+   * belongs to a caller that already owns UI, not here.
    *
    * This reports; it does not decide. Recovery itself is unchanged.
    */

--- a/src/database/storage/SQLitePersistenceService.ts
+++ b/src/database/storage/SQLitePersistenceService.ts
@@ -37,15 +37,57 @@ export class SQLitePersistenceService {
             : JSON.stringify(integrityResult) ?? 'unknown';
           throw new Error(`Database integrity check failed: ${integrityMessage}`);
         }
-      } catch {
+      } catch (integrityError) {
+        this.reportCacheRebuild('failed its integrity check', integrityError, data.byteLength);
         return this.recreateCorruptedDatabase(sqlite3, schemaSql);
       }
 
       return db;
     } catch (error) {
-      console.error('[SQLiteCacheManager] Failed to load from blob store:', error);
+      this.reportCacheRebuild('could not be read or opened', error);
       return this.recreateCorruptedDatabase(sqlite3, schemaSql);
     }
+  }
+
+  /**
+   * Announce a cache rebuild on the console, loudly enough that a user can find
+   * it. This path used to be a bare `catch {}`: the cache was silently
+   * discarded and rebuilt, so the only thing anyone ever saw was the downstream
+   * symptom — an empty or half-populated view — with nothing in the console
+   * tying it back to a corrupt database. Issue #209 stayed undiagnosable for
+   * months for exactly that reason.
+   *
+   * Only reached on a genuine failure. An absent, empty or older-schema cache
+   * all take other branches and stay silent, so this line appearing at all
+   * means something really was wrong with the blob.
+   *
+   * Deliberately `console.error` and nothing else. `logger.systemWarn` and
+   * `systemLog` are no-ops in this build, so routing through them would
+   * re-hide the event. A `Notice` is not raised here: this runs during cache
+   * open, well before the workspace is ready, and this class is pure
+   * persistence with no Obsidian dependency. `console.error` is what the
+   * Obsidian developer console and `obsidian-cli dev:errors` both read, which
+   * is where a bug report gets written from. If a user-facing surface is ever
+   * wanted, it belongs to a caller that already owns UI, not here.
+   *
+   * This reports; it does not decide. Recovery itself is unchanged.
+   */
+  private reportCacheRebuild(reason: string, cause: unknown, discardedBytes?: number): void {
+    const causeText = cause instanceof Error ? cause.message : String(cause);
+    const sizeText = discardedBytes === undefined
+      ? ''
+      : ` Discarded cache was ${discardedBytes} bytes.`;
+
+    console.error(
+      `[SQLiteCacheManager] Local cache database ${reason} — discarding it and rebuilding from scratch. ` +
+      `Cause: ${causeText}.${sizeText} ` +
+      'This rebuild deletes no user data of its own: the SQLite cache is a derived index, and the ' +
+      'JSONL event store is the source of truth. Existing data reappears only once that event store ' +
+      'is replayed into the new cache — so if anything still looks missing after this, the replay is ' +
+      'what to investigate, not the rebuild. ' +
+      'If this line appears on every start, the cache is being corrupted again after each rebuild — report it with this line.',
+      cause
+    );
   }
 
   async saveDatabase(sqlite3: SQLiteWasmModule, db: SQLiteDatabaseHandle): Promise<void> {
@@ -71,8 +113,15 @@ export class SQLitePersistenceService {
   async recreateCorruptedDatabase(sqlite3: SQLiteWasmModule, schemaSql: string): Promise<SQLiteDatabaseHandle> {
     try {
       await this.blobStore.remove();
-    } catch {
-      void 0;
+    } catch (removeError) {
+      // Non-fatal: the fresh database is written over the old blob below. Still
+      // worth saying, because a remove that keeps failing is the difference
+      // between "corrupted once" and "corruption we can never clear".
+      console.warn(
+        '[SQLiteCacheManager] Could not delete the corrupt cache blob before rebuilding it; ' +
+        'the rebuild continues and will overwrite it.',
+        removeError
+      );
     }
 
     const db = this.createFreshDatabase(sqlite3, schemaSql);

--- a/tests/unit/SQLitePersistenceService.test.ts
+++ b/tests/unit/SQLitePersistenceService.test.ts
@@ -48,6 +48,29 @@ function createService() {
   };
 }
 
+/** Flatten every argument of every call into one searchable string. */
+function messagesFrom(spy: jest.SpyInstance): string {
+  return spy.mock.calls
+    .map(call => call.map(arg => (arg instanceof Error ? arg.message : String(arg))).join(' '))
+    .join('\n');
+}
+
+/**
+ * Only the composed message — `call[0]` — with the trailing Error argument
+ * excluded.
+ *
+ * This distinction is the whole assertion, not a detail. The Error object is
+ * also handed to `console.error` as a second argument, so a message that
+ * interpolated *none* of the cause would still satisfy a search across all
+ * arguments and the test would pass while the useful half of the report had
+ * been deleted. What a bug report actually carries is the red line someone
+ * copies; an object the console renders behind a disclosure triangle is not
+ * that. So assert the cause against the composed string.
+ */
+function formattedFrom(spy: jest.SpyInstance): string {
+  return spy.mock.calls.map(call => String(call[0])).join('\n');
+}
+
 describe('SQLitePersistenceService', () => {
   it('creates a fresh schema database when the blob store has no data', async () => {
     const { service, blobStore, bridge, db, sqlite3 } = createService();
@@ -75,10 +98,208 @@ describe('SQLitePersistenceService', () => {
     blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
     bridge.getIntegrityCheckResult = jest.fn().mockReturnValue('corrupt') as typeof bridge.getIntegrityCheckResult;
 
-    const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
 
-    expect(result).toBe(db);
-    expect(blobStore.remove).toHaveBeenCalled();
-    expect(blobStore.write).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+      expect(result).toBe(db);
+      expect(blobStore.remove).toHaveBeenCalled();
+      expect(blobStore.write).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  // Regression (#209): this recovery ran inside a bare `catch {}`. The cache was
+  // discarded and rebuilt with nothing written to the console, so the reporter's
+  // log showed only the downstream symptom and the cause stayed invisible for
+  // months. The rebuild must announce itself.
+  describe('corrupt-cache recovery is observable', () => {
+    it('logs the integrity failure, its cause and the rebuild-from-event-store consequence', async () => {
+      const { service, blobStore, bridge, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3, 4, 5]).buffer);
+      bridge.getIntegrityCheckResult = jest.fn()
+        .mockReturnValue('*** in database main ***\nPage 3 is never used') as typeof bridge.getIntegrityCheckResult;
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        expect(errSpy).toHaveBeenCalled();
+        const formatted = formattedFrom(errSpy);
+        expect(formatted).toContain('integrity check');
+        expect(formatted).toContain('rebuilding from scratch');
+        // The sqlite integrity_check output must survive into the composed
+        // message — it is the only clue about what actually went wrong, and it
+        // has to be in the line someone copies, not only in the Error argument.
+        expect(formatted).toContain('Page 3 is never used');
+        // And the user has to be told the rebuild itself did not destroy anything.
+        expect(formatted).toContain('event store');
+        expect(formatted).toContain('5 bytes');
+        // The Error object still goes along for a console reader who wants the stack.
+        expect(errSpy.mock.calls.some(call => call[1] instanceof Error)).toBe(true);
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    // The two halves of the reassurance are different claims and must not be
+    // collapsed: "this rebuild threw nothing away" is a fact about the rebuild,
+    // whereas "your data is back" depends on a replay that happens elsewhere and
+    // can independently fail. A message that only promised the second would send
+    // someone with a genuinely broken replay away reassured.
+    it('separates "the rebuild lost nothing" from "the replay has to run"', async () => {
+      const { service, blobStore, bridge, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      bridge.getIntegrityCheckResult = jest.fn().mockReturnValue('corrupt') as typeof bridge.getIntegrityCheckResult;
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        const formatted = formattedFrom(errSpy);
+        expect(formatted).toContain('deletes no user data');
+        expect(formatted).toContain('source of truth');
+        expect(formatted).toContain('replayed');
+        expect(formatted).toContain('if anything still looks missing after this');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('logs when the integrity check itself throws rather than returning a verdict', async () => {
+      const { service, blobStore, bridge, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      bridge.getIntegrityCheckResult = jest.fn(() => {
+        throw new Error('database disk image is malformed');
+      }) as typeof bridge.getIntegrityCheckResult;
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        const formatted = formattedFrom(errSpy);
+        expect(formatted).toContain('integrity check');
+        expect(formatted).toContain('database disk image is malformed');
+        expect(formatted).toContain('event store');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('logs when the blob cannot be deserialized at all', async () => {
+      const { service, blobStore, bridge, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      bridge.deserializeDatabase = jest.fn(() => {
+        throw new Error('not a database');
+      }) as typeof bridge.deserializeDatabase;
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        const formatted = formattedFrom(errSpy);
+        expect(formatted).toContain('not a database');
+        expect(formatted).toContain('rebuilding from scratch');
+        expect(formatted).toContain('event store');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
+
+    it('warns but still rebuilds when the corrupt blob cannot be deleted', async () => {
+      const { service, blobStore, bridge, db, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      bridge.getIntegrityCheckResult = jest.fn().mockReturnValue('corrupt') as typeof bridge.getIntegrityCheckResult;
+      blobStore.remove.mockRejectedValue(new Error('EPERM: operation not permitted'));
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        // Behaviour unchanged: the rebuild still happens.
+        expect(result).toBe(db);
+        expect(blobStore.write).toHaveBeenCalledWith(expect.any(ArrayBuffer));
+
+        const warned = messagesFrom(warnSpy);
+        expect(warned).toContain('EPERM: operation not permitted');
+      } finally {
+        warnSpy.mockRestore();
+        errSpy.mockRestore();
+      }
+    });
+  });
+
+  // The other half of "say so": a report that also fires on ordinary launches is
+  // worth nothing, because every user learns to ignore it. None of these is
+  // corruption, and none of them may produce a line.
+  describe('benign launches stay silent', () => {
+    async function expectSilent(
+      arrange: (ctx: ReturnType<typeof createService>) => void
+    ): Promise<void> {
+      const ctx = createService();
+      arrange(ctx);
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        await ctx.service.loadDatabase(ctx.sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        expect(messagesFrom(errSpy)).toBe('');
+        expect(messagesFrom(warnSpy)).toBe('');
+        // Recovery must not have been entered at all.
+        expect(ctx.blobStore.remove).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+        errSpy.mockRestore();
+      }
+    }
+
+    it('says nothing on a first launch, when no cache blob exists yet', async () => {
+      await expectSilent(({ blobStore }) => {
+        blobStore.read.mockResolvedValue(null);
+      });
+    });
+
+    it('says nothing when the cache blob exists but is zero bytes', async () => {
+      await expectSilent(({ blobStore }) => {
+        blobStore.read.mockResolvedValue(new ArrayBuffer(0));
+      });
+    });
+
+    it('says nothing when a healthy cache loads normally', async () => {
+      await expectSilent(({ blobStore }) => {
+        blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      });
+    });
+
+    // A cache written by an older schema version is upgraded by SchemaMigrator
+    // *after* loadDatabase returns. `PRAGMA integrity_check` reports on page
+    // structure and says nothing about `user_version`, so an upgrade must reach
+    // the migrator as an ordinary healthy load — never be mistaken for
+    // corruption and thrown away, which would turn every version bump into a
+    // full rebuild.
+    it('hands an older-schema cache back intact rather than treating the upgrade as corruption', async () => {
+      const { service, blobStore, bridge, db, sqlite3 } = createService();
+      blobStore.read.mockResolvedValue(new Uint8Array([1, 2, 3]).buffer);
+      // Structurally sound database, older `user_version` — exactly what a
+      // pre-v16 install presents on the launch that upgrades it.
+      bridge.getIntegrityCheckResult = jest.fn().mockReturnValue('ok') as typeof bridge.getIntegrityCheckResult;
+
+      const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        const result = await service.loadDatabase(sqlite3, 'CREATE TABLE test (id TEXT);');
+
+        // The deserialized handle survives, so the migrator upgrades real data
+        // instead of an empty replacement.
+        expect(result).toBe(db);
+        expect(bridge.deserializeDatabase).toHaveBeenCalled();
+        expect(blobStore.remove).not.toHaveBeenCalled();
+        expect(messagesFrom(errSpy)).toBe('');
+      } finally {
+        errSpy.mockRestore();
+      }
+    });
   });
 });


### PR DESCRIPTION
Follow-up to #209. Rebased onto `7afcfade`.

## Why

`SQLitePersistenceService` swallowed the integrity-check failure in a bare `catch {}`. The database was quietly rebuilt and the user saw only downstream symptoms — repeated `waitForQueryReady` timeouts, embeddings skipped, tool calls hanging.

Recovery being *safe* is exactly why nobody noticed it happening. The cache is rebuildable by design, so discarding it is the right move; that is what made the silence defensible-looking and still wrong.

## What changed

`reportCacheRebuild` logs at `console.error`, naming the failure, the raw `integrity_check` output or thrown cause, the size of the discarded blob, and what "rebuilt" does and does not promise. The outer read/deserialize catch routes through the same reporter, and the `blobStore.remove()` bare catch now warns.

**The recovery logic itself is untouched.** This only stops it being invisible.

## The message keeps two claims apart

"The rebuild lost nothing" and "your data is back" are different facts, and the message says both separately:

- The rebuild destroys nothing that is not also in the JSONL event store. The cache is a derived index.
- The data reappears only once that event store is **replayed**, which happens a layer up.

The replay does reliably fire on this path, and the reason is worth recording: the sync watermark lives in `sync_state` **inside the blob being discarded**. `HybridStorageAdapter.performInitialization` reads `getSyncState()`, gets `null`, and takes the `runStartupFullRebuild` → `syncCoordinator.fullRebuild()` branch — the same entry point the manual "Nexus: Rebuild cache" command uses. `applied_events` is empty too, so nothing is skipped. It is fail-safe: the watermark cannot outlive the blob it lives in.

But it can still fail on its own — a `fullRebuild` returning `success: false`, or the startup idle watchdog — and then init settles in `error` and the cache stays empty. A flat "no data is lost" would send exactly that user away reassured, so the line points at the replay as the thing to investigate if anything still looks missing.

## Where the message goes — a decision, not an accident

`console.error` and nothing else.

- `logger.systemWarn` and `systemLog` are **no-ops** in this build (`src/utils/logger.ts`), so routing through them would re-hide the thing this PR exists to surface.
- There is no console interception or persisted error capture anywhere in `src/` — verified, not assumed.
- `console.error` *is* a diagnostic surface: it is what Obsidian's developer console shows and what `obsidian-cli dev:errors` reads, which is the gate `scripts/verify-in-obsidian.mjs` and the release protocol already fail on.
- **No `Notice`.** This runs during cache open, before the workspace is ready, in a class with no Obsidian dependency. A user-facing surface belongs to a caller that already owns UI. Reasonable follow-up; deliberately not here.

## Not noisy on the happy path

A report that also fires on ordinary launches is worth nothing. Five tests hold the benign paths silent: no blob yet, a zero-byte blob, a healthy load, and an older-schema cache.

That last one matters with `CURRENT_SCHEMA_VERSION` now at 16. **A schema upgrade is not corruption.** `getIntegrityCheckResult` is `PRAGMA integrity_check`, which reports on page structure and says nothing about `user_version`, so an upgrade reaches `SchemaMigrator` as an ordinary healthy load. The test asserts the deserialized handle survives to the migrator rather than being replaced by an empty one — otherwise every version bump would become a full rebuild.

## Tests, and a survivor the first draft could not catch

Ten mutations of this diff, ten killed.

One is worth naming. The cause assertions read `console.error`'s **first argument only**. Searching all arguments — as the first draft did — is silently satisfied by the `Error` object passed alongside the message, so deleting the interpolated cause from the composed message left every test green while gutting the half of the line a bug report is actually written from. The regression showed up one argument away from where it was introduced. Fixed by asserting against the composed string, with a separate assertion that the `Error` is still passed for a console reader who wants the stack.

## Verification

`npx tsc --noEmit --skipLibCheck` clean · full Jest suite 4889 passed / 0 failed / 37 skipped · `npm run build` exit 0 with the mobile reachability scan clean (404 modules, no Node built-in reachable from init). No new imports; nothing here is desktop-only.

No live proof in this branch — that needs a deliberately corrupted cache in a running vault, which this branch does not own. Handed off as a scripted procedure instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
