### PR TITLE
ci: run PR checks on Node 22, which the test suite actually requires

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,12 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: '20.19.0'
+          # 22.x, not the 20.19.0 the release workflow pins: the test suite
+          # uses the global WebSocket (tests/unit/*RealtimeVoiceSession, the
+          # realtimeVoice services), which Node only exposes globally from 21.
+          # On 20 these suites die with `ReferenceError: WebSocket is not
+          # defined` - which is what the first PR run of this workflow found.
+          node-version: '22.x'
           cache: npm
 
       # `npm run lint` chains `lint:mobile`, which shells out to the Python 3


### PR DESCRIPTION
**Merge this before the other open PRs** — they will all fail CI until it lands.

## What happened

The first ever run of the new PR workflow failed, and not because of the PR it ran on. Six tests across two suites:

```
FAIL tests/unit/OpenAILiveTranscribeSession.test.ts
FAIL tests/unit/AssemblyAIRealtimeVoiceSession.test.ts

    ReferenceError: WebSocket is not defined
  > 35 |     session.websocket = { readyState: WebSocket.OPEN, send };
```

## Cause

Both workflows pin **Node 20.19.0**, and Node only exposes `WebSocket` as a global from **21** onward. Local development runs Node 22, where the whole suite is green — which is exactly why this went unnoticed. This repo had no PR-time checks at all before today, so no CI job had ever run the tests on the pinned version.

In other words: **the test suite has never been runnable on the Node version the workflows pin.** The new gate found that on its first outing, which is a reasonable argument for the gate.

## Production code is unaffected

`src/services/realtimeVoice/*` use the same global, but the plugin runs inside Electron, which provides it. This is a test-environment problem only.

## Scope

`pr.yml` moves to `22.x`. **`release.yml` deliberately keeps `20.19.0`** — it only builds the artifact and never runs the suite, and changing what produces the shipped bundle as a side effect of a test fix would be the wrong trade.

## Worth a separate look

`package.json` declares `engines.node >= 18.0.0`, which the test suite now demonstrably contradicts. I did not change it here — the right value depends on what you intend to support for contributors versus consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_