### PR TITLE
fix: make an empty workspaceId fail like an omitted one (#214)

### DIFF
--- a/cli-first-tool-schemas.json
+++ b/cli-first-tool-schemas.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-21T15:43:30.479Z",
+  "generatedAt": "2026-08-24T15:25:30.810Z",
   "selector": "--help",
   "toolCount": 79,
   "agentCount": 14,

--- a/schemas/5.17.2/cli-tools.json
+++ b/schemas/5.17.2/cli-tools.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-08-21T15:43:30.479Z",
+  "generatedAt": "2026-08-24T15:25:30.810Z",
   "selector": "--help",
   "toolCount": 79,
   "agentCount": 14,

--- a/schemas/5.17.2/mcp-tools.json
+++ b/schemas/5.17.2/mcp-tools.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "nexusVersion": "5.17.2",
-  "generatedAt": "2026-08-21T15:43:30.479Z",
+  "generatedAt": "2026-08-24T15:25:30.810Z",
   "toolCount": 2,
   "tools": [
     {
@@ -12,7 +12,7 @@
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace ID. Optional. Defaults to \"default\"."
+            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list this call returns."
           },
           "sessionId": {
             "type": "string",
@@ -52,7 +52,7 @@
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace ID. Optional. Defaults to \"default\"."
+            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools."
           },
           "sessionId": {
             "type": "string",

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -642,8 +642,10 @@ function isMeaningfulContextValue(value: unknown): boolean {
   return !isPlaceholderText(value);
 }
 
-// workspaceId/sessionId carry valid silent defaults, so absence/empty is fine
-// ("default" / auto-session). Only a present, non-empty placeholder is junk.
+// sessionId carries a valid silent default (auto-session), and an absent or
+// empty workspaceId is refused outright by normalizeContext — see
+// WORKSPACE_ID_REQUIRED_MESSAGE. So blank is never this function's business;
+// only a present, non-empty placeholder is junk.
 function isPlaceholderJunk(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   if (value.trim().length === 0) return false;
@@ -653,7 +655,9 @@ function isPlaceholderJunk(value: unknown): boolean {
 /**
  * Collect predictable steering for a useTools context block.
  * - memory + goal: hard-required (empty or placeholder → steer).
- * - workspaceId + sessionId: default silently; steer only if present-but-junk.
+ * - workspaceId: requiredness is enforced once, in normalizeContext; here we
+ *   only steer a present-but-junk value.
+ * - sessionId: defaults silently; steer only if present-but-junk.
  * Pure — no agent registry needed, so the eval harness can call it directly.
  */
 export function collectContextContractViolations(
@@ -676,7 +680,7 @@ export function collectContextContractViolations(
   if (isPlaceholderJunk(params.workspaceId)) {
     violations.push({
       field: 'workspaceId',
-      message: 'The "workspaceId" looks like a placeholder. Use "default" for the global workspace, or a real workspace ID — or omit it to default to "default".',
+      message: 'The "workspaceId" looks like a placeholder. Use "default" for the global workspace, or an exact workspace name or ID from getTools — it is required, so there is nothing to fall back to.',
     });
   }
   if (isPlaceholderJunk(params.sessionId)) {
@@ -738,6 +742,45 @@ function normalizeVerbatimValues(raw: unknown): Record<string, string> | undefin
   return Object.keys(raw).length > 0 ? (raw as Record<string, string>) : undefined;
 }
 
+// ---------------------------------------------------------------------------
+// workspaceId requiredness (#214)
+//
+// `workspaceId` is in the `required` array of both envelope schemas, and on the
+// MCP path that array IS enforced at runtime (ValidationService → validateParams
+// → "Missing required parameter: workspaceId"). But `required` only asks whether
+// the key is PRESENT, so `workspaceId: ""` sailed through and the old
+// `params.workspaceId || 'default'` here quietly filed the call under the global
+// workspace — a caller whose template rendered to empty behaved completely
+// differently from one that omitted the field, and its traces, sessions and
+// states landed somewhere it never asked for.
+//
+// So: empty, blank and absent all fail the same way, and they fail HERE because
+// schema `required` is documentation plus CLI-normalizer hints, not validation.
+// There is no session stickiness to fall back on (see #214) — nothing remembers
+// the workspace a session was already working in, so a silent default is a guess
+// dressed up as a decision. Surrounding whitespace is trimmed rather than
+// refused: ` default ` is unambiguous, and trimming keeps it from reaching the
+// repository guard as a distinct path segment.
+// ---------------------------------------------------------------------------
+
+export const WORKSPACE_ID_REQUIRED_MESSAGE =
+  '"workspaceId" is required and must not be empty. Pass "default" for the global workspace, '
+  + 'or an exact workspace name or id from the availableWorkspaces list returned by getTools. '
+  + 'An empty string is not treated as "default" — it is rejected, exactly like omitting the field.';
+
+/**
+ * Resolve the envelope's workspaceId, or throw a recoverable steering error.
+ * @param raw - The caller-supplied top-level workspaceId
+ * @returns The trimmed workspace identifier
+ */
+export function normalizeRequiredWorkspaceId(raw: unknown): string {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (trimmed.length === 0) {
+    throw new Error(WORKSPACE_ID_REQUIRED_MESSAGE);
+  }
+  return trimmed;
+}
+
 export class ToolCliNormalizer {
   constructor(private agentRegistry: Map<string, IAgent>) {}
 
@@ -760,7 +803,7 @@ export class ToolCliNormalizer {
     }
 
     return {
-      workspaceId: params.workspaceId || 'default',
+      workspaceId: normalizeRequiredWorkspaceId(params.workspaceId),
       sessionId: params.sessionId || `session_${Date.now()}`,
       memory: params.memory || '',
       goal: params.goal || '',

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -243,7 +243,7 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
       properties: {
         workspaceId: {
           type: 'string',
-          description: 'Workspace ID. Optional. Defaults to "default".'
+          description: 'Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as "default". Pass "default" for the global workspace, or an exact value from the availableWorkspaces list this call returns.'
         },
         sessionId: {
           type: 'string',

--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -63,7 +63,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
       properties: {
         workspaceId: {
           type: 'string',
-          description: 'Workspace ID. Optional. Defaults to "default".'
+          description: 'Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as "default". Pass "default" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools.'
         },
         sessionId: {
           type: 'string',

--- a/src/agents/toolManager/types.ts
+++ b/src/agents/toolManager/types.ts
@@ -142,7 +142,7 @@ export function getTopLevelToolContextSchema(): Record<string, unknown> {
   return {
     workspaceId: {
       type: 'string',
-      description: 'Workspace ID. Use "default" for the global workspace. Do not invent workspace IDs.'
+      description: 'Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as "default". Use "default" for the global workspace. Do not invent workspace IDs.'
     },
     sessionId: {
       type: 'string',

--- a/src/database/repositories/ProjectRepository.ts
+++ b/src/database/repositories/ProjectRepository.ts
@@ -34,6 +34,7 @@ import { PaginatedResult, PaginationParams } from '../../types/pagination/Pagina
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { resolveMetadataUpdate } from './metadataUpdate';
 import { purgeProjectRows } from '../taskOwnership';
+import { taskStreamPath } from './base/workspaceStreamPath';
 
 interface ProjectRow extends DatabaseRow {
   id: string;
@@ -57,7 +58,7 @@ export class ProjectRepository
   protected readonly entityType = 'project';
 
   protected jsonlPath(workspaceId: string): string {
-    return `tasks/tasks_${workspaceId}.jsonl`;
+    return taskStreamPath(workspaceId, this.entityType);
   }
 
   constructor(deps: RepositoryDependencies) {

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -33,6 +33,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { purgeSessionRows } from '../sessionOwnership';
+import { workspaceStreamPath } from './base/workspaceStreamPath';
 
 type SqliteValue = string | number | null;
 
@@ -59,7 +60,7 @@ export class SessionRepository
   protected readonly tableName = 'sessions';
   protected readonly entityType = 'session';
   // Sessions write to workspace JSONL file
-  protected readonly jsonlPath = (workspaceId: string): string => `workspaces/ws_${workspaceId}.jsonl`;
+  protected readonly jsonlPath = (workspaceId: string): string => workspaceStreamPath(workspaceId, this.entityType);
 
   constructor(deps: RepositoryDependencies) {
     super(deps);

--- a/src/database/repositories/StateRepository.ts
+++ b/src/database/repositories/StateRepository.ts
@@ -35,6 +35,7 @@ import { PaginatedResult, PaginationParams } from '../../types/pagination/Pagina
 import { QueryParams } from './base/BaseRepository';
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { deriveStateMetadata, resolveStateDescription } from '../utils/stateContent';
+import { workspaceStreamPath } from './base/workspaceStreamPath';
 
 interface StateRow extends DatabaseRow {
   id: string;
@@ -64,7 +65,7 @@ export class StateRepository
   protected readonly tableName = 'states';
   protected readonly entityType = 'state';
   // States write to workspace JSONL file
-  protected readonly jsonlPath: (workspaceId: string) => string = (workspaceId) => `workspaces/ws_${workspaceId}.jsonl`;
+  protected readonly jsonlPath: (workspaceId: string) => string = (workspaceId) => workspaceStreamPath(workspaceId, this.entityType);
 
   // In-memory cache for full state data (since content not in SQLite)
   private stateContentCache: Map<string, StateData> = new Map();

--- a/src/database/repositories/TaskRepository.ts
+++ b/src/database/repositories/TaskRepository.ts
@@ -45,6 +45,7 @@ import { PaginatedResult, PaginationParams } from '../../types/pagination/Pagina
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { purgeTaskRows } from '../taskOwnership';
 import { resolveMetadataUpdate } from './metadataUpdate';
+import { taskStreamPath } from './base/workspaceStreamPath';
 
 interface TaskRow extends DatabaseRow {
   id: string;
@@ -80,7 +81,7 @@ export class TaskRepository
   protected readonly entityType = 'task';
 
   protected jsonlPath(workspaceId: string): string {
-    return `tasks/tasks_${workspaceId}.jsonl`;
+    return taskStreamPath(workspaceId, this.entityType);
   }
 
   constructor(deps: RepositoryDependencies) {

--- a/src/database/repositories/TraceRepository.ts
+++ b/src/database/repositories/TraceRepository.ts
@@ -27,6 +27,7 @@ import { MemoryTraceData } from '../../types/storage/HybridStorageTypes';
 import { TraceAddedEvent } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { DatabaseRow, QueryParams } from './base/BaseRepository';
+import { workspaceStreamPath } from './base/workspaceStreamPath';
 
 interface TraceRow extends DatabaseRow {
   id: string;
@@ -51,7 +52,7 @@ export class TraceRepository
   protected readonly tableName = 'memory_traces';
   protected readonly entityType = 'trace';
   // Traces write to workspace JSONL file
-  protected readonly jsonlPath: (workspaceId: string) => string = (workspaceId) => `workspaces/ws_${workspaceId}.jsonl`;
+  protected readonly jsonlPath: (workspaceId: string) => string = (workspaceId) => workspaceStreamPath(workspaceId, this.entityType);
 
   constructor(deps: RepositoryDependencies) {
     super(deps);

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -36,7 +36,7 @@ import { QueryOptions } from '../interfaces/IStorageAdapter';
 import { QueryCache } from '../optimizations/QueryCache';
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { purgeWorkspaceRows, workspaceOwnedStreamPaths } from '../workspaceOwnership';
-import { workspaceStreamPath } from './base/workspaceStreamPath';
+import { workspaceStreamPath, workspaceStreamPathForRemoval } from './base/workspaceStreamPath';
 
 type SqliteValue = string | number | null;
 
@@ -270,8 +270,15 @@ export class WorkspaceRepository
   async delete(id: string): Promise<void> {
     try {
       // 1. Tombstone, so a stream we fail to remove still cancels itself out.
+      //
+      // Minted with the REMOVAL guard, not `this.jsonlPath` (the write guard):
+      // the streams most in need of a permanent delete are the malformed ones
+      // the write guard now refuses to create, and they are already on disk.
+      // Routing this through the write tier would throw here and skip both the
+      // stream removal and the SQLite purge below, making every pre-existing
+      // phantom workspace undeletable. Path safety is still enforced.
       await this.writeEvent<WorkspaceDeletedEvent>(
-        this.jsonlPath(id),
+        workspaceStreamPathForRemoval(id, this.entityType),
         {
           type: 'workspace_deleted',
           workspaceId: id

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -36,6 +36,7 @@ import { QueryOptions } from '../interfaces/IStorageAdapter';
 import { QueryCache } from '../optimizations/QueryCache';
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { purgeWorkspaceRows, workspaceOwnedStreamPaths } from '../workspaceOwnership';
+import { workspaceStreamPath } from './base/workspaceStreamPath';
 
 type SqliteValue = string | number | null;
 
@@ -64,7 +65,7 @@ export class WorkspaceRepository
 
   protected readonly tableName = 'workspaces';
   protected readonly entityType = 'workspace';
-  protected readonly jsonlPath = (id: string): string => `workspaces/ws_${id}.jsonl`;
+  protected readonly jsonlPath = (id: string): string => workspaceStreamPath(id, this.entityType);
 
   constructor(deps: RepositoryDependencies) {
     super(deps);

--- a/src/database/repositories/base/workspaceStreamPath.ts
+++ b/src/database/repositories/base/workspaceStreamPath.ts
@@ -36,13 +36,39 @@
 const MAX_WORKSPACE_ID_LENGTH = 200;
 
 /**
- * Why an id is unusable, or null when it is fine.
- * Exported for tests; production callers use assertUsableWorkspaceId.
+ * Why an id can never be part of a path, or null when it is fine.
+ *
+ * The PATH-SAFETY tier, enforced on every mint including removals: these are the
+ * strings that would escape the stream directory or corrupt the filename, as
+ * opposed to merely being an implausible workspace.
  */
-export function describeUnusableWorkspaceId(workspaceId: unknown): string | null {
+function describePathUnsafeWorkspaceId(workspaceId: unknown): string | null {
   if (typeof workspaceId !== 'string') {
     return `expected a string, got ${workspaceId === null ? 'null' : Array.isArray(workspaceId) ? 'array' : typeof workspaceId}`;
   }
+  // eslint-disable-next-line no-control-regex -- matching control characters is the point: they must never reach a filename
+  if (/[\x00-\x1f\x7f]/.test(workspaceId)) {
+    return 'it contains control characters';
+  }
+  if (workspaceId.includes('/') || workspaceId.includes('\\')) {
+    return 'it contains a path separator';
+  }
+  // normalizePath() does not strip "..", so confinement needs an explicit guard.
+  if (workspaceId === '.' || workspaceId === '..' || workspaceId.includes('..')) {
+    return 'it contains a path traversal segment';
+  }
+  return null;
+}
+
+/**
+ * Why an id is not a legitimate workspace, or null when it is fine.
+ *
+ * The WRITE tier. Every reason here describes a string that IS a usable path
+ * segment but can never name a real workspace, so minting a NEW stream from it
+ * would create exactly the phantom directories this module exists to prevent.
+ * Removal deliberately does not apply this tier — see `assertPathSafeWorkspaceId`.
+ */
+function describeUnconventionalWorkspaceId(workspaceId: string): string | null {
   if (workspaceId.length === 0) {
     return 'it is empty';
   }
@@ -58,17 +84,6 @@ export function describeUnusableWorkspaceId(workspaceId: unknown): string | null
   if (workspaceId.startsWith('-')) {
     return 'it looks like a command-line flag, not a workspace';
   }
-  // eslint-disable-next-line no-control-regex -- matching control characters is the point: they must never reach a filename
-  if (/[\x00-\x1f\x7f]/.test(workspaceId)) {
-    return 'it contains control characters';
-  }
-  if (workspaceId.includes('/') || workspaceId.includes('\\')) {
-    return 'it contains a path separator';
-  }
-  // normalizePath() does not strip "..", so confinement needs an explicit guard.
-  if (workspaceId === '.' || workspaceId === '..' || workspaceId.includes('..')) {
-    return 'it contains a path traversal segment';
-  }
   if (workspaceId.length > MAX_WORKSPACE_ID_LENGTH) {
     return `it is longer than ${MAX_WORKSPACE_ID_LENGTH} characters`;
   }
@@ -76,20 +91,59 @@ export function describeUnusableWorkspaceId(workspaceId: unknown): string | null
 }
 
 /**
- * Throw unless `workspaceId` can safely become a path segment.
+ * Why an id is unusable for a WRITE, or null when it is fine.
+ * Both tiers: path safety first, then workspace plausibility.
+ * Exported for tests; production callers use assertUsableWorkspaceId.
+ */
+export function describeUnusableWorkspaceId(workspaceId: unknown): string | null {
+  const unsafe = describePathUnsafeWorkspaceId(workspaceId);
+  if (unsafe !== null) return unsafe;
+  return describeUnconventionalWorkspaceId(workspaceId as string);
+}
+
+/** Shared error shape, so a refusal reads the same wherever it is raised. */
+function refuse(workspaceId: unknown, entityType: string, reason: string, verb: string): never {
+  const shown = typeof workspaceId === 'string' ? `"${workspaceId}"` : String(workspaceId);
+  throw new Error(
+    `Refusing to ${verb} ${entityType} events under workspace ${shown}: ${reason}. `
+    + 'Pass "default" for the global workspace, or an exact workspace name or id.'
+  );
+}
+
+/**
+ * Throw unless `workspaceId` can safely become a path segment AND could plausibly
+ * be a real workspace. This is the guard for everything that WRITES.
  * @param workspaceId - Caller-supplied workspace identifier (id or name)
  * @param entityType - Repository entity type, for the error message
  * @returns The same id, narrowed to string
  */
 export function assertUsableWorkspaceId(workspaceId: unknown, entityType: string): string {
   const reason = describeUnusableWorkspaceId(workspaceId);
-  if (reason !== null) {
-    const shown = typeof workspaceId === 'string' ? `"${workspaceId}"` : String(workspaceId);
-    throw new Error(
-      `Refusing to store ${entityType} events under workspace ${shown}: ${reason}. `
-      + 'Pass "default" for the global workspace, or an exact workspace name or id.'
-    );
-  }
+  if (reason !== null) refuse(workspaceId, entityType, reason, 'store');
+  return workspaceId as string;
+}
+
+/**
+ * Throw only if `workspaceId` cannot safely become a path segment.
+ *
+ * The REMOVAL guard. A permanent delete has to be able to address a stream that
+ * is already on disk, and the streams most in need of removal are precisely the
+ * malformed ones this module now refuses to create — `ws_--workspaceId`, `ws_`,
+ * the padded and the over-long. Applying the write tier to a delete would make
+ * every pre-existing phantom permanently undeletable and would stop
+ * `WorkspaceRepository.delete` before it ever reached `workspaceOwnedStreamPaths`,
+ * so the whole #347 purge would be dead code for exactly the vaults that need it.
+ *
+ * Path safety is still enforced, and that is a tightening rather than a
+ * loosening: a traversal id used to reach `deleteStream` unchecked.
+ *
+ * @param workspaceId - Workspace identifier of a stream being removed
+ * @param entityType - Repository entity type, for the error message
+ * @returns The same id, narrowed to string
+ */
+export function assertPathSafeWorkspaceId(workspaceId: unknown, entityType: string): string {
+  const reason = describePathUnsafeWorkspaceId(workspaceId);
+  if (reason !== null) refuse(workspaceId, entityType, reason, 'remove');
   return workspaceId as string;
 }
 
@@ -101,4 +155,14 @@ export function workspaceStreamPath(workspaceId: unknown, entityType: string): s
 /** `tasks/tasks_<workspaceId>.jsonl` — task and project streams. */
 export function taskStreamPath(workspaceId: unknown, entityType: string): string {
   return `tasks/tasks_${assertUsableWorkspaceId(workspaceId, entityType)}.jsonl`;
+}
+
+/**
+ * `workspaces/ws_<id>.jsonl` for a stream being REMOVED, not written.
+ *
+ * Same template as `workspaceStreamPath`, path-safety tier only, so a permanent
+ * delete can still address a malformed stream that predates the write guard.
+ */
+export function workspaceStreamPathForRemoval(workspaceId: unknown, entityType: string): string {
+  return `workspaces/ws_${assertPathSafeWorkspaceId(workspaceId, entityType)}.jsonl`;
 }

--- a/src/database/repositories/base/workspaceStreamPath.ts
+++ b/src/database/repositories/base/workspaceStreamPath.ts
@@ -1,0 +1,104 @@
+/**
+ * Location: src/database/repositories/base/workspaceStreamPath.ts
+ *
+ * Repository-boundary guard for workspace-keyed event streams (#214).
+ *
+ * Four repositories mint a JSONL path directly from a caller-supplied
+ * workspaceId — `workspaces/ws_<id>.jsonl` (session/state/trace/workspace) and
+ * `tasks/tasks_<id>.jsonl` (task/project, whose `jsonlPath` parameter is a
+ * workspaceId despite the file name). Until now nothing between the caller and
+ * that mint checked the id, so any string became a directory on disk, silently
+ * and permanently: a flag name that leaked in as a value (`ws_--workspaceId`),
+ * the empty id (`ws_`), a path fragment.
+ *
+ * Scope, deliberately: this is a STRUCTURAL guard, not a workspace lookup. It
+ * rejects strings that can never be a legitimate workspace id OR a legitimate
+ * workspace name, and nothing else. It does NOT ask whether the workspace
+ * exists — that check needs the live list, lives at the envelope
+ * (`ToolBatchExecutionService.validateWorkspaceId`), and cannot move down here
+ * without making every repository depend on the service that owns one of them.
+ * So a well-formed id for a workspace that does not exist still passes; a
+ * truncated or zero-filled UUID is indistinguishable from a short real id at
+ * this layer and is the envelope's job.
+ *
+ * Names are accepted on purpose. A caller may legitimately hold a workspace
+ * NAME (the envelope accepts one), and names contain spaces, accents and
+ * punctuation. Rejecting those here would turn a working call into a hard
+ * error, so only characters that break the path itself are refused.
+ *
+ * Related files:
+ * - src/database/repositories/base/BaseRepository.ts - writeEvent / jsonlPath
+ * - src/agents/toolManager/services/ToolBatchExecutionService.ts - envelope guard
+ * - src/agents/toolManager/services/ToolCliNormalizer.ts - envelope requiredness
+ */
+
+/** Longest id we will turn into a path segment. Filenames cap near 255 bytes. */
+const MAX_WORKSPACE_ID_LENGTH = 200;
+
+/**
+ * Why an id is unusable, or null when it is fine.
+ * Exported for tests; production callers use assertUsableWorkspaceId.
+ */
+export function describeUnusableWorkspaceId(workspaceId: unknown): string | null {
+  if (typeof workspaceId !== 'string') {
+    return `expected a string, got ${workspaceId === null ? 'null' : Array.isArray(workspaceId) ? 'array' : typeof workspaceId}`;
+  }
+  if (workspaceId.length === 0) {
+    return 'it is empty';
+  }
+  if (workspaceId.trim().length === 0) {
+    return 'it is blank';
+  }
+  if (workspaceId !== workspaceId.trim()) {
+    return 'it has leading or trailing whitespace';
+  }
+  // A leaked CLI flag name (`--workspaceId`, `--id`) is the census class that
+  // proved an argument name can travel all the way to the storage layer as a
+  // value. No workspace is named with a leading dash.
+  if (workspaceId.startsWith('-')) {
+    return 'it looks like a command-line flag, not a workspace';
+  }
+  // eslint-disable-next-line no-control-regex -- matching control characters is the point: they must never reach a filename
+  if (/[\x00-\x1f\x7f]/.test(workspaceId)) {
+    return 'it contains control characters';
+  }
+  if (workspaceId.includes('/') || workspaceId.includes('\\')) {
+    return 'it contains a path separator';
+  }
+  // normalizePath() does not strip "..", so confinement needs an explicit guard.
+  if (workspaceId === '.' || workspaceId === '..' || workspaceId.includes('..')) {
+    return 'it contains a path traversal segment';
+  }
+  if (workspaceId.length > MAX_WORKSPACE_ID_LENGTH) {
+    return `it is longer than ${MAX_WORKSPACE_ID_LENGTH} characters`;
+  }
+  return null;
+}
+
+/**
+ * Throw unless `workspaceId` can safely become a path segment.
+ * @param workspaceId - Caller-supplied workspace identifier (id or name)
+ * @param entityType - Repository entity type, for the error message
+ * @returns The same id, narrowed to string
+ */
+export function assertUsableWorkspaceId(workspaceId: unknown, entityType: string): string {
+  const reason = describeUnusableWorkspaceId(workspaceId);
+  if (reason !== null) {
+    const shown = typeof workspaceId === 'string' ? `"${workspaceId}"` : String(workspaceId);
+    throw new Error(
+      `Refusing to store ${entityType} events under workspace ${shown}: ${reason}. `
+      + 'Pass "default" for the global workspace, or an exact workspace name or id.'
+    );
+  }
+  return workspaceId as string;
+}
+
+/** `workspaces/ws_<id>.jsonl` — session, state, trace and workspace streams. */
+export function workspaceStreamPath(workspaceId: unknown, entityType: string): string {
+  return `workspaces/ws_${assertUsableWorkspaceId(workspaceId, entityType)}.jsonl`;
+}
+
+/** `tasks/tasks_<workspaceId>.jsonl` — task and project streams. */
+export function taskStreamPath(workspaceId: unknown, entityType: string): string {
+  return `tasks/tasks_${assertUsableWorkspaceId(workspaceId, entityType)}.jsonl`;
+}

--- a/tests/unit/EnvelopeWorkspaceIdRequired.test.ts
+++ b/tests/unit/EnvelopeWorkspaceIdRequired.test.ts
@@ -1,0 +1,197 @@
+/**
+ * tests/unit/EnvelopeWorkspaceIdRequired.test.ts — issue #214.
+ *
+ * The envelope disagreed with itself about `workspaceId` in two ways:
+ *
+ * 1. OMISSION vs EMPTY STRING. Both envelope schemas list `workspaceId` in
+ *    `required`, and on the MCP path that array IS enforced at runtime
+ *    (ValidationService → validateParams → "Missing required parameter"), so
+ *    omitting the field hard-fails. But `required` only asks whether the key is
+ *    PRESENT — `workspaceId: ""` passed that check and then hit
+ *    `params.workspaceId || 'default'` in ToolCliNormalizer.normalizeContext,
+ *    which silently filed the call under the global workspace. A caller whose
+ *    template rendered to empty behaved completely differently from one that
+ *    omitted the field, and nothing told it so.
+ *
+ * 2. THE SCHEMA CONTRADICTED ITSELF. The parameter description read "Workspace
+ *    ID. Optional. Defaults to \"default\"." while the same schema listed the
+ *    field as required. Requiredness is the half that is actually enforced —
+ *    and with no session stickiness (the other half of #214, deliberately not
+ *    implemented) a silent default is a guess, not a decision — so the
+ *    description was corrected to match the contract, not the other way round.
+ *
+ * The guard lives in the normalizer because tool parameter schemas are
+ * documentation plus CLI-normalizer hints, not runtime validation.
+ */
+import {
+  ToolCliNormalizer,
+  WORKSPACE_ID_REQUIRED_MESSAGE,
+  normalizeRequiredWorkspaceId
+} from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import { UseToolTool } from '../../src/agents/toolManager/tools/useTools';
+import { GetToolsTool } from '../../src/agents/toolManager/tools/getTools';
+import { ToolBatchExecutionService } from '../../src/agents/toolManager/services/ToolBatchExecutionService';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { UseToolParams } from '../../src/agents/toolManager/types';
+
+const FILLED_CONTEXT = {
+  sessionId: 'note-cleanup',
+  memory: 'Reviewed the vault and listed the workspaces.',
+  goal: 'Move the archived note into place.',
+  tool: 'content read --path notes/source.md'
+};
+
+/** Minimal registry so `normalizeExecutionCalls` can resolve a real command. */
+function createRegistry(): Map<string, IAgent> {
+  const readTool = {
+    slug: 'read',
+    name: 'Read',
+    description: 'Read a note',
+    version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path']
+    }),
+    getResultSchema: () => ({ type: 'object' })
+  };
+  const agent = {
+    name: 'contentManager',
+    description: 'Content manager',
+    version: '1.0.0',
+    getTools: () => [readTool],
+    getTool: (slug: string) => (slug === 'read' ? readTool : undefined),
+    initialize: jest.fn(),
+    executeTool: jest.fn(),
+    setAgentManager: jest.fn()
+  };
+  return new Map<string, IAgent>([['contentManager', agent as unknown as IAgent]]);
+}
+
+function createNormalizer(): ToolCliNormalizer {
+  return new ToolCliNormalizer(createRegistry());
+}
+
+function createUseTool(): { tool: UseToolTool; execute: jest.SpyInstance } {
+  const batchExecutionService = {
+    execute: jest.fn().mockResolvedValue({ success: true })
+  } as unknown as ToolBatchExecutionService;
+  const tool = new UseToolTool(batchExecutionService, createNormalizer());
+  return { tool, execute: batchExecutionService.execute as unknown as jest.SpyInstance };
+}
+
+describe('envelope workspaceId requiredness (#214)', () => {
+  describe('empty behaves exactly like omitted', () => {
+    // Pre-fix these three diverged: undefined and '' both silently became
+    // 'default' inside normalizeContext, while the MCP layer rejected only the
+    // omission. Now all three fail identically, at the same layer.
+    const blanks: Array<[string, unknown]> = [
+      ['omitted', undefined],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+      ['tab and newline', '\t\n'],
+      ['null', null]
+    ];
+
+    it.each(blanks)('rejects %s with the one shared message', (_label, value) => {
+      const normalizer = createNormalizer();
+      expect(() =>
+        normalizer.normalizeContext({ ...FILLED_CONTEXT, workspaceId: value } as UseToolParams)
+      ).toThrow(WORKSPACE_ID_REQUIRED_MESSAGE);
+    });
+
+    it('says plainly that "" is not read as "default"', () => {
+      // The message has to name the coercion that used to happen, because the
+      // caller most likely to hit this is a template that rendered to empty.
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('empty string is not treated as "default"');
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('"default"');
+    });
+
+    it('never silently substitutes "default" for a blank value', () => {
+      for (const [, value] of blanks) {
+        expect(() => normalizeRequiredWorkspaceId(value)).toThrow(WORKSPACE_ID_REQUIRED_MESSAGE);
+      }
+    });
+  });
+
+  describe('a real workspace still passes', () => {
+    it('keeps an explicit id', () => {
+      const context = createNormalizer().normalizeContext({
+        ...FILLED_CONTEXT,
+        workspaceId: 'a8fbad11-7412-49c8-bce0-5690e2c1d197'
+      } as UseToolParams);
+      expect(context.workspaceId).toBe('a8fbad11-7412-49c8-bce0-5690e2c1d197');
+    });
+
+    it('keeps an explicit "default"', () => {
+      const context = createNormalizer().normalizeContext({
+        ...FILLED_CONTEXT,
+        workspaceId: 'default'
+      } as UseToolParams);
+      expect(context.workspaceId).toBe('default');
+    });
+
+    it('trims surrounding whitespace instead of minting " Desenvolvedor "', () => {
+      // Unambiguous, so trimming beats rejecting — and it stops a padded value
+      // from reaching the repository guard as its own path segment.
+      const context = createNormalizer().normalizeContext({
+        ...FILLED_CONTEXT,
+        workspaceId: '  Desenvolvedor  '
+      } as UseToolParams);
+      expect(context.workspaceId).toBe('Desenvolvedor');
+    });
+  });
+
+  describe('useTools execution', () => {
+    it('refuses to execute anything when workspaceId is an empty string', async () => {
+      const { tool, execute } = createUseTool();
+      await expect(
+        tool.execute({ ...FILLED_CONTEXT, workspaceId: '' } as UseToolParams)
+      ).rejects.toThrow(WORKSPACE_ID_REQUIRED_MESSAGE);
+      // Pre-fix this batch ran, in the "default" workspace.
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it('executes normally with a real workspaceId', async () => {
+      const { tool, execute } = createUseTool();
+      const result = await tool.execute({
+        ...FILLED_CONTEXT,
+        workspaceId: 'Desenvolvedor'
+      } as UseToolParams);
+      expect(result).toEqual({ success: true });
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(execute.mock.calls[0][0].context.workspaceId).toBe('Desenvolvedor');
+    });
+  });
+
+  describe('schema text agrees with the enforced contract', () => {
+    const schemas: Array<[string, () => Record<string, unknown>]> = [
+      ['useTools', () => createUseTool().tool.getParameterSchema()],
+      [
+        'getTools',
+        () =>
+          new GetToolsTool(new Map<string, IAgent>(), {
+            workspaces: [],
+            customAgents: [],
+            vaultRoot: []
+          }).getParameterSchema()
+      ]
+    ];
+
+    it.each(schemas)('%s lists workspaceId as required', (_name, getSchema) => {
+      const schema = getSchema();
+      expect(schema.required).toContain('workspaceId');
+    });
+
+    it.each(schemas)('%s no longer describes workspaceId as optional', (_name, getSchema) => {
+      const schema = getSchema();
+      const properties = schema.properties as Record<string, { description: string }>;
+      const description = properties.workspaceId.description;
+      expect(description).toMatch(/required/i);
+      expect(description).not.toMatch(/optional/i);
+      // The specific claim that regressed: "Defaults to \"default\"".
+      expect(description).not.toMatch(/defaults to/i);
+    });
+  });
+});

--- a/tests/unit/WorkspaceStreamPathGuard.test.ts
+++ b/tests/unit/WorkspaceStreamPathGuard.test.ts
@@ -20,11 +20,17 @@
 import {
   describeUnusableWorkspaceId,
   workspaceStreamPath,
-  taskStreamPath
+  taskStreamPath,
+  workspaceStreamPathForRemoval
 } from '../../src/database/repositories/base/workspaceStreamPath';
 import { SessionRepository } from '../../src/database/repositories/SessionRepository';
 import { TaskRepository } from '../../src/database/repositories/TaskRepository';
+import { WorkspaceRepository } from '../../src/database/repositories/WorkspaceRepository';
 import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEventStore';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { createMockApp } from '../helpers/mockVaultAdapter';
 
 function createMockDeps(): RepositoryDependencies & { appendEvent: jest.Mock } {
   const appendEvent = jest.fn().mockImplementation((_path: string, ev: Record<string, unknown>) => ({
@@ -81,6 +87,26 @@ describe('workspace stream path guard (#214)', () => {
       expect(describeUnusableWorkspaceId(value)).not.toBeNull();
       expect(() => workspaceStreamPath(value, 'session')).toThrow(/Refusing to store session events/);
       expect(() => taskStreamPath(value, 'task')).toThrow(/Refusing to store task events/);
+    });
+
+    // The reason is user-facing steering copy — the model is expected to read it
+    // and self-correct — and the checks overlap enough that a deleted clause is
+    // silently covered by the next one with the WRONG wording ('' reported as
+    // 'blank', '   ' as padded). Pinning each reason is what makes those cases
+    // distinguishable.
+    it.each([
+      ['', 'it is empty'],
+      ['   ', 'it is blank'],
+      [' default ', 'it has leading or trailing whitespace'],
+      ['--workspaceId', 'it looks like a command-line flag, not a workspace'],
+      ['default/nested', 'it contains a path separator'],
+      // A traversal WITH a slash reports the separator first; '..' is the case
+      // that actually exercises the traversal clause.
+      ['..', 'it contains a path traversal segment'],
+      ['default\u0000', 'it contains control characters'],
+      ['x'.repeat(201), 'it is longer than 200 characters']
+    ])('explains %j with the reason that actually fits it', (value, reason) => {
+      expect(describeUnusableWorkspaceId(value)).toBe(reason);
     });
 
     it('names the workspace, the reason and the way out', () => {
@@ -152,6 +178,74 @@ describe('workspace stream path guard (#214)', () => {
 
       expect(deps.appendEvent).toHaveBeenCalledTimes(1);
       expect(deps.appendEvent.mock.calls[0][0]).toBe('workspaces/ws_Desenvolvedor.jsonl');
+    });
+  });
+  // ==========================================================================
+  // Removal is NOT a write (#347 interaction).
+  //
+  // #347 made permanent workspace delete purge every stream the workspace owns.
+  // Its first step appends a `workspace_deleted` tombstone, and that append used
+  // to be minted by `this.jsonlPath` — the WRITE guard. Applying the write tier
+  // to a delete throws before the purge ever runs, so the malformed streams this
+  // guard now refuses to CREATE would have become permanently undeletable —
+  // exactly the 41-of-56 phantoms in the census that motivated the guard.
+  //
+  // So removal enforces path safety only. That is still a tightening: before
+  // this, a traversal id reached `deleteStream` completely unchecked.
+  // ==========================================================================
+  describe('removal tier', () => {
+    it.each([
+      ['the empty id', ''],
+      ['a leaked flag name', '--workspaceId'],
+      ['a padded id', '  ws-real  '],
+      ['an over-long id', 'w'.repeat(250)]
+    ])('mints a removal path for %s, which the write tier refuses', (_label, value) => {
+      expect(() => workspaceStreamPath(value, 'workspace')).toThrow(/Refusing to store/);
+      expect(workspaceStreamPathForRemoval(value, 'workspace')).toBe(`workspaces/ws_${value}.jsonl`);
+    });
+
+    it.each([
+      ['a traversal id', '../../escape'],
+      ['a path separator', 'a/b']
+    ])('still refuses %s, because removal cannot escape the stream directory', (_label, value) => {
+      expect(() => workspaceStreamPathForRemoval(value, 'workspace')).toThrow(/Refusing to remove/);
+    });
+
+    it('lets a pre-existing phantom workspace actually be deleted', async () => {
+      const { app } = createMockApp({ withLocalStorage: true });
+      const vaultEventStore = new VaultEventStore({
+        app,
+        resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+      });
+      const jsonlWriter = new JSONLWriter({
+        app,
+        basePath: '.obsidian/plugins/nexus/data',
+        readBasePaths: ['.obsidian/plugins/nexus/data'],
+        vaultEventStore
+      });
+      const deps: RepositoryDependencies = {
+        sqliteCache: {
+          run: jest.fn(async () => undefined),
+          query: jest.fn(async () => []),
+          queryOne: jest.fn(async () => null),
+          transaction: jest.fn((fn: () => Promise<unknown>) => fn())
+        } as never,
+        jsonlWriter,
+        queryCache: new QueryCache()
+      };
+
+      // A phantom that predates the write guard, as found in the real vault.
+      const phantom = '--workspaceId';
+      await jsonlWriter.appendEvents(`workspaces/ws_${phantom}.jsonl`, [
+        { type: 'workspace_created', data: { id: phantom, name: 'Phantom', rootFolder: '/', created: 1 } }
+      ] as never);
+      expect(await vaultEventStore.listFiles('workspaces')).toContain(`workspaces/ws_${phantom}.jsonl`);
+
+      await new WorkspaceRepository(deps).delete(phantom);
+
+      // With the tombstone minted by the write guard this threw
+      // "it looks like a command-line flag" and the stream survived.
+      expect(await vaultEventStore.listFiles('workspaces')).not.toContain(`workspaces/ws_${phantom}.jsonl`);
     });
   });
 });

--- a/tests/unit/WorkspaceStreamPathGuard.test.ts
+++ b/tests/unit/WorkspaceStreamPathGuard.test.ts
@@ -1,0 +1,157 @@
+/**
+ * tests/unit/WorkspaceStreamPathGuard.test.ts — issue #214.
+ *
+ * Envelope validation (#311, #317) only guards callers that come through
+ * `useTools`. Everything below it minted a JSONL path straight from a
+ * caller-supplied workspaceId — `workspaces/ws_<id>.jsonl` for session, state,
+ * trace and workspace events, `tasks/tasks_<workspaceId>.jsonl` for task and
+ * project events — so any string that reached a repository by another door
+ * became a directory on disk, silently and permanently. The reporter's census
+ * of one real vault found 41 of 56 workspace directories were phantoms,
+ * including `ws_--workspaceId`, `ws_--id` and one named `ws_` (the empty id).
+ *
+ * The guard is structural on purpose: it refuses strings that can be neither a
+ * workspace id NOR a workspace name, and asks nothing about whether the
+ * workspace exists — that needs the live list, belongs at the envelope, and
+ * cannot move down here without every repository depending on the service that
+ * owns one of them. So real names with spaces and accents still pass, and a
+ * well-formed id for a workspace that no longer exists still passes.
+ */
+import {
+  describeUnusableWorkspaceId,
+  workspaceStreamPath,
+  taskStreamPath
+} from '../../src/database/repositories/base/workspaceStreamPath';
+import { SessionRepository } from '../../src/database/repositories/SessionRepository';
+import { TaskRepository } from '../../src/database/repositories/TaskRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+
+function createMockDeps(): RepositoryDependencies & { appendEvent: jest.Mock } {
+  const appendEvent = jest.fn().mockImplementation((_path: string, ev: Record<string, unknown>) => ({
+    ...ev,
+    id: 'evt-x',
+    timestamp: Date.now(),
+    deviceId: 'dev-1'
+  }));
+  return {
+    appendEvent,
+    sqliteCache: {
+      queryOne: jest.fn(),
+      query: jest.fn().mockResolvedValue([]),
+      run: jest.fn(),
+      transaction: jest.fn((fn: () => Promise<unknown>) => fn())
+    } as never,
+    jsonlWriter: {
+      appendEvent,
+      readEvents: jest.fn().mockResolvedValue([])
+    } as never,
+    queryCache: {
+      cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+      invalidateByType: jest.fn(),
+      invalidateById: jest.fn(),
+      invalidate: jest.fn()
+    } as never
+  };
+}
+
+describe('workspace stream path guard (#214)', () => {
+  describe('ids that must never become a directory', () => {
+    // One case per class the census turned up, plus the traversal case the
+    // repo's own rule about normalizePath() not stripping ".." implies.
+    const rejected: Array<[string, unknown]> = [
+      ['the empty id — the directory literally named ws_', ''],
+      ['a blank id', '   '],
+      ['a padded id', ' default '],
+      ['a leaked long flag name', '--workspaceId'],
+      ['a leaked short flag name', '--id'],
+      ['a single dash argument', '-w'],
+      ['a path separator', 'default/nested'],
+      ['a windows path separator', 'workspaces\\default'],
+      ['a traversal segment', '../../etc/passwd'],
+      ['a bare traversal', '..'],
+      ['a newline', 'default\ndefault'],
+      ['a null byte', 'default\u0000'],
+      ['a non-string', 42],
+      ['null', null],
+      ['undefined', undefined],
+      ['an absurdly long id', 'x'.repeat(201)]
+    ];
+
+    it.each(rejected)('rejects %s', (_label, value) => {
+      expect(describeUnusableWorkspaceId(value)).not.toBeNull();
+      expect(() => workspaceStreamPath(value, 'session')).toThrow(/Refusing to store session events/);
+      expect(() => taskStreamPath(value, 'task')).toThrow(/Refusing to store task events/);
+    });
+
+    it('names the workspace, the reason and the way out', () => {
+      expect(() => workspaceStreamPath('--workspaceId', 'trace')).toThrow(
+        /"--workspaceId".*command-line flag.*Pass "default" for the global workspace/s
+      );
+    });
+  });
+
+  describe('ids that must keep working', () => {
+    // Rejecting any of these would turn a working call into a hard error.
+    const accepted: string[] = [
+      'default',
+      'a8fbad11-7412-49c8-bce0-5690e2c1d197',
+      'ws-1',
+      '__system_guides__',
+      'Desenvolvedor',
+      'Desenvolvimento & Automação',           // a real name: spaces and accents
+      'Default Workspace',
+      '5078340f-0000-0000-0000-000000000000',  // zero-filled: needs the live list
+      'a8fbad11',                              // truncated: needs the live list
+      'x'.repeat(200)
+    ];
+
+    it.each(accepted)('accepts %s', (value) => {
+      expect(describeUnusableWorkspaceId(value)).toBeNull();
+      expect(workspaceStreamPath(value, 'session')).toBe(`workspaces/ws_${value}.jsonl`);
+      expect(taskStreamPath(value, 'task')).toBe(`tasks/tasks_${value}.jsonl`);
+    });
+  });
+
+  describe('at the repository boundary', () => {
+    it('SessionRepository writes no event for the empty workspace id', async () => {
+      const deps = createMockDeps();
+      const repo = new SessionRepository(deps);
+
+      await expect(
+        repo.create({ workspaceId: '', name: 'Session' } as never)
+      ).rejects.toThrow(/Refusing to store session events/);
+      // Pre-fix this appended session_created to "workspaces/ws_.jsonl".
+      expect(deps.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('SessionRepository writes no event for a leaked flag name', async () => {
+      const deps = createMockDeps();
+      const repo = new SessionRepository(deps);
+
+      await expect(
+        repo.create({ workspaceId: '--workspaceId', name: 'Session' } as never)
+      ).rejects.toThrow(/Refusing to store session events/);
+      expect(deps.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('TaskRepository writes no event for a traversal id', async () => {
+      const deps = createMockDeps();
+      const repo = new TaskRepository(deps);
+
+      await expect(
+        repo.create({ workspaceId: '../../escape', projectId: 'proj-1', title: 'T' } as never)
+      ).rejects.toThrow(/Refusing to store task events/);
+      expect(deps.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('still writes to the right shard for a real workspace', async () => {
+      const deps = createMockDeps();
+      const repo = new SessionRepository(deps);
+
+      await repo.create({ workspaceId: 'Desenvolvedor', name: 'Session' } as never);
+
+      expect(deps.appendEvent).toHaveBeenCalledTimes(1);
+      expect(deps.appendEvent.mock.calls[0][0]).toBe('workspaces/ws_Desenvolvedor.jsonl');
+    });
+  });
+});

--- a/tool-schemas.json
+++ b/tool-schemas.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "nexusVersion": "5.17.2",
-  "generatedAt": "2026-08-21T15:43:30.479Z",
+  "generatedAt": "2026-08-24T15:25:30.810Z",
   "toolCount": 2,
   "tools": [
     {
@@ -12,7 +12,7 @@
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace ID. Optional. Defaults to \"default\"."
+            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list this call returns."
           },
           "sessionId": {
             "type": "string",
@@ -52,7 +52,7 @@
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace ID. Optional. Defaults to \"default\"."
+            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools."
           },
           "sessionId": {
             "type": "string",


### PR DESCRIPTION
Addresses the validation half of #214. **Stickiness is deliberately not implemented here** — see below.

## The inconsistency

Omitting `workspaceId` correctly hard-failed. `workspaceId: ''` did not.

`required` **is** genuinely enforced at runtime — `ValidationService` → `validateParams` walks the array, which is why omission failed. But that check is `hasProperty`, so an empty string satisfied it and flowed into `params.workspaceId || 'default'` in `ToolCliNormalizer.normalizeContext`.

That is the shape most likely to bite a caller building the envelope programmatically: a template that renders to empty behaves completely differently from one that omits the field.

**The schema also contradicted itself** — describing `workspaceId` as *"Optional. Defaults to default"* while listing it as `required`. The `required` list was the truth; the descriptions in `useTools.ts`, `getTools.ts` and `types.ts` were the lie, and are corrected. Relaxing to optional instead would have re-armed the misfiling this issue is about, since `getTools` already returns the live workspace list.

## The empty string was not harmless

Grepped before changing it. Nothing depends on `'' === default`:

- the in-app chat path substitutes `'default'` for both `undefined` and `''` *before* reaching the normalizer
- `TaskBoardView`'s `workspaceId: ''` means "all workspaces" for in-memory filtering and never becomes a path
- `TaskManagerTools` already rejected `''`, so the envelope now agrees with it

One live path *did* depend on it, and only to produce garbage: `getTools` with `''` flowed into `createAutoSession('')` and minted `workspaces/ws_.jsonl` — **the mysterious `ws_` directory from the census in #214**. The repository guard now throws there, and `ToolExecutionStrategy` already catches that and falls back to an in-memory session id.

## Second commit: a repository-layer guard

Validation previously depended entirely on the envelope being the only door. The guard is **structural, not a lookup** — it refuses what can be neither an id nor a name (empty, padded, `--flag`, separators, `..`, control characters, absurd length) across all six workspace-keyed repositories.

It deliberately still accepts real names with spaces and accents, which legitimately reach `SessionRepository` today, and zero-filled or truncated UUIDs — rejecting those needs the live workspace list, which would make every repository depend on the service that owns one of them.

## Not in scope

Stickiness is genuinely unimplemented — after ~130 envelope calls, `getAllSessionContexts()` returned size 0. That is a design question about where session state should live, not a validation bug, and it deserves its own discussion.

## Verification

- 8 of 16 envelope cases and 3 of 31 guard cases **fail pre-fix** (`git stash push -- src`, re-run, pop)
- The guard module is new, so its pure-function cases cannot fail pre-fix; the three repository-boundary cases (`appendEvent` never called) carry that proof instead
- `npx jest tests/unit` — 328 suites, 4341 tests
- `npm run build` clean; `check_documented_commands.py README.md` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_