### PR TITLE
fix: make permanent workspace delete remove everything it owns

### DIFF
--- a/.claude/skills/nexus-storage/references/failure-modes.md
+++ b/.claude/skills/nexus-storage/references/failure-modes.md
@@ -31,6 +31,28 @@ the applier. Re-verify by rebuilding the cache again and confirming survival.
 The inverse: something deleted from SQLite without appending a deletion event.
 Replay faithfully restores what the event store still says exists.
 
+**Appending the deletion event is not sufficient, and stopping there is how this
+ships twice.** Three further things have to hold, and a delete has failed on all
+of them at once:
+
+- **The applier must delete as much as the delete did.** Replay reaches the
+  tombstone only after re-applying every event that created the entity's
+  children, so an applier narrower than the live delete leaves those children as
+  orphans on every rebuild.
+- **Nothing cascades in SQLite.** The schema declares `ON DELETE CASCADE` in
+  several places, but FK enforcement is off — SQLite's per-connection default,
+  and nothing turns it on (`grep -rn "foreign_keys" src/` returns nothing). A
+  `DELETE FROM workspaces` removes exactly one row. Delete children explicitly,
+  child-before-parent, and put the statement list in ONE place both the
+  repository and the applier call, or the two drift.
+- **One entity can own more than one stream.** A workspace owns
+  `workspaces/ws_<id>` *and* `tasks/tasks_<id>`; a tombstone in the first says
+  nothing about the second, and `fullRebuild` replays every stream it lists.
+  Derive the set from the repositories' `jsonlPath`, do not assume one.
+
+Do not settle for "the row is gone from the UI". The check is
+`adapter.rebuildCache()` followed by a count per table, in the running app.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.claude/skills/nexus-storage/refinement-log.md
+++ b/.claude/skills/nexus-storage/refinement-log.md
@@ -33,3 +33,15 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   nothing because the failing caller holds the previous instance. | Added the
   symptom entry with both survivor shapes, the listener-count probe, and the
   prototype-patch attribution trick. | references/failure-modes.md.
+
+- 2026-08-15 | Fixing permanent workspace deletion: the "Data reappeared after a
+  rebuild" entry pointed at a missing deletion event, but the delete already
+  appended one and the data came back anyway. Three facts the skill did not
+  carry decided the bug, and each cost a source read: the applier handling the
+  tombstone was narrower than the live delete, FK enforcement is off so no
+  declared `ON DELETE CASCADE` ever fires (`grep -rn "foreign_keys" src/`
+  returns nothing), and a workspace owns two streams — `workspaces/ws_<id>` and
+  `tasks/tasks_<id>` — so a tombstone in one says nothing about the other. |
+  Sharpened the entry with the three additional conditions and named
+  `rebuildCache()` plus a per-table count in the running app as the check.
+  | references/failure-modes.md.

--- a/.cline/skills/nexus-storage/references/failure-modes.md
+++ b/.cline/skills/nexus-storage/references/failure-modes.md
@@ -31,6 +31,28 @@ the applier. Re-verify by rebuilding the cache again and confirming survival.
 The inverse: something deleted from SQLite without appending a deletion event.
 Replay faithfully restores what the event store still says exists.
 
+**Appending the deletion event is not sufficient, and stopping there is how this
+ships twice.** Three further things have to hold, and a delete has failed on all
+of them at once:
+
+- **The applier must delete as much as the delete did.** Replay reaches the
+  tombstone only after re-applying every event that created the entity's
+  children, so an applier narrower than the live delete leaves those children as
+  orphans on every rebuild.
+- **Nothing cascades in SQLite.** The schema declares `ON DELETE CASCADE` in
+  several places, but FK enforcement is off — SQLite's per-connection default,
+  and nothing turns it on (`grep -rn "foreign_keys" src/` returns nothing). A
+  `DELETE FROM workspaces` removes exactly one row. Delete children explicitly,
+  child-before-parent, and put the statement list in ONE place both the
+  repository and the applier call, or the two drift.
+- **One entity can own more than one stream.** A workspace owns
+  `workspaces/ws_<id>` *and* `tasks/tasks_<id>`; a tombstone in the first says
+  nothing about the second, and `fullRebuild` replays every stream it lists.
+  Derive the set from the repositories' `jsonlPath`, do not assume one.
+
+Do not settle for "the row is gone from the UI". The check is
+`adapter.rebuildCache()` followed by a count per table, in the running app.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.cline/skills/nexus-storage/refinement-log.md
+++ b/.cline/skills/nexus-storage/refinement-log.md
@@ -33,3 +33,15 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   nothing because the failing caller holds the previous instance. | Added the
   symptom entry with both survivor shapes, the listener-count probe, and the
   prototype-patch attribution trick. | references/failure-modes.md.
+
+- 2026-08-15 | Fixing permanent workspace deletion: the "Data reappeared after a
+  rebuild" entry pointed at a missing deletion event, but the delete already
+  appended one and the data came back anyway. Three facts the skill did not
+  carry decided the bug, and each cost a source read: the applier handling the
+  tombstone was narrower than the live delete, FK enforcement is off so no
+  declared `ON DELETE CASCADE` ever fires (`grep -rn "foreign_keys" src/`
+  returns nothing), and a workspace owns two streams — `workspaces/ws_<id>` and
+  `tasks/tasks_<id>` — so a tombstone in one says nothing about the other. |
+  Sharpened the entry with the three additional conditions and named
+  `rebuildCache()` plus a per-table count in the running app as the check.
+  | references/failure-modes.md.

--- a/.codex/skills/nexus-storage/references/failure-modes.md
+++ b/.codex/skills/nexus-storage/references/failure-modes.md
@@ -53,6 +53,28 @@ the legacy fallbacks but keep destination reads enabled.
 The inverse: something deleted from SQLite without appending a deletion event.
 Replay faithfully restores what the event store still says exists.
 
+**Appending the deletion event is not sufficient, and stopping there is how this
+ships twice.** Three further things have to hold, and a delete has failed on all
+of them at once:
+
+- **The applier must delete as much as the delete did.** Replay reaches the
+  tombstone only after re-applying every event that created the entity's
+  children, so an applier narrower than the live delete leaves those children as
+  orphans on every rebuild.
+- **Nothing cascades in SQLite.** The schema declares `ON DELETE CASCADE` in
+  several places, but FK enforcement is off — SQLite's per-connection default,
+  and nothing turns it on (`grep -rn "foreign_keys" src/` returns nothing). A
+  `DELETE FROM workspaces` removes exactly one row. Delete children explicitly,
+  child-before-parent, and put the statement list in ONE place both the
+  repository and the applier call, or the two drift.
+- **One entity can own more than one stream.** A workspace owns
+  `workspaces/ws_<id>` *and* `tasks/tasks_<id>`; a tombstone in the first says
+  nothing about the second, and `fullRebuild` replays every stream it lists.
+  Derive the set from the repositories' `jsonlPath`, do not assume one.
+
+Do not settle for "the row is gone from the UI". The check is
+`adapter.rebuildCache()` followed by a count per table, in the running app.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.codex/skills/nexus-storage/refinement-log.md
+++ b/.codex/skills/nexus-storage/refinement-log.md
@@ -60,3 +60,15 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   nothing because the failing caller holds the previous instance. | Added the
   symptom entry with both survivor shapes, the listener-count probe, and the
   prototype-patch attribution trick. | references/failure-modes.md.
+
+- 2026-08-15 | Fixing permanent workspace deletion: the "Data reappeared after a
+  rebuild" entry pointed at a missing deletion event, but the delete already
+  appended one and the data came back anyway. Three facts the skill did not
+  carry decided the bug, and each cost a source read: the applier handling the
+  tombstone was narrower than the live delete, FK enforcement is off so no
+  declared `ON DELETE CASCADE` ever fires (`grep -rn "foreign_keys" src/`
+  returns nothing), and a workspace owns two streams — `workspaces/ws_<id>` and
+  `tasks/tasks_<id>` — so a tombstone in one says nothing about the other. |
+  Sharpened the entry with the three additional conditions and named
+  `rebuildCache()` plus a per-table count in the running app as the check.
+  | references/failure-modes.md.

--- a/.skills/nexus-storage/references/failure-modes.md
+++ b/.skills/nexus-storage/references/failure-modes.md
@@ -31,6 +31,28 @@ the applier. Re-verify by rebuilding the cache again and confirming survival.
 The inverse: something deleted from SQLite without appending a deletion event.
 Replay faithfully restores what the event store still says exists.
 
+**Appending the deletion event is not sufficient, and stopping there is how this
+ships twice.** Three further things have to hold, and a delete has failed on all
+of them at once:
+
+- **The applier must delete as much as the delete did.** Replay reaches the
+  tombstone only after re-applying every event that created the entity's
+  children, so an applier narrower than the live delete leaves those children as
+  orphans on every rebuild.
+- **Nothing cascades in SQLite.** The schema declares `ON DELETE CASCADE` in
+  several places, but FK enforcement is off — SQLite's per-connection default,
+  and nothing turns it on (`grep -rn "foreign_keys" src/` returns nothing). A
+  `DELETE FROM workspaces` removes exactly one row. Delete children explicitly,
+  child-before-parent, and put the statement list in ONE place both the
+  repository and the applier call, or the two drift.
+- **One entity can own more than one stream.** A workspace owns
+  `workspaces/ws_<id>` *and* `tasks/tasks_<id>`; a tombstone in the first says
+  nothing about the second, and `fullRebuild` replays every stream it lists.
+  Derive the set from the repositories' `jsonlPath`, do not assume one.
+
+Do not settle for "the row is gone from the UI". The check is
+`adapter.rebuildCache()` followed by a count per table, in the running app.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.skills/nexus-storage/refinement-log.md
+++ b/.skills/nexus-storage/refinement-log.md
@@ -33,3 +33,15 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   nothing because the failing caller holds the previous instance. | Added the
   symptom entry with both survivor shapes, the listener-count probe, and the
   prototype-patch attribution trick. | references/failure-modes.md.
+
+- 2026-08-15 | Fixing permanent workspace deletion: the "Data reappeared after a
+  rebuild" entry pointed at a missing deletion event, but the delete already
+  appended one and the data came back anyway. Three facts the skill did not
+  carry decided the bug, and each cost a source read: the applier handling the
+  tombstone was narrower than the live delete, FK enforcement is off so no
+  declared `ON DELETE CASCADE` ever fires (`grep -rn "foreign_keys" src/`
+  returns nothing), and a workspace owns two streams — `workspaces/ws_<id>` and
+  `tasks/tasks_<id>` — so a tombstone in one says nothing about the other. |
+  Sharpened the entry with the three additional conditions and named
+  `rebuildCache()` plus a per-table count in the running app as the check.
+  | references/failure-modes.md.

--- a/src/database/repositories/WorkspaceRepository.ts
+++ b/src/database/repositories/WorkspaceRepository.ts
@@ -35,6 +35,7 @@ import { PaginatedResult, PaginationParams } from '../../types/pagination/Pagina
 import { QueryOptions } from '../interfaces/IStorageAdapter';
 import { QueryCache } from '../optimizations/QueryCache';
 import { parseJsonColumn } from '../utils/jsonColumn';
+import { purgeWorkspaceRows, workspaceOwnedStreamPaths } from '../workspaceOwnership';
 
 type SqliteValue = string | number | null;
 
@@ -226,23 +227,79 @@ export class WorkspaceRepository
     }
   }
 
+  /**
+   * Permanently delete a workspace and everything keyed to it.
+   *
+   * This is the only destructive delete in the storage layer and it is reachable
+   * only from the settings UI (`WorkspacesTab`) — the AI gets `archiveWorkspace`,
+   * which is reversible. Do not expose it to a tool.
+   *
+   * ## Ordering, and what happens when half of it fails
+   *
+   * JSONL is the source of truth and SQLite is a rebuildable cache, so the two
+   * halves are NOT symmetric and the order is a deliberate choice:
+   *
+   *   1. Tombstone. A `workspace_deleted` event goes into the workspace stream
+   *      first. If everything after this fails, the stream that survives is
+   *      self-cancelling — replay creates the workspace and its children, then
+   *      `WorkspaceEventApplier.applyWorkspaceDeleted` purges all of them again
+   *      (both paths share `purgeWorkspaceRows`). It also makes
+   *      `reconcileMissingWorkspaces` skip the file.
+   *   2. Streams. Both owned streams are removed (workspace AND tasks — see
+   *      `workspaceOwnedStreamPaths`). Every removal is attempted even if an
+   *      earlier one throws, so a retry has less to do, and the errors are
+   *      aggregated and rethrown.
+   *   3. SQLite. Only if step 2 removed everything.
+   *
+   * The failure modes this produces, on purpose:
+   *
+   * - **Stream removal fails** → we throw BEFORE touching SQLite. Nothing is
+   *   destroyed, the workspace still lists, and `WorkspaceService` skips its
+   *   'deleted' notification because we threw. The delete is a retryable no-op.
+   * - **SQLite purge fails** (a local transaction, so barely reachable) → the
+   *   rows are stale cache over a JSONL store that no longer has the workspace.
+   *   The next `rebuildCache()` clears them. It converges on deleted.
+   *
+   * The order is chosen so that every partial failure converges toward the
+   * user's intent (deleted) rather than away from it. The opposite order —
+   * SQLite first — converges on the workspace coming BACK with all its states
+   * at the next rebuild, which is the shape of #333 and the bug this method
+   * was rewritten to remove.
+   */
   async delete(id: string): Promise<void> {
     try {
-      await this.transaction(async () => {
-        // 1. Write event to JSONL
-        await this.writeEvent<WorkspaceDeletedEvent>(
-          this.jsonlPath(id),
-          {
-            type: 'workspace_deleted',
-            workspaceId: id
-          }
-        );
+      // 1. Tombstone, so a stream we fail to remove still cancels itself out.
+      await this.writeEvent<WorkspaceDeletedEvent>(
+        this.jsonlPath(id),
+        {
+          type: 'workspace_deleted',
+          workspaceId: id
+        }
+      );
 
-        // 2. Delete from SQLite (cascades to sessions, states, traces)
-        await this.sqliteCache.run('DELETE FROM workspaces WHERE id = ?', [id]);
+      // 2. Remove the source of truth: every stream the workspace owns.
+      const streamFailures: string[] = [];
+      for (const streamPath of workspaceOwnedStreamPaths(id)) {
+        try {
+          await this.jsonlWriter.deleteStream(streamPath);
+        } catch (error) {
+          streamFailures.push(error instanceof Error ? error.message : String(error));
+        }
+      }
+      if (streamFailures.length > 0) {
+        throw new Error(
+          `Workspace ${id} was not deleted: its event stream(s) could not be removed ` +
+          `(${streamFailures.join('; ')}). Nothing was removed from the cache, so the ` +
+          'workspace is unchanged and the delete can be retried.'
+        );
+      }
+
+      // 3. Now the cache, which is only ever catching up to the event store.
+      await this.transaction(async () => {
+        await purgeWorkspaceRows(this.sqliteCache, id);
       });
 
-      // 3. Invalidate cache
+      // 4. Invalidate cache
       this.invalidateCache();
       this.log('delete', { id });
     } catch (error) {

--- a/src/database/storage/JSONLWriter.ts
+++ b/src/database/storage/JSONLWriter.ts
@@ -538,6 +538,31 @@ export class JSONLWriter {
   }
 
   /**
+   * Permanently remove a logical event stream — every shard of it on a
+   * vault-root install, plus any legacy flat file of the same name.
+   *
+   * Warning: this destroys the source of truth for that stream and cannot be
+   * undone. It exists for the one operation that is meant to be permanent:
+   * deleting a workspace from the settings UI. Everything reachable by the AI
+   * uses a deletion EVENT (a tombstone) instead.
+   *
+   * Idempotent — removing an already-removed stream succeeds — so a delete that
+   * failed partway can be retried as a whole.
+   *
+   * @param relativePath - Logical path relative to basePath (e.g. 'workspaces/ws_123.jsonl')
+   * @throws Error if removal fails
+   */
+  async deleteStream(relativePath: string): Promise<void> {
+    try {
+      await this.router.deleteStream(relativePath, this.basePath);
+    } catch (error) {
+      console.error(`[JSONLWriter] Failed to delete stream ${relativePath}:`, error);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to delete stream ${relativePath}: ${message}`);
+    }
+  }
+
+  /**
    * Get file modification time
    *
    * @param relativePath - File path relative to basePath

--- a/src/database/storage/StorageRouter.ts
+++ b/src/database/storage/StorageRouter.ts
@@ -223,6 +223,31 @@ export class StorageRouter {
     }
   }
 
+  /**
+   * Permanently remove a logical stream from BOTH layouts.
+   *
+   * `deleteFile` only reaches the legacy flat `<basePath>/<relativePath>` file.
+   * On a vault-root install the events live in a sharded DIRECTORY, so a delete
+   * that only called `deleteFile` removed nothing at all and the next
+   * `rebuildCache()` replayed the stream back into the cache.
+   *
+   * Both branches run — a vault that migrated may still have the legacy file
+   * sitting next to the sharded directory, and leaving it behind resurrects the
+   * entity just as effectively.
+   */
+  async deleteStream(relativePath: string, basePath: string): Promise<void> {
+    if (this.vaultEventStore) {
+      const eventPath = this.getVaultEventLogicalPath(relativePath);
+      if (eventPath) {
+        await this.vaultEventStore.deleteStream(eventPath);
+      }
+    }
+
+    for (const variant of this.getLogicalPathVariants(relativePath)) {
+      await this.deleteFile(variant, basePath);
+    }
+  }
+
   // -- File Metadata ----------------------------------------------------------
 
   async getFileModTime(relativePath: string): Promise<number | null> {

--- a/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
+++ b/src/database/storage/vaultRoot/ShardedJsonlStreamStore.ts
@@ -235,6 +235,37 @@ export class ShardedJsonlStreamStore<TEvent extends object> {
     });
   }
 
+  /**
+   * Permanently remove a whole logical stream: every file in its directory and
+   * then the directory itself.
+   *
+   * Deliberately removes EVERY file it finds, not just files matching
+   * `SHARD_FILE_PATTERN`. Cloud-sync conflict siblings (`shard-000001 (1).jsonl`)
+   * hold real events and would otherwise be left behind to be replayed by the
+   * next rebuild — a stream that deletes down to "only the events a conflict
+   * copy happens to hold" is worse than one that is not deleted at all.
+   *
+   * Returns `false` when the stream directory did not exist, which makes the
+   * call idempotent and therefore safe to retry after a partial failure.
+   */
+  async deleteStream(relativeStreamPath: string): Promise<boolean> {
+    const streamPath = this.getStreamPath(relativeStreamPath);
+
+    return this.locks.acquire(streamPath, async () => {
+      if (!(await this.app.vault.adapter.exists(streamPath))) {
+        return false;
+      }
+
+      const listing = await this.app.vault.adapter.list(streamPath);
+      for (const filePath of listing.files) {
+        await this.app.vault.adapter.remove(normalizePath(filePath));
+      }
+
+      await this.app.vault.adapter.rmdir(streamPath, true);
+      return true;
+    });
+  }
+
   private normalizeRelativeStreamPath(relativeStreamPath: string): string {
     return normalizePath(relativeStreamPath).replace(/^\/+|\/+$/g, '');
   }

--- a/src/database/storage/vaultRoot/VaultEventStore.ts
+++ b/src/database/storage/vaultRoot/VaultEventStore.ts
@@ -123,6 +123,17 @@ export class VaultEventStore {
     return (await handle.shardStore.readEvents(handle.relativeStreamPath)) as TEvent[];
   }
 
+  /**
+   * Permanently remove a logical stream and every shard under it.
+   *
+   * Returns `false` when there was nothing on disk. Idempotent, so a caller
+   * that failed halfway can simply run the whole delete again.
+   */
+  async deleteStream(relativePath: string): Promise<boolean> {
+    const handle = this.resolveStreamHandle(relativePath);
+    return handle.shardStore.deleteStream(handle.relativeStreamPath);
+  }
+
   async listFiles(category: EventStreamCategory): Promise<string[]> {
     const categoryRoot = this.getCategoryRootPath(category);
     if (!(await this.app.vault.adapter.exists(categoryRoot))) {

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -22,6 +22,7 @@ import {
   ToolOperationIndeterminateEvent,
 } from '../interfaces/StorageEvents';
 import { ISQLiteCacheManager } from './SyncCoordinator';
+import { purgeWorkspaceRows } from '../workspaceOwnership';
 
 export class WorkspaceEventApplier {
   private sqliteCache: ISQLiteCacheManager;
@@ -138,11 +139,25 @@ export class WorkspaceEventApplier {
     }
   }
 
+  /**
+   * A `workspace_deleted` event has to remove everything the workspace owns,
+   * not just its row.
+   *
+   * This runs during replay — `rebuildCache()` and cross-device sync — where the
+   * events that created the workspace's sessions, states and traces have already
+   * been applied from the same stream moments earlier. Deleting only the
+   * `workspaces` row left every one of those children behind as an orphan that
+   * reappeared on every rebuild: the schema declares `ON DELETE CASCADE`, but FK
+   * enforcement is off on the shared connection, so nothing cascaded.
+   *
+   * `purgeWorkspaceRows` is shared with `WorkspaceRepository.delete` precisely so
+   * the live delete and the replay of that delete cannot drift apart.
+   */
   private async applyWorkspaceDeleted(event: WorkspaceDeletedEvent): Promise<void> {
     if (!this.isValidWorkspaceId(event.workspaceId)) {
       return;
     }
-    await this.sqliteCache.run('DELETE FROM workspaces WHERE id = ?', [event.workspaceId]);
+    await purgeWorkspaceRows(this.sqliteCache, event.workspaceId);
   }
 
   private async applySessionCreated(event: SessionCreatedEvent): Promise<void> {

--- a/src/database/workspaceOwnership.ts
+++ b/src/database/workspaceOwnership.ts
@@ -1,0 +1,133 @@
+/**
+ * Location: src/database/workspaceOwnership.ts
+ *
+ * The single definition of what a workspace owns, in both stores.
+ *
+ * Permanent workspace deletion is a human action from the settings UI (the AI
+ * only gets the reversible `archiveWorkspace`). It has to remove the workspace
+ * AND everything keyed to it, from the JSONL event store first and the SQLite
+ * cache second — see `WorkspaceRepository.delete` for the ordering rationale.
+ *
+ * Two code paths delete a workspace and they MUST agree:
+ *
+ *  1. `WorkspaceRepository.delete` — the live delete.
+ *  2. `WorkspaceEventApplier.applyWorkspaceDeleted` — replay, i.e. what a
+ *     `rebuildCache()` or a sync from another device does with a
+ *     `workspace_deleted` event.
+ *
+ * If (2) disagreed with (1), a rebuild would replay `workspace_created`,
+ * `session_created`, `state_saved`, `trace_added` … and then a delete that only
+ * removed the workspace row — resurrecting every child as an orphan. That is
+ * exactly the defect this module exists to prevent, and it is why the purge
+ * lives here instead of being written twice.
+ *
+ * NOT owned by a workspace, deliberately:
+ * - `conversations` (and `conversation_embedding_metadata`). `workspaceId` is a
+ *   nullable back-reference, not ownership: a conversation is a first-class
+ *   entity with its own event stream and survives the workspace it was linked
+ *   to. Deleting them here would destroy data the user never asked to delete.
+ *
+ * Related Files:
+ * - src/database/schema/schema.ts — the FK CASCADE declarations that do NOT
+ *   fire, because FK enforcement is off on the shared connection (SQLite's
+ *   per-connection default; the schema says so for `note_properties` too).
+ * - src/database/repositories/WorkspaceRepository.ts
+ * - src/database/sync/WorkspaceEventApplier.ts
+ */
+
+type PurgeParams = Array<string | number | null | boolean>;
+
+/**
+ * Minimal SQLite surface the purge needs. Satisfied by both
+ * `SQLiteCacheManager` (repository path) and `ISQLiteCacheManager` (replay path).
+ */
+export interface WorkspacePurgeTarget {
+  run(sql: string, params?: PurgeParams): Promise<unknown>;
+  query<T>(sql: string, params?: PurgeParams): Promise<T[]>;
+}
+
+/**
+ * Every SQLite table keyed to a workspace, in child-before-parent order.
+ *
+ * Order matters even without FK enforcement: `task_dependencies` and
+ * `task_note_links` are reached THROUGH `tasks`, so the `tasks` rows have to
+ * still be there when those two run.
+ *
+ * `workspace_fts` is absent on purpose — an `AFTER DELETE ON workspaces`
+ * trigger maintains it (schema.ts), and that trigger does fire.
+ */
+const WORKSPACE_OWNED_DELETES: readonly string[] = [
+  // Task graph edges, resolved through the workspace's tasks.
+  `DELETE FROM task_dependencies
+     WHERE taskId IN (SELECT id FROM tasks WHERE workspaceId = ?)
+        OR dependsOnTaskId IN (SELECT id FROM tasks WHERE workspaceId = ?)`,
+  `DELETE FROM task_note_links
+     WHERE taskId IN (SELECT id FROM tasks WHERE workspaceId = ?)`,
+  'DELETE FROM tasks WHERE workspaceId = ?',
+  'DELETE FROM projects WHERE workspaceId = ?',
+  'DELETE FROM memory_traces WHERE workspaceId = ?',
+  'DELETE FROM states WHERE workspaceId = ?',
+  'DELETE FROM sessions WHERE workspaceId = ?',
+  'DELETE FROM workspaces WHERE id = ?'
+];
+
+/** How many `?` placeholders each statement above takes. */
+function placeholderCount(sql: string): number {
+  return (sql.match(/\?/g) ?? []).length;
+}
+
+/**
+ * Delete every SQLite row the workspace owns, including the workspace row.
+ *
+ * Idempotent: re-running against an already-purged workspace is a no-op, which
+ * is what makes a failed delete safe to retry.
+ *
+ * Callers are expected to wrap this in a transaction where one is available.
+ */
+export async function purgeWorkspaceRows(
+  sqlite: WorkspacePurgeTarget,
+  workspaceId: string
+): Promise<void> {
+  // Trace embeddings are a vec0 virtual table keyed by the metadata rowid, so
+  // they cannot be reached by a workspaceId predicate. `clearAllData` does not
+  // clear them either (embeddings are not replayable from JSONL), so nothing
+  // else would ever collect these rows. Same two-step delete as
+  // TraceEmbeddingService.
+  const embeddingRows = await sqlite.query<{ rowid: number }>(
+    'SELECT rowid FROM trace_embedding_metadata WHERE workspaceId = ?',
+    [workspaceId]
+  );
+  for (const row of embeddingRows) {
+    await sqlite.run('DELETE FROM trace_embeddings WHERE rowid = ?', [row.rowid]);
+  }
+  await sqlite.run('DELETE FROM trace_embedding_metadata WHERE workspaceId = ?', [workspaceId]);
+
+  for (const sql of WORKSPACE_OWNED_DELETES) {
+    const params: PurgeParams = Array.from(
+      { length: placeholderCount(sql) },
+      () => workspaceId
+    );
+    await sqlite.run(sql, params);
+  }
+}
+
+/**
+ * Every JSONL stream a workspace owns, as logical paths for `JSONLWriter`.
+ *
+ * There are two, not one. Workspace/session/state/trace events live in the
+ * workspace stream; project/task events live in a SEPARATE `tasks_<id>` stream
+ * (see `TaskRepository.jsonlPath` / `ProjectRepository.jsonlPath`). Removing
+ * only the first leaves the tasks stream to be replayed in full by the next
+ * `rebuildCache()`.
+ *
+ * The order is removal order and it is deliberate: the workspace stream is the
+ * one carrying the `workspace_deleted` tombstone, so it goes LAST. If removal
+ * fails partway, the tombstone is still on disk and the next rebuild still
+ * resolves to "deleted" instead of resurrecting the workspace.
+ */
+export function workspaceOwnedStreamPaths(workspaceId: string): string[] {
+  return [
+    `tasks/tasks_${workspaceId}.jsonl`,
+    `workspaces/ws_${workspaceId}.jsonl`
+  ];
+}

--- a/src/database/workspaceOwnership.ts
+++ b/src/database/workspaceOwnership.ts
@@ -68,6 +68,12 @@ const WORKSPACE_OWNED_DELETES: readonly string[] = [
   'DELETE FROM memory_traces WHERE workspaceId = ?',
   'DELETE FROM states WHERE workspaceId = ?',
   'DELETE FROM sessions WHERE workspaceId = ?',
+  // Tool operation receipts carry a NOT NULL workspaceId and are appended to the
+  // workspace's own stream (`ToolOperationRepository.path`), so they are owned on
+  // both sides — unlike `conversations`, whose workspaceId is nullable. Removing
+  // the stream already handles the JSONL half; without this line the SQLite half
+  // would be left behind exactly like the other children were.
+  'DELETE FROM tool_operation_receipts WHERE workspaceId = ?',
   'DELETE FROM workspaces WHERE id = ?'
 ];
 

--- a/tests/helpers/mockVaultAdapter.ts
+++ b/tests/helpers/mockVaultAdapter.ts
@@ -5,7 +5,8 @@
  *
  * The adapter maintains a Map-backed file system and Set-backed
  * directory tree, supporting exists / read / write / append / stat /
- * list / mkdir — the same surface area as Obsidian's DataAdapter.
+ * list / mkdir / remove / rmdir — the same surface area as Obsidian's
+ * DataAdapter.
  */
 
 import type { App } from 'obsidian';
@@ -24,6 +25,8 @@ export type MockAdapter = {
   stat: jest.Mock<Promise<{ mtime: number; size: number } | null>, [string]>;
   list: jest.Mock<Promise<{ files: string[]; folders: string[] }>, [string]>;
   mkdir: jest.Mock<Promise<void>, [string]>;
+  remove: jest.Mock<Promise<void>, [string]>;
+  rmdir: jest.Mock<Promise<void>, [string, boolean?]>;
 };
 
 export interface CreateMockAppOptions {
@@ -121,6 +124,37 @@ export function createMockApp(options: CreateMockAppOptions = {}): {
     }),
     mkdir: jest.fn(async (path: string) => {
       addDirectoryTree(path.replace(/\\/g, '/'));
+    }),
+    remove: jest.fn(async (path: string) => {
+      const normalizedPath = path.replace(/\\/g, '/');
+      if (!files.delete(normalizedPath)) {
+        throw new Error(`Missing file: ${normalizedPath}`);
+      }
+    }),
+    // Mirrors DataAdapter.rmdir: non-recursive refuses a non-empty directory,
+    // so a caller that forgets to clear the shards first fails here the way it
+    // would in Obsidian rather than silently "succeeding".
+    rmdir: jest.fn(async (path: string, recursive?: boolean) => {
+      const normalizedPath = path.replace(/\\/g, '/').replace(/\/+$/g, '');
+      const isUnder = (candidate: string): boolean =>
+        candidate === normalizedPath || candidate.startsWith(`${normalizedPath}/`);
+
+      const containedFiles = Array.from(files.keys()).filter(isUnder);
+      const containedDirs = Array.from(directories.values()).filter(
+        dir => isUnder(dir) && dir !== normalizedPath
+      );
+
+      if (!recursive && (containedFiles.length > 0 || containedDirs.length > 0)) {
+        throw new Error(`Directory not empty: ${normalizedPath}`);
+      }
+
+      for (const filePath of containedFiles) {
+        files.delete(filePath);
+      }
+      for (const dirPath of containedDirs) {
+        directories.delete(dirPath);
+      }
+      directories.delete(normalizedPath);
     })
   };
 

--- a/tests/unit/WorkspaceDeleteOwnership.test.ts
+++ b/tests/unit/WorkspaceDeleteOwnership.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Regression tests for permanent workspace deletion (#219 follow-up).
+ *
+ * Before the fix, `deleteWorkspace` ran a single
+ * `DELETE FROM workspaces WHERE id = ?` and touched no JSONL at all beyond
+ * appending a `workspace_deleted` tombstone. Measured in a real vault, deleting
+ * a workspace holding 2 sessions / 2 states / 2 traces / 1 project / 2 tasks
+ * left behind:
+ *
+ *   SQLite: sessions 2, states 2, memory_traces 2, projects 1, tasks 2
+ *   JSONL:  workspaces/ws_<id>/ (8 events) and tasks/tasks_<id>/ (3 events)
+ *
+ * and running `rebuildCache()` reproduced the exact same orphan set, because
+ * SQLite is dropped and replayed from those two surviving streams. Every test
+ * here fails against that code.
+ */
+
+import { WorkspaceRepository } from '../../src/database/repositories/WorkspaceRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { WorkspaceEventApplier } from '../../src/database/sync/WorkspaceEventApplier';
+import { ShardedJsonlStreamStore } from '../../src/database/storage/vaultRoot/ShardedJsonlStreamStore';
+import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEventStore';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { SyncCoordinator, type ISQLiteCacheManager } from '../../src/database/sync/SyncCoordinator';
+import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { createMockApp } from '../helpers/mockVaultAdapter';
+
+const WS = 'ws-owned';
+
+/** Records every statement so a test can ask "what did the cache actually see?". */
+function createRecordingSqlite() {
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  const cache = {
+    run: jest.fn(async (sql: string, params: unknown[] = []) => {
+      statements.push({ sql, params });
+      return undefined;
+    }),
+    query: jest.fn(async () => []),
+    queryOne: jest.fn(async () => null),
+    transaction: jest.fn((fn: () => Promise<unknown>) => fn()),
+    getSyncState: jest.fn(async () => null),
+    updateSyncState: jest.fn(async () => undefined),
+    isEventApplied: jest.fn(async () => false),
+    markEventApplied: jest.fn(async () => undefined),
+    clearAllData: jest.fn(async () => undefined),
+    rebuildFTSIndexes: jest.fn(async () => undefined),
+    save: jest.fn(async () => undefined)
+  };
+  const tablesTouchedBy = (verb: string): string[] =>
+    statements
+      .filter(s => s.sql.trim().toUpperCase().startsWith(verb))
+      .map(s => {
+        const m = s.sql.match(/(?:DELETE FROM|INSERT (?:OR (?:REPLACE|IGNORE) )?INTO|UPDATE)\s+([a-zA-Z_]+)/i);
+        return m ? m[1] : s.sql;
+      });
+  return { cache, statements, tablesTouchedBy };
+}
+
+describe('permanent workspace delete removes everything the workspace owns', () => {
+  // ==========================================================================
+  // The replay half. This is what decides the outcome of `rebuildCache()`.
+  // ==========================================================================
+  describe('WorkspaceEventApplier: replaying workspace_deleted', () => {
+    it('purges every workspace-keyed table, not just the workspaces row', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply({
+        id: 'evt-del',
+        type: 'workspace_deleted',
+        deviceId: 'dev',
+        timestamp: 10,
+        workspaceId: WS
+      } as never);
+
+      const deleted = tablesTouchedBy('DELETE');
+      // Pre-fix this array was exactly ['workspaces'].
+      expect(deleted).toEqual(
+        expect.arrayContaining([
+          'task_dependencies',
+          'task_note_links',
+          'tasks',
+          'projects',
+          'memory_traces',
+          'states',
+          'sessions',
+          'workspaces',
+          'trace_embedding_metadata'
+        ])
+      );
+    });
+
+    it('deletes children before the parent rows they are reached through', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply({
+        id: 'evt-del',
+        type: 'workspace_deleted',
+        deviceId: 'dev',
+        timestamp: 10,
+        workspaceId: WS
+      } as never);
+
+      const deleted = tablesTouchedBy('DELETE');
+      // task_dependencies/task_note_links are resolved through `tasks`, so the
+      // tasks rows must still exist when they run.
+      expect(deleted.indexOf('task_dependencies')).toBeLessThan(deleted.indexOf('tasks'));
+      expect(deleted.indexOf('task_note_links')).toBeLessThan(deleted.indexOf('tasks'));
+      // The workspaces row goes last so nothing is orphaned mid-purge.
+      expect(deleted.indexOf('workspaces')).toBe(deleted.length - 1);
+    });
+
+    it('leaves conversations alone — they outlive the workspace by design', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply({
+        id: 'evt-del',
+        type: 'workspace_deleted',
+        deviceId: 'dev',
+        timestamp: 10,
+        workspaceId: WS
+      } as never);
+
+      expect(tablesTouchedBy('DELETE')).not.toContain('conversations');
+      expect(tablesTouchedBy('DELETE')).not.toContain('messages');
+    });
+  });
+
+  // ==========================================================================
+  // The stream half.
+  // ==========================================================================
+  describe('ShardedJsonlStreamStore.deleteStream', () => {
+    it('removes every shard including cloud-sync conflict copies, then the directory', async () => {
+      const { app, adapter } = createMockApp({ initialFiles: {
+        'Nexus/data/workspaces/ws_a/shard-000001.jsonl': '{"id":"1"}\n',
+        'Nexus/data/workspaces/ws_a/shard-000002.jsonl': '{"id":"2"}\n',
+        'Nexus/data/workspaces/ws_a/shard-000002 (1).jsonl': '{"id":"3"}\n'
+      }});
+      const store = new ShardedJsonlStreamStore({ app, rootPath: 'Nexus/data', maxShardBytes: 1024 });
+
+      await expect(store.deleteStream('workspaces/ws_a')).resolves.toBe(true);
+
+      expect(await adapter.exists('Nexus/data/workspaces/ws_a')).toBe(false);
+      expect(await adapter.exists('Nexus/data/workspaces/ws_a/shard-000001.jsonl')).toBe(false);
+      // The conflict sibling holds real events; leaving it turns the delete into
+      // a partial truncation on the next rebuild.
+      expect(await adapter.exists('Nexus/data/workspaces/ws_a/shard-000002 (1).jsonl')).toBe(false);
+      expect(await store.readEvents('workspaces/ws_a')).toEqual([]);
+    });
+
+    it('is idempotent, so a failed delete can be retried whole', async () => {
+      const { app } = createMockApp();
+      const store = new ShardedJsonlStreamStore({ app, rootPath: 'Nexus/data', maxShardBytes: 1024 });
+
+      await expect(store.deleteStream('workspaces/ws_missing')).resolves.toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // The live delete, wired to a real event store over a real (mock) vault.
+  // ==========================================================================
+  describe('WorkspaceRepository.delete over a real event store', () => {
+    function build() {
+      const { app, adapter } = createMockApp({ withLocalStorage: true });
+      const vaultEventStore = new VaultEventStore({
+        app,
+        resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+      });
+      const jsonlWriter = new JSONLWriter({
+        app,
+        basePath: '.obsidian/plugins/nexus/data',
+        readBasePaths: ['.obsidian/plugins/nexus/data'],
+        vaultEventStore
+      });
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const deps: RepositoryDependencies = {
+        sqliteCache: cache as never,
+        jsonlWriter,
+        queryCache: new QueryCache()
+      };
+      return { app, adapter, vaultEventStore, jsonlWriter, cache, tablesTouchedBy, deps };
+    }
+
+    /** Seeds both streams a workspace owns with the events a real one carries. */
+    async function seedStreams(jsonlWriter: JSONLWriter) {
+      await jsonlWriter.appendEvents(`workspaces/ws_${WS}.jsonl`, [
+        { type: 'workspace_created', data: { id: WS, name: 'Owned', rootFolder: '/', created: 1 } },
+        { type: 'session_created', workspaceId: WS, data: { id: 'sess-1', name: 'S1', startTime: 2 } },
+        { type: 'state_saved', workspaceId: WS, sessionId: 'sess-1', data: { id: 'st-1', name: 'St1', created: 3, stateJson: '{}' } },
+        { type: 'trace_added', workspaceId: WS, sessionId: 'sess-1', data: { id: 'tr-1', content: 'trace', traceType: 'note' } }
+      ] as never);
+      await jsonlWriter.appendEvents(`tasks/tasks_${WS}.jsonl`, [
+        { type: 'project_created', data: { id: 'proj-1', workspaceId: WS, name: 'P1', status: 'active', created: 4, updated: 4 } },
+        { type: 'task_created', data: { id: 'task-1', projectId: 'proj-1', workspaceId: WS, title: 'T1', status: 'todo', priority: 'medium', created: 5, updated: 5 } }
+      ] as never);
+    }
+
+    it('removes BOTH owned streams, not just the workspace stream', async () => {
+      const { jsonlWriter, vaultEventStore, deps } = build();
+      await seedStreams(jsonlWriter);
+      expect(await vaultEventStore.listFiles('workspaces')).toContain(`workspaces/ws_${WS}.jsonl`);
+      expect(await vaultEventStore.listFiles('tasks')).toContain(`tasks/tasks_${WS}.jsonl`);
+
+      await new WorkspaceRepository(deps).delete(WS);
+
+      // The tasks stream is a separate file that no workspace-stream tombstone
+      // reaches. Pre-fix both of these still listed.
+      expect(await vaultEventStore.listFiles('workspaces')).not.toContain(`workspaces/ws_${WS}.jsonl`);
+      expect(await vaultEventStore.listFiles('tasks')).not.toContain(`tasks/tasks_${WS}.jsonl`);
+    });
+
+    it('purges the workspace-keyed SQLite tables as well', async () => {
+      const { jsonlWriter, deps, tablesTouchedBy } = build();
+      await seedStreams(jsonlWriter);
+
+      await new WorkspaceRepository(deps).delete(WS);
+
+      expect(tablesTouchedBy('DELETE')).toEqual(
+        expect.arrayContaining(['tasks', 'projects', 'memory_traces', 'states', 'sessions', 'workspaces'])
+      );
+    });
+
+    it('writes the tombstone before removing the streams', async () => {
+      const { jsonlWriter, vaultEventStore, deps } = build();
+      await seedStreams(jsonlWriter);
+      const appendSpy = jest.spyOn(jsonlWriter, 'appendEvent');
+      const removeSpy = jest.spyOn(vaultEventStore, 'deleteStream');
+
+      await new WorkspaceRepository(deps).delete(WS);
+
+      expect(appendSpy).toHaveBeenCalledWith(
+        `workspaces/ws_${WS}.jsonl`,
+        expect.objectContaining({ type: 'workspace_deleted', workspaceId: WS })
+      );
+      const tombstoneOrder = appendSpy.mock.invocationCallOrder[0];
+      const firstRemovalOrder = removeSpy.mock.invocationCallOrder[0];
+      expect(tombstoneOrder).toBeLessThan(firstRemovalOrder);
+    });
+
+    describe('partial failure', () => {
+      it('does not touch SQLite when a stream cannot be removed, so the delete stays retryable', async () => {
+        const { jsonlWriter, deps, tablesTouchedBy } = build();
+        await seedStreams(jsonlWriter);
+        jest.spyOn(jsonlWriter, 'deleteStream').mockRejectedValue(new Error('vault is locked'));
+
+        await expect(new WorkspaceRepository(deps).delete(WS)).rejects.toThrow(/was not deleted/);
+
+        // Pre-fix, the workspaces row was deleted regardless — a workspace that
+        // stopped listing but came straight back on the next rebuild.
+        expect(tablesTouchedBy('DELETE')).toEqual([]);
+      });
+
+      it('attempts every stream before reporting, so a retry has less to do', async () => {
+        const { jsonlWriter, deps } = build();
+        await seedStreams(jsonlWriter);
+        const deleteStream = jest
+          .spyOn(jsonlWriter, 'deleteStream')
+          .mockRejectedValue(new Error('vault is locked'));
+
+        await expect(new WorkspaceRepository(deps).delete(WS)).rejects.toThrow();
+
+        expect(deleteStream).toHaveBeenCalledTimes(2);
+      });
+
+      it('removes the tasks stream first, so the tombstone survives longest', async () => {
+        const { jsonlWriter, deps } = build();
+        await seedStreams(jsonlWriter);
+        const deleteStream = jest.spyOn(jsonlWriter, 'deleteStream');
+
+        await new WorkspaceRepository(deps).delete(WS);
+
+        expect(deleteStream.mock.calls.map(c => c[0])).toEqual([
+          `tasks/tasks_${WS}.jsonl`,
+          `workspaces/ws_${WS}.jsonl`
+        ]);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // The rebuild path — the only test that proves the delete is real.
+  // ==========================================================================
+  describe('rebuildCache() after a delete', () => {
+    it('replays nothing for the deleted workspace', async () => {
+      const { app } = createMockApp({ withLocalStorage: true });
+      const vaultEventStore = new VaultEventStore({
+        app,
+        resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+      });
+      const jsonlWriter = new JSONLWriter({
+        app,
+        basePath: '.obsidian/plugins/nexus/data',
+        readBasePaths: ['.obsidian/plugins/nexus/data'],
+        vaultEventStore
+      });
+      const { cache, statements } = createRecordingSqlite();
+
+      await jsonlWriter.appendEvents(`workspaces/ws_${WS}.jsonl`, [
+        { type: 'workspace_created', data: { id: WS, name: 'Owned', rootFolder: '/', created: 1 } },
+        { type: 'session_created', workspaceId: WS, data: { id: 'sess-1', name: 'S1', startTime: 2 } },
+        { type: 'state_saved', workspaceId: WS, sessionId: 'sess-1', data: { id: 'st-1', name: 'St1', created: 3, stateJson: '{}' } },
+        { type: 'trace_added', workspaceId: WS, sessionId: 'sess-1', data: { id: 'tr-1', content: 'trace', traceType: 'note' } }
+      ] as never);
+      await jsonlWriter.appendEvents(`tasks/tasks_${WS}.jsonl`, [
+        { type: 'project_created', data: { id: 'proj-1', workspaceId: WS, name: 'P1', status: 'active', created: 4, updated: 4 } },
+        { type: 'task_created', data: { id: 'task-1', projectId: 'proj-1', workspaceId: WS, title: 'T1', status: 'todo', priority: 'medium', created: 5, updated: 5 } }
+      ] as never);
+
+      const repo = new WorkspaceRepository({
+        sqliteCache: cache as never,
+        jsonlWriter,
+        queryCache: new QueryCache()
+      });
+      await repo.delete(WS);
+
+      // Everything up to here is setup; the rebuild is the assertion.
+      statements.length = 0;
+      const coordinator = new SyncCoordinator(
+        jsonlWriter as never,
+        cache as unknown as ISQLiteCacheManager
+      );
+      const result = await coordinator.fullRebuild();
+
+      expect(result.success).toBe(true);
+      const writes = statements.filter(s => !/^\s*DELETE/i.test(s.sql));
+      const resurrected = writes.filter(s => JSON.stringify(s.params).includes(WS));
+      // Pre-fix: the two streams survived, so the rebuild re-inserted the
+      // workspace's sessions, states, traces, project and task.
+      expect(resurrected).toEqual([]);
+    });
+  });
+});

--- a/tests/unit/WorkspaceDeleteOwnership.test.ts
+++ b/tests/unit/WorkspaceDeleteOwnership.test.ts
@@ -85,9 +85,38 @@ describe('permanent workspace delete removes everything the workspace owns', () 
           'states',
           'sessions',
           'workspaces',
-          'trace_embedding_metadata'
+          'trace_embedding_metadata',
+          'tool_operation_receipts'
         ])
       );
+    });
+
+    it('purges tool operation receipts, which are workspace-owned on both sides', async () => {
+      // `tool_operation_receipts` arrived with the agent-runtime work (#356),
+      // after this fix was first written. It belongs to the workspace by the
+      // same test the rest of this module applies: a NOT NULL `workspaceId`,
+      // and events appended to the workspace's own stream
+      // (`ToolOperationRepository.path` → `workspaces/ws_<id>.jsonl`). That
+      // makes it unlike `conversations`, whose workspaceId is a nullable
+      // back-reference. Removing the stream covers the JSONL half; this covers
+      // the cache half, which would otherwise be orphaned exactly as every
+      // other child table was before this fix.
+      const { cache, statements } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply({
+        id: 'evt-del',
+        type: 'workspace_deleted',
+        deviceId: 'dev',
+        timestamp: 10,
+        workspaceId: WS
+      } as never);
+
+      const receiptDelete = statements.find(s =>
+        /DELETE FROM tool_operation_receipts/i.test(s.sql)
+      );
+      expect(receiptDelete).toBeDefined();
+      expect(receiptDelete?.params).toEqual([WS]);
     });
 
     it('deletes children before the parent rows they are reached through', async () => {


### PR DESCRIPTION
Permanent workspace deletion removed the `workspaces` row and left everything else behind.

Stays **UI-only**: no delete tool is added and none becomes reachable. The AI still gets `archiveWorkspace`, which is reversible.

## Measured before fixing

Seeded a workspace with 2 sessions / 2 states / 2 traces / 1 project / 2 tasks in a real headless Obsidian and deleted it through the exact `WorkspacesTab` call. Only the `workspaces` row and its FTS entry went.

**Survivors:** sessions 2, states 2, memory_traces 2, projects 1, tasks 2, plus `workspaces/ws_<id>/` (8 events, tombstone appended) and `tasks/tasks_<id>/` (3 events, untouched).

`rebuildCache()` reproduced that orphan set **identically**, so this was never cache-only residue. The original report of "orphan states rows" understated it — every child table survived.

## Two independent causes, both proven

1. **The declared `ON DELETE CASCADE`s never fire.** SQLite foreign-key enforcement is off and nothing turns it on — `grep -rn "foreign_keys" src/` returns nothing. `schema.ts` already notes this for `note_properties`; it applies file-wide.
2. **Nothing could remove a stream.** `StorageRouter.deleteFile` only reached a legacy flat file that a vault-root install never wrote, and the tasks stream carries no tombstone at all.

## What a workspace actually owns

**SQLite:** sessions, states, memory_traces, projects, tasks (and `task_dependencies` / `task_note_links` through them), plus `trace_embedding_metadata` and its vec0 rows — which nothing in the system would ever have collected, since `clearAllData` skips them too. `workspace_fts` was already handled by a delete trigger.

**JSONL: two streams, not one** — `workspaces/ws_<id>` and `tasks/tasks_<id>`.

**Conversations are deliberately not owned** — nullable back-reference, own stream, outlives the workspace. A test pins that boundary so a future "tidy up" does not quietly widen the blast radius.

## Ownership is declared once

New `src/database/workspaceOwnership.ts`. Both the live delete and `applyWorkspaceDeleted` (the replay path) go through it, so they cannot drift — and that drift is precisely what made the rebuild resurrect the children.

Stream removal is new and idempotent, from `ShardedJsonlStreamStore` up through `JSONLWriter`. It removes cloud-sync conflict siblings too; leaving one turns a delete into a partial truncation.

## Partial failure, chosen rather than incidental

**Order: tombstone → streams → SQLite. Throw on any failure. Purge the cache only if the JSONL side finished.**

The halves are not symmetric, so the choice is by *direction of convergence*:

- a **stream** failure leaves the workspace fully intact and retryable
- a **SQLite** failure leaves stale rows over an event store that no longer has the workspace — which the next rebuild clears

Both converge on deleted. SQLite-first converges on the workspace **coming back with all its states**, which is the #333 shape.

The tasks stream goes first so the tombstone-bearing stream survives longest: once the tombstone lands, every later failure still resolves to deleted, leaving only disk bytes.

## Evidence

12 regression tests; **11 fail against pre-fix code** (verified by checking out the base commit's `src/`). The 12th is the conversations-boundary guard, which correctly passes both ways.

Live on a cold start: after delete every table 0 and both stream directories gone; **after `rebuildCache()`, identical — nothing returned**. A stream left on disk with a tombstone replays to 0/0/0/0. Full process restart: no resurrection, `dev:errors` clean. A simulated `EBUSY` vault throws with the workspace fully intact, and a retry completes it.

`npx jest tests/unit tests/integration` — 4378 passing. `npm run build` green.

## Neighbouring gaps found, measured, not fixed

None qualified as small-and-obviously-correct:

- **`deleteSession` writes no event at all**, so a deleted session **comes back on rebuild** (0 → 1) and its states are never removed. Same family, and the most serious one left.
- Deleting a project orphans its tasks — same unenforced-FK shape.
- Deleting a conversation leaks its stream directory (disk growth only; that replay self-cancels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6aSoCAS5gNoew6n9qv6DJ)_