### PR TITLE
fix: give session deletion an event, so a deleted session stays deleted

### DIFF
--- a/.claude/skills/nexus-storage/references/failure-modes.md
+++ b/.claude/skills/nexus-storage/references/failure-modes.md
@@ -53,6 +53,32 @@ of them at once:
 Do not settle for "the row is gone from the UI". The check is
 `adapter.rebuildCache()` followed by a count per table, in the running app.
 
+## "There is no deletion event to fix — the type does not exist"
+
+Do not assume a delete writes an event just because its siblings do. Session
+deletion had no `session_deleted` type at all: `SessionRepository.delete` ran one
+`DELETE FROM sessions` and touched JSONL never, so a deleted session was measured
+coming back on the next rebuild (`sessions 0 → 1`), with its states and traces
+still in the cache from before. Start every deletion investigation with
+`grep -rn "<entity>_deleted" src/`; an empty result is the diagnosis.
+
+Adding the type is a three-place change — the interface plus both union/guard
+lists in `StorageEvents.ts`, the applier `case`, and the repository write — and
+then two questions have to be answered explicitly:
+
+- **Which stream does the tombstone go in, and does this entity own one?** A
+  session owns none: its events live in the *parent workspace's* stream, shared
+  with the workspace and its sibling sessions. There is nothing to remove from
+  disk and removing that file would destroy the parent — the tombstone IS the
+  removal. Contrast a workspace, which owns two streams that must both go.
+- **Does old JSONL need a backfill?** For a brand-new deletion type, no, and
+  synthesising one is dangerous: the only signal that a pre-fix delete happened
+  is "present in JSONL, absent from SQLite", which is also what a cold, partial
+  or mid-hydration cache looks like. Writing tombstones from that inference turns
+  a rebuildable cache state into permanent data loss, inverting the invariant in
+  `storage-model.md`. Old streams simply have no tombstone; the entity comes back
+  once and the user's next delete is permanent.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.cline/skills/nexus-storage/references/failure-modes.md
+++ b/.cline/skills/nexus-storage/references/failure-modes.md
@@ -53,6 +53,32 @@ of them at once:
 Do not settle for "the row is gone from the UI". The check is
 `adapter.rebuildCache()` followed by a count per table, in the running app.
 
+## "There is no deletion event to fix — the type does not exist"
+
+Do not assume a delete writes an event just because its siblings do. Session
+deletion had no `session_deleted` type at all: `SessionRepository.delete` ran one
+`DELETE FROM sessions` and touched JSONL never, so a deleted session was measured
+coming back on the next rebuild (`sessions 0 → 1`), with its states and traces
+still in the cache from before. Start every deletion investigation with
+`grep -rn "<entity>_deleted" src/`; an empty result is the diagnosis.
+
+Adding the type is a three-place change — the interface plus both union/guard
+lists in `StorageEvents.ts`, the applier `case`, and the repository write — and
+then two questions have to be answered explicitly:
+
+- **Which stream does the tombstone go in, and does this entity own one?** A
+  session owns none: its events live in the *parent workspace's* stream, shared
+  with the workspace and its sibling sessions. There is nothing to remove from
+  disk and removing that file would destroy the parent — the tombstone IS the
+  removal. Contrast a workspace, which owns two streams that must both go.
+- **Does old JSONL need a backfill?** For a brand-new deletion type, no, and
+  synthesising one is dangerous: the only signal that a pre-fix delete happened
+  is "present in JSONL, absent from SQLite", which is also what a cold, partial
+  or mid-hydration cache looks like. Writing tombstones from that inference turns
+  a rebuildable cache state into permanent data loss, inverting the invariant in
+  `storage-model.md`. Old streams simply have no tombstone; the entity comes back
+  once and the user's next delete is permanent.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.codex/skills/nexus-storage/references/failure-modes.md
+++ b/.codex/skills/nexus-storage/references/failure-modes.md
@@ -75,6 +75,32 @@ of them at once:
 Do not settle for "the row is gone from the UI". The check is
 `adapter.rebuildCache()` followed by a count per table, in the running app.
 
+## "There is no deletion event to fix — the type does not exist"
+
+Do not assume a delete writes an event just because its siblings do. Session
+deletion had no `session_deleted` type at all: `SessionRepository.delete` ran one
+`DELETE FROM sessions` and touched JSONL never, so a deleted session was measured
+coming back on the next rebuild (`sessions 0 → 1`), with its states and traces
+still in the cache from before. Start every deletion investigation with
+`grep -rn "<entity>_deleted" src/`; an empty result is the diagnosis.
+
+Adding the type is a three-place change — the interface plus both union/guard
+lists in `StorageEvents.ts`, the applier `case`, and the repository write — and
+then two questions have to be answered explicitly:
+
+- **Which stream does the tombstone go in, and does this entity own one?** A
+  session owns none: its events live in the *parent workspace's* stream, shared
+  with the workspace and its sibling sessions. There is nothing to remove from
+  disk and removing that file would destroy the parent — the tombstone IS the
+  removal. Contrast a workspace, which owns two streams that must both go.
+- **Does old JSONL need a backfill?** For a brand-new deletion type, no, and
+  synthesising one is dangerous: the only signal that a pre-fix delete happened
+  is "present in JSONL, absent from SQLite", which is also what a cold, partial
+  or mid-hydration cache looks like. Writing tombstones from that inference turns
+  a rebuildable cache state into permanent data loss, inverting the invariant in
+  `storage-model.md`. Old streams simply have no tombstone; the entity comes back
+  once and the user's next delete is permanent.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/.skills/nexus-storage/references/failure-modes.md
+++ b/.skills/nexus-storage/references/failure-modes.md
@@ -53,6 +53,32 @@ of them at once:
 Do not settle for "the row is gone from the UI". The check is
 `adapter.rebuildCache()` followed by a count per table, in the running app.
 
+## "There is no deletion event to fix — the type does not exist"
+
+Do not assume a delete writes an event just because its siblings do. Session
+deletion had no `session_deleted` type at all: `SessionRepository.delete` ran one
+`DELETE FROM sessions` and touched JSONL never, so a deleted session was measured
+coming back on the next rebuild (`sessions 0 → 1`), with its states and traces
+still in the cache from before. Start every deletion investigation with
+`grep -rn "<entity>_deleted" src/`; an empty result is the diagnosis.
+
+Adding the type is a three-place change — the interface plus both union/guard
+lists in `StorageEvents.ts`, the applier `case`, and the repository write — and
+then two questions have to be answered explicitly:
+
+- **Which stream does the tombstone go in, and does this entity own one?** A
+  session owns none: its events live in the *parent workspace's* stream, shared
+  with the workspace and its sibling sessions. There is nothing to remove from
+  disk and removing that file would destroy the parent — the tombstone IS the
+  removal. Contrast a workspace, which owns two streams that must both go.
+- **Does old JSONL need a backfill?** For a brand-new deletion type, no, and
+  synthesising one is dangerous: the only signal that a pre-fix delete happened
+  is "present in JSONL, absent from SQLite", which is also what a cold, partial
+  or mid-hydration cache looks like. Writing tombstones from that inference turns
+  a rebuildable cache state into permanent data loss, inverting the invariant in
+  `storage-model.md`. Old streams simply have no tombstone; the entity comes back
+  once and the user's next delete is permanent.
+
 ## "The view says 'no tasks' but the data is there"
 
 A read raced startup hydration. Await `waitForQueryReady()` (optional on

--- a/src/database/interfaces/StorageEvents.ts
+++ b/src/database/interfaces/StorageEvents.ts
@@ -164,6 +164,28 @@ export interface SessionUpdatedEvent extends BaseStorageEvent {
   }>;
 }
 
+/**
+ * Event: Session deleted
+ *
+ * The tombstone that makes a permanent session delete survive a cache rebuild.
+ *
+ * A session has no stream of its own — this event is appended to the parent
+ * workspace's stream, where it cancels out the `session_created`, `state_saved`
+ * and `trace_added` events replayed just before it. Without it, replay had
+ * nothing to apply and a deleted session came back on the next `rebuildCache()`.
+ *
+ * `WorkspaceEventApplier.applySessionDeleted` is the other half; both it and
+ * `SessionRepository.delete` purge through `sessionOwnership.purgeSessionRows`
+ * so the live delete and its replay cannot drift.
+ */
+export interface SessionDeletedEvent extends BaseStorageEvent {
+  type: 'session_deleted';
+  /** Parent workspace ID — identifies the stream this tombstone belongs to */
+  workspaceId: string;
+  /** Target session ID */
+  sessionId: string;
+}
+
 // ============================================================================
 // State Events
 // ============================================================================
@@ -746,6 +768,7 @@ export type WorkspaceEvent =
   | WorkspaceDeletedEvent
   | SessionCreatedEvent
   | SessionUpdatedEvent
+  | SessionDeletedEvent
   | StateSavedEvent
   | StateUpdatedEvent
   | StateDeletedEvent
@@ -800,6 +823,7 @@ export function isWorkspaceEvent(event: StorageEvent): event is WorkspaceEvent {
     'workspace_deleted',
     'session_created',
     'session_updated',
+    'session_deleted',
     'state_saved',
     'state_updated',
     'state_deleted',
@@ -890,6 +914,7 @@ export function isUpdateEvent(event: StorageEvent): boolean {
 export function isDeletionEvent(event: StorageEvent): boolean {
   return [
     'workspace_deleted',
+    'session_deleted',
     'conversation_deleted',
     'state_deleted',
     'message_deleted',

--- a/src/database/repositories/ConversationRepository.ts
+++ b/src/database/repositories/ConversationRepository.ts
@@ -348,7 +348,24 @@ export class ConversationRepository
   }
 
   /**
-   * Delete a conversation
+   * Delete a conversation, permanently.
+   *
+   * Ordering matches `WorkspaceRepository.delete` and for the same reason:
+   * tombstone, then the source of truth, then the cache. Every partial failure
+   * has to converge on "deleted" rather than on the conversation coming back.
+   *
+   *   1. Tombstone. If step 2 then fails, replay still cancels the conversation
+   *      out and nothing resurrects.
+   *   2. Remove the stream — the conversation's OWN stream, which also carries
+   *      its messages (`MessageRepository.jsonlPath` is the same file). A
+   *      failure here throws BEFORE SQLite is touched, leaving a retryable
+   *      no-op rather than a half-deleted conversation.
+   *   3. SQLite, which is only ever catching up to the event store.
+   *
+   * Deleting the stream is what makes this permanent, and it is deliberate:
+   * this path is reached only from the chat UI's own delete
+   * (ChatView → ConversationManager → ChatService → ConversationService), never
+   * from a tool. No AI-reachable surface deletes a conversation.
    */
   async delete(id: string): Promise<void> {
     try {
@@ -361,7 +378,14 @@ export class ConversationRepository
         }
       );
 
-      // 2. Delete from SQLite. Messages are NOT cascaded despite the FK: SQLite
+      // 2. Remove the conversation's event stream. Without this the directory
+      //    `<storage>/conversations/conv_<id>/` survived the delete and the
+      //    rebuild — the tombstone kept it out of the cache, but the source of
+      //    truth was never actually removed. Uses the same idempotent
+      //    `deleteStream` chain as the workspace delete, so a retry is safe.
+      await this.jsonlWriter.deleteStream(this.jsonlPath(id));
+
+      // 3. Delete from SQLite. Messages are NOT cascaded despite the FK: SQLite
       //    foreign-key enforcement is off on this connection, so the rows stayed
       //    behind as orphans until the next rebuild (measured: 1 message row for
       //    a 1-message conversation). `ConversationEventApplier` has always
@@ -369,7 +393,7 @@ export class ConversationRepository
       await this.sqliteCache.run('DELETE FROM messages WHERE conversationId = ?', [id]);
       await this.sqliteCache.run(`DELETE FROM ${this.tableName} WHERE id = ?`, [id]);
 
-      // 3. Invalidate cache
+      // 4. Invalidate cache
       this.invalidateCache();
 
     } catch (error) {

--- a/src/database/repositories/ConversationRepository.ts
+++ b/src/database/repositories/ConversationRepository.ts
@@ -361,7 +361,12 @@ export class ConversationRepository
         }
       );
 
-      // 2. Delete from SQLite — messages are cascaded via foreign key constraint
+      // 2. Delete from SQLite. Messages are NOT cascaded despite the FK: SQLite
+      //    foreign-key enforcement is off on this connection, so the rows stayed
+      //    behind as orphans until the next rebuild (measured: 1 message row for
+      //    a 1-message conversation). `ConversationEventApplier` has always
+      //    deleted them explicitly on replay; this is the live path catching up.
+      await this.sqliteCache.run('DELETE FROM messages WHERE conversationId = ?', [id]);
       await this.sqliteCache.run(`DELETE FROM ${this.tableName} WHERE id = ?`, [id]);
 
       // 3. Invalidate cache

--- a/src/database/repositories/ProjectRepository.ts
+++ b/src/database/repositories/ProjectRepository.ts
@@ -33,6 +33,7 @@ import {
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { parseJsonColumn } from '../utils/jsonColumn';
 import { resolveMetadataUpdate } from './metadataUpdate';
+import { purgeProjectRows } from '../taskOwnership';
 
 interface ProjectRow extends DatabaseRow {
   id: string;
@@ -230,6 +231,21 @@ export class ProjectRepository
     }
   }
 
+  /**
+   * Permanently delete a project and every task it owns.
+   *
+   * The `ON DELETE CASCADE` the old comment relied on never fired — SQLite
+   * foreign-key enforcement is off on this connection — so the tasks, their
+   * dependency edges and their note links were left behind, and `rebuildCache()`
+   * reproduced them because replay dropped only the `projects` row too.
+   * `purgeProjectRows` is shared with `TaskEventApplier.applyProjectDeleted` so
+   * the two paths cannot drift.
+   *
+   * Ordering: the `project_deleted` tombstone is written first, so if the SQLite
+   * purge fails the cache is merely stale over an event store that already says
+   * "deleted" and the next rebuild converges on deleted. The reverse order
+   * converges on the project coming back.
+   */
   async delete(id: string): Promise<void> {
     try {
       // Look up the project to get workspaceId for JSONL path
@@ -248,8 +264,8 @@ export class ProjectRepository
           }
         );
 
-        // 2. Delete from SQLite (cascades to tasks, deps, note links)
-        await this.sqliteCache.run('DELETE FROM projects WHERE id = ?', [id]);
+        // 2. Delete from SQLite — every row the project owns, not just its own.
+        await purgeProjectRows(this.sqliteCache, id);
       });
 
       // 3. Invalidate cache (project + all tasks in project)

--- a/src/database/repositories/SessionRepository.ts
+++ b/src/database/repositories/SessionRepository.ts
@@ -28,9 +28,11 @@ import {
 import { SessionMetadata } from '../../types/storage/HybridStorageTypes';
 import {
   SessionCreatedEvent,
-  SessionUpdatedEvent
+  SessionUpdatedEvent,
+  SessionDeletedEvent
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
+import { purgeSessionRows } from '../sessionOwnership';
 
 type SqliteValue = string | number | null;
 
@@ -205,20 +207,63 @@ export class SessionRepository
     }
   }
 
+  /**
+   * Permanently delete a session and everything keyed to it.
+   *
+   * Reachable from the storage adapter and the memory/session services — never
+   * from a tool. The AI has no session delete; do not expose one.
+   *
+   * ## Ordering, and what happens when half of it fails
+   *
+   * JSONL is the source of truth and SQLite is a rebuildable cache, so the two
+   * halves are not symmetric:
+   *
+   *   1. Tombstone. A `session_deleted` event goes into the parent workspace's
+   *      stream first. That stream is shared with the workspace and its sibling
+   *      sessions, so — unlike a workspace delete — there is no file to remove:
+   *      the tombstone IS the removal. On replay it cancels out the
+   *      `session_created` / `state_saved` / `trace_added` events that precede
+   *      it, through the same `purgeSessionRows` used below.
+   *   2. SQLite. Only after the event is on disk.
+   *
+   * The failure modes this produces, on purpose:
+   *
+   * - **Tombstone write fails** → we throw before touching SQLite. Nothing is
+   *   destroyed, the session still lists, the delete is a retryable no-op.
+   * - **SQLite purge fails** → the rows are stale cache over an event store that
+   *   already says "deleted". The next `rebuildCache()` clears them. It
+   *   converges on deleted.
+   *
+   * The opposite order — SQLite first — converges on the session coming BACK
+   * with all its states and traces at the next rebuild. That was the measured
+   * pre-fix behaviour: `sessions 0 → 1` across a rebuild, with 2 states and
+   * 2 traces that never left in the first place.
+   */
   async delete(id: string): Promise<void> {
     try {
-      await this.transaction(async () => {
-        // Get workspace ID first
-        const session = await this.getById(id);
-        if (!session) {
-          throw new Error(`Session not found: ${id}`);
-        }
+      // The workspace ID routes the JSONL write, so it has to be read before
+      // anything is removed.
+      const session = await this.getById(id);
+      if (!session) {
+        throw new Error(`Session not found: ${id}`);
+      }
 
-        // Delete from SQLite (cascades to states and traces)
-        await this.sqliteCache.run('DELETE FROM sessions WHERE id = ?', [id]);
+      // 1. Tombstone in the source of truth.
+      await this.writeEvent<SessionDeletedEvent>(
+        this.jsonlPath(session.workspaceId),
+        {
+          type: 'session_deleted',
+          workspaceId: session.workspaceId,
+          sessionId: id
+        }
+      );
+
+      // 2. Now the cache, which is only ever catching up to the event store.
+      await this.transaction(async () => {
+        await purgeSessionRows(this.sqliteCache, id);
       });
 
-      // Invalidate cache
+      // 3. Invalidate cache
       this.invalidateCache();
       this.log('delete', { id });
     } catch (error) {

--- a/src/database/repositories/TaskRepository.ts
+++ b/src/database/repositories/TaskRepository.ts
@@ -43,6 +43,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { PaginatedResult, PaginationParams } from '../../types/pagination/PaginationTypes';
 import { parseJsonColumn } from '../utils/jsonColumn';
+import { purgeTaskRows } from '../taskOwnership';
 import { resolveMetadataUpdate } from './metadataUpdate';
 
 interface TaskRow extends DatabaseRow {
@@ -291,8 +292,11 @@ export class TaskRepository
           }
         );
 
-        // 2. Delete from SQLite (cascades: deps + note links removed, children parentTaskId set null)
-        await this.sqliteCache.run('DELETE FROM tasks WHERE id = ?', [id]);
+        // 2. Delete from SQLite. The cascade named in the old comment never
+        //    fired (FK enforcement is off), so the deps, note links and the
+        //    children's parentTaskId are handled explicitly — shared with
+        //    `TaskEventApplier.applyTaskDeleted` so replay does the same.
+        await purgeTaskRows(this.sqliteCache, id);
       });
 
       // 3. Invalidate cache

--- a/src/database/sessionOwnership.ts
+++ b/src/database/sessionOwnership.ts
@@ -61,10 +61,30 @@ export interface SessionPurgeTarget {
  *
  * No FTS table is keyed to a session (`workspace_fts` tracks workspaces and is
  * maintained by a trigger that does fire), so none is listed.
+ *
+ * The list is meant to be complete against the schema, and completeness has a
+ * mechanical test: every table declaring a NOT NULL `sessionId` is owned and
+ * must appear here. As of schema 15 that is exactly `states`, `memory_traces`
+ * and `tool_operation_receipts`. The three tables whose `sessionId` is NULLABLE
+ * — `conversations`, `trace_embedding_metadata` and
+ * `conversation_embedding_metadata` — are back-references rather than ownership;
+ * see the block above for the first and `purgeSessionRows` for the second.
+ * `SessionDeleteOwnership.test.ts` asserts that correspondence against
+ * `SCHEMA_SQL` so a new table cannot be added without this list noticing.
  */
 const SESSION_OWNED_DELETES: readonly string[] = [
   'DELETE FROM states WHERE sessionId = ?',
   'DELETE FROM memory_traces WHERE sessionId = ?',
+  // Tool operation receipts (schema 15) carry a NOT NULL sessionId and are
+  // appended to the workspace's own stream — the SAME stream the session's own
+  // events live in (`ToolOperationRepository.path`) — so the `session_deleted`
+  // tombstone is their JSONL-side removal too, exactly as it is for states and
+  // traces. Without this line a session delete left every receipt behind as an
+  // orphan pointing at a session that no longer exists, and every rebuild
+  // faithfully reproduced them: replay re-applies `tool_operation_started`
+  // before it reaches the tombstone. This is the session-side twin of the same
+  // line in `workspaceOwnership.ts`.
+  'DELETE FROM tool_operation_receipts WHERE sessionId = ?',
   'DELETE FROM sessions WHERE id = ?'
 ];
 

--- a/src/database/sessionOwnership.ts
+++ b/src/database/sessionOwnership.ts
@@ -1,0 +1,99 @@
+/**
+ * Location: src/database/sessionOwnership.ts
+ *
+ * The single definition of what a session owns in the SQLite cache.
+ *
+ * Sibling of `workspaceOwnership.ts` and `taskOwnership.ts`, and it exists for
+ * the same reason: two code paths delete a session and they MUST agree.
+ *
+ *  1. `SessionRepository.delete` — the live delete.
+ *  2. `WorkspaceEventApplier.applySessionDeleted` — replay, i.e. what a
+ *     `rebuildCache()` or a sync from another device does with a
+ *     `session_deleted` event.
+ *
+ * If (2) disagreed with (1), a rebuild would replay `session_created`,
+ * `state_saved`, `trace_added` … and then a delete that only removed the
+ * `sessions` row, resurrecting every state and trace as an orphan.
+ *
+ * Measured against the pre-fix code in a real vault (Obsidian 1.13.7, headless):
+ * deleting a session holding 2 states / 2 traces / 1 trace embedding left
+ * `states 2, memory_traces 2, trace_embedding_metadata 1` behind, and the next
+ * `rebuildCache()` put the session itself back (`sessions 0 → 1`) because no
+ * event was ever written.
+ *
+ * ## What a session does NOT own
+ *
+ * - **Its JSONL stream.** A session has no stream of its own: session, state and
+ *   trace events are all appended to the *workspace's* stream
+ *   (`SessionRepository.jsonlPath`). Removing that file would destroy the
+ *   workspace and its sibling sessions, so a session delete is a tombstone-only
+ *   operation — `session_deleted` cancels the earlier events out on replay.
+ * - **`conversations` (and `conversation_embedding_metadata`).** `sessionId` is a
+ *   nullable back-reference, not ownership — same call as `workspaceOwnership.ts`.
+ *   A conversation is a first-class entity with its own event stream and outlives
+ *   the session it was linked to. (Measured aside: replay does not restore
+ *   `conversations.sessionId` at all, so it is not even a reliable link.)
+ *
+ * Related Files:
+ * - src/database/schema/schema.ts — the FK CASCADE declarations that do NOT
+ *   fire, because FK enforcement is off on the shared connection.
+ * - src/database/repositories/SessionRepository.ts
+ * - src/database/sync/WorkspaceEventApplier.ts
+ */
+
+type PurgeParams = Array<string | number | null | boolean>;
+
+/**
+ * Minimal SQLite surface the purge needs. Satisfied by both
+ * `SQLiteCacheManager` (repository path) and `ISQLiteCacheManager` (replay path).
+ */
+export interface SessionPurgeTarget {
+  run(sql: string, params?: PurgeParams): Promise<unknown>;
+  query<T>(sql: string, params?: PurgeParams): Promise<T[]>;
+}
+
+/**
+ * Every SQLite table keyed to a session, in child-before-parent order.
+ *
+ * `states` and `memory_traces` declare `ON DELETE CASCADE` on `sessionId`; the
+ * cascade never fires, so they are listed here explicitly. The `sessions` row
+ * goes last so nothing is orphaned mid-purge.
+ *
+ * No FTS table is keyed to a session (`workspace_fts` tracks workspaces and is
+ * maintained by a trigger that does fire), so none is listed.
+ */
+const SESSION_OWNED_DELETES: readonly string[] = [
+  'DELETE FROM states WHERE sessionId = ?',
+  'DELETE FROM memory_traces WHERE sessionId = ?',
+  'DELETE FROM sessions WHERE id = ?'
+];
+
+/**
+ * Delete every SQLite row the session owns, including the session row.
+ *
+ * Idempotent: re-running against an already-purged session is a no-op, which is
+ * what makes a failed delete safe to retry.
+ *
+ * Callers are expected to wrap this in a transaction where one is available.
+ */
+export async function purgeSessionRows(
+  sqlite: SessionPurgeTarget,
+  sessionId: string
+): Promise<void> {
+  // Trace embeddings are a vec0 virtual table keyed by the metadata rowid, so
+  // they cannot be reached by a sessionId predicate. Same two-step delete as
+  // TraceEmbeddingService and `purgeWorkspaceRows`. This runs first, while the
+  // metadata rows that name the rowids are still there.
+  const embeddingRows = await sqlite.query<{ rowid: number }>(
+    'SELECT rowid FROM trace_embedding_metadata WHERE sessionId = ?',
+    [sessionId]
+  );
+  for (const row of embeddingRows) {
+    await sqlite.run('DELETE FROM trace_embeddings WHERE rowid = ?', [row.rowid]);
+  }
+  await sqlite.run('DELETE FROM trace_embedding_metadata WHERE sessionId = ?', [sessionId]);
+
+  for (const sql of SESSION_OWNED_DELETES) {
+    await sqlite.run(sql, [sessionId]);
+  }
+}

--- a/src/database/storage/JSONLWriter.ts
+++ b/src/database/storage/JSONLWriter.ts
@@ -542,9 +542,12 @@ export class JSONLWriter {
    * vault-root install, plus any legacy flat file of the same name.
    *
    * Warning: this destroys the source of truth for that stream and cannot be
-   * undone. It exists for the one operation that is meant to be permanent:
-   * deleting a workspace from the settings UI. Everything reachable by the AI
-   * uses a deletion EVENT (a tombstone) instead.
+   * undone. It exists for the deletions that are meant to be permanent and are
+   * driven by a human from the UI: deleting a workspace from the settings tab,
+   * and deleting a conversation from the chat sidebar. Everything reachable by
+   * the AI uses a deletion EVENT (a tombstone) instead — and so does every
+   * entity that owns no stream of its own, such as a session, whose events live
+   * in its parent workspace's stream.
    *
    * Idempotent — removing an already-removed stream succeeds — so a delete that
    * failed partway can be retried as a whole.

--- a/src/database/sync/TaskEventApplier.ts
+++ b/src/database/sync/TaskEventApplier.ts
@@ -24,6 +24,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { ISQLiteCacheManager } from './SyncCoordinator';
 import { resolveWorkspaceId } from './resolveWorkspaceId';
+import { purgeProjectRows, purgeTaskRows } from '../taskOwnership';
 
 /**
  * Normalize a workspaceId that may be a name string instead of a UUID.
@@ -138,8 +139,12 @@ export class TaskEventApplier {
 
   private async applyProjectDeleted(event: ProjectDeletedEvent): Promise<void> {
     if (!event.projectId) return;
-    // CASCADE will handle tasks, dependencies, and note links
-    await this.sqliteCache.run('DELETE FROM projects WHERE id = ?', [event.projectId]);
+    // CASCADE does NOT handle tasks, dependencies and note links: FK enforcement
+    // is off on the shared connection, so this replay used to re-create every
+    // task from `task_created` and then drop only the project row, leaving the
+    // exact same orphans behind on every rebuild. `purgeProjectRows` is shared
+    // with `ProjectRepository.delete` so the two paths cannot drift.
+    await purgeProjectRows(this.sqliteCache, event.projectId);
   }
 
   private async applyTaskCreated(event: TaskCreatedEvent): Promise<void> {
@@ -205,7 +210,10 @@ export class TaskEventApplier {
 
   private async applyTaskDeleted(event: TaskDeletedEvent): Promise<void> {
     if (!event.taskId) return;
-    await this.sqliteCache.run('DELETE FROM tasks WHERE id = ?', [event.taskId]);
+    // Same unenforced-FK story as project_deleted: the dependency edges, note
+    // links and the children's parentTaskId have to be handled here, or every
+    // rebuild reproduces them pointing at a task that no longer exists.
+    await purgeTaskRows(this.sqliteCache, event.taskId);
   }
 
   private async applyDependencyAdded(event: TaskDependencyAddedEvent): Promise<void> {

--- a/src/database/sync/WorkspaceEventApplier.ts
+++ b/src/database/sync/WorkspaceEventApplier.ts
@@ -12,6 +12,7 @@ import {
   WorkspaceDeletedEvent,
   SessionCreatedEvent,
   SessionUpdatedEvent,
+  SessionDeletedEvent,
   StateSavedEvent,
   StateUpdatedEvent,
   StateDeletedEvent,
@@ -23,6 +24,7 @@ import {
 } from '../interfaces/StorageEvents';
 import { ISQLiteCacheManager } from './SyncCoordinator';
 import { purgeWorkspaceRows } from '../workspaceOwnership';
+import { purgeSessionRows } from '../sessionOwnership';
 
 export class WorkspaceEventApplier {
   private sqliteCache: ISQLiteCacheManager;
@@ -58,6 +60,9 @@ export class WorkspaceEventApplier {
         break;
       case 'session_updated':
         await this.applySessionUpdated(event);
+        break;
+      case 'session_deleted':
+        await this.applySessionDeleted(event);
         break;
       case 'state_saved':
         await this.applyStateSaved(event);
@@ -181,6 +186,25 @@ export class WorkspaceEventApplier {
         1
       ]
     );
+  }
+
+  /**
+   * A `session_deleted` event has to remove everything the session owns, not
+   * just its row.
+   *
+   * This runs during replay — `rebuildCache()` and cross-device sync — where the
+   * `session_created`, `state_saved` and `trace_added` events for this session
+   * were applied from the same workspace stream moments earlier. The tombstone
+   * is what cancels them out; a session has no stream of its own to remove.
+   *
+   * `purgeSessionRows` is shared with `SessionRepository.delete` precisely so
+   * the live delete and the replay of that delete cannot drift apart.
+   */
+  private async applySessionDeleted(event: SessionDeletedEvent): Promise<void> {
+    if (!event.sessionId) {
+      return;
+    }
+    await purgeSessionRows(this.sqliteCache, event.sessionId);
   }
 
   private async applySessionUpdated(event: SessionUpdatedEvent): Promise<void> {

--- a/src/database/taskOwnership.ts
+++ b/src/database/taskOwnership.ts
@@ -1,0 +1,123 @@
+/**
+ * Location: src/database/taskOwnership.ts
+ *
+ * The single definition of what a project and a task own in the SQLite cache.
+ *
+ * Sibling of `sessionOwnership.ts` (and `workspaceOwnership.ts`), for the same
+ * reason: two code paths delete each of these and they MUST agree.
+ *
+ *  1. `ProjectRepository.delete` / `TaskRepository.delete` — the live delete.
+ *  2. `TaskEventApplier.applyProjectDeleted` / `applyTaskDeleted` — replay, i.e.
+ *     what a `rebuildCache()` or a sync from another device does with the
+ *     `project_deleted` / `task_deleted` event.
+ *
+ * Both sides said "CASCADE will handle it". It does not: SQLite foreign-key
+ * enforcement is per-connection and off by default, and nothing in this plugin
+ * turns it on, so every `ON DELETE CASCADE` in `schema.ts` is documentation.
+ *
+ * Measured against the pre-fix code in a real vault (Obsidian 1.13.7, headless):
+ *
+ * - Deleting a project with 3 tasks (1 dependency edge, 1 note link) removed the
+ *   `projects` row and left `tasks 3, task_dependencies 1, task_note_links 1`.
+ *   `rebuildCache()` reproduced exactly the same orphans, because replay applies
+ *   `task_created` and then a `project_deleted` that only dropped the project.
+ * - Deleting a single task left `task_dependencies 1, task_note_links 1` and a
+ *   child task still pointing at the deleted parent — also reproduced by the
+ *   rebuild.
+ *
+ * Related Files:
+ * - src/database/schema/schema.ts — the FK declarations that never fire.
+ * - src/database/repositories/ProjectRepository.ts
+ * - src/database/repositories/TaskRepository.ts
+ * - src/database/sync/TaskEventApplier.ts
+ */
+
+type PurgeParams = Array<string | number | null | boolean>;
+
+/**
+ * Minimal SQLite surface the purges need. Satisfied by both
+ * `SQLiteCacheManager` (repository path) and `ISQLiteCacheManager` (replay path).
+ */
+export interface TaskPurgeTarget {
+  run(sql: string, params?: PurgeParams): Promise<unknown>;
+}
+
+/** How many `?` placeholders a statement takes. */
+function placeholderCount(sql: string): number {
+  return (sql.match(/\?/g) ?? []).length;
+}
+
+/**
+ * Run statements that all bind the same single id, once per `?`.
+ * Same shape as `purgeWorkspaceRows`, so the three ownership modules read alike.
+ */
+async function runAll(
+  sqlite: TaskPurgeTarget,
+  statements: readonly string[],
+  id: string
+): Promise<void> {
+  for (const sql of statements) {
+    const params: PurgeParams = Array.from({ length: placeholderCount(sql) }, () => id);
+    await sqlite.run(sql, params);
+  }
+}
+
+/**
+ * Every SQLite statement a project delete needs, in child-before-parent order.
+ *
+ * Order is forced by the data, not by taste:
+ *  1. `task_dependencies` and `task_note_links` are reached THROUGH `tasks`, so
+ *     the task rows must still exist when they run.
+ *  2. `parentTaskId` is declared `ON DELETE SET NULL`, not CASCADE — a surviving
+ *     task (possibly in another project) that pointed at a removed task must be
+ *     detached rather than deleted, or the board would lose unrelated work.
+ *  3. Only then the `tasks` rows, and last the `projects` row.
+ */
+const PROJECT_OWNED_STATEMENTS: readonly string[] = [
+  `DELETE FROM task_dependencies
+     WHERE taskId IN (SELECT id FROM tasks WHERE projectId = ?)
+        OR dependsOnTaskId IN (SELECT id FROM tasks WHERE projectId = ?)`,
+  'DELETE FROM task_note_links WHERE taskId IN (SELECT id FROM tasks WHERE projectId = ?)',
+  'UPDATE tasks SET parentTaskId = NULL WHERE parentTaskId IN (SELECT id FROM tasks WHERE projectId = ?)',
+  'DELETE FROM tasks WHERE projectId = ?',
+  'DELETE FROM projects WHERE id = ?'
+];
+
+/** The same set for one task, in the same order and for the same reasons. */
+const TASK_OWNED_STATEMENTS: readonly string[] = [
+  'DELETE FROM task_dependencies WHERE taskId = ? OR dependsOnTaskId = ?',
+  'DELETE FROM task_note_links WHERE taskId = ?',
+  'UPDATE tasks SET parentTaskId = NULL WHERE parentTaskId = ?',
+  'DELETE FROM tasks WHERE id = ?'
+];
+
+/**
+ * Delete every SQLite row the project owns, including the project row.
+ *
+ * Idempotent, so a delete that failed partway can be retried whole.
+ * Callers are expected to wrap this in a transaction where one is available.
+ */
+export async function purgeProjectRows(
+  sqlite: TaskPurgeTarget,
+  projectId: string
+): Promise<void> {
+  await runAll(sqlite, PROJECT_OWNED_STATEMENTS, projectId);
+}
+
+/**
+ * Delete every SQLite row a single task owns, including the task row.
+ *
+ * Sub-tasks are NOT deleted — `parentTaskId` is `ON DELETE SET NULL` in the
+ * schema, so a child of a deleted task is detached and survives. Removing it
+ * would destroy work the user did not ask to delete, and neither the live path
+ * nor the replay path ever claimed to.
+ *
+ * Idempotent. Callers are expected to wrap this in a transaction where one is
+ * available.
+ */
+export async function purgeTaskRows(
+  sqlite: TaskPurgeTarget,
+  taskId: string
+): Promise<void> {
+  await runAll(sqlite, TASK_OWNED_STATEMENTS, taskId);
+}

--- a/tests/unit/ConversationDeleteOrphans.test.ts
+++ b/tests/unit/ConversationDeleteOrphans.test.ts
@@ -10,6 +10,12 @@
  *
  * The conversation tombstone itself was already correct — the conversation does
  * not come back — so this is the live path catching up to the replay path.
+ *
+ * The second gap measured in the same run WAS deferred: the stream directory
+ * `Nexus/data/conversations/conv_<id>/` survived both the delete and the
+ * rebuild, because removing it needed the `deleteStream` chain that landed with
+ * #347. That chain is on main now, so it is wired up here — the follow-up the
+ * PR description promised.
  */
 
 import { ConversationRepository } from '../../src/database/repositories/ConversationRepository';
@@ -49,7 +55,7 @@ describe('ConversationRepository.delete', () => {
       jsonlWriter,
       queryCache: new QueryCache()
     };
-    return { deps, statements, vaultEventStore };
+    return { deps, statements, vaultEventStore, jsonlWriter };
   }
 
   it('deletes the messages too, instead of trusting a cascade that never fires', async () => {
@@ -66,16 +72,61 @@ describe('ConversationRepository.delete', () => {
     expect(deletes.every(s => s.params[0] === CONV)).toBe(true);
   });
 
-  it('still writes the tombstone first, so the delete survives a rebuild', async () => {
-    const { deps, vaultEventStore } = build();
+  it('removes the conversation stream, which carries the messages too', async () => {
+    const { deps, jsonlWriter, vaultEventStore } = build();
+    await jsonlWriter.appendEvents(`conversations/conv_${CONV}.jsonl`, [
+      { type: 'conversation_created', conversationId: CONV, data: { id: CONV, title: 'T' } },
+      { type: 'message_added', conversationId: CONV, data: { id: 'msg-1', role: 'user', content: 'hi' } }
+    ] as never);
+    expect(await vaultEventStore.listFiles('conversations'))
+      .toContain(`conversations/conv_${CONV}.jsonl`);
 
     await new ConversationRepository(deps).delete(CONV);
 
+    // Pre-fix the directory survived the delete AND the rebuild: the tombstone
+    // kept the rows out of the cache, but the source of truth was still there.
+    expect(await vaultEventStore.listFiles('conversations'))
+      .not.toContain(`conversations/conv_${CONV}.jsonl`);
+  });
+
+  it('writes the tombstone before removing the stream, so a failed removal still cancels out', async () => {
+    const { deps, jsonlWriter } = build();
+    const appendSpy = jest.spyOn(jsonlWriter, 'appendEvent');
+    const removeSpy = jest.spyOn(jsonlWriter, 'deleteStream');
+
+    await new ConversationRepository(deps).delete(CONV);
+
+    expect(appendSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith(`conversations/conv_${CONV}.jsonl`);
+    expect(appendSpy.mock.invocationCallOrder[0])
+      .toBeLessThan(removeSpy.mock.invocationCallOrder[0]);
+  });
+
+  it('leaves the tombstone behind and does not touch SQLite when the stream cannot be removed', async () => {
+    const { deps, jsonlWriter, vaultEventStore, statements } = build();
+    jest.spyOn(jsonlWriter, 'deleteStream').mockRejectedValue(new Error('vault is locked'));
+
+    await expect(new ConversationRepository(deps).delete(CONV))
+      .rejects.toThrow('vault is locked');
+
+    expect(statements.filter(s => /^\s*DELETE/i.test(s.sql))).toEqual([]);
     const events = await vaultEventStore.readEvents<{ type: string; conversationId?: string }>(
       `conversations/conv_${CONV}.jsonl`
     );
     expect(events).toEqual([
       expect.objectContaining({ type: 'conversation_deleted', conversationId: CONV })
     ]);
+  });
+
+  it('does not delete a sibling conversation stream', async () => {
+    const { deps, jsonlWriter, vaultEventStore } = build();
+    await jsonlWriter.appendEvents(`conversations/conv_bystander.jsonl`, [
+      { type: 'conversation_created', conversationId: 'bystander', data: { id: 'bystander', title: 'B' } }
+    ] as never);
+
+    await new ConversationRepository(deps).delete(CONV);
+
+    expect(await vaultEventStore.listFiles('conversations'))
+      .toContain('conversations/conv_bystander.jsonl');
   });
 });

--- a/tests/unit/ConversationDeleteOrphans.test.ts
+++ b/tests/unit/ConversationDeleteOrphans.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Regression test for the live conversation delete.
+ *
+ * `ConversationEventApplier.applyConversationDeleted` has always removed the
+ * messages explicitly, but `ConversationRepository.delete` relied on the
+ * `ON DELETE CASCADE` declared on `messages.conversationId`. FK enforcement is
+ * off on this connection, so the cascade never fired: measured in a real vault,
+ * deleting a 1-message conversation left `conversations 0, messages 1`, and the
+ * orphan only disappeared at the next `rebuildCache()`.
+ *
+ * The conversation tombstone itself was already correct — the conversation does
+ * not come back — so this is the live path catching up to the replay path.
+ */
+
+import { ConversationRepository } from '../../src/database/repositories/ConversationRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEventStore';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { createMockApp } from '../helpers/mockVaultAdapter';
+
+const CONV = 'conv-target';
+
+describe('ConversationRepository.delete', () => {
+  function build() {
+    const { app } = createMockApp({ withLocalStorage: true });
+    const vaultEventStore = new VaultEventStore({
+      app,
+      resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+    });
+    const jsonlWriter = new JSONLWriter({
+      app,
+      basePath: '.obsidian/plugins/nexus/data',
+      readBasePaths: ['.obsidian/plugins/nexus/data'],
+      vaultEventStore
+    });
+    const statements: Array<{ sql: string; params: unknown[] }> = [];
+    const cache = {
+      run: jest.fn(async (sql: string, params: unknown[] = []) => {
+        statements.push({ sql, params });
+        return undefined;
+      }),
+      query: jest.fn(async () => []),
+      queryOne: jest.fn(async () => null),
+      transaction: jest.fn((fn: () => Promise<unknown>) => fn())
+    };
+    const deps: RepositoryDependencies = {
+      sqliteCache: cache as never,
+      jsonlWriter,
+      queryCache: new QueryCache()
+    };
+    return { deps, statements, vaultEventStore };
+  }
+
+  it('deletes the messages too, instead of trusting a cascade that never fires', async () => {
+    const { deps, statements } = build();
+
+    await new ConversationRepository(deps).delete(CONV);
+
+    const deletes = statements.filter(s => /^\s*DELETE/i.test(s.sql));
+    // Pre-fix this was the conversations row alone.
+    expect(deletes.map(s => s.sql)).toEqual([
+      expect.stringMatching(/DELETE FROM messages WHERE conversationId = \?/i),
+      expect.stringMatching(/DELETE FROM conversations WHERE id = \?/i)
+    ]);
+    expect(deletes.every(s => s.params[0] === CONV)).toBe(true);
+  });
+
+  it('still writes the tombstone first, so the delete survives a rebuild', async () => {
+    const { deps, vaultEventStore } = build();
+
+    await new ConversationRepository(deps).delete(CONV);
+
+    const events = await vaultEventStore.readEvents<{ type: string; conversationId?: string }>(
+      `conversations/conv_${CONV}.jsonl`
+    );
+    expect(events).toEqual([
+      expect.objectContaining({ type: 'conversation_deleted', conversationId: CONV })
+    ]);
+  });
+});

--- a/tests/unit/SessionDeleteOwnership.test.ts
+++ b/tests/unit/SessionDeleteOwnership.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Regression tests for permanent session deletion.
+ *
+ * Before the fix, `deleteSession` ran a single
+ * `DELETE FROM sessions WHERE id = ?` and wrote NO event at all — the
+ * `session_deleted` type did not exist (`grep -rn "session_deleted" src/`
+ * returned nothing). Measured in a real vault (Obsidian 1.13.7, headless),
+ * deleting a session holding 2 states / 2 traces / 1 trace embedding left:
+ *
+ *   after delete : sessions 0, states 2, memory_traces 2, trace_embedding_metadata 1
+ *   after rebuild: sessions 1, states 2, memory_traces 2
+ *
+ * i.e. the session itself came BACK, because the workspace stream still held
+ * `session_created` and replay had no tombstone to cancel it with. Every test
+ * here fails against that code.
+ */
+
+import { SessionRepository } from '../../src/database/repositories/SessionRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { WorkspaceEventApplier } from '../../src/database/sync/WorkspaceEventApplier';
+import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEventStore';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { SyncCoordinator, type ISQLiteCacheManager } from '../../src/database/sync/SyncCoordinator';
+import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { createMockApp } from '../helpers/mockVaultAdapter';
+
+const WS = 'ws-owner';
+const SESSION = 'sess-target';
+const BYSTANDER = 'sess-bystander';
+
+/**
+ * Records every statement so a test can ask "what did the cache actually see?",
+ * and answers the one read the delete makes (the session's workspaceId).
+ */
+function createRecordingSqlite() {
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  const cache = {
+    run: jest.fn(async (sql: string, params: unknown[] = []) => {
+      statements.push({ sql, params });
+      return undefined;
+    }),
+    query: jest.fn(async () => []),
+    queryOne: jest.fn(async (sql: string, params: unknown[] = []) => {
+      if (/FROM sessions/i.test(sql)) {
+        return { id: params[0], workspaceId: WS, name: 'S', startTime: 1, isActive: 1 };
+      }
+      return null;
+    }),
+    transaction: jest.fn((fn: () => Promise<unknown>) => fn()),
+    getSyncState: jest.fn(async () => null),
+    updateSyncState: jest.fn(async () => undefined),
+    isEventApplied: jest.fn(async () => false),
+    markEventApplied: jest.fn(async () => undefined),
+    clearAllData: jest.fn(async () => undefined),
+    rebuildFTSIndexes: jest.fn(async () => undefined),
+    save: jest.fn(async () => undefined)
+  };
+  const tablesTouchedBy = (verb: string): string[] =>
+    statements
+      .filter(s => s.sql.trim().toUpperCase().startsWith(verb))
+      .map(s => {
+        const m = s.sql.match(/(?:DELETE FROM|INSERT (?:OR (?:REPLACE|IGNORE) )?INTO|UPDATE)\s+([a-zA-Z_]+)/i);
+        return m ? m[1] : s.sql;
+      });
+  return { cache, statements, tablesTouchedBy };
+}
+
+function build() {
+  const { app } = createMockApp({ withLocalStorage: true });
+  const vaultEventStore = new VaultEventStore({
+    app,
+    resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+  });
+  const jsonlWriter = new JSONLWriter({
+    app,
+    basePath: '.obsidian/plugins/nexus/data',
+    readBasePaths: ['.obsidian/plugins/nexus/data'],
+    vaultEventStore
+  });
+  const { cache, statements, tablesTouchedBy } = createRecordingSqlite();
+  const deps: RepositoryDependencies = {
+    sqliteCache: cache as never,
+    jsonlWriter,
+    queryCache: new QueryCache()
+  };
+  return { app, vaultEventStore, jsonlWriter, cache, statements, tablesTouchedBy, deps };
+}
+
+/** The events a real workspace stream carries for a session with children. */
+async function seedWorkspaceStream(jsonlWriter: JSONLWriter) {
+  await jsonlWriter.appendEvents(`workspaces/ws_${WS}.jsonl`, [
+    { type: 'workspace_created', data: { id: WS, name: 'Owner', rootFolder: '/', created: 1 } },
+    { type: 'session_created', workspaceId: WS, data: { id: SESSION, name: 'S1', startTime: 2 } },
+    { type: 'session_created', workspaceId: WS, data: { id: BYSTANDER, name: 'S2', startTime: 3 } },
+    { type: 'state_saved', workspaceId: WS, sessionId: SESSION, data: { id: 'st-1', name: 'St1', created: 4, stateJson: '{}' } },
+    { type: 'state_saved', workspaceId: WS, sessionId: SESSION, data: { id: 'st-2', name: 'St2', created: 5, stateJson: '{}' } },
+    { type: 'trace_added', workspaceId: WS, sessionId: SESSION, data: { id: 'tr-1', content: 'trace', traceType: 'note' } },
+    { type: 'state_saved', workspaceId: WS, sessionId: BYSTANDER, data: { id: 'st-3', name: 'St3', created: 6, stateJson: '{}' } }
+  ] as never);
+}
+
+describe('permanent session delete removes everything the session owns', () => {
+  // ==========================================================================
+  // The replay half. This is what decides the outcome of `rebuildCache()`.
+  // ==========================================================================
+  describe('WorkspaceEventApplier: replaying session_deleted', () => {
+    const tombstone = {
+      id: 'evt-del',
+      type: 'session_deleted',
+      deviceId: 'dev',
+      timestamp: 10,
+      workspaceId: WS,
+      sessionId: SESSION
+    };
+
+    it('purges every session-keyed table, not just the sessions row', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      // Pre-fix this array was empty: the applier had no case for the event
+      // type at all, and the switch has no default branch.
+      expect(tablesTouchedBy('DELETE')).toEqual(
+        expect.arrayContaining([
+          'trace_embedding_metadata',
+          'states',
+          'memory_traces',
+          'sessions'
+        ])
+      );
+    });
+
+    it('deletes the sessions row last, so nothing is orphaned mid-purge', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const deleted = tablesTouchedBy('DELETE');
+      expect(deleted.indexOf('sessions')).toBe(deleted.length - 1);
+      expect(deleted.indexOf('states')).toBeLessThan(deleted.indexOf('sessions'));
+      expect(deleted.indexOf('memory_traces')).toBeLessThan(deleted.indexOf('sessions'));
+    });
+
+    it('scopes every statement to the session, never to the workspace', async () => {
+      const { cache, statements } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const deletes = statements.filter(s => /^\s*DELETE/i.test(s.sql));
+      expect(deletes.length).toBeGreaterThan(0);
+      for (const statement of deletes) {
+        expect(statement.params).not.toContain(WS);
+      }
+    });
+
+    it('leaves conversations alone — they outlive the session by design', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      expect(tablesTouchedBy('DELETE')).not.toContain('conversations');
+      expect(tablesTouchedBy('DELETE')).not.toContain('messages');
+    });
+
+    it('ignores a tombstone with no sessionId rather than purging everything', async () => {
+      const { cache, tablesTouchedBy } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply({ ...tombstone, sessionId: '' } as never);
+
+      expect(tablesTouchedBy('DELETE')).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // The live delete, wired to a real event store over a real (mock) vault.
+  // ==========================================================================
+  describe('SessionRepository.delete over a real event store', () => {
+    it('writes a session_deleted tombstone into the parent workspace stream', async () => {
+      const { jsonlWriter, vaultEventStore, deps } = build();
+      await seedWorkspaceStream(jsonlWriter);
+
+      await new SessionRepository(deps).delete(SESSION);
+
+      const events = await vaultEventStore.readEvents<{ type: string; sessionId?: string }>(
+        `workspaces/ws_${WS}.jsonl`
+      );
+      // Pre-fix: no event of any kind was written by a session delete.
+      expect(events.filter(e => e.type === 'session_deleted')).toEqual([
+        expect.objectContaining({ type: 'session_deleted', sessionId: SESSION, workspaceId: WS })
+      ]);
+    });
+
+    it('never removes the workspace stream — it is shared with the workspace and its siblings', async () => {
+      const { jsonlWriter, vaultEventStore, deps } = build();
+      await seedWorkspaceStream(jsonlWriter);
+
+      await new SessionRepository(deps).delete(SESSION);
+
+      expect(await vaultEventStore.listFiles('workspaces')).toContain(`workspaces/ws_${WS}.jsonl`);
+      const events = await vaultEventStore.readEvents<{ type: string; data?: { id?: string } }>(
+        `workspaces/ws_${WS}.jsonl`
+      );
+      expect(events.some(e => e.type === 'workspace_created')).toBe(true);
+      expect(
+        events.some(e => e.type === 'session_created' && e.data?.id === BYSTANDER)
+      ).toBe(true);
+    });
+
+    it('purges the session-keyed SQLite tables, not just the sessions row', async () => {
+      const { jsonlWriter, deps, tablesTouchedBy } = build();
+      await seedWorkspaceStream(jsonlWriter);
+
+      await new SessionRepository(deps).delete(SESSION);
+
+      // Pre-fix this array was exactly ['sessions'].
+      expect(tablesTouchedBy('DELETE')).toEqual(
+        expect.arrayContaining(['states', 'memory_traces', 'sessions'])
+      );
+    });
+
+    it('writes the tombstone before it touches the cache', async () => {
+      const { jsonlWriter, deps, cache } = build();
+      await seedWorkspaceStream(jsonlWriter);
+      const appendSpy = jest.spyOn(jsonlWriter, 'appendEvent');
+
+      await new SessionRepository(deps).delete(SESSION);
+
+      expect(appendSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        cache.run.mock.invocationCallOrder[0]
+      );
+    });
+
+    describe('partial failure', () => {
+      it('does not touch SQLite when the tombstone cannot be written, so the delete stays retryable', async () => {
+        const { jsonlWriter, deps, tablesTouchedBy } = build();
+        await seedWorkspaceStream(jsonlWriter);
+        jest.spyOn(jsonlWriter, 'appendEvent').mockRejectedValue(new Error('vault is locked'));
+
+        await expect(new SessionRepository(deps).delete(SESSION)).rejects.toThrow('vault is locked');
+
+        // Pre-fix the sessions row was deleted regardless — a session that
+        // stopped listing and came straight back on the next rebuild.
+        expect(tablesTouchedBy('DELETE')).toEqual([]);
+      });
+
+      it('refuses to delete a session that does not exist rather than writing a stray tombstone', async () => {
+        const { jsonlWriter, vaultEventStore, deps } = build();
+        await seedWorkspaceStream(jsonlWriter);
+        const repo = new SessionRepository(deps);
+        jest.spyOn(repo, 'getById').mockResolvedValue(null);
+
+        await expect(repo.delete('ghost')).rejects.toThrow(/not found/i);
+
+        const events = await vaultEventStore.readEvents<{ type: string }>(
+          `workspaces/ws_${WS}.jsonl`
+        );
+        expect(events.some(e => e.type === 'session_deleted')).toBe(false);
+      });
+    });
+  });
+
+  // ==========================================================================
+  // The rebuild path — the only test that proves the delete is real.
+  // ==========================================================================
+  describe('rebuildCache() after a delete', () => {
+    /**
+     * A session has no stream of its own, so replay legitimately re-inserts the
+     * session, its states and its traces before reaching the tombstone. What has
+     * to be true is that the tombstone comes after and cancels them — the net
+     * effect being an empty session. Row-level proof needs a real SQLite (the
+     * wasm is mocked in Jest); it is in the live rig. Here we pin the ordering
+     * property that produces it.
+     */
+    it('ends the replay of the session with a purge, not an insert', async () => {
+      const { jsonlWriter, deps, cache, statements } = build();
+      await seedWorkspaceStream(jsonlWriter);
+
+      await new SessionRepository(deps).delete(SESSION);
+
+      // Everything up to here is setup; the rebuild is the assertion.
+      statements.length = 0;
+      const coordinator = new SyncCoordinator(
+        jsonlWriter as never,
+        cache as unknown as ISQLiteCacheManager
+      );
+      const result = await coordinator.fullRebuild();
+
+      expect(result.success).toBe(true);
+
+      const touchingSession = statements.filter(s =>
+        JSON.stringify(s.params).includes(SESSION)
+      );
+      const purges = touchingSession.filter(s => /^\s*DELETE/i.test(s.sql));
+      // Pre-fix this was zero: the stream still held session_created,
+      // state_saved and trace_added, and nothing in the replay removed them —
+      // the measured `sessions 0 → 1` across a rebuild.
+      expect(purges.length).toBeGreaterThan(0);
+
+      const lastTouch = touchingSession[touchingSession.length - 1];
+      expect(lastTouch.sql).toMatch(/DELETE FROM sessions/i);
+
+      // Every insert for this session is undone by a later purge.
+      const lastInsert = touchingSession
+        .map((s, i) => ({ s, i }))
+        .filter(({ s }) => /^\s*INSERT/i.test(s.sql))
+        .pop();
+      const firstPurge = touchingSession.findIndex(s => /^\s*DELETE/i.test(s.sql));
+      expect(lastInsert).toBeDefined();
+      expect(firstPurge).toBeGreaterThan((lastInsert as { i: number }).i);
+
+      // The rebuild must still restore the rest of the workspace.
+      const writes = statements.filter(s => /^\s*INSERT/i.test(s.sql));
+      expect(writes.some(s => JSON.stringify(s.params).includes(BYSTANDER))).toBe(true);
+      expect(writes.some(s => JSON.stringify(s.params).includes(WS))).toBe(true);
+    });
+  });
+});

--- a/tests/unit/SessionDeleteOwnership.test.ts
+++ b/tests/unit/SessionDeleteOwnership.test.ts
@@ -22,6 +22,8 @@ import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEvent
 import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
 import { SyncCoordinator, type ISQLiteCacheManager } from '../../src/database/sync/SyncCoordinator';
 import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { purgeSessionRows } from '../../src/database/sessionOwnership';
+import { SCHEMA_SQL } from '../../src/database/schema/schema';
 import { createMockApp } from '../helpers/mockVaultAdapter';
 
 const WS = 'ws-owner';
@@ -86,6 +88,28 @@ function build() {
   return { app, vaultEventStore, jsonlWriter, cache, statements, tablesTouchedBy, deps };
 }
 
+/**
+ * A `tool_operation_started` event, as `ToolOperationRepository.start` writes it
+ * — into `workspaces/ws_<id>.jsonl`, the SAME stream the session's own events
+ * live in.
+ */
+function receiptStarted(operationId: string, sessionId: string) {
+  return {
+    type: 'tool_operation_started',
+    workspaceId: WS,
+    data: {
+      operationId,
+      signature: `sig-${operationId}`,
+      origin: 'native-chat',
+      workspaceId: WS,
+      sessionId,
+      replayPolicy: 'never',
+      replayable: false,
+      commandSummary: 'content write --path a.md'
+    }
+  };
+}
+
 /** The events a real workspace stream carries for a session with children. */
 async function seedWorkspaceStream(jsonlWriter: JSONLWriter) {
   await jsonlWriter.appendEvents(`workspaces/ws_${WS}.jsonl`, [
@@ -95,9 +119,122 @@ async function seedWorkspaceStream(jsonlWriter: JSONLWriter) {
     { type: 'state_saved', workspaceId: WS, sessionId: SESSION, data: { id: 'st-1', name: 'St1', created: 4, stateJson: '{}' } },
     { type: 'state_saved', workspaceId: WS, sessionId: SESSION, data: { id: 'st-2', name: 'St2', created: 5, stateJson: '{}' } },
     { type: 'trace_added', workspaceId: WS, sessionId: SESSION, data: { id: 'tr-1', content: 'trace', traceType: 'note' } },
-    { type: 'state_saved', workspaceId: WS, sessionId: BYSTANDER, data: { id: 'st-3', name: 'St3', created: 6, stateJson: '{}' } }
+    { type: 'state_saved', workspaceId: WS, sessionId: BYSTANDER, data: { id: 'st-3', name: 'St3', created: 6, stateJson: '{}' } },
+    receiptStarted('op-target', SESSION),
+    receiptStarted('op-bystander', BYSTANDER)
   ] as never);
 }
+
+/**
+ * Every table `SCHEMA_SQL` declares, with the `sessionId` column declaration if
+ * it has one. Parsed rather than hand-listed so a table added later cannot slip
+ * past the completeness test below.
+ */
+function sessionKeyedTables(): Array<{ table: string; notNull: boolean }> {
+  const found: Array<{ table: string; notNull: boolean }> = [];
+  const createTable = /CREATE\s+(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)([^;]*);/gi;
+  for (const match of SCHEMA_SQL.matchAll(createTable)) {
+    const [, table, body] = match;
+    for (const line of body.split('\n')) {
+      if (line.includes('FOREIGN KEY')) continue;
+      const column = line.trim().match(/^sessionId\s+TEXT(\s+NOT\s+NULL)?/i);
+      if (column) {
+        found.push({ table, notNull: Boolean(column[1]) });
+        break;
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * The purge list has to be complete against the schema, and "complete" has a
+ * mechanical definition here: a NOT NULL `sessionId` means the row cannot exist
+ * without the session, so the session owns it and deleting the session must
+ * delete it. A nullable `sessionId` is a back-reference to an entity that
+ * outlives the session, and purging it would destroy data nobody asked to
+ * delete.
+ *
+ * This is the check that would have caught `tool_operation_receipts`: it arrived
+ * with schema 15, after this branch was cut, and merged in with no textual
+ * conflict at all.
+ */
+describe('the session purge list is complete against SCHEMA_SQL', () => {
+  /**
+   * Nullable `sessionId`, deliberately NOT purged as ownership. Each entry
+   * carries the reason it is excluded, so adding one is a decision rather than
+   * an omission.
+   */
+  const DELIBERATE_EXCLUSIONS: Record<string, string> = {
+    conversations:
+      'first-class entity with its own event stream; sessionId is a nullable ' +
+      'back-reference and the conversation outlives the session',
+    conversation_embedding_metadata:
+      'keyed to conversations, which are excluded above, and embeddings are not ' +
+      'replayable from JSONL'
+  };
+
+  /**
+   * Nullable `sessionId`, but purged anyway — the rows are derived from
+   * `memory_traces`, which the session does own, so leaving them would strand
+   * embeddings pointing at traces that no longer exist.
+   */
+  const PURGED_DESPITE_NULLABLE = ['trace_embedding_metadata'];
+
+  function tablesPurgedBySession(): Promise<string[]> {
+    const touched: string[] = [];
+    const sqlite = {
+      run: async (sql: string) => {
+        const match = sql.match(/DELETE FROM\s+(\w+)/i);
+        if (match) touched.push(match[1]);
+      },
+      query: async () => []
+    };
+    return purgeSessionRows(sqlite, SESSION).then(() => touched);
+  }
+
+  it('purges every table whose sessionId is NOT NULL', async () => {
+    const owned = sessionKeyedTables()
+      .filter(t => t.notNull)
+      .map(t => t.table);
+    const purged = await tablesPurgedBySession();
+
+    // Not an empty-set tautology: if the parse ever stops finding tables this
+    // test would pass vacuously.
+    expect(owned.length).toBeGreaterThanOrEqual(3);
+    expect(owned).toEqual(
+      expect.arrayContaining(['states', 'memory_traces', 'tool_operation_receipts'])
+    );
+    for (const table of owned) {
+      expect(purged).toContain(table);
+    }
+  });
+
+  it('purges nothing whose sessionId is nullable except the documented cases', async () => {
+    const nullable = sessionKeyedTables()
+      .filter(t => !t.notNull)
+      .map(t => t.table);
+    const purged = await tablesPurgedBySession();
+
+    expect(nullable.length).toBeGreaterThan(0);
+    for (const table of nullable) {
+      if (PURGED_DESPITE_NULLABLE.includes(table)) {
+        expect(purged).toContain(table);
+        continue;
+      }
+      // A nullable sessionId that is neither purged nor documented means
+      // somebody added a table and nobody decided what a delete should do
+      // with it.
+      expect(Object.keys(DELIBERATE_EXCLUSIONS)).toContain(table);
+      expect(purged).not.toContain(table);
+    }
+  });
+
+  it('purges the sessions row itself, last', async () => {
+    const purged = await tablesPurgedBySession();
+    expect(purged[purged.length - 1]).toBe('sessions');
+  });
+});
 
 describe('permanent session delete removes everything the session owns', () => {
   // ==========================================================================
@@ -126,9 +263,32 @@ describe('permanent session delete removes everything the session owns', () => {
           'trace_embedding_metadata',
           'states',
           'memory_traces',
+          'tool_operation_receipts',
           'sessions'
         ])
       );
+    });
+
+    /**
+     * `tool_operation_receipts` (schema 15) landed after this branch was cut and
+     * merged into it without a single textual conflict, which is exactly how a
+     * purge list goes stale. Its `sessionId` is TEXT NOT NULL, so a session owns
+     * its receipts by the same rule that makes it own its states and traces —
+     * and its events are appended to the same workspace stream, so replay
+     * re-creates them right before it reaches the tombstone.
+     */
+    it('purges the tool operation receipts the session owns', async () => {
+      const { cache, statements } = createRecordingSqlite();
+      const applier = new WorkspaceEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const receiptPurge = statements.find(s =>
+        /DELETE FROM tool_operation_receipts/i.test(s.sql)
+      );
+      expect(receiptPurge).toBeDefined();
+      expect(receiptPurge?.sql).toMatch(/WHERE\s+sessionId\s*=\s*\?/i);
+      expect(receiptPurge?.params).toEqual([SESSION]);
     });
 
     it('deletes the sessions row last, so nothing is orphaned mid-purge', async () => {
@@ -141,6 +301,7 @@ describe('permanent session delete removes everything the session owns', () => {
       expect(deleted.indexOf('sessions')).toBe(deleted.length - 1);
       expect(deleted.indexOf('states')).toBeLessThan(deleted.indexOf('sessions'));
       expect(deleted.indexOf('memory_traces')).toBeLessThan(deleted.indexOf('sessions'));
+      expect(deleted.indexOf('tool_operation_receipts')).toBeLessThan(deleted.indexOf('sessions'));
     });
 
     it('scopes every statement to the session, never to the workspace', async () => {
@@ -219,7 +380,12 @@ describe('permanent session delete removes everything the session owns', () => {
 
       // Pre-fix this array was exactly ['sessions'].
       expect(tablesTouchedBy('DELETE')).toEqual(
-        expect.arrayContaining(['states', 'memory_traces', 'sessions'])
+        expect.arrayContaining([
+          'states',
+          'memory_traces',
+          'tool_operation_receipts',
+          'sessions'
+        ])
       );
     });
 
@@ -313,10 +479,36 @@ describe('permanent session delete removes everything the session owns', () => {
       expect(lastInsert).toBeDefined();
       expect(firstPurge).toBeGreaterThan((lastInsert as { i: number }).i);
 
+      // The receipts specifically: replay re-inserts the target session's
+      // receipt from `tool_operation_started` in the same stream, and the
+      // tombstone has to remove it again. Without the purge line the row is
+      // reproduced on every single rebuild.
+      const receiptInsert = touchingSession.findIndex(s =>
+        /INSERT[\s\S]*INTO tool_operation_receipts/i.test(s.sql)
+      );
+      const receiptPurge = touchingSession.findIndex(s =>
+        /DELETE FROM tool_operation_receipts/i.test(s.sql)
+      );
+      expect(receiptInsert).toBeGreaterThanOrEqual(0);
+      expect(receiptPurge).toBeGreaterThan(receiptInsert);
+
       // The rebuild must still restore the rest of the workspace.
       const writes = statements.filter(s => /^\s*INSERT/i.test(s.sql));
       expect(writes.some(s => JSON.stringify(s.params).includes(BYSTANDER))).toBe(true);
       expect(writes.some(s => JSON.stringify(s.params).includes(WS))).toBe(true);
+
+      // The bystander session's receipt is a bystander too.
+      const survivingReceipts = statements.filter(
+        s => /INSERT[\s\S]*INTO tool_operation_receipts/i.test(s.sql)
+          && JSON.stringify(s.params).includes(BYSTANDER)
+      );
+      expect(survivingReceipts.length).toBe(1);
+      expect(
+        statements.some(
+          s => /DELETE FROM tool_operation_receipts/i.test(s.sql)
+            && JSON.stringify(s.params).includes(BYSTANDER)
+        )
+      ).toBe(false);
     });
   });
 });

--- a/tests/unit/TaskDeleteOwnership.test.ts
+++ b/tests/unit/TaskDeleteOwnership.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for project and task deletion.
+ *
+ * Both the live delete and the replay of it said "CASCADE will handle it".
+ * It does not — SQLite foreign-key enforcement is per-connection and off by
+ * default, and nothing in this plugin turns it on. Measured in a real vault
+ * (Obsidian 1.13.7, headless):
+ *
+ *   delete a project with 3 tasks / 1 dependency edge / 1 note link
+ *     after delete : projects 0, tasks 3, task_dependencies 1, task_note_links 1
+ *     after rebuild: projects 0, tasks 3, task_dependencies 1, task_note_links 1
+ *
+ *   delete a single task with 1 incoming dependency / 1 note link / 1 child
+ *     after delete : task_dependencies 1, task_note_links 1, child.parentTaskId = <deleted id>
+ *     after rebuild: identical
+ *
+ * The rebuild reproduces the orphans rather than clearing them, because replay
+ * re-creates every task from `task_created` and then drops only the parent row.
+ * Every test here fails against that code.
+ */
+
+import { ProjectRepository } from '../../src/database/repositories/ProjectRepository';
+import { TaskRepository } from '../../src/database/repositories/TaskRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { TaskEventApplier } from '../../src/database/sync/TaskEventApplier';
+import { VaultEventStore } from '../../src/database/storage/vaultRoot/VaultEventStore';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { type ISQLiteCacheManager } from '../../src/database/sync/SyncCoordinator';
+import { QueryCache } from '../../src/database/optimizations/QueryCache';
+import { createMockApp } from '../helpers/mockVaultAdapter';
+
+const WS = 'ws-tasks';
+const PROJECT = 'proj-target';
+const TASK = 'task-target';
+
+function createRecordingSqlite(row: Record<string, unknown> | null) {
+  const statements: Array<{ sql: string; params: unknown[] }> = [];
+  const cache = {
+    run: jest.fn(async (sql: string, params: unknown[] = []) => {
+      statements.push({ sql, params });
+      return undefined;
+    }),
+    query: jest.fn(async () => []),
+    queryOne: jest.fn(async () => row),
+    transaction: jest.fn((fn: () => Promise<unknown>) => fn()),
+    getSyncState: jest.fn(async () => null),
+    updateSyncState: jest.fn(async () => undefined),
+    isEventApplied: jest.fn(async () => false),
+    markEventApplied: jest.fn(async () => undefined),
+    clearAllData: jest.fn(async () => undefined),
+    rebuildFTSIndexes: jest.fn(async () => undefined),
+    save: jest.fn(async () => undefined)
+  };
+  const touched = (verb: string): string[] =>
+    statements
+      .filter(s => s.sql.trim().toUpperCase().startsWith(verb))
+      .map(s => {
+        const m = s.sql.match(/(?:DELETE FROM|INSERT (?:OR (?:REPLACE|IGNORE) )?INTO|UPDATE)\s+([a-zA-Z_]+)/i);
+        return m ? m[1] : s.sql;
+      });
+  return { cache, statements, touched };
+}
+
+function buildDeps(row: Record<string, unknown> | null) {
+  const { app } = createMockApp({ withLocalStorage: true });
+  const vaultEventStore = new VaultEventStore({
+    app,
+    resolution: { resolvedPath: 'Nexus', dataPath: 'Nexus/data', maxShardBytes: 4096 }
+  });
+  const jsonlWriter = new JSONLWriter({
+    app,
+    basePath: '.obsidian/plugins/nexus/data',
+    readBasePaths: ['.obsidian/plugins/nexus/data'],
+    vaultEventStore
+  });
+  const recording = createRecordingSqlite(row);
+  const deps: RepositoryDependencies = {
+    sqliteCache: recording.cache as never,
+    jsonlWriter,
+    queryCache: new QueryCache()
+  };
+  return { ...recording, jsonlWriter, vaultEventStore, deps };
+}
+
+describe('deleting a project takes its tasks with it', () => {
+  const tombstone = {
+    id: 'evt-proj-del',
+    type: 'project_deleted',
+    deviceId: 'dev',
+    timestamp: 10,
+    projectId: PROJECT
+  };
+
+  describe('TaskEventApplier: replaying project_deleted', () => {
+    it('removes the tasks and their edges, not just the projects row', async () => {
+      const { cache, touched } = createRecordingSqlite(null);
+      const applier = new TaskEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      // Pre-fix this array was exactly ['projects'].
+      expect(touched('DELETE')).toEqual(
+        expect.arrayContaining(['task_dependencies', 'task_note_links', 'tasks', 'projects'])
+      );
+    });
+
+    it('resolves the edges through tasks before the tasks rows are gone', async () => {
+      const { cache, touched } = createRecordingSqlite(null);
+      const applier = new TaskEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const deleted = touched('DELETE');
+      expect(deleted.indexOf('task_dependencies')).toBeLessThan(deleted.indexOf('tasks'));
+      expect(deleted.indexOf('task_note_links')).toBeLessThan(deleted.indexOf('tasks'));
+      expect(deleted.indexOf('projects')).toBe(deleted.length - 1);
+    });
+
+    it('detaches surviving sub-tasks instead of deleting them (parentTaskId is SET NULL)', async () => {
+      const { cache, statements } = createRecordingSqlite(null);
+      const applier = new TaskEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const detach = statements.find(s => /UPDATE tasks SET parentTaskId = NULL/i.test(s.sql));
+      expect(detach).toBeDefined();
+      // and it runs while the tasks it references still exist
+      const detachIndex = statements.indexOf(detach as { sql: string; params: unknown[] });
+      const taskDelete = statements.findIndex(s => /DELETE FROM tasks/i.test(s.sql));
+      expect(detachIndex).toBeLessThan(taskDelete);
+    });
+  });
+
+  describe('ProjectRepository.delete', () => {
+    it('writes the tombstone and purges the tasks the project owns', async () => {
+      const { deps, touched, vaultEventStore } = buildDeps({
+        id: PROJECT, workspaceId: WS, name: 'P', status: 'active', created: 1, updated: 1
+      });
+
+      await new ProjectRepository(deps).delete(PROJECT);
+
+      const events = await vaultEventStore.readEvents<{ type: string }>(`tasks/tasks_${WS}.jsonl`);
+      expect(events.some(e => e.type === 'project_deleted')).toBe(true);
+      // Pre-fix: ['projects'] only, so the three tasks stayed in the cache.
+      expect(touched('DELETE')).toEqual(
+        expect.arrayContaining(['task_dependencies', 'task_note_links', 'tasks', 'projects'])
+      );
+    });
+
+    it('scopes the purge to this project, never to the whole workspace', async () => {
+      const { deps, statements } = buildDeps({
+        id: PROJECT, workspaceId: WS, name: 'P', status: 'active', created: 1, updated: 1
+      });
+
+      await new ProjectRepository(deps).delete(PROJECT);
+
+      for (const statement of statements.filter(s => /^\s*(DELETE|UPDATE)/i.test(s.sql))) {
+        expect(statement.params).not.toContain(WS);
+        expect(statement.params.every(p => p === PROJECT)).toBe(true);
+      }
+    });
+  });
+});
+
+describe('deleting a task takes its edges with it', () => {
+  const tombstone = {
+    id: 'evt-task-del',
+    type: 'task_deleted',
+    deviceId: 'dev',
+    timestamp: 11,
+    taskId: TASK
+  };
+
+  describe('TaskEventApplier: replaying task_deleted', () => {
+    it('removes dependency edges and note links, and detaches children', async () => {
+      const { cache, touched, statements } = createRecordingSqlite(null);
+      const applier = new TaskEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      // Pre-fix this array was exactly ['tasks'].
+      expect(touched('DELETE')).toEqual(
+        expect.arrayContaining(['task_dependencies', 'task_note_links', 'tasks'])
+      );
+      expect(statements.some(s => /UPDATE tasks SET parentTaskId = NULL/i.test(s.sql))).toBe(true);
+    });
+
+    it('removes edges in both directions — a task is also a dependency of others', async () => {
+      const { cache, statements } = createRecordingSqlite(null);
+      const applier = new TaskEventApplier(cache as unknown as ISQLiteCacheManager);
+
+      await applier.apply(tombstone as never);
+
+      const edges = statements.find(s => /DELETE FROM task_dependencies/i.test(s.sql));
+      expect(edges?.sql).toMatch(/taskId = \?/i);
+      expect(edges?.sql).toMatch(/dependsOnTaskId = \?/i);
+    });
+  });
+
+  describe('TaskRepository.delete', () => {
+    it('purges the edges alongside the task row', async () => {
+      const { deps, touched } = buildDeps({
+        id: TASK, projectId: PROJECT, workspaceId: WS, title: 'T', status: 'todo',
+        priority: 'medium', created: 1, updated: 1
+      });
+
+      await new TaskRepository(deps).delete(TASK);
+
+      expect(touched('DELETE')).toEqual(
+        expect.arrayContaining(['task_dependencies', 'task_note_links', 'tasks'])
+      );
+    });
+  });
+});


### PR DESCRIPTION
Companion to #347. Same family, three different failures.

Rebased onto #347 (`adec3542`). Two things changed in the rebase beyond conflict resolution — see **Post-rebase additions** at the bottom.

## Sessions: the delete was cache-only by construction

`session_deleted` **did not exist as an event type**. `grep -rn "session_deleted" src/` returned nothing, so `deleteSession` wrote no event, replay had nothing to apply, and the row came back on the next rebuild.

Measured on a seeded vault — 1 workspace, 2 sessions, 2 states + 2 traces + 1 trace-embedding row on the target:

| | pre-fix after delete | pre-fix after rebuild | post-fix |
|---|---|---|---|
| sessions | 0 | **1 — resurrected** | 0, still 0 after rebuild |
| states | 2 | 2 | 0 |
| memory_traces | 2 | 2 | 0 |
| trace_embedding_metadata | 1 | 1 | 0 |

Bystander session, its state and trace, the workspace, and the linked conversation are all untouched — pinned by tests.

**A session owns no stream.** Its events live in the parent workspace's shared stream, so none of #347's stream-removal machinery applies here: the tombstone *is* the removal. There is a test asserting the workspace stream and the sibling session survive.

## Projects and tasks: the same unenforced-FK shape

Deleting a project with 3 tasks, 1 dependency edge and 1 note link left `tasks 3, task_dependencies 1, task_note_links 1` — and the rebuild **reproduced** them.

Single-task delete leaked too: `task_dependencies 1, task_note_links 1`, and a child task's `parentTaskId` still pointing at the deleted parent.

`taskOwnership.ts` handles both. Note the parent link is `SET NULL`, not `CASCADE`, so sub-tasks are **detached rather than deleted** — that is the declared intent, and the fix honours it instead of cascading.

## Conversations: two gaps, both now fixed

The live delete left **1 orphan `messages` row** that only self-healed on rebuild. Fixed here — it needed nothing from #347.

The stream-directory leak was deferred to #347's `deleteStream` chain. That chain is on main now, so **the deferred one-liner has landed** (see below).

## Migration: none, deliberately

The only signal of a pre-fix delete is "present in JSONL, absent from SQLite" — which is **indistinguishable from a cold or partial cache**. Backfilling would turn rebuildable state into permanent loss.

Verified in both directions live: a stream written by the pre-fix build shows the session back, and one re-delete makes it permanent through a rebuild; and an unknown event type injected into a real stream is silently dropped with the rebuild succeeding — which is exactly how an older build will treat `session_deleted`.

No migration is added and none is needed: `CURRENT_SCHEMA_VERSION` stays at **15**. This branch touches neither `schema.ts` nor `SchemaMigrator.ts`, so it does not contend with #346 for a version number.

## Partial failure

Tombstone first, cache second, in both fixes. A failed tombstone throws before touching SQLite and is a retryable no-op (tested: zero statements issued). A failed purge leaves a stale cache over an event store that already says deleted, and the next rebuild converges on deleted. The reverse order converges on resurrection — the measured bug.

---

## Post-rebase additions

### 1. `tool_operation_receipts` was silently missing from the session purge

#356 added `tool_operation_receipts` (schema 15) after this branch was cut, and it merged in with **zero textual conflicts** — which is exactly how a purge list goes stale. Its `sessionId` is `TEXT NOT NULL`, so a session owns its receipts by the same rule that makes it own its states and traces, and the receipt events are appended to `workspaces/ws_<id>.jsonl` (`ToolOperationRepository.path`) — the *same* stream the session's own events live in, so the tombstone is their JSONL-side removal too.

Without the line, a session delete left every receipt orphaned, and every rebuild faithfully reproduced them: replay re-applies `tool_operation_started` before it reaches the tombstone. This is the session-side twin of the line #347 added to `workspaceOwnership.ts` for the same table.

**Completeness is now mechanical rather than asserted.** `SessionDeleteOwnership` parses `SCHEMA_SQL` and requires that:

| table | `sessionId` | disposition |
|---|---|---|
| `states` | NOT NULL | purged |
| `memory_traces` | NOT NULL | purged |
| `tool_operation_receipts` | NOT NULL | purged — **this was the gap** |
| `trace_embedding_metadata` | nullable | purged anyway: derived from `memory_traces`, which the session does own |
| `conversations` | nullable | **excluded** — first-class entity with its own stream, outlives the session |
| `conversation_embedding_metadata` | nullable | **excluded** — keyed to conversations, excluded above |

A NOT NULL `sessionId` that is not purged fails the test; a nullable one that is neither purged nor listed with a documented reason also fails. A table added later cannot slip past it.

### 2. The deferred conversation `deleteStream` one-liner

`ConversationRepository.delete` now removes the conversation's own stream after writing the tombstone, using #347's `deleteStream` chain. The conversation's stream also carries its messages (`MessageRepository.jsonlPath` resolves to the same file), so one removal covers both.

Ordering follows `WorkspaceRepository.delete`: tombstone → stream → SQLite. A failed stream removal throws before the cache is touched, leaving the tombstone on disk and the delete a retryable no-op.

This makes conversation deletion permanent, which is safe because the path is UI-only — ChatView → ConversationManager → ChatService → ConversationService → `adapter.deleteConversation`. No tool reaches it, so nothing AI-reachable gained a destructive delete. `JSONLWriter.deleteStream`'s doc comment, which named the workspace delete as its only caller, is updated accordingly.

## Evidence

- `npx tsc --noEmit --skipLibCheck` — clean.
- `npx jest --runInBand` — **4746 passing, 0 failing**, 37 skipped.
- `npm run build` — green, including `schemas:check` (79 CLI tools / 2 MCP tools unchanged) and the mobile-reachability scan. No generated-source drift.
- `check_schema_consistency.py` — `CURRENT_SCHEMA_VERSION`, `MIGRATIONS` and `SCHEMA_SQL` agree at 15.

Discrimination, measured against `adec3542`'s repository and applier code: `SessionDeleteOwnership` 9/16 fail, `ConversationDeleteOrphans` 4/5 fail, `TaskDeleteOwnership` 7/8 fail.

Mutation-tested per fix:

- Deleting `'DELETE FROM tool_operation_receipts WHERE sessionId = ?'` → **5 tests fail**, including the rebuild-ordering one that shows the receipt re-inserted and never removed.
- Deleting the `deleteStream` call in `ConversationRepository.delete` → **3 tests fail**, including the partial-failure one.

Nothing tool-reachable was added — sessions are context fields, no tool deletes one, and conversation deletion remains UI-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
