### PR TITLE
Disclose what Nexus talks to, and stop identifying as another project

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,34 @@ Native chat works on mobile (iOS and Android). Desktop-only features gracefully 
 
 Mobile support is new and may have bugs. Please [report issues on GitHub](https://github.com/ProfSynapse/nexus/issues).
 
+## Network Use
+
+**Nexus does not call out on its own.** Nothing is sent when the plugin loads, and there is no telemetry, analytics, crash reporting, or usage tracking of any kind. Your notes stay in your vault unless you do something that sends them somewhere. Every request below is listed with the action that causes it.
+
+**AI provider APIs.** Contacted only once you enter that provider's API key and then use it. Your prompt — and whatever vault content the agent decides to include — goes to the provider you chose, and your key is only ever sent to the provider it belongs to.
+
+| | |
+|---|---|
+| Chat and models | `openrouter.ai`, `api.openai.com`, `api.anthropic.com`, `generativelanguage.googleapis.com`, `api.mistral.ai`, `api.groq.com`, `api.deepseek.com`, `api.perplexity.ai`, `router.requesty.ai`, `api.githubcopilot.com` |
+| Voice and transcription | `api.elevenlabs.io`, `api.deepgram.com`, `api.assemblyai.com`, `streaming.assemblyai.com` |
+| Sign-in flows | `auth.openai.com` and `chatgpt.com` (OpenAI Codex), `api.github.com` (GitHub Copilot) |
+
+Ollama and LM Studio talk to your own machine and leave it entirely.
+
+**Downloads for optional desktop features.** A few features fetch their engine the first time you enable them, rather than shipping inside `main.js` — the download is cached and does not repeat. Never enabling the feature means never making the request.
+
+| Feature | Downloads from |
+|---|---|
+| Semantic search | `cdn.jsdelivr.net` (transformers.js), `huggingface.co` (embedding model) |
+| Vector cache | `cdn.jsdelivr.net` or `unpkg.com` (`sqlite3.wasm`) |
+| Data analysis | `cdn.jsdelivr.net` (Pyodide), `files.pythonhosted.org` (openpyxl) |
+| PDF ingestion | `cdn.jsdelivr.net` (pdf.js worker) |
+| In-browser local models | `cdn.jsdelivr.net`, `esm.run`, `huggingface.co`, `raw.githubusercontent.com` (model weights) |
+
+**Housekeeping.** Opening Nexus settings checks for a newer version (`api.github.com`, `raw.githubusercontent.com`). Asking an agent to load the built-in guides workspace fetches the current guides (`raw.githubusercontent.com`).
+
+**Not requests.** Two things look like external hosts but aren't. Calls to OpenRouter and Requesty carry `HTTP-Referer: https://synapticlabs.ai` and `X-Title: Nexus` — the app-attribution headers those routers show in their dashboards. They are header *values*; nothing is fetched from that address. And buttons like *Download Node.js* or *Get an API key* open `nodejs.org`, `ollama.com`, `lmstudio.ai`, `claude.ai`, `github.com`, or the provider's own console (`platform.openai.com`, `console.anthropic.com`, `aistudio.google.com`, and so on) **in your browser** — the plugin never retrieves them.
+
 ## Use Cases
 
 | If you want to... | Start here |

--- a/src/services/llm/adapters/BaseAdapter.ts
+++ b/src/services/llm/adapters/BaseAdapter.ts
@@ -22,6 +22,7 @@ import {
   SearchResult,
   ToolCall
 } from './types';
+import { BRAND_NAME } from '../../../constants/branding';
 import { BaseCache, CacheManager } from '../utils/CacheManager';
 import { LLMCostCalculator } from '../utils/LLMCostCalculator';
 import { TokenUsageExtractor } from '../utils/TokenUsageExtractor';
@@ -667,7 +668,11 @@ export abstract class BaseAdapter {
   protected buildHeaders(additionalHeaders?: Record<string, string>): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      'User-Agent': 'Synaptic-Lab-Kit/1.0.0',
+      // Every adapter that calls buildHeaders() advertises this to its provider.
+      // It said 'Synaptic-Lab-Kit/1.0.0' until 2026-08-15 — another project's
+      // name, left behind by the rename. Adapters that must impersonate a
+      // specific client (GithubCopilotAdapter) override it deliberately.
+      'User-Agent': BRAND_NAME,
       ...additionalHeaders
     };
 

--- a/src/services/llm/adapters/requesty/RequestyAdapter.ts
+++ b/src/services/llm/adapters/requesty/RequestyAdapter.ts
@@ -4,6 +4,7 @@
  * Based on Requesty streaming documentation
  */
 
+import { BRAND_NAME } from '../../../../constants/branding';
 import { BaseAdapter } from '../BaseAdapter';
 import {
   GenerateOptions,
@@ -111,9 +112,13 @@ export class RequestyAdapter extends BaseAdapter {
         headers: {
           ...this.buildHeaders(),
           'Authorization': `Bearer ${this.apiKey}`,
-          'HTTP-Referer': 'https://synaptic-lab-kit.com',
-          'X-Title': 'Synaptic Lab Kit',
-          'User-Agent': 'Synaptic-Lab-Kit/1.0.0'
+          // Attribution only — these are header VALUES that show up in Requesty's
+          // dashboard, not request targets. Nothing is ever fetched from the
+          // referer. They read 'synaptic-lab-kit.com' / 'Synaptic Lab Kit' until
+          // 2026-08-15: a paste from another project, pointing at a domain that
+          // no longer resolves. Keep them in step with the OpenRouter adapters.
+          'HTTP-Referer': 'https://synapticlabs.ai',
+          'X-Title': BRAND_NAME
         },
         body: JSON.stringify({
           model: options?.model || this.currentModel,
@@ -221,9 +226,10 @@ export class RequestyAdapter extends BaseAdapter {
       headers: {
         ...this.buildHeaders(),
         'Authorization': `Bearer ${this.apiKey}`,
-        'HTTP-Referer': 'https://synaptic-lab-kit.com',
-        'X-Title': 'Synaptic Lab Kit',
-        'User-Agent': 'Synaptic-Lab-Kit/1.0.0'
+        // See the note on the streaming request above: attribution headers, not
+        // request targets.
+        'HTTP-Referer': 'https://synapticlabs.ai',
+        'X-Title': BRAND_NAME
       },
       body: JSON.stringify(requestBody),
       timeoutMs: 60_000


### PR DESCRIPTION
Obsidian's community scorecard asks that external network calls be disclosed in the README and made only with user knowledge. The README said nothing about networking at all. Tracing the domains it lists turned up a stale identity in our outbound headers as well.

## The README section

The scorecard's domain list is not usable as-is — it flattens three different things into one list:

- actual outbound requests,
- `HTTP-Referer` header **values**,
- and `window.open` targets that hand off to the user's browser.

Transcribing it would have claimed Nexus contacts sites it never touches. The new `## Network Use` section separates them, and groups the real requests by the action that triggers them.

The load-bearing claim — nothing fires at plugin load, no telemetry — is verified rather than assumed. Both automatic-looking callers turn out to be user-triggered: `UpdateManager` runs only from `SettingsView`, and the guides fetch only from `memoryManager loadWorkspace`. (Every apparent "telemetry" grep hit was `ToolStatu`**`sEntry`** colliding case-insensitively with "sentry".)

Audited in both directions: every host named in the README exists in `src/`, and every `https://` host in `src/` is either listed or provably a `signupUrl:` link. That caught `api.githubcopilot.com`, a real chat endpoint I had first mis-filed as a browser link.

## The header fix

`BaseAdapter.buildHeaders()` sent `User-Agent: Synaptic-Lab-Kit/1.0.0`, so every adapter inheriting it — Requesty, OpenRouter, Perplexity, the OpenAI deep-research handler — announced a different project's name to its provider. `RequestyAdapter` also hardcoded `HTTP-Referer: https://synaptic-lab-kit.com` and `X-Title: Synaptic Lab Kit` at both request sites.

All of it predates the Nexus rename (`8f1be1a3`), and that referer domain no longer resolves, so Requesty's dashboard was attributing this plugin's traffic to a dead address. Every sibling adapter already used `synapticlabs.ai` and `BRAND_NAME`.

`GithubCopilotAdapter` keeps its `GitHubCopilotChat/0.17.1` User-Agent — that one impersonates a specific client deliberately, because Copilot's API requires it.

## Testing

`327/327` suites, `4298/4298` tests pass. (`verifyInObsidianScript` fails only on machines with `/Applications/Obsidian.app` on PATH, where the real binary shadows the test's `obsidian-cli` stub — pre-existing and unrelated; it passes with a hermetic PATH.)

## Follow-ups filed

Tracing the CDN hosts for the disclosure produced #350 (no integrity verification on any of the seven runtime fetches) and a correction on #349, whose "inline the pdf.js worker" suggestion does not survive the arithmetic — 2.22 MB payload against 0.54 MB of bundle headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
