### PR TITLE
Declare the Obsidian version Nexus actually needs (minAppVersion 1.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Release](https://img.shields.io/github/v/release/ProfSynapse/claudesidian-mcp?label=release)](https://github.com/ProfSynapse/claudesidian-mcp/releases)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Obsidian](https://img.shields.io/badge/Obsidian-1.6%2B-6f42c1)](https://obsidian.md/plugins)
+[![Obsidian](https://img.shields.io/badge/Obsidian-1.10%2B-6f42c1)](https://obsidian.md/plugins)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-43853d)](package.json)
 
 # Nexus MCP for Obsidian

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,36 +200,21 @@ export default defineConfig([
         },
     },
 
-    // Bases API (1.10.0) vs minAppVersion (1.8.7) — the ONE file allowed to
-    // name it. `obsidianmd/no-unsupported-api` is right that
-    // `Plugin.registerBasesView` and `BasesView` post-date minAppVersion; this
-    // file is the runtime guard the rule is asking for and exists precisely so
-    // nothing else has to reference those symbols:
-    //   - `registerBasesView` is read once, behind `typeof === 'function'`, and
-    //     bound; on an older app the whole feature (and its agent) is absent.
-    //   - `BasesView` is dereferenced only inside the view factory, which
-    //     Obsidian calls only when the Bases API exists. At module scope it
-    //     would be `class extends undefined` and would take plugin init down.
-    // Inline eslint-disable is blocked for obsidianmd rules (the
-    // obsidian-releases bot rejects it), so this is handled at config level —
-    // the same pattern as the no-nodejs-modules block above.
+    // NOTE — there used to be a block here turning `obsidianmd/no-unsupported-api`
+    // off for `basesAvailability.ts` and `baseResultHarvester.ts`, on the grounds
+    // that the Bases API (1.10.0) post-dated `minAppVersion` (1.8.7) but was
+    // reached only behind runtime guards. The reasoning was sound and the code
+    // still carries those guards — but the suppression could never achieve its
+    // purpose: Obsidian's community scanner runs this rule with its own config
+    // and never reads ours, so it reported all 23 sites on every published
+    // version regardless. Community review also disallows suppressing this rule.
     //
-    // `baseResultHarvester.ts` is exempt for the same reason, one step further
-    // out: it reads `BasesQueryResult` / `BasesEntry` / `BasesEntryGroup` off a
-    // live view. The only thing that ever calls it is the analyze runner, which
-    // only runs once Obsidian has constructed a `nexus-analyze` view — which
-    // requires the Bases API to exist AND the agent to have been registered,
-    // which `ensureAnalyzeViewRegistered` gates. On an app without Bases the
-    // whole agent is absent, so there is no reachable path to these symbols.
-    {
-        files: [
-            "src/agents/baseManager/services/basesAvailability.ts",
-            "src/agents/baseManager/services/baseResultHarvester.ts",
-        ],
-        rules: {
-            "obsidianmd/no-unsupported-api": "off",
-        },
-    },
+    // Fixed properly in 5.18.0 by raising `minAppVersion` to 1.10.0, which is
+    // simply true — Nexus does name Bases APIs. Users below 1.10.0 are not
+    // stranded: `versions.json` pins 5.17.1 at 1.8.7, so Obsidian offers them
+    // that build instead. The rule now guards these files for real; do not add
+    // the exemption back. If it fires, the code named an API newer than the
+    // manifest claims, which is a fact to fix rather than silence.
 
     // ── Mobile-safety import guard for shared UI primitives (issue #221) ─────
     // src/settings/components/** holds the primitives every settings surface

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "nexus",
   "name": "Nexus",
   "version": "5.17.1",
-  "minAppVersion": "1.8.7",
+  "minAppVersion": "1.10.0",
   "description": "Agentic AI for your vault. Use Claude, ChatGPT, Gemini, and local models to chat, search, create, and manage your notes with semantic memory, image generation, and MCP server integration.",
   "author": "Synaptic Labs",
   "authorUrl": "https://github.com/ProfSynapse",

--- a/tests/unit/basesViewLazyBinding.test.ts
+++ b/tests/unit/basesViewLazyBinding.test.ts
@@ -2,12 +2,22 @@
  * `BasesView` must never be dereferenced at module load.
  *
  * `src/agents/baseManager/services/basesAvailability.ts` imports `BasesView`
- * from 'obsidian' as a VALUE, and `BasesView` is `@since 1.10.0` — newer than
- * the manifest's `minAppVersion` of 1.8.7. That is only safe because esbuild
- * emits `obsidian` as an external CJS require, so the binding resolves as a
- * property access (`import_obsidian.BasesView`) at call time, inside
- * `createAnalyzeView`, rather than when the module is evaluated. On an Obsidian
- * without the Bases API the property is simply never read.
+ * from 'obsidian' as a VALUE. Until 5.18.0 that was unsafe on its face —
+ * `BasesView` is `@since 1.10.0` and `minAppVersion` was 1.8.7 — and this test
+ * existed to prove the binding was nonetheless lazy. `minAppVersion` is 1.10.0
+ * now, so the version gap is gone and that original reason with it.
+ *
+ * The invariant is still worth pinning, for a narrower reason: Bases is a CORE
+ * PLUGIN that the user can disable, and `registerBasesView` is documented to
+ * return false when Bases is not enabled in the vault. Whether `BasesView`
+ * itself is absent from the module in that state is NOT something we have
+ * verified, so the lazy binding stays as defence in depth rather than because
+ * we know it is load-bearing.
+ *
+ * It is safe because esbuild emits `obsidian` as an external CJS require, so
+ * the binding resolves as a property access (`import_obsidian.BasesView`) at
+ * call time, inside `createAnalyzeView`, rather than when the module is
+ * evaluated. Where the property is missing it is simply never read.
  *
  * The whole guarantee therefore rests on the emitted shape, not on the source.
  * Change `format` away from `cjs`, or hoist the `class ... extends BasesView`
@@ -24,7 +34,9 @@
  * module scope and never used does NOT trip these tests — it never reaches the
  * bundle. Only a *reachable* top-level dereference is caught. That is the shape
  * a real regression has (the class is returned by the factory, so it is kept),
- * but do not read a green run here as "no post-1.8.7 symbol is used eagerly".
+ * but do not read a green run here as "no post-1.10.0 symbol is used eagerly".
+ * `obsidianmd/no-unsupported-api` is the check for that, and as of 5.18.0 it is
+ * active on these files — the config exemption it used to have was removed.
  */
 import * as esbuild from 'esbuild';
 import path from 'path';


### PR DESCRIPTION
Clears the 23 `obsidianmd/no-unsupported-api` errors on the community scorecard.

## The finding is correct

`basesAvailability.ts` and `baseResultHarvester.ts` name Bases APIs that are all `@since 1.10.0`, while `manifest.json` claimed `minAppVersion: 1.8.7`.

The code was safe, which is a different claim:

- **19 of 23 sites** are in `baseResultHarvester.ts`, whose import is `import type { ... } from 'obsidian'`. Those symbols are erased at compile time — `BasesEntry` appears **0 times in `main.js`**.
- **The other 4** are the only runtime references: `registerBasesView` behind `typeof === 'function'`, `class extends BasesView` inside a factory Obsidian only calls when Bases exists (pinned by `tests/unit/basesViewLazyBinding.test.ts`), and `this.config?.name` inside that class.

But safety was never what the rule checks. The manifest asserted Nexus runs on 1.8.7 while the source named 1.10.0 APIs, and that assertion was false.

## Why the previous mitigation could not have worked

`eslint.config.mjs` turned the rule off for these two files, with a careful comment explaining the runtime guards. That reasoning was sound and the guards remain — but the suppression was structurally incapable of doing its job: **Obsidian's scanner runs the rule with its own config and never reads ours.** Our lint stayed green while every published version was reported with all 23 errors. Community review also disallows suppressing this rule.

The exemption is removed. `--print-config` now resolves `obsidianmd/no-unsupported-api` to **severity 2** on both files, and `npm run lint` is clean — the rule passes on its merits rather than being silenced.

## Nobody gets stranded

`versions.json` pins **5.17.1 → 1.8.7**. Per [Obsidian's documented fallback](https://docs.obsidian.md/Reference/Versions), a user below 1.10.0 is offered that build rather than a failed install. They stop receiving updates; they keep a working plugin.

The cost is small: Bases shipped in 1.9.0 and went GA in 1.9.10, but the plugin API this code uses arrived in **1.10.0 on 2025-10-01** — three minor versions behind current (1.13.4), on an auto-updating app.

## Also

- README's Obsidian badge said 1.6+; now 1.10+.
- `basesViewLazyBinding.test.ts` kept, header corrected. Its original rationale (the version gap) is gone, but Bases is a core plugin the user can disable, and whether `BasesView` is absent in that state is **not** something we verified — so the lazy binding stays as defence in depth, and the header now says so rather than implying it is load-bearing.

## Not included

The `getSettingDefinitions()` warning wants **1.13.0** — a much larger jump for a Warning rather than an Error. Deliberately left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
