### PR TITLE
Fix load-state after incomplete storage migration

### DIFF
--- a/.codex/skills/nexus-storage/references/failure-modes.md
+++ b/.codex/skills/nexus-storage/references/failure-modes.md
@@ -26,6 +26,28 @@ default, so an unknown type is dropped in silence during replay.
 Fix: write through the repository (event first, then cache) and add the `case` to
 the applier. Re-verify by rebuilding the cache again and confirming survival.
 
+## "A list tool returns an entity, but loading it by ID or name says not found"
+
+Check `pluginStorage.migration.state` before blaming the point lookup. Affected
+builds could keep legacy roots readable but disable `VaultEventStore` reads
+during a pending or failed cutover, even though writes already went to the
+vault-root destination. SQLite could still contain metadata replayed from those
+shards. The result was a split read path: list queries saw the SQLite row, while
+repositories that needed the JSONL body saw only legacy files and returned null.
+A just-created entity could appear healthy until reload because its body was
+still in the repository's in-memory write cache.
+
+Confirm all three facts before changing data: the metadata row lists, the event
+body exists under the resolved vault-root stream, and the persisted migration
+state is `pending` or `failed`. Do not hand-copy or edit shards. Fix the cutover
+read policy or resolve the migration conflict, then verify a cold point lookup;
+an in-session lookup can be a cache hit and is not proof.
+
+The runtime invariant is: read the configured vault-root destination first at
+every migration phase, retain legacy roots only as fallbacks until verification,
+and let `StorageRouter` deduplicate by event ID. After verified cutover, remove
+the legacy fallbacks but keep destination reads enabled.
+
 ## "Data reappeared after a rebuild"
 
 The inverse: something deleted from SQLite without appending a deletion event.

--- a/.codex/skills/nexus-storage/refinement-log.md
+++ b/.codex/skills/nexus-storage/refinement-log.md
@@ -4,6 +4,15 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
 
 <!-- YYYY-MM-DD | observation | change made | file(s) touched -->
 
+- 2026-08-23 | A failed vault-root migration left SQLite state metadata visible
+  to `list-states` while `load-state` could not read the intact `state_saved`
+  body in the destination shard. Fresh states worked only from the repository's
+  in-memory cache. The symptom map had no entry for this split read policy. |
+  Added a failure-mode entry that checks the persisted migration state, proves
+  metadata/event/cache behavior separately, forbids shard repair by hand, and
+  records the destination-first read invariant for every migration phase. |
+  references/failure-modes.md.
+
 - 2026-08-14 | The hydration-gate entry said "await `waitForQueryReady()`", and the
   notes-index startup did exactly that and still failed: the background startup
   rebuild never left the `running` phase, so the gate resolved false after its 120s

--- a/.codex/skills/nexus-testing/protocols/live-loop.md
+++ b/.codex/skills/nexus-testing/protocols/live-loop.md
@@ -57,8 +57,13 @@ Obsidian (the headless container) to turn a skip into a failure.
    | `nexus` | `--vault <name>` | `$NEXUS_VAULT`, else the single open vault |
 
    Because `obsidian`'s default follows window focus, an unattended run MUST
-   pass `vault=<name>` explicitly. Confine every write to one scratch folder in
-   that vault and touch nothing else.
+   pass `vault=<name>` explicitly. Immediately verify the target with
+   `obsidian vault vault=<name> info=name` before any write. On a multi-window
+   macOS install the CLI has been observed silently ignoring a spaced vault name
+   and continuing against the focused renderer; a successful command is not
+   proof that targeting worked. If the reported name is wrong, stop rather than
+   running diagnostics or mutations against the fallback vault. Confine every
+   write to one scratch folder in the verified vault and touch nothing else.
 
 2. **Build before you reload.** Reload only after a build that succeeded in the
    same run, or you will spend the loop diagnosing the previous bundle.

--- a/.codex/skills/nexus-testing/refinement-log.md
+++ b/.codex/skills/nexus-testing/refinement-log.md
@@ -4,6 +4,13 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
 
 <!-- YYYY-MM-DD | observation | change made | file(s) touched -->
 
+2026-08-23 | On a multi-window macOS install, `obsidian eval vault="Rose N
+Thorn" ...` and `obsidian vault vault="Rose N Thorn" info=name` both returned
+the focused `Code` vault without an error. The live-loop treated an explicit
+vault argument as sufficient proof of targeting. | Added a mandatory harmless
+vault-name probe and a stop condition when the CLI silently falls back to the
+focused renderer. | `protocols/live-loop.md`, `refinement-log.md`.
+
 2026-08-21 | On macOS, the packaged verifier put `vault=<name>` before the CLI
 subcommand, while the installed CLI accepted `obsidian eval vault=<name> ...`.
 The existing stubs accepted arguments in any order and hid the defect. | Moved

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -401,12 +401,14 @@ export class HybridStorageAdapter implements IStorageAdapter {
     this.jsonlWriter.setBasePath(plan.vaultWriteBasePath);
     const migrationComplete = plan.state.migration.state === 'verified'
       || plan.state.migration.state === 'not_needed';
-    // Legacy roots are migration inputs, not permanent read replicas. Keeping
-    // them active after cutover can resurrect deleted data and race cloud-sync
-    // deletion/placeholder operations during every startup read.
+    // The configured vault root is the active write destination at every
+    // migration phase, so it must also remain the first read source. Otherwise
+    // events written while migration is pending or failed are invisible after
+    // an in-memory cache miss. Legacy roots remain fallback inputs only until
+    // cutover; StorageRouter reads vault-root first and deduplicates by event ID.
     this.jsonlWriter.setReadBasePaths(migrationComplete ? [] : plan.legacyReadBasePaths);
     this.jsonlWriter.setVaultEventStore(this.vaultEventStore);
-    this.jsonlWriter.setVaultEventStoreReadEnabled(migrationComplete);
+    this.jsonlWriter.setVaultEventStoreReadEnabled(true);
     this.sqliteCache.setDbPath(plan.pluginCacheDbPath);
     this.wireReconcilePipeline();
   }

--- a/tests/unit/HybridStorageAdapter.test.ts
+++ b/tests/unit/HybridStorageAdapter.test.ts
@@ -8,6 +8,10 @@ import { StartupHydrationController } from '../../src/database/adapters/lifecycl
 import { InitLifecycleController } from '../../src/database/adapters/lifecycle/InitLifecycleController';
 import { ReconciliationCoordinator } from '../../src/database/adapters/lifecycle/ReconciliationCoordinator';
 import { ConversationEventApplier } from '../../src/database/sync/ConversationEventApplier';
+import { JSONLWriter } from '../../src/database/storage/JSONLWriter';
+import { StateRepository } from '../../src/database/repositories/StateRepository';
+import type { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+import { createMockApp } from '../helpers/mockVaultAdapter';
 
 describe('HybridStorageAdapter', () => {
   afterEach(() => {
@@ -106,7 +110,7 @@ describe('HybridStorageAdapter', () => {
       expect(adapter.sqliteCache.setDbPath).toHaveBeenCalledWith('.obsidian/plugins/claudesidian-mcp/data/cache.db');
     });
 
-    it('keeps detected legacy roots readable while migration is pending', () => {
+    it('keeps the destination and detected legacy roots readable while migration is pending', () => {
       const adapter = Object.create(HybridStorageAdapter.prototype) as HybridStorageAdapter & {
         app: unknown;
         basePath: string;
@@ -155,7 +159,134 @@ describe('HybridStorageAdapter', () => {
         '.obsidian/plugins/claudesidian-mcp/data',
         '.nexus'
       ]);
-      expect(adapter.jsonlWriter.setVaultEventStoreReadEnabled).toHaveBeenCalledWith(false);
+      expect(adapter.jsonlWriter.setVaultEventStoreReadEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('reads the configured destination before legacy fallbacks after migration fails', async () => {
+      const { app } = createMockApp({
+        withLocalStorage: true,
+        initialFiles: {
+          '.nexus/workspaces/ws_ws-1.jsonl': [
+            JSON.stringify({
+              id: 'shared-event',
+              type: 'state_saved',
+              deviceId: 'legacy',
+              timestamp: 1,
+              workspaceId: 'ws-1',
+              sessionId: 'session-1',
+              data: { id: 'shared-state', name: 'Legacy copy', created: 1, stateJson: '{}' }
+            }),
+            JSON.stringify({
+              id: 'legacy-only',
+              type: 'state_saved',
+              deviceId: 'legacy',
+              timestamp: 2,
+              workspaceId: 'ws-1',
+              sessionId: 'session-1',
+              data: { id: 'legacy-state', name: 'Legacy state', created: 2, stateJson: '{}' }
+            })
+          ].join('\n') + '\n',
+          'Nexus/data/workspaces/ws_ws-1/shard-000001.jsonl': [
+            JSON.stringify({
+              id: 'shared-event',
+              type: 'state_saved',
+              deviceId: 'vault-root',
+              timestamp: 3,
+              workspaceId: 'ws-1',
+              sessionId: 'session-1',
+              data: { id: 'shared-state', name: 'Vault copy', created: 3, stateJson: '{}' }
+            }),
+            JSON.stringify({
+              id: 'vault-only-state',
+              type: 'state_saved',
+              deviceId: 'vault-root',
+              timestamp: 4,
+              workspaceId: 'ws-1',
+              sessionId: 'session-1',
+              data: {
+                id: 'state-1',
+                name: 'Chapter checkpoint',
+                created: 4,
+                stateJson: JSON.stringify({ chapter: 7 })
+              }
+            })
+          ].join('\n') + '\n'
+        }
+      });
+      const writer = new JSONLWriter({
+        app,
+        basePath: '.nexus',
+        readBasePaths: ['.nexus']
+      });
+      const adapter = Object.create(HybridStorageAdapter.prototype) as HybridStorageAdapter & {
+        app: typeof app;
+        jsonlWriter: JSONLWriter;
+        sqliteCache: { setDbPath: jest.Mock<void, [string]> };
+      };
+      adapter.app = app;
+      adapter.jsonlWriter = writer;
+      adapter.sqliteCache = { setDbPath: jest.fn() };
+
+      (adapter as unknown as { applyStoragePlan: (plan: unknown) => void }).applyStoragePlan({
+        vaultWriteBasePath: 'Nexus/data',
+        legacyReadBasePaths: ['.nexus'],
+        pluginCacheDbPath: '.obsidian/plugins/claudesidian-mcp/data/cache.db',
+        state: {
+          storageVersion: 2,
+          sourceOfTruthLocation: 'legacy-dotnexus',
+          migration: {
+            state: 'failed',
+            legacySourcesDetected: ['.nexus'],
+            activeDestination: 'Nexus/data'
+          }
+        },
+        roots: {},
+        vaultRoot: {
+          configuredPath: 'Nexus',
+          resolvedPath: 'Nexus',
+          dataPath: 'Nexus/data',
+          guidesPath: 'Nexus/guides',
+          maxShardBytes: 1024
+        }
+      });
+
+      const events = await writer.readEvents('workspaces/ws_ws-1.jsonl');
+
+      expect(events.map(event => event.id)).toEqual([
+        'shared-event',
+        'vault-only-state',
+        'legacy-only'
+      ]);
+      expect(events.find(event => event.id === 'shared-event')?.deviceId).toBe('vault-root');
+
+      const repository = new StateRepository({
+        sqliteCache: {
+          queryOne: jest.fn().mockResolvedValue({
+            id: 'state-1',
+            workspaceId: 'ws-1',
+            sessionId: 'session-1',
+            name: 'Chapter checkpoint',
+            description: null,
+            created: 4,
+            tagsJson: null
+          }),
+          query: jest.fn(),
+          run: jest.fn(),
+          transaction: jest.fn()
+        },
+        jsonlWriter: writer,
+        queryCache: {
+          cachedQuery: jest.fn((_key: string, fn: () => Promise<unknown>) => fn()),
+          invalidateByType: jest.fn(),
+          invalidateById: jest.fn(),
+          invalidate: jest.fn()
+        }
+      } as unknown as RepositoryDependencies);
+
+      await expect(repository.getStateData('state-1')).resolves.toMatchObject({
+        id: 'state-1',
+        content: { chapter: 7 }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- keep the configured vault-root destination readable during pending and failed migrations
- retain legacy event roots only as fallback reads until migration verification
- add a cold-read regression proving destination-first deduplication and `StateRepository` body loading
- document the split-read failure mode and safer Obsidian vault targeting

## Root cause

The storage cutover gate disabled `VaultEventStore` reads before migration verification while writes already targeted the vault root. SQLite could therefore list state metadata whose `state_saved` body was invisible to `load-state`. Fresh states could appear healthy because `StateRepository` still held their bodies in memory.

## Verification

- `npx jest tests/unit/HybridStorageAdapter.test.ts --runInBand --no-coverage`
- targeted storage/memory slice: 125 tests passed
- `npm test -- --runInBand`: 4,618 passed, 36 skipped
- `npm run build`
- rebuilt plugin reloaded in the verified `Code` vault with no `dev:errors`
- read-only Nexus CLI memory command succeeded against the reloaded bundle
- Nexus storage/testing skill validation and drift checks passed
