### PR TITLE
fix: resolve chatService lazily so subagents survive a plugin reload

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@
 - **Nothing about read-only commands is recorded.** Receipts cover commands that change things; reading a note never copies its contents into the event log.
 
 **Fixes**
+- **Subagents work again after a plugin reload.** Chat is rebuilt by Obsidian before Nexus has finished starting its services, and the chat view was holding on to the empty slot where the chat service would later appear. Subagent setup then failed every time the plugin reloaded, so asking an agent to delegate work answered "Subagent executor not initialized" and the agent status panel stayed empty until the chat tab was closed and reopened. Chat now looks the service up when it needs it.
 - **Gemini's thinking is now actually visible.** Reasoning displayed for every other provider but never for Gemini: Google only returns a model's thought summaries when the request asks for them, and Nexus never asked. Gemini models now stream their reasoning into chat like the rest.
 - Saved states could disappear after a storage migration that had not finished. Nexus stopped reading the destination folder until the migration was verified, while already writing there — so a state's metadata was listed but its contents could not be loaded, and fresh states only appeared to work because they were still held in memory ([#355](https://github.com/ProfSynapse/nexus/pull/355)).
 - Switching between providers is more reliable. Each provider now owns its own setup and cleanup, so disposing of one can no longer interfere with the one replacing it.

--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -117,10 +117,21 @@ export class ChatView extends ItemView {
   // Layout elements
   private layoutElements!: ChatLayoutElements;
 
+  /**
+   * `chatService` is NOT guaranteed to be present here. Obsidian's view factory
+   * (ChatUIManager.registerViewEarly) constructs ChatView during layout
+   * restoration — on every plugin reload and on cold start — which runs before
+   * the plugin's async service graph has produced chatService, so the factory
+   * passes null. `waitForChatServiceAndInitialize()` fills the field in later.
+   *
+   * Consequence: every collaborator below must receive chatService through a
+   * `getChatService()` accessor. Capturing `this.chatService` by value in this
+   * constructor pins the null forever and the collaborator never recovers.
+   */
   constructor(leaf: WorkspaceLeaf, private chatService: ChatService) {
     super(leaf);
     this.sessionCoordinator = new ChatSessionCoordinator({
-      chatService: this.chatService,
+      getChatService: () => this.chatService ?? null,
       component: this,
       getContainerEl: () => this.containerEl,
       getChatTitleEl: () => this.layoutElements?.chatTitle ?? null,
@@ -140,7 +151,7 @@ export class ChatView extends ItemView {
     });
     this.sendCoordinator = new ChatSendCoordinator({
       app: this.app,
-      chatService: this.chatService,
+      getChatService: () => this.chatService ?? null,
       getContainerEl: () => this.containerEl,
       getConversationManager: () => this.conversationManager ?? null,
       getMessageManager: () => this.messageManager ?? null,
@@ -158,7 +169,7 @@ export class ChatView extends ItemView {
     this.subagentIntegration = new ChatSubagentIntegration({
       app: this.app,
       component: this,
-      chatService: this.chatService,
+      getChatService: () => this.chatService ?? null,
       getConversationManager: () => this.conversationManager ?? null,
       getModelAgentManager: () => this.modelAgentManager ?? null,
       getStreamingController: () => this.streamingController ?? null,

--- a/src/ui/chat/services/ChatSendCoordinator.ts
+++ b/src/ui/chat/services/ChatSendCoordinator.ts
@@ -102,7 +102,12 @@ interface StorageAdapterLike {
 
 interface ChatSendCoordinatorDependencies {
   app: App;
-  chatService: ChatService;
+  /**
+   * Resolved lazily — see the note on ChatSubagentIntegration's getChatService.
+   * ChatView is constructed before the plugin's service graph produces
+   * chatService, so this dependency must never be captured by value.
+   */
+  getChatService: () => ChatService | null;
   getContainerEl: () => HTMLElement;
   getConversationManager: () => ConversationManagerLike | null;
   getMessageManager: () => MessageManagerLike | null;
@@ -366,15 +371,16 @@ export class ChatSendCoordinator {
     // Save conversation with ALL messages intact — compaction is view-layer only.
     // The boundaryMessageId in metadata.compaction.frontier tells the LLM prompt
     // assembly layer which messages to include.
-    const conversationService = this.deps.chatService.getConversationService();
+    const chatService = this.deps.getChatService();
+    const conversationService = chatService?.getConversationService();
     if (conversationService?.updateConversation) {
       await conversationService.updateConversation(conversation.id, {
         title: conversation.title,
         messages: conversation.messages,
         metadata: conversation.metadata
       });
-    } else {
-      await this.deps.chatService.updateConversation(conversation);
+    } else if (chatService) {
+      await chatService.updateConversation(conversation);
     }
 
     this.deps.onUpdateContextProgress();

--- a/src/ui/chat/services/ChatSessionCoordinator.ts
+++ b/src/ui/chat/services/ChatSessionCoordinator.ts
@@ -65,7 +65,12 @@ interface UIStateControllerLike {
 }
 
 interface ChatSessionCoordinatorDependencies {
-  chatService: ChatService;
+  /**
+   * Resolved lazily — see the note on ChatSubagentIntegration's getChatService.
+   * ChatView is constructed before the plugin's service graph produces
+   * chatService, so this dependency must never be captured by value.
+   */
+  getChatService: () => ChatService | null;
   component: Component;
   getContainerEl: () => HTMLElement;
   getChatTitleEl: () => HTMLElement | null;
@@ -113,7 +118,12 @@ export class ChatSessionCoordinator {
       return;
     }
 
-    const conversation = await this.deps.chatService.getConversation(conversationId);
+    const chatService = this.deps.getChatService();
+    if (!chatService) {
+      return;
+    }
+
+    const conversation = await chatService.getConversation(conversationId);
     if (!conversation) {
       return;
     }
@@ -235,7 +245,7 @@ export class ChatSessionCoordinator {
 
     await modelAgentManager.initializeDefaults();
 
-    const hasProviders = this.deps.chatService.hasConfiguredProviders();
+    const hasProviders = this.deps.getChatService()?.hasConfiguredProviders() ?? false;
     uiStateController.showWelcomeState(hasProviders);
 
     const chatTitle = this.deps.getChatTitleEl();

--- a/src/ui/chat/services/ChatSubagentIntegration.ts
+++ b/src/ui/chat/services/ChatSubagentIntegration.ts
@@ -71,7 +71,16 @@ interface ChatSubagentIntegrationResult {
 interface ChatSubagentIntegrationDependencies {
   app: App;
   component: Component;
-  chatService: ChatService;
+  /**
+   * Resolved lazily, never captured at construction time.
+   *
+   * Obsidian's view factory constructs ChatView during layout restoration,
+   * which happens before the plugin's async service graph has produced
+   * `chatService`. A dependency captured by value inside that window stays null
+   * for the whole life of the view, even after the poller in
+   * `ChatView.waitForChatServiceAndInitialize()` assigns the real service.
+   */
+  getChatService: () => ChatService | null;
   getConversationManager: () => ConversationManagerLike | null;
   getModelAgentManager: () => ModelAgentManagerLike | null;
   getStreamingController: () => StreamingController | null;
@@ -135,7 +144,13 @@ export class ChatSubagentIntegration {
         return { preservationService: null, subagentController: null };
       }
 
-      const llmService = this.deps.chatService.getLLMService();
+      const chatService = this.deps.getChatService();
+      if (!chatService) {
+        console.warn('[ChatSubagentIntegration] Cannot initialize: chatService not available');
+        return { preservationService: null, subagentController: null };
+      }
+
+      const llmService = chatService.getLLMService();
       if (!llmService) {
         console.warn('[ChatSubagentIntegration] Cannot initialize: llmService not available');
         return { preservationService: null, subagentController: null };
@@ -154,7 +169,7 @@ export class ChatSubagentIntegration {
       subagentController.initialize(
         {
           app: this.deps.app,
-          chatService: this.deps.chatService,
+          chatService,
           directToolExecutor,
           promptManagerAgent,
           storageAdapter,

--- a/tests/mocks/obsidian/index.ts
+++ b/tests/mocks/obsidian/index.ts
@@ -50,6 +50,7 @@ export {
   Scope,
   Modal,
   Component,
+  ItemView,
   MarkdownRenderer,
   Plugin,
   Menu,

--- a/tests/mocks/obsidian/views.ts
+++ b/tests/mocks/obsidian/views.ts
@@ -2,7 +2,7 @@
  * Obsidian view/lifecycle mocks: Modal, Scope, Component, Plugin, Menu.
  */
 
-import { createMockElement, App, EventRef } from './core';
+import { createMockElement, App, EventRef, WorkspaceLeaf } from './core';
 
 // Scope mock
 export class Scope {
@@ -142,6 +142,52 @@ export class Component {
 
   registerEvent(eventRef: EventRef): void {
     void eventRef;
+  }
+}
+
+/**
+ * ItemView mock.
+ *
+ * Deliberately minimal: `leaf`, `app`, `containerEl` and the Component
+ * lifecycle it inherits — the only ItemView surface the plugin's views touch.
+ *
+ * `containerEl.children` is left EMPTY on purpose. Real Obsidian puts the
+ * content host at `containerEl.children[1]`, and the plugin reads exactly that.
+ * A test that needs the content host must populate `children` itself, so that
+ * the "no container" early-return is never taken by accident and never
+ * mistaken for the real path.
+ */
+export class ItemView extends Component {
+  leaf: WorkspaceLeaf;
+  app: App;
+  containerEl: HTMLElement;
+  icon = '';
+
+  constructor(leaf: WorkspaceLeaf) {
+    super();
+    this.leaf = leaf;
+    this.app = (leaf as unknown as { app?: App })?.app ?? new App();
+    this.containerEl = createMockElement('div');
+  }
+
+  getViewType(): string {
+    return 'mock-view';
+  }
+
+  getDisplayText(): string {
+    return 'Mock view';
+  }
+
+  getIcon(): string {
+    return this.icon;
+  }
+
+  onOpen(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  onClose(): Promise<void> {
+    return Promise.resolve();
   }
 }
 

--- a/tests/unit/ChatSendCoordinator.test.ts
+++ b/tests/unit/ChatSendCoordinator.test.ts
@@ -145,7 +145,7 @@ function createHarness(provider = 'github-copilot') {
 
   const coordinator = new ChatSendCoordinator({
     app: {} as never,
-    chatService: chatService as never,
+    getChatService: () => chatService as never,
     getContainerEl: () => containerEl,
     getConversationManager: () => conversationManager,
     getMessageManager: () => messageManager,

--- a/tests/unit/ChatSessionCoordinator.test.ts
+++ b/tests/unit/ChatSessionCoordinator.test.ts
@@ -101,7 +101,7 @@ function createCoordinatorHarness() {
   const onClearAgentStatus = jest.fn();
 
   const coordinator = new ChatSessionCoordinator({
-    chatService: chatService as never,
+    getChatService: () => chatService as never,
     component,
       getContainerEl: () => containerEl as unknown as HTMLElement,
       getChatTitleEl: () => chatTitleEl as unknown as HTMLElement,

--- a/tests/unit/ChatSubagentIntegration.test.ts
+++ b/tests/unit/ChatSubagentIntegration.test.ts
@@ -79,9 +79,9 @@ describe('ChatSubagentIntegration', () => {
     const integration = new ChatSubagentIntegration({
       app: {} as App,
       component: {} as Component,
-      chatService: {
+      getChatService: () => ({
         getLLMService: jest.fn(() => llmService),
-      } as never,
+      }) as never,
       getConversationManager: () => conversationManager,
       getModelAgentManager: () => modelAgentManager,
       getStreamingController: () => streamingController,
@@ -165,9 +165,9 @@ describe('ChatSubagentIntegration', () => {
     const integration = new ChatSubagentIntegration({
       app: {} as App,
       component: {} as Component,
-      chatService: {
+      getChatService: () => ({
         getLLMService: jest.fn(() => ({ name: 'llm-service' })),
-      } as never,
+      }) as never,
       getConversationManager: () => null,
       getModelAgentManager: () => null,
       getStreamingController: () => null,

--- a/tests/unit/ChatViewChatServiceWiring.test.ts
+++ b/tests/unit/ChatViewChatServiceWiring.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression: ChatView must not capture `chatService` by value at construction.
+ *
+ * Obsidian's view factory (ChatUIManager.registerViewEarly) builds ChatView
+ * during layout restoration — on every `plugin:reload` and on cold start — which
+ * runs BEFORE the plugin's async service graph has produced `chatService`, so it
+ * passes null. `waitForChatServiceAndInitialize()` assigns the real service to
+ * the field a moment later.
+ *
+ * Any collaborator that copied `this.chatService` into a deps object inside the
+ * constructor therefore held null forever. ChatSubagentIntegration did, and
+ * dereferenced it unguarded:
+ *
+ *     TypeError: Cannot read properties of null (reading 'getLLMService')
+ *
+ * which meant SubagentController never initialized, PromptManagerAgent never
+ * received a SubagentExecutor, and the `promptManager subagent` tool answered
+ * "Subagent executor not initialized" for the whole life of that view.
+ *
+ * These tests exercise the REAL ChatView constructor and the REAL
+ * ChatSubagentIntegration. The only doubles are the leaf-level services the
+ * integration reaches for, and SubagentController (mocked so the test can read
+ * the dependency bag it was handed). Nothing here re-implements the code under
+ * test.
+ */
+
+// streaming-markdown is ESM-only and unresolvable from Jest's CJS runtime; it
+// sits far down ChatView's import graph (MessageDisplay -> MessageBubble ->
+// MarkdownRenderer) and none of its behaviour is under test here.
+jest.mock(
+  'streaming-markdown',
+  () => ({
+    default_renderer: () => ({}),
+    parser: () => ({}),
+    parser_write: () => undefined,
+    parser_end: () => undefined,
+  }),
+  { virtual: true }
+);
+
+const subagentControllerInitializeCalls: unknown[][] = [];
+const subagentControllerInstances: unknown[] = [];
+
+jest.mock('../../src/ui/chat/controllers/SubagentController', () => ({
+  SubagentController: jest.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.initialize = jest.fn((...args: unknown[]) => {
+      subagentControllerInitializeCalls.push(args);
+    });
+    this.setNavigationCallbacks = jest.fn();
+    this.cleanup = jest.fn();
+    subagentControllerInstances.push(this);
+    return this;
+  }),
+}));
+
+import type { WorkspaceLeaf } from 'obsidian';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface Harness {
+  view: any;
+  chatService: { getLLMService: jest.Mock; getConversationService: jest.Mock };
+  warnings: string[];
+}
+
+async function buildHarness(): Promise<Harness> {
+  const { ChatView } = await import('../../src/ui/chat/ChatView');
+
+  const llmService = { id: 'llm-service' };
+  const chatService = {
+    getLLMService: jest.fn(() => llmService),
+    getConversationService: jest.fn(() => ({ id: 'conversation-service' })),
+  };
+
+  const promptManagerAgent = { setSubagentExecutor: jest.fn() };
+  const agentManager = {
+    getAgent: jest.fn((name: string) => (name === 'promptManager' ? promptManagerAgent : null)),
+    getAgents: jest.fn(() => []),
+  };
+  const plugin = {
+    getService: jest.fn(async (name: string) => {
+      if (name === 'directToolExecutor') return { executeToolCalls: jest.fn(), getAvailableTools: jest.fn() };
+      if (name === 'agentManager') return agentManager;
+      return null;
+    }),
+    getServiceIfReady: jest.fn((name: string) =>
+      name === 'hybridStorageAdapter' ? { id: 'storage-adapter' } : null
+    ),
+  };
+
+  const app = { plugins: { getPlugin: (id: string) => (id === 'nexus' ? plugin : null) } };
+  const leaf = { app } as unknown as WorkspaceLeaf;
+
+  // The reload window: Obsidian constructs the view before chatService exists.
+  const view = new ChatView(leaf, null as never) as any;
+  view.app = app;
+
+  // Controllers that initializeArchitecture() would have built by the time
+  // subagent init runs. Stubbed because they are not what this test is about.
+  view.streamingController = { startStreaming: jest.fn(), updateStreamingChunk: jest.fn(), finalizeStreaming: jest.fn() };
+  view.toolEventCoordinator = { handleToolCallsDetected: jest.fn() };
+
+  const warnings: string[] = [];
+  jest.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  });
+
+  return { view, chatService, warnings };
+}
+
+describe('ChatView chatService wiring across the reload window', () => {
+  beforeEach(() => {
+    subagentControllerInitializeCalls.length = 0;
+    subagentControllerInstances.length = 0;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('initializes subagent infrastructure with the chatService assigned AFTER construction', async () => {
+    const { view, chatService } = await buildHarness();
+
+    // What waitForChatServiceAndInitialize() does once the service resolves.
+    view.chatService = chatService;
+
+    await view.initializeSubagentInfrastructure();
+
+    expect(view.subagentController).not.toBeNull();
+    expect(view.preservationService).not.toBeNull();
+
+    expect(subagentControllerInitializeCalls).toHaveLength(1);
+    const deps = subagentControllerInitializeCalls[0][0] as { chatService: unknown; llmService: unknown };
+    // The live service, not the null the constructor was handed.
+    expect(deps.chatService).toBe(chatService);
+    expect(deps.llmService).toBe(chatService.getLLMService.mock.results[0].value);
+  });
+
+  it('degrades to a null result instead of throwing when chatService never arrives', async () => {
+    const { view, warnings } = await buildHarness();
+
+    // chatService stays null — the poll timed out.
+    await expect(view.initializeSubagentInfrastructure()).resolves.toBeUndefined();
+
+    expect(view.subagentController).toBeNull();
+    expect(view.preservationService).toBeNull();
+    expect(warnings.some(w => w.includes('chatService not available'))).toBe(true);
+    expect(subagentControllerInitializeCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The bug

Every `plugin:reload` logged three errors and left subagent infrastructure dead:

```
[ERROR] [ChatSubagentIntegration] Failed to initialize subagent infrastructure:
        TypeError: Cannot read properties of null (reading 'getLLMService')
[ERROR] [ChatView] Failed to initialize subagent infrastructure: (same)
[ERROR] [ChatView] Failed to initialize subagent infrastructure: (same)
```

It is `null` *of* `getLLMService`, so `chatService` was null — not the llmService.
Pre-existing, not introduced by #356 or #357.

## Root cause — a dependency captured by value across an async gap

`ChatUIManager.registerViewEarly()` registers the chat view during `onload()` so
Obsidian can restore the leaf. Its factory runs during layout restoration, which
happens **before** the plugin's async service graph has produced `chatService`,
so it calls `new ChatView(leaf, null)` — the file even says so:

```ts
// Register ChatView with Obsidian - chatService may be null initially
```

`ChatView`'s constructor then copied `this.chatService` **by value** into three
collaborator dependency bags — `ChatSessionCoordinator`, `ChatSendCoordinator`
and `ChatSubagentIntegration`:

```ts
this.subagentIntegration = new ChatSubagentIntegration({
  chatService: this.chatService,   // null, forever
  getConversationManager: () => …, // every sibling is an accessor
```

`waitForChatServiceAndInitialize()` assigns the real service to the **field**
moments later, but the copies keep the null for the life of the view.
`ChatSubagentIntegration.initialize()` then dereferenced its copy unguarded,
while all four sibling dependencies around it were null-checked.

This is the same defect class as the findReplace/App-threading bug fixed in
v5.2.1: captured at construction instead of resolved lazily.

The lazy-init retry at `ChatView.handleOpenAgentStatus()` re-runs the same code
against the same captured null, so **nothing ever recovers** — not a retry, not a
later reload. Only closing and reopening the chat tab (which constructs a fresh
`ChatView` with a live `chatService`) clears it.

## User-visible impact — real, and a release blocker

Proved live in the running plugin, before the fix:

```
$ obsidian-cli eval vault="Code" code="…getLeavesOfType('nexus-chat')…"
=> [{"t":"nexus-chat","hasChatService":true,"subagentController":"null","preservation":"null"}]
```

The view *has* a chatService (the field was filled in later) yet the subagent
controller and preservation service are both null. Downstream:

```
=> {"agentManager":true,"promptManager":true,"toolFound":true,"hasExecutor":false}
```

`SubagentController` never initialized → `PromptManagerAgent` never received a
`SubagentExecutor` → `promptManager subagent` answers
`"Subagent executor not initialized"` for every delegation, and the agent status
panel shows `Subagent system unavailable`. Subagent delegation is simply broken
after a reload. Context compaction survives, because
`ensurePreservationServiceAndCompact()` reads `this.chatService` (the field) and
lazily rebuilds its own preservation service.

## The fix

1. **Root cause.** All three collaborators now take `getChatService(): ChatService | null`
   instead of a captured value — matching the accessor style every other
   dependency in those same bags already used. `ChatView` passes
   `() => this.chatService ?? null`.
2. **Defence in depth.** `ChatSubagentIntegration` now guards the null and
   degrades to the same warn-and-return-null-object path as its siblings instead
   of throwing.
3. `ChatView`'s constructor documents that `chatService` may legitimately be null
   at construction, so the next collaborator does not repeat the capture.

The guard alone would have silenced the errors without fixing anything — hence
the accessor, and hence the verification below asserts on *initialized*, not on
*quiet*.

## Regression test — deliberate red/green

`tests/unit/ChatViewChatServiceWiring.test.ts` drives the **real** `ChatView`
constructor and the **real** `ChatSubagentIntegration` through the reload window:
construct with a null chatService, assign the service afterwards the way the
poller does, then run subagent init. The only doubles are the leaf services the
integration reaches for and `SubagentController` (mocked so the test can read the
dependency bag it was handed). Nothing re-implements the code under test.

**Red** (`git stash push -- src/`, i.e. the test against `main`'s source):

```
TypeError: Cannot read properties of null (reading 'getLLMService')
Rejected to value: [TypeError: Cannot read properties of null (reading 'getLLMService')]
```

The production error, verbatim, from a Jest lane.

**Green** after the fix: 2/2 pass. Full suite green (4703 passing; the single
`CacheBackendMigration.edge` failure is a pre-existing timing flake — 176ms vs a
150ms bound — and passes in isolation). `npm run lint` clean. `tsc --noEmit` clean.

Supporting change: `tests/mocks/obsidian/` gained an `ItemView` mock, without
which no test could import `ChatView` at all — which is why the only existing
ChatView test re-implements the method under test in a hand-written double.
`containerEl.children` is left deliberately empty and documented, so a future
test cannot silently take the "no container" early return and mistake it for the
real path.

## Live verification (`nexus-testing` / `protocols/live-loop.md`)

Vault confirmed as `Code` in every probe (`app.vault.getName()`), never trusted
from the `vault=` flag. No vault writes — read-only `eval` probes only.

**Before** — `dev:console clear` → `plugin:reload id=nexus` → wait → `dev:console level=error`:

```
08:08:23 [ERROR] [ChatSubagentIntegration] Failed to initialize subagent infrastructure: … 'getLLMService'
08:08:23 [ERROR] [ChatView] Failed to initialize subagent infrastructure: … 'getLLMService'
08:08:23 [ERROR] [ChatView] Failed to initialize subagent infrastructure: … 'getLLMService'
```

**After** — same sequence with this branch's bundle:

```
=== ERRORS ===
No console messages captured.
$ obsidian-cli dev:errors vault="Code"
No errors captured.
```

**And actually initialized**, not merely silent:

```
=> [{"vault":"Code","hasChatService":true,"subagentController":"set",
     "subagentInitialized":true,"preservation":"set"}]
=> {"vault":"Code","toolFound":true,"hasExecutor":true,"hasContextProvider":true}
```

`SubagentController.isInitialized()` is `true`, the preservation service exists,
and the `promptManager` subagent tool has both its executor and its context
provider.

**Survives a clean re-run** (second `clear` → `reload` → wait):

```
=== RE-RUN errors ===
No console messages captured.
=== RE-RUN state ===
=> [{"vault":"Code","subagentInitialized":true,"preservation":true}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
