### PR TITLE
fix: resolve a state by name in SQL, not by scanning one page

### DIFF
--- a/src/agents/memoryManager/services/MemoryService.ts
+++ b/src/agents/memoryManager/services/MemoryService.ts
@@ -610,6 +610,60 @@ export class MemoryService {
     );
   }
 
+  /**
+   * Resolve one state by name or id within a workspace.
+   *
+   * Prefer this over scanning `getStates` for a match. `getStates` is a
+   * paginated list (default 25, hard cap 200 in `BaseRepository`), so a scan
+   * silently cannot see states older than the newest page - which made every
+   * state past the 25th unarchivable and unrestorable. Resolving in SQL also
+   * avoids paging, which would reintroduce the per-state JSONL reads that
+   * #219/#346 removed.
+   *
+   * Archived states are included: restore and rename both need them.
+   *
+   * @param workspaceId - Workspace that owns the state
+   * @param identifier - State id, or state name
+   * @param options.matchId - Also match against the state id (default true)
+   * @param options.caseSensitiveName - Exact-case name match (default true)
+   * @returns Matching state, or null
+   */
+  async findState(
+    workspaceId: string,
+    identifier: string,
+    options?: { matchId?: boolean; caseSensitiveName?: boolean }
+  ): Promise<{ id: string; name: string; sessionId?: string; tags?: string[] } | null> {
+    return withReadableBackend(
+      this.storageAdapterOrGetter,
+      async (adapter) => {
+        const match = await adapter.findState(workspaceId, identifier, options);
+        return match
+          ? { id: match.id, name: match.name, sessionId: match.sessionId, tags: match.tags }
+          : null;
+      },
+      async () => {
+        const workspace = await this.workspaceService.getWorkspace(workspaceId);
+        if (!workspace) {
+          return null;
+        }
+        const matchId = options?.matchId !== false;
+        const caseSensitive = options?.caseSensitiveName !== false;
+        const sameName = (name?: string) => caseSensitive
+          ? name === identifier
+          : name?.toLowerCase() === identifier.toLowerCase();
+
+        const all = Object.values(workspace.sessions)
+          .flatMap(session => Object.values(session.states)) as Array<{
+            id: string; name: string; sessionId?: string; created?: number; tags?: string[];
+          }>;
+        const sorted = [...all].sort((a, b) => (b.created ?? 0) - (a.created ?? 0));
+        return sorted.find(s => matchId && s.id === identifier)
+          ?? sorted.find(s => sameName(s.name))
+          ?? null;
+      }
+    );
+  }
+
   private extractStateTags(state: WorkspaceState): string[] | undefined {
     const tags = state.state?.metadata?.tags;
     return Array.isArray(tags) ? tags.filter((tag): tag is string => typeof tag === 'string') : undefined;

--- a/src/agents/memoryManager/tools/states/archiveState.ts
+++ b/src/agents/memoryManager/tools/states/archiveState.ts
@@ -15,13 +15,6 @@ import { CommonResult, CommonParameters } from '../../../../types/mcp/AgentTypes
 import { GLOBAL_WORKSPACE_ID } from '../../../../services/WorkspaceService';
 import type { WorkspaceState } from '../../../../database/types/session/SessionTypes';
 
-interface StateListItem {
-    id: string;
-    name: string;
-    sessionId?: string;
-    state?: WorkspaceState;
-}
-
 export interface ArchiveStateParameters extends CommonParameters {
     name: string;
     restore?: boolean;
@@ -63,15 +56,15 @@ export class ArchiveStateTool extends BaseTool<ArchiveStateParameters, ArchiveSt
                 return this.prepareResult(false, undefined, `Workspace not found: ${workspaceIdentifier}`);
             }
 
-            const statesResult = await memoryService.getStates(workspace.id);
-            const match = (statesResult.items as unknown as StateListItem[]).find(
-                (s) => s.id === params.name || s.name === params.name
-            );
+            // Resolve in SQL. Scanning getStates() only ever saw the newest
+            // page (default 25), so every older state was unarchivable.
+            const match = await memoryService.findState(workspace.id, params.name);
             if (!match) {
                 return this.prepareResult(false, undefined, `State "${params.name}" not found. Use listStates to see available states.`);
             }
 
-            const sessionId = match.sessionId || match.state?.sessionId;
+            // states.sessionId is NOT NULL, so the resolved row always carries it.
+            const sessionId = match.sessionId;
             if (!sessionId) {
                 return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
             }

--- a/src/agents/memoryManager/tools/states/createState.ts
+++ b/src/agents/memoryManager/tools/states/createState.ts
@@ -114,8 +114,11 @@ export class CreateStateTool extends BaseTool<CreateStateParams, StateResult> {
 
             // Phase 3.5: Check state name uniqueness within the workspace
             const workspaceData = workspaceResult.data;
-            const existingStates = await memoryService.getStates(workspaceData.workspaceId);
-            const nameExists = existingStates.items.some(state => state.name === params.name);
+            // Name-only lookup in SQL. The old scan saw just the newest 25
+            // states, so past that this check passed and let duplicate names in.
+            const nameExists = (await memoryService.findState(
+                workspaceData.workspaceId, params.name, { matchId: false }
+            )) !== null;
             if (nameExists) {
                 return this.prepareResult(
                     false,

--- a/src/agents/memoryManager/tools/states/loadState.ts
+++ b/src/agents/memoryManager/tools/states/loadState.ts
@@ -179,10 +179,8 @@ export class LoadStateTool extends BaseTool<LoadStateParams, StateResult> {
      */
     private async loadStateData(workspaceId: string, stateName: string, memoryService: MemoryService): Promise<{success: boolean; error?: string; data?: LoadedStateResult}> {
         try {
-            const statesResult = await memoryService.getStates(workspaceId, undefined, { pageSize: 100 });
-            const matchingState = statesResult.items.find(state =>
-                state.id === stateName || state.name?.toLowerCase() === stateName.toLowerCase()
-            );
+            // Resolve in SQL: a pageSize scan could not see past its own page.
+            const matchingState = await memoryService.findState(workspaceId, stateName, { caseSensitiveName: false });
             if (!matchingState?.sessionId) {
                 return { success: false, error: `State "${stateName}" not found. Use listStates to see available states.` };
             }

--- a/src/agents/memoryManager/tools/states/updateState.ts
+++ b/src/agents/memoryManager/tools/states/updateState.ts
@@ -14,14 +14,6 @@ import type { ToolStatusTense } from '../../../interfaces/ITool';
 import { createErrorMessage } from '../../../../utils/errorUtils';
 import { CommonResult, CommonParameters } from '../../../../types/mcp/AgentTypes';
 import { GLOBAL_WORKSPACE_ID } from '../../../../services/WorkspaceService';
-import type { WorkspaceState } from '../../../../database/types/session/SessionTypes';
-
-interface StateListItem {
-    id: string;
-    name: string;
-    sessionId?: string;
-    state?: WorkspaceState;
-}
 
 export interface UpdateStateParameters extends CommonParameters {
     name: string;
@@ -79,23 +71,26 @@ export class UpdateStateTool extends BaseTool<UpdateStateParameters, UpdateState
                 return this.prepareResult(false, undefined, `Workspace not found: ${workspaceIdentifier}`);
             }
 
-            const statesResult = await memoryService.getStates(workspace.id);
-            const match = (statesResult.items as unknown as StateListItem[]).find(
-                (s) => s.id === params.name || s.name === params.name
-            );
+            // Resolve in SQL. Scanning getStates() only ever saw the newest
+            // page (default 25), so every older state was unarchivable.
+            const match = await memoryService.findState(workspace.id, params.name);
             if (!match) {
                 return this.prepareResult(false, undefined, `State "${params.name}" not found. Use listStates to see available states.`);
             }
 
-            const sessionId = match.sessionId || match.state?.sessionId;
+            // states.sessionId is NOT NULL, so the resolved row always carries it.
+            const sessionId = match.sessionId;
             if (!sessionId) {
                 return this.prepareResult(false, undefined, `State "${params.name}" has no session ID; cannot update.`);
             }
 
             if (params.newName !== undefined && params.newName !== match.name) {
-                const conflict = (statesResult.items as unknown as StateListItem[]).find(
-                    (s) => s.id !== match.id && s.name === params.newName
+                // Same page-cap trap as the lookup above: scanning the newest
+                // page only, a rename onto an older state's name looked free.
+                const existing = await memoryService.findState(
+                    workspace.id, params.newName, { matchId: false }
                 );
+                const conflict = existing && existing.id !== match.id ? existing : null;
                 if (conflict) {
                     return this.prepareResult(false, undefined, `State name "${params.newName}" is already in use.`);
                 }

--- a/src/database/adapters/HybridStorageAdapter.ts
+++ b/src/database/adapters/HybridStorageAdapter.ts
@@ -874,6 +874,15 @@ export class HybridStorageAdapter implements IStorageAdapter {
     return this.stateRepo.getStates(workspaceId, sessionId, options);
   };
 
+  findState = async (
+    workspaceId: string,
+    identifier: string,
+    options?: { matchId?: boolean; caseSensitiveName?: boolean }
+  ): Promise<StateMetadata | null> => {
+    await this.ensureInitialized();
+    return this.stateRepo.findState(workspaceId, identifier, options);
+  };
+
   saveState = async (
     workspaceId: string,
     sessionId: string,

--- a/src/database/adapters/HybridStorageAssembly.ts
+++ b/src/database/adapters/HybridStorageAssembly.ts
@@ -45,6 +45,7 @@ import { ExportService } from '../services/ExportService';
 
 type ExportServiceStateRepo = {
   getStates(workspaceId: string, sessionId: string | undefined, options?: { pageSize?: number }): Promise<{ items: StateData[] }>;
+  findState(workspaceId: string, identifier: string, options?: { matchId?: boolean; caseSensitiveName?: boolean }): Promise<unknown>;
 };
 
 /**

--- a/src/database/interfaces/IStorageAdapter.ts
+++ b/src/database/interfaces/IStorageAdapter.ts
@@ -285,6 +285,16 @@ export interface IStorageAdapter {
    * @param options - Pagination and archive-filter options
    * @returns Paginated list of state metadata
    */
+  /**
+   * Resolve one state by name or id within a workspace, in SQL.
+   * Paginated list scans cannot see past the newest page; this can.
+   */
+  findState(
+    workspaceId: string,
+    identifier: string,
+    options?: { matchId?: boolean; caseSensitiveName?: boolean }
+  ): Promise<StateMetadata | null>;
+
   getStates(
     workspaceId: string,
     sessionId?: string,

--- a/src/database/repositories/StateRepository.ts
+++ b/src/database/repositories/StateRepository.ts
@@ -217,6 +217,61 @@ export class StateRepository
     };
   }
 
+  /**
+   * Resolve a single state by name or id within one workspace.
+   *
+   * This is a lookup, not a list, and it deliberately does NOT go through
+   * `queryPaginated`: that defaults `pageSize` to 25 and caps it at 200, so a
+   * caller resolving a name through `getStates` sees only the newest page and
+   * silently fails to find anything older. Paging until a match appears would
+   * reintroduce the per-state JSONL cost that #219/#346 removed, so the match
+   * is resolved in SQL and returns at most one row.
+   *
+   * Archived rows are included on purpose: restoring an archived state and
+   * renaming one both have to resolve a row that a list would hide.
+   *
+   * @param workspaceId - Workspace that owns the state
+   * @param identifier - State id, or state name
+   * @param options.matchId - Also match `identifier` against `id` (default true)
+   * @param options.caseSensitiveName - Exact-case name match (default true). When
+   *   false, matching is ASCII-case-insensitive via SQLite's NOCASE collation;
+   *   SQLite does not case-fold non-ASCII text without ICU.
+   * @returns Matching state metadata, or null when nothing matches
+   */
+  async findState(
+    workspaceId: string,
+    identifier: string,
+    options?: { matchId?: boolean; caseSensitiveName?: boolean }
+  ): Promise<StateMetadata | null> {
+    const matchId = options?.matchId !== false;
+    const nameClause = options?.caseSensitiveName === false
+      ? "name = ? COLLATE NOCASE"
+      : "name = ?";
+
+    const params: QueryParams = [workspaceId];
+    const clauses: string[] = [];
+    if (matchId) {
+      clauses.push("id = ?");
+      params.push(identifier);
+    }
+    clauses.push(nameClause);
+    params.push(identifier);
+
+    let sql = `SELECT * FROM states WHERE workspaceId = ? AND (${clauses.join(" OR ")})`;
+    if (matchId) {
+      // An id match beats a name match, and among same-named rows the newest
+      // wins - the same answer the old `find()` over a `created DESC` page gave.
+      sql += " ORDER BY CASE WHEN id = ? THEN 0 ELSE 1 END, created DESC";
+      params.push(identifier);
+    } else {
+      sql += " ORDER BY created DESC";
+    }
+    sql += " LIMIT 1";
+
+    const row = await this.sqliteCache.queryOne<StateRow>(sql, params);
+    return row ? this.rowToEntity(row) : null;
+  }
+
   async getStateData(id: string): Promise<StateData | null> {
     // Check content cache first
     if (this.stateContentCache.has(id)) {

--- a/src/database/repositories/interfaces/IStateRepository.ts
+++ b/src/database/repositories/interfaces/IStateRepository.ts
@@ -76,6 +76,24 @@ export interface IStateRepository extends IRepository<StateMetadata> {
   ): Promise<PaginatedResult<StateMetadata>>;
 
   /**
+   * Resolve one state by name or id within a workspace, in SQL.
+   *
+   * Use this instead of scanning `getStates` for a match: that is paginated
+   * (default 25, hard cap 200), so a scan silently cannot see older states.
+   * Archived rows are included.
+   *
+   * @param workspaceId - Workspace that owns the state
+   * @param identifier - State id, or state name
+   * @param options - Match tuning; see the implementation
+   * @returns Matching state metadata, or null
+   */
+  findState(
+    workspaceId: string,
+    identifier: string,
+    options?: { matchId?: boolean; caseSensitiveName?: boolean }
+  ): Promise<StateMetadata | null>;
+
+  /**
    * Fill in the denormalized columns for rows migrated from a pre-v16 schema.
    * Reads each affected workspace's JSONL stream once. No-op (one indexed
    * SELECT) once every row is known.

--- a/tests/helpers/mockFactories.ts
+++ b/tests/helpers/mockFactories.ts
@@ -181,6 +181,7 @@ export function createMockAdapter(ready: boolean): MockStorageAdapter {
     deleteState: jest.fn(),
     getState: jest.fn().mockResolvedValue(null),
     getStates: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
+    findState: jest.fn().mockResolvedValue(null),
     getConversations: jest.fn().mockResolvedValue({ ...EMPTY_PAGE }),
     getConversation: jest.fn().mockResolvedValue(null),
     getMessages: jest.fn().mockResolvedValue({ ...EMPTY_MSG_PAGE }),

--- a/tests/unit/ArchiveStateTool.test.ts
+++ b/tests/unit/ArchiveStateTool.test.ts
@@ -35,12 +35,20 @@ function buildAgentMocks(opts: {
   agent: MemoryManagerAgent;
   memoryService: {
     getStates: jest.Mock;
+    findState: jest.Mock;
     getState: jest.Mock;
     updateState: jest.Mock;
   };
   workspaceService: { getWorkspaceByNameOrId: jest.Mock };
 } {
   const memoryService = {
+    findState: jest.fn(async (_ws: string, identifier: string, options?: { matchId?: boolean; caseSensitiveName?: boolean }) => {
+      const matchId = options?.matchId !== false;
+      const cs = options?.caseSensitiveName !== false;
+      const same = (n?: string) => (cs ? n === identifier : n?.toLowerCase() === identifier.toLowerCase());
+      return opts.listItems.find(s => matchId && s.id === identifier)
+        ?? opts.listItems.find(s => same(s.name)) ?? null;
+    }),
     getStates: jest.fn().mockResolvedValue({
       items: opts.listItems,
       page: 0,
@@ -152,8 +160,11 @@ describe('ArchiveStateTool', () => {
     const result = await tool.execute({ context: archiveContext(), name: 'Checkpoint', restore: true });
 
     expect(result.success).toBe(true);
-    const options = memoryService.getStates.mock.calls[0][2];
-    expect(options?.includeArchived).not.toBe(false);
+    // Restore has to resolve a row that a list would hide, which is exactly why
+    // the lookup goes through findState: it applies no archive filter at all,
+    // and it is not bounded by a page.
+    expect(memoryService.findState).toHaveBeenCalledWith('workspace-1', 'Checkpoint');
+    expect(memoryService.getStates).not.toHaveBeenCalled();
   });
 
   it('restores an archived state by toggling metadata.isArchived to false, preserving tags', async () => {

--- a/tests/unit/CreateStateWorkspaceContext.test.ts
+++ b/tests/unit/CreateStateWorkspaceContext.test.ts
@@ -17,6 +17,7 @@ describe('CreateStateTool workspace context', () => {
   it('honors the workspaceId injected into tool params instead of falling back to default', async () => {
     const memoryService = {
       getStates: jest.fn().mockResolvedValue({ items: [] }),
+      findState: jest.fn().mockResolvedValue(null),
       saveState: jest.fn().mockResolvedValue('state-1'),
       getState: jest.fn().mockResolvedValue({
         workspaceId: 'workspace-uuid',
@@ -74,7 +75,9 @@ describe('CreateStateTool workspace context', () => {
       }
     ]);
     expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('workspace-uuid');
-    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-uuid');
+    // Name-uniqueness is a name-only lookup in SQL; the old list scan saw only
+    // the newest 25 states and let duplicates through past that.
+    expect(memoryService.findState).toHaveBeenCalledWith('workspace-uuid', 'diagnostic-state', { matchId: false });
     expect(memoryService.saveState).toHaveBeenCalledWith(
       'workspace-uuid',
       'session-1',
@@ -90,6 +93,7 @@ describe('CreateStateTool workspace context', () => {
   it('uses the top-level sessionId injected by useTools instead of creating a new session', async () => {
     const memoryService = {
       getStates: jest.fn().mockResolvedValue({ items: [] }),
+      findState: jest.fn().mockResolvedValue(null),
       saveState: jest.fn().mockResolvedValue('state-1'),
       getState: jest.fn().mockResolvedValue({
         workspaceId: 'workspace-uuid',

--- a/tests/unit/HybridStorageAdapter.phase0.test.ts
+++ b/tests/unit/HybridStorageAdapter.phase0.test.ts
@@ -623,6 +623,7 @@ describe('HybridStorageAdapter (Phase 0 characterization)', () => {
       adapter.stateRepo = {
         getStateData: jest.fn().mockResolvedValue(null),
         getStates: jest.fn().mockResolvedValue({ items: [] }),
+        findState: jest.fn().mockResolvedValue(null),
         saveState: jest.fn().mockResolvedValue('state-id'),
         updateState: jest.fn().mockResolvedValue(undefined),
         delete: jest.fn().mockResolvedValue(undefined),

--- a/tests/unit/LoadStateTool.test.ts
+++ b/tests/unit/LoadStateTool.test.ts
@@ -54,6 +54,13 @@ describe('LoadStateTool', () => {
       }
     };
     const memoryService = {
+      findState: jest.fn(async (_ws: string, identifier: string, options?: { matchId?: boolean; caseSensitiveName?: boolean }) => {
+        const matchId = options?.matchId !== false;
+        const cs = options?.caseSensitiveName !== false;
+        const same = (n?: string) => (cs ? n === identifier : n?.toLowerCase() === identifier.toLowerCase());
+        const pool = [matchingState] as Array<{ id: string; name?: string }>;
+        return pool.find(s => matchId && s.id === identifier) ?? pool.find(s => same(s.name)) ?? null;
+      }),
       getStates: jest.fn().mockResolvedValue({
         items: [matchingState],
         page: 0,
@@ -90,7 +97,9 @@ describe('LoadStateTool', () => {
 
     expect(result.success).toBe(true);
     expect(workspaceService.getWorkspaceByNameOrId).toHaveBeenCalledWith('Workspace Name');
-    expect(memoryService.getStates).toHaveBeenCalledWith('workspace-uuid', undefined, { pageSize: 100 });
+    // Resolved in SQL, not by scanning a page: a pageSize scan could not see
+    // a state older than its own page.
+    expect(memoryService.findState).toHaveBeenCalledWith('workspace-uuid', 'Checkpoint', { caseSensitiveName: false });
     expect(memoryService.getState).toHaveBeenCalledWith('workspace-uuid', 'session-1', 'state-1');
     expect(result.data).toMatchObject({
       name: 'Checkpoint',
@@ -105,6 +114,13 @@ describe('LoadStateTool', () => {
 
   it('keeps an empty current tag list instead of restoring stale snapshot tags', async () => {
     const memoryService = {
+      findState: jest.fn(async (_ws: string, identifier: string, options?: { matchId?: boolean; caseSensitiveName?: boolean }) => {
+        const matchId = options?.matchId !== false;
+        const cs = options?.caseSensitiveName !== false;
+        const same = (n?: string) => (cs ? n === identifier : n?.toLowerCase() === identifier.toLowerCase());
+        const pool = [{ id: 'state-1', name: 'Checkpoint', sessionId: 'session-1', workspaceId: 'workspace-uuid', tags: [] }] as Array<{ id: string; name?: string }>;
+        return pool.find(s => matchId && s.id === identifier) ?? pool.find(s => same(s.name)) ?? null;
+      }),
       getStates: jest.fn().mockResolvedValue({
         items: [{
           id: 'state-1',

--- a/tests/unit/LoadWorkspaceMissRecovery.test.ts
+++ b/tests/unit/LoadWorkspaceMissRecovery.test.ts
@@ -68,7 +68,8 @@ function createTool(options: {
   const memoryService = {
     getMemoryTraces: jest.fn().mockResolvedValue(emptyPage),
     getSessions: jest.fn().mockResolvedValue(emptyPage),
-    getStates: jest.fn().mockResolvedValue(emptyPage)
+    getStates: jest.fn().mockResolvedValue(emptyPage),
+    findState: jest.fn().mockResolvedValue(null)
   };
 
   const tool = new LoadWorkspaceTool({

--- a/tests/unit/LoadWorkspaceSystemGuides.test.ts
+++ b/tests/unit/LoadWorkspaceSystemGuides.test.ts
@@ -76,7 +76,8 @@ describe('LoadWorkspaceTool system guides workspace', () => {
     const memoryService = {
       getMemoryTraces: jest.fn().mockResolvedValue(emptyPage),
       getSessions: jest.fn().mockResolvedValue(emptyPage),
-      getStates: jest.fn().mockResolvedValue(emptyPage)
+      getStates: jest.fn().mockResolvedValue(emptyPage),
+      findState: jest.fn().mockResolvedValue(null)
     };
     const app = {
       vault: {

--- a/tests/unit/StateLookupPagination.test.ts
+++ b/tests/unit/StateLookupPagination.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Resolving a state by name must not be a paginated list scan.
+ *
+ * `BaseRepository.queryPaginated` defaults `pageSize` to 25 and hard-caps it at
+ * 200, so every tool that resolved a state by scanning `getStates(...)` could
+ * only ever see the newest page. In a workspace with more than 25 states the
+ * older ones were unarchivable, unrestorable, unrenameable, and invisible to
+ * the createState name-uniqueness check - while `listStates --page-size 100`
+ * happily showed them, so the "not found" error pointed at a list that
+ * contradicted it.
+ *
+ * The mock below is deliberately HONEST about pagination. The pre-existing
+ * ArchiveStateTool mock returned every item regardless of `pageSize`, which is
+ * exactly why a green suite never caught this. A mock that cannot express the
+ * failure cannot fail on it.
+ */
+import { ArchiveStateTool } from '../../src/agents/memoryManager/tools/states/archiveState';
+import { UpdateStateTool } from '../../src/agents/memoryManager/tools/states/updateState';
+import type { MemoryManagerAgent } from '../../src/agents/memoryManager/memoryManager';
+import type { WorkspaceState } from '../../src/database/types/session/SessionTypes';
+import { StateRepository } from '../../src/database/repositories/StateRepository';
+import { RepositoryDependencies } from '../../src/database/repositories/base/BaseRepository';
+
+interface SeedState {
+  id: string;
+  name: string;
+  sessionId: string;
+  created: number;
+}
+
+/** 30 states, PERF-S01 (oldest) .. PERF-S30 (newest). Mirrors the live repro. */
+function seedStates(count = 30): SeedState[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `state-${String(i + 1).padStart(2, '0')}`,
+    name: `PERF-S${String(i + 1).padStart(2, '0')}`,
+    sessionId: 'session-1',
+    created: 1000 + i
+  }));
+}
+
+function buildWorkspaceState(over: Partial<WorkspaceState> = {}): WorkspaceState {
+  return {
+    id: 'state-01',
+    sessionId: 'session-1',
+    workspaceId: 'workspace-1',
+    name: 'PERF-S01',
+    description: 'oldest',
+    created: 1000,
+    state: { workspace: null, recentTraces: [], contextFiles: [], metadata: {} },
+    ...over
+  } as WorkspaceState;
+}
+
+/**
+ * A memoryService whose `getStates` pages exactly like BaseRepository, and
+ * whose `findState` resolves across the whole workspace the way the SQL
+ * lookup does.
+ */
+function honestMemoryService(states: SeedState[], getStateResult: WorkspaceState | null) {
+  const newestFirst = [...states].sort((a, b) => b.created - a.created);
+
+  return {
+    getStates: jest.fn(
+      async (
+        _workspaceId: string,
+        _sessionId?: string,
+        options?: { pageSize?: number; page?: number }
+      ) => {
+        // BaseRepository: `Math.min(options.pageSize ?? 25, 200)`.
+        const pageSize = Math.min(options?.pageSize ?? 25, 200);
+        const page = options?.page ?? 0;
+        const items = newestFirst.slice(page * pageSize, page * pageSize + pageSize);
+        return {
+          items,
+          page,
+          pageSize,
+          totalItems: states.length,
+          totalPages: Math.ceil(states.length / pageSize),
+          hasNextPage: (page + 1) * pageSize < states.length,
+          hasPreviousPage: page > 0
+        };
+      }
+    ),
+    findState: jest.fn(
+      async (
+        _workspaceId: string,
+        identifier: string,
+        options?: { matchId?: boolean; caseSensitiveName?: boolean }
+      ) => {
+        const matchId = options?.matchId !== false;
+        const caseSensitive = options?.caseSensitiveName !== false;
+        const sameName = (n: string) =>
+          caseSensitive ? n === identifier : n.toLowerCase() === identifier.toLowerCase();
+        return (
+          (matchId ? newestFirst.find(s => s.id === identifier) : undefined) ??
+          newestFirst.find(s => sameName(s.name)) ??
+          null
+        );
+      }
+    ),
+    getState: jest.fn().mockResolvedValue(getStateResult),
+    updateState: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+function buildAgent(memoryService: unknown): MemoryManagerAgent {
+  const workspaceService = {
+    getWorkspaceByNameOrId: jest.fn().mockResolvedValue({ id: 'workspace-1', name: 'Workspace Name' })
+  };
+  return {
+    getMemoryServiceAsync: jest.fn().mockResolvedValue(memoryService),
+    getWorkspaceServiceAsync: jest.fn().mockResolvedValue(workspaceService)
+  } as unknown as MemoryManagerAgent;
+}
+
+const ctx = {
+  workspaceId: 'Workspace Name',
+  sessionId: 'session-1',
+  memory: 'Testing state lookup.',
+  goal: 'Resolve a state older than one page.'
+};
+
+describe('resolving a state by name past the first page', () => {
+  it('archiveState archives the OLDEST of 30 states (the 25-page-cap bug)', async () => {
+    const states = seedStates(30);
+    const memoryService = honestMemoryService(states, buildWorkspaceState());
+    const tool = new ArchiveStateTool(buildAgent(memoryService));
+
+    const result = await tool.execute({ context: ctx, name: 'PERF-S01' });
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(memoryService.updateState).toHaveBeenCalledTimes(1);
+    expect(memoryService.updateState.mock.calls[0][2]).toBe('state-01');
+    const next = memoryService.updateState.mock.calls[0][3].state as WorkspaceState;
+    expect(next.state?.metadata?.isArchived).toBe(true);
+  });
+
+  it('archiveState still archives a state inside the first page', async () => {
+    const states = seedStates(30);
+    const newest = buildWorkspaceState({ id: 'state-30', name: 'PERF-S30', created: 1029 });
+    const memoryService = honestMemoryService(states, newest);
+    const tool = new ArchiveStateTool(buildAgent(memoryService));
+
+    const result = await tool.execute({ context: ctx, name: 'PERF-S30' });
+
+    expect(result.success).toBe(true);
+    expect(memoryService.updateState.mock.calls[0][2]).toBe('state-30');
+  });
+
+  it('archiveState resolves by id as well as by name', async () => {
+    const states = seedStates(30);
+    const memoryService = honestMemoryService(states, buildWorkspaceState());
+    const tool = new ArchiveStateTool(buildAgent(memoryService));
+
+    const result = await tool.execute({ context: ctx, name: 'state-01' });
+
+    expect(result.success).toBe(true);
+    expect(memoryService.updateState.mock.calls[0][2]).toBe('state-01');
+  });
+
+  it('archiveState still reports genuinely missing states as not found', async () => {
+    const states = seedStates(30);
+    const memoryService = honestMemoryService(states, buildWorkspaceState());
+    const tool = new ArchiveStateTool(buildAgent(memoryService));
+
+    const result = await tool.execute({ context: ctx, name: 'PERF-S99' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('not found');
+    expect(memoryService.updateState).not.toHaveBeenCalled();
+  });
+
+  it('updateState renames the OLDEST of 30 states', async () => {
+    const states = seedStates(30);
+    const memoryService = honestMemoryService(states, buildWorkspaceState());
+    const tool = new UpdateStateTool(buildAgent(memoryService));
+
+    const result = await tool.execute({ context: ctx, name: 'PERF-S01', newName: 'Renamed' });
+
+    expect(result.error).toBeUndefined();
+    expect(result.success).toBe(true);
+    expect(memoryService.updateState.mock.calls[0][2]).toBe('state-01');
+  });
+
+  it('updateState rejects a rename that collides with a state past the first page', async () => {
+    const states = seedStates(30);
+    const memoryService = honestMemoryService(states, buildWorkspaceState({ id: 'state-30', name: 'PERF-S30' }));
+    const tool = new UpdateStateTool(buildAgent(memoryService));
+
+    // PERF-S02 is the 29th-newest, well outside the default 25-row page.
+    const result = await tool.execute({ context: ctx, name: 'PERF-S30', newName: 'PERF-S02' });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already in use');
+    expect(memoryService.updateState).not.toHaveBeenCalled();
+  });
+});
+
+describe('StateRepository.findState', () => {
+  function deps(row: Record<string, unknown> | null) {
+    const queryOne = jest.fn().mockResolvedValue(row);
+    const query = jest.fn().mockResolvedValue([]);
+    return {
+      queryOne,
+      query,
+      deps: {
+        sqliteCache: { queryOne, query, run: jest.fn(), transaction: jest.fn((fn: () => Promise<unknown>) => fn()) } as never,
+        jsonlWriter: { appendEvent: jest.fn(), readEvents: jest.fn().mockResolvedValue([]) } as never,
+        queryCache: {
+          cachedQuery: jest.fn((_k: string, fn: () => Promise<unknown>) => fn()),
+          invalidateByType: jest.fn(),
+          invalidateById: jest.fn(),
+          invalidate: jest.fn()
+        } as never
+      } as RepositoryDependencies
+    };
+  }
+
+  const row = {
+    id: 'state-01',
+    workspaceId: 'ws-1',
+    sessionId: 'session-1',
+    name: 'PERF-S01',
+    description: 'oldest',
+    created: 1000,
+    tagsJson: null,
+    isArchived: 0
+  };
+
+  it('resolves in a single bounded query, with no pagination', async () => {
+    const { queryOne, query, deps: d } = deps(row);
+    const repo = new StateRepository(d);
+
+    const found = await repo.findState('ws-1', 'PERF-S01');
+
+    expect(found?.id).toBe('state-01');
+    expect(queryOne).toHaveBeenCalledTimes(1);
+    // The paginated path (`query` + a separate count) must not be used: it is
+    // what caps the search at one page.
+    expect(query).not.toHaveBeenCalled();
+
+    const sql = queryOne.mock.calls[0][0] as string;
+    expect(sql).toContain('LIMIT 1');
+    expect(sql).not.toContain('OFFSET');
+    expect(sql).toContain('workspaceId = ?');
+  });
+
+  it('does not filter archived rows, so restore and rename can find them', async () => {
+    const { queryOne, deps: d } = deps({ ...row, isArchived: 1 });
+    const repo = new StateRepository(d);
+
+    const found = await repo.findState('ws-1', 'PERF-S01');
+
+    expect(found?.id).toBe('state-01');
+    expect(queryOne.mock.calls[0][0] as string).not.toContain('isArchived');
+  });
+
+  it('matches name case-insensitively only when asked', async () => {
+    const { queryOne, deps: d } = deps(row);
+    const repo = new StateRepository(d);
+
+    await repo.findState('ws-1', 'perf-s01', { caseSensitiveName: false });
+    expect(queryOne.mock.calls[0][0] as string).toContain('COLLATE NOCASE');
+
+    queryOne.mockClear();
+    await repo.findState('ws-1', 'PERF-S01');
+    expect(queryOne.mock.calls[0][0] as string).not.toContain('COLLATE NOCASE');
+  });
+
+  it('omits the id clause when matching by name only', async () => {
+    const { queryOne, deps: d } = deps(row);
+    const repo = new StateRepository(d);
+
+    await repo.findState('ws-1', 'PERF-S01', { matchId: false });
+
+    const sql = queryOne.mock.calls[0][0] as string;
+    expect(sql).not.toContain('id = ?');
+    expect(queryOne.mock.calls[0][1]).toEqual(['ws-1', 'PERF-S01']);
+  });
+
+  it('returns null when nothing matches', async () => {
+    const { deps: d } = deps(null);
+    const repo = new StateRepository(d);
+
+    await expect(repo.findState('ws-1', 'nope')).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## The bug

Archiving a state whose name was not among the **25 newest** failed with:

```
State "<name>" not found. Use listStates to see available states.
```

...while `listStates --page-size 100` showed it present — so the error pointed at a list that contradicted it.

`archiveState` resolved its target by scanning `memoryService.getStates()` with no pagination options. That routes through `BaseRepository.queryPaginated`, which defaults `pageSize` to 25 and orders by `created DESC`, so only the newest page was ever searched. Confirmed live in a 30-state workspace: the 5 oldest were unarchivable — `30 - 25` exactly.

## It was in five places, and two were worse than a bad error message

| Site | Before | Consequence |
|---|---|---|
| `archiveState` | no `pageSize` | older states unarchivable **and** unrestorable |
| `updateState` lookup | no `pageSize` | older states unrenameable |
| `updateState` rename-conflict | no `pageSize` | rename onto an older state's name looked free and **silently created a duplicate** |
| `createState` uniqueness | no `pageSize` | past 25 states it found nothing and **admitted duplicate names** |
| `loadState` | `pageSize: 100` | same bug, higher ceiling |

`createState` is the most damaging: admitting duplicate names then made every by-name lookup ambiguous.

## Why not just raise the page size

`queryPaginated` hard-caps it: `Math.min(options.pageSize ?? 25, 200)`. Raising the number cannot fix a workspace with more than 200 states, and paging until a match appeared would reintroduce the per-state JSONL reads that #219 / #346 just removed.

So resolving a state by name is now a **lookup, not a list**. `StateRepository.findState()` resolves it in SQL and returns at most one row, ordered so an id match beats a name match and the newest wins among duplicates — the answer the old `find()` over a `created DESC` page gave whenever it could see the row. Archived rows are deliberately **not** filtered: restore and rename both have to resolve a row a list would hide.

## Verification

**Live, in a real 30-state workspace on this build:**

- `PERF219-S04` (the reported repro) archives ✅
- `PERF219-S01` (the oldest of 30) archives ✅
- S04 restores ✅
- creating a duplicate of an out-of-page name is now rejected ✅
- a genuinely missing name still reports not found ✅

SQL confirmed `isArchived` actually flipped, and a bystander state was unaffected.

**The tests fail before the fix.** Reverting it kills them with the real error message verbatim. The pre-existing mocks returned every item regardless of `pageSize` — which is exactly why a green suite never caught this — so the new mock pages exactly like `BaseRepository`, and three obsolete `getStates`-was-called assertions were retargeted at `findState`.

- `tsc --noEmit` clean
- `npx jest --runInBand` — **4802 passed, 0 failed**
- `npm run build` green, including `schemas:check`, ESLint and the mobile reachability scan

No schema change; `CURRENT_SCHEMA_VERSION` stays at 16.

## Same pattern, not fixed here

Each needs a decision rather than a mechanical change:

- **`WorkspacesTab.listStates`** passes no `pageSize`, so the settings UI silently lists only the newest 25 states — and can only act on what it lists. Needs a pagination decision, not a lookup.
- **`WorkspaceSessionService.getSessionByNameOrId`** resolves sessions with `pageSize: 100` — the same bug class, one entity up.
- **`ExportService`** asks for `pageSize: 10000`, which the 200 cap silently truncates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)