### PR TITLE
fix: stop background indexing from outliving the plugin instance

### DIFF
--- a/src/services/embeddings/EmbeddingManager.ts
+++ b/src/services/embeddings/EmbeddingManager.ts
@@ -57,6 +57,13 @@ export class EmbeddingManager {
 
   private isEnabled: boolean;
   private isInitialized = false;
+  /**
+   * Handle for the deferred runBackgroundIndexing kick-off, so shutdown() can
+   * cancel it. A bare window.setTimeout here is unclearable: nothing else holds
+   * the id, and the callback fires ~3s later against whatever state the plugin
+   * is in by then — including an unloaded one, whose database handle is closed.
+   */
+  private backgroundIndexingTimer: number | null = null;
 
   constructor(
     app: App,
@@ -109,7 +116,8 @@ export class EmbeddingManager {
 
       // Start background indexing after a brief delay
       // This ensures the plugin is fully loaded before we start heavy processing
-      window.setTimeout(() => {
+      this.backgroundIndexingTimer = window.setTimeout(() => {
+        this.backgroundIndexingTimer = null;
         void this.runBackgroundIndexing();
       }, 3000); // 3-second delay
 
@@ -131,6 +139,14 @@ export class EmbeddingManager {
    * Called during plugin unload
    */
   async shutdown(): Promise<void> {
+    // Cleared before the isEnabled bail-out on purpose: this timer is the one
+    // thing that can still fire after shutdown() returns, so it is cancelled
+    // unconditionally rather than behind a flag that may have changed.
+    if (this.backgroundIndexingTimer !== null) {
+      window.clearTimeout(this.backgroundIndexingTimer);
+      this.backgroundIndexingTimer = null;
+    }
+
     if (!this.isEnabled) {
       return;
     }

--- a/src/services/embeddings/IndexingQueue.ts
+++ b/src/services/embeddings/IndexingQueue.ts
@@ -55,6 +55,21 @@ export class IndexingQueue extends Events {
   private isPaused = false;
   private abortController: AbortController | null = null;
 
+  /**
+   * Set by destroy() at plugin unload and never cleared.
+   *
+   * Without it this queue outlives the plugin instance that owns it. `cancel()`
+   * aborts only the phase that happens to be running, but `runBackgroundIndexing`
+   * awaits three phases in sequence and each one mints a fresh AbortController,
+   * so aborting phase 1 does not stop phases 2 and 3 - they start *after* the
+   * unload and iterate against a SQLiteCacheManager whose handle close() already
+   * nulled. `isRunning` is also false during filterUnindexedNotes(), which is one
+   * db.queryOne per markdown file. The result is the "Database not initialized"
+   * burst that grows with every reload, exactly as NotesIndexBuilder.stop()
+   * documents for the notes index.
+   */
+  private destroyed = false;
+
   // Tuning parameters
   private readonly BATCH_SIZE = 1;           // Process one at a time for memory
   private readonly YIELD_INTERVAL_MS = 50;   // Yield to UI between notes
@@ -85,7 +100,7 @@ export class IndexingQueue extends Events {
    * Start initial indexing of all notes
    */
   async startFullIndex(): Promise<void> {
-    if (this.isRunning) {
+    if (this.destroyed || this.isRunning) {
       return;
     }
 
@@ -121,7 +136,7 @@ export class IndexingQueue extends Events {
     this.processedCount = 0;
     this.startTime = Date.now();
     this.processingTimes = [];
-    this.abortController = new AbortController();
+    this.abortController = this.createAbortController();
 
     await this.processQueue();
   }
@@ -131,7 +146,7 @@ export class IndexingQueue extends Events {
    * Delegates to TraceIndexer for the actual work.
    */
   async startTraceIndex(): Promise<void> {
-    if (this.isRunning) {
+    if (this.destroyed || this.isRunning) {
       return;
     }
 
@@ -140,7 +155,7 @@ export class IndexingQueue extends Events {
     }
 
     this.isRunning = true;
-    this.abortController = new AbortController();
+    this.abortController = this.createAbortController();
 
     this.traceIndexer = new TraceIndexer(
       this.db,
@@ -193,7 +208,7 @@ export class IndexingQueue extends Events {
    * Delegates to ConversationIndexer for the actual work.
    */
   async startConversationIndex(): Promise<void> {
-    if (this.isRunning) {
+    if (this.destroyed || this.isRunning) {
       return;
     }
 
@@ -202,7 +217,7 @@ export class IndexingQueue extends Events {
     }
 
     this.isRunning = true;
-    this.abortController = new AbortController();
+    this.abortController = this.createAbortController();
 
     this.conversationIndexer = new ConversationIndexer(
       this.db,
@@ -279,8 +294,25 @@ export class IndexingQueue extends Events {
   /**
    * Cancel indexing entirely
    */
+  /**
+   * A fresh controller for a phase, already aborted if the queue is destroyed.
+   *
+   * Closes the window between a phase's `destroyed` guard and its controller
+   * assignment: an unload landing in that gap aborts the outgoing controller,
+   * and without this the incoming one would come up live and run on regardless.
+   */
+  private createAbortController(): AbortController {
+    const controller = new AbortController();
+    if (this.destroyed) {
+      controller.abort();
+    }
+    return controller;
+  }
+
   cancel(): void {
-    if (!this.isRunning) return;
+    // Deliberately NOT gated on isRunning: the gap between phases, and the whole
+    // of filterUnindexedNotes(), run with isRunning === false, and those are
+    // precisely the windows an unload has to be able to interrupt.
     this.abortController?.abort();
     this.queue = [];
   }
@@ -289,6 +321,7 @@ export class IndexingQueue extends Events {
    * Clean up all resources (called on plugin unload)
    */
   destroy(): void {
+    this.destroyed = true;
     this.cancel();
     // Obsidian's Events doesn't have removeAllListeners — handled by GC after cancel()
   }
@@ -345,6 +378,7 @@ export class IndexingQueue extends Events {
     const needsIndexing: TFile[] = [];
 
     for (const note of notes) {
+      if (this.destroyed) break;
       try {
         const content = await this.app.vault.cachedRead(note);
         const contentHash = hashContent(preprocessContent(content) ?? '');
@@ -390,7 +424,7 @@ export class IndexingQueue extends Events {
       });
 
       while (this.queue.length > 0) {
-        if (this.abortController?.signal.aborted) {
+        if (this.destroyed || this.abortController?.signal.aborted) {
           this.emitProgress({
             phase: 'paused',
             totalNotes: this.totalCount,

--- a/src/services/embeddings/TraceIndexer.ts
+++ b/src/services/embeddings/TraceIndexer.ts
@@ -132,7 +132,13 @@ export class TraceIndexer {
           }
 
         } catch (error) {
-          console.error(`[TraceIndexer] Failed to embed trace ${trace.id}:`, error);
+          // Not the embedding itself: embedTrace() catches its own failures and
+          // never rethrows, so the only thing that can land here is the periodic
+          // db.save() above, on every saveInterval-th item.
+          console.error(
+            `[TraceIndexer] Failed to persist embeddings around trace ${trace.id}:`,
+            error
+          );
         }
 
         // Yield to UI

--- a/tests/unit/EmbeddingManagerShutdownTimer.test.ts
+++ b/tests/unit/EmbeddingManagerShutdownTimer.test.ts
@@ -1,0 +1,117 @@
+/**
+ * EmbeddingManager deferred-start teardown test.
+ *
+ * initialize() schedules runBackgroundIndexing ~3s later. If the plugin is
+ * unloaded inside that window and the timer id is not retained, the callback
+ * still fires -- against an EmbeddingManager whose collaborators are already
+ * torn down and whose SQLiteCacheManager handle close() has nulled. Every
+ * subsequent query then throws "Database not initialized".
+ *
+ * The IndexingQueue is mocked here on purpose: its own `destroyed` guard would
+ * otherwise mask whether the timer was really cancelled, and this test exists to
+ * pin the timer specifically.
+ */
+
+jest.mock('../../src/services/embeddings/EmbeddingEngine', () => ({
+  EmbeddingEngine: jest.fn().mockImplementation(() => ({
+    dispose: jest.fn().mockResolvedValue(undefined)
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingService', () => ({
+  EmbeddingService: jest.fn().mockImplementation(() => ({
+    isServiceEnabled: jest.fn().mockReturnValue(true),
+    getStats: jest.fn().mockResolvedValue({ noteCount: 0, traceCount: 0, conversationChunkCount: 0 })
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingWatcher', () => ({
+  EmbeddingWatcher: jest.fn().mockImplementation(() => ({
+    start: jest.fn(),
+    stop: jest.fn()
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingStatusBar', () => ({
+  EmbeddingStatusBar: jest.fn().mockImplementation(() => ({
+    init: jest.fn(),
+    destroy: jest.fn()
+  }))
+}));
+
+const startFullIndex = jest.fn().mockResolvedValue(undefined);
+const startTraceIndex = jest.fn().mockResolvedValue(undefined);
+const startConversationIndex = jest.fn().mockResolvedValue(undefined);
+const queueDestroy = jest.fn();
+
+jest.mock('../../src/services/embeddings/IndexingQueue', () => ({
+  IndexingQueue: jest.fn().mockImplementation(() => ({
+    startFullIndex,
+    startTraceIndex,
+    startConversationIndex,
+    destroy: queueDestroy,
+    isIndexing: jest.fn().mockReturnValue(false)
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/adapter/createRetrievalDreamService', () => ({
+  createRetrievalDreamService: jest.fn().mockReturnValue(null)
+}));
+
+import { EmbeddingManager } from '../../src/services/embeddings/EmbeddingManager';
+import type { App, Plugin } from 'obsidian';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+
+function createManager() {
+  const app = {
+    vault: { adapter: {}, configDir: '.obsidian' }
+  } as unknown as App;
+
+  const plugin = {
+    settings: { embeddings: { retrievalLearning: false } },
+    addCommand: jest.fn(),
+    registerInterval: jest.fn()
+  } as unknown as Plugin;
+
+  const db = {} as unknown as SQLiteCacheManager;
+
+  return new EmbeddingManager(app, plugin, db, true);
+}
+
+describe('EmbeddingManager deferred background indexing', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    startFullIndex.mockClear();
+    startTraceIndex.mockClear();
+    startConversationIndex.mockClear();
+    queueDestroy.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not start background indexing when shutdown lands inside the 3s window', async () => {
+    const manager = createManager();
+    manager.initialize();
+
+    await manager.shutdown();
+    jest.advanceTimersByTime(10_000);
+    await Promise.resolve();
+
+    expect(queueDestroy).toHaveBeenCalled();
+    expect(startFullIndex).not.toHaveBeenCalled();
+    expect(startTraceIndex).not.toHaveBeenCalled();
+    expect(startConversationIndex).not.toHaveBeenCalled();
+  });
+
+  it('still starts background indexing when no shutdown intervenes', async () => {
+    const manager = createManager();
+    manager.initialize();
+
+    jest.advanceTimersByTime(3_000);
+    await Promise.resolve();
+
+    expect(startFullIndex).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/IndexingQueueDestroy.test.ts
+++ b/tests/unit/IndexingQueueDestroy.test.ts
@@ -1,0 +1,138 @@
+/**
+ * IndexingQueue teardown tests.
+ *
+ * Regression cover for the orphaned background-indexing loop: an IndexingQueue
+ * belonging to an unloaded plugin instance kept iterating against the
+ * SQLiteCacheManager that the same instance's unload had already closed, logging
+ * "Database not initialized" once per item for minutes, with the burst growing
+ * on every reload.
+ *
+ * The mock db here deliberately throws that exact error once close() has been
+ * called. A mock that kept answering after close would make every test below
+ * pass against the un-fixed code, which is precisely how the bug shipped.
+ */
+
+import { IndexingQueue } from '../../src/services/embeddings/IndexingQueue';
+import type { EmbeddingService } from '../../src/services/embeddings/EmbeddingService';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+import type { App, TFile } from 'obsidian';
+
+function makeFiles(count: number): TFile[] {
+  return Array.from({ length: count }, (_, i) => ({
+    path: `note-${i}.md`,
+    basename: `note-${i}`,
+    extension: 'md'
+  })) as unknown as TFile[];
+}
+
+function createHarness(fileCount: number) {
+  let closed = false;
+
+  const queryOne = jest.fn(async () => {
+    if (closed) {
+      // Exactly what SQLiteCacheManager.getDbOrThrow() does after close().
+      throw new Error('Database not initialized');
+    }
+    return null;
+  });
+
+  const db = {
+    queryOne,
+    query: jest.fn().mockResolvedValue([]),
+    run: jest.fn().mockResolvedValue(undefined),
+    save: jest.fn().mockResolvedValue(undefined),
+    close: () => { closed = true; }
+  } as unknown as SQLiteCacheManager & { close(): void };
+
+  const embeddingService = {
+    isServiceEnabled: jest.fn().mockReturnValue(true),
+    initialize: jest.fn().mockResolvedValue(undefined),
+    embedNote: jest.fn().mockResolvedValue(undefined)
+  } as unknown as EmbeddingService;
+
+  const files = makeFiles(fileCount);
+  const app = {
+    vault: {
+      getMarkdownFiles: () => files,
+      cachedRead: jest.fn().mockResolvedValue('content')
+    }
+  } as unknown as App;
+
+  const queue = new IndexingQueue(app, embeddingService, db);
+
+  return { queue, db, embeddingService, queryOne, files };
+}
+
+describe('IndexingQueue teardown', () => {
+  it('stops scanning notes as soon as destroy() is called', async () => {
+    // filterUnindexedNotes() runs one queryOne per markdown file, and it runs
+    // with isRunning === false -- the window the old cancel() could not touch.
+    const { queue, db, queryOne } = createHarness(50);
+
+    const DESTROY_AFTER = 3;
+    queryOne.mockImplementation(async () => {
+      if (queryOne.mock.calls.length === DESTROY_AFTER) {
+        queue.destroy();
+        (db as unknown as { close(): void }).close();
+      }
+      return null;
+    });
+
+    await queue.startFullIndex();
+
+    // Before the fix the loop ran all 50 files, every one of them throwing
+    // "Database not initialized" into the console.
+    expect(queryOne).toHaveBeenCalledTimes(DESTROY_AFTER);
+  });
+
+  it('refuses to start the trace phase after destroy()', async () => {
+    // runBackgroundIndexing awaits three phases in sequence. Aborting phase 1
+    // used to leave phases 2 and 3 free to start, each minting a fresh
+    // AbortController against the now-closed handle.
+    const { queue, db, embeddingService } = createHarness(1);
+
+    queue.destroy();
+    (db as unknown as { close(): void }).close();
+    (embeddingService.isServiceEnabled as jest.Mock).mockClear();
+
+    await queue.startTraceIndex();
+
+    expect(embeddingService.isServiceEnabled).not.toHaveBeenCalled();
+  });
+
+  it('refuses to start the conversation phase after destroy()', async () => {
+    const { queue, db, embeddingService } = createHarness(1);
+
+    queue.destroy();
+    (db as unknown as { close(): void }).close();
+    (embeddingService.isServiceEnabled as jest.Mock).mockClear();
+
+    await queue.startConversationIndex();
+
+    expect(embeddingService.isServiceEnabled).not.toHaveBeenCalled();
+  });
+
+  it('refuses to restart the note phase after destroy()', async () => {
+    const { queue, db, queryOne } = createHarness(5);
+
+    queue.destroy();
+    (db as unknown as { close(): void }).close();
+    queryOne.mockClear();
+
+    await queue.startFullIndex();
+
+    expect(queryOne).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent -- a second destroy() is harmless', async () => {
+    const { queue, db, queryOne } = createHarness(5);
+
+    queue.destroy();
+    queue.destroy();
+    (db as unknown as { close(): void }).close();
+    queryOne.mockClear();
+
+    await expect(queue.startFullIndex()).resolves.toBeUndefined();
+    expect(queryOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Symptom

After a plugin reload the console logs, once per item for minutes:

```
[SQLiteCacheManager] QueryOne failed: Error: Database not initialized ... runBackgroundIndexing
[TraceEmbeddingService] Failed to embed trace <id>: Database not initialized
[TraceIndexer] Failed to embed trace <id>: Database not initialized
```

The burst grows with the reload count. Observed live on a real vault.

## Cause

The logs come from an `IndexingQueue`/`TraceIndexer` loop belonging to the **previous** plugin instance, still iterating against the `SQLiteCacheManager` that the same instance's unload already closed (`this.db = null` happens only in `SQLiteCacheManager.close()`, reached via `PluginLifecycleManager.shutdown()` → `HybridStorageAdapter.close()`).

Four independent reasons it survived unload:

1. `EmbeddingManager.shutdown()` → `queue.destroy()` → `IndexingQueue.cancel()`, and `cancel()` early-returned on `if (!this.isRunning) return;`. But `isRunning` is false for the whole of `filterUnindexedNotes()` — one `db.queryOne` per markdown file — and in the gap between phases. Those are exactly the windows an unload has to be able to interrupt.
2. No `destroyed` flag existed. `runBackgroundIndexing` awaits three phases in sequence, and phases 2 and 3 each construct a **new** `AbortController`. Aborting phase 1 at unload did not stop phases 2 and 3, which then started *after* the unload against the closed handle.
3. `EmbeddingManager.initialize()` scheduled `runBackgroundIndexing` with a bare `window.setTimeout(…, 3000)` — no stored handle, so nothing could clear it.
4. Per-item `try/catch` swallows every failure, leaving the (replaced) abort signal as the only exit.

The precedent for the correct shape is `NotesIndexBuilder.stop()`, which documents this exact failure — "the 'Database not initialized' burst grows with the reload count" — for the notes index. The embedding queue never got the equivalent treatment.

## Fix

- `IndexingQueue` gains a `destroyed` flag, set by `destroy()` and never cleared, checked at the top of `startFullIndex` / `startTraceIndex` / `startConversationIndex`, inside the `filterUnindexedNotes` walk, and in the `processQueue` loop.
- `cancel()` now aborts unconditionally instead of early-returning on `!isRunning`.
- `EmbeddingManager` retains the 3000 ms handle and clears it in `shutdown()`, **before** the `isEnabled` bail-out — that timer is the one thing that can still fire after `shutdown()` returns.
- Phase controllers are minted through `createAbortController()`, which returns a pre-aborted controller when the queue is destroyed. This closes a race not in the original diagnosis: each phase creates its controller *after* its `destroyed` check, so an unload landing in that gap would abort the outgoing controller and let the incoming one come up live.

Because the abort signal now genuinely reflects `destroy()`, the existing `abortSignal?.aborted` checks in the `TraceIndexer` / `ConversationIndexer` item loops become effective exits rather than dead guards.

### Also

`[TraceIndexer] Failed to embed trace <id>` was a misnomer — verified that `TraceEmbeddingService.embedTrace()` catches its own failures and never rethrows, so that `catch` could only ever be reached by the periodic `db.save()`. Message corrected.

## Tests

The db mock throws the real `Database not initialized` once `close()` has been called. A mock that kept answering after close would make every test pass against the un-fixed code — which is how this shipped in the first place.

Verified by stashing the source and re-running, not by assumption:

- All **5** `IndexingQueueDestroy` tests fail without the fix (including 5 stray `queryOne` calls against a closed handle where 0 are expected).
- The shutdown-timer test isolates its own fix: without it, background indexing starts 1× after `shutdown()`. Its positive control passes either way, so it is not a tautology.

## Gate

- `npx tsc --noEmit --skipLibCheck` — 0 errors
- `npx jest --runInBand` — **4896 passed, 0 failed**, 37 skipped
- `npm run build` — exit 0 (checked via file, not through a pipe), mobile scan `clean: no Node built-in is statically reachable from init`

## Deliberately out of scope

`SQLiteMaintenanceService.clearAllData()` drops `conversation_embeddings` and clears `embedding_backfill_state` on every `fullRebuild`, and nothing re-derives them: `cache-rebuilt` is fired only from `StorageMaintenanceService.rebuildCache()`, the startup rebuild path never fires it, and the only subscriber in the codebase is the notes index. Verified — and note it drops *only* conversation embeddings; note and trace embeddings are untouched.

Not wired here on purpose. A `cache-rebuilt` subscriber would call `startConversationIndex()`, which early-returns while `isRunning` is true — and the note phase runs for hours on a large vault. Added today it would silently no-op in the common case, which is worse than no subscription. It needs the phase ordering fixed first (conversations are ~169 items and run behind ~18k notes), and firing from the startup path touches `runStartupFullRebuild`, which #341 currently rewrites. Best done as a follow-up once #341 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)