### PR TITLE
fix: index conversations first, and re-derive them after a cache rebuild

### DIFF
--- a/src/core/PluginLifecycleManager.ts
+++ b/src/core/PluginLifecycleManager.ts
@@ -337,6 +337,22 @@ export class PluginLifecycleManager {
             this.embeddingManager.initialize();
             (this.config.plugin as PluginWithServices).embeddingManager = this.embeddingManager;
 
+            // "Nexus: Rebuild cache" DROPs conversation_embeddings and clears
+            // embedding_backfill_state, and the JSONL replay does not restore
+            // them — the same hazard the notes index subscribes for. Without
+            // this a mid-session rebuild leaves chat search dead until the next
+            // plugin load. registerEvent so the ref is dropped on unload.
+            //
+            // Only the mid-session rebuild needs the signal: the startup rebuild
+            // runs before embeddings exist, and initialize()'s own background
+            // pass (conversations first) already covers that case.
+            const manager = this.embeddingManager;
+            this.config.plugin.registerEvent(
+                storageAdapter.onCacheRebuilt(() => {
+                    void manager.reindexAfterCacheRebuild();
+                })
+            );
+
             // Wire embedding service into ChatTraceService
             const embeddingService = this.embeddingManager.getService();
             if (embeddingService) {

--- a/src/services/embeddings/EmbeddingManager.ts
+++ b/src/services/embeddings/EmbeddingManager.ts
@@ -185,6 +185,46 @@ export class EmbeddingManager {
   }
 
   /**
+   * Re-derive embeddings after the cache database was thrown away and rebuilt.
+   *
+   * `SQLiteMaintenanceService.clearAllData()` DROPs `conversation_embeddings`
+   * and clears `embedding_backfill_state` at the start of every full rebuild.
+   * The JSONL replay restores conversations and messages but knows nothing
+   * about their embeddings, so without this a mid-session "Nexus: Rebuild
+   * cache" silently leaves chat search dead for the rest of the session.
+   *
+   * The in-flight phase is cancelled first: the phases are gated on
+   * `isRunning`, so a re-index requested while the long note walk is running
+   * would otherwise no-op. `cancel()` does not set the queue's `destroyed`
+   * flag, which is what makes the restart below legal.
+   */
+  async reindexAfterCacheRebuild(): Promise<void> {
+    if (!this.isEnabled || !this.queue) {
+      return;
+    }
+
+    try {
+      this.queue.cancel();
+      await this.waitForQueueIdle();
+      await this.runBackgroundIndexing();
+    } catch (error) {
+      console.error('[EmbeddingManager] Re-index after cache rebuild failed:', error);
+    }
+  }
+
+  /**
+   * Wait for the queue to observe its own cancellation. Bounded: if the phase
+   * refuses to settle we start anyway, and the `isRunning` guards make the
+   * re-index a no-op rather than letting two walks run at once.
+   */
+  private async waitForQueueIdle(timeoutMs = 10_000): Promise<void> {
+    const startedAt = Date.now();
+    while (this.queue?.isIndexing() && Date.now() - startedAt < timeoutMs) {
+      await new Promise(resolve => window.setTimeout(resolve, 100));
+    }
+  }
+
+  /**
    * Get the embedding service (for external use)
    */
   getService(): EmbeddingService | null {
@@ -315,15 +355,27 @@ export class EmbeddingManager {
     }
 
     try {
-      // Phase 1: Index all notes
-      await this.queue.startFullIndex();
+      // Cheapest-first, and deliberately so.
+      //
+      // The three phases are independent - conversations read conversations/
+      // messages, traces read memory_traces, notes read the vault - so the order
+      // is free, and it should be driven by how long each phase makes the others
+      // wait. A vault with 18k notes takes hours to index; the few hundred
+      // conversations behind it then have no chat search for that whole time.
+      // Since clearAllData() drops conversation embeddings on every full
+      // rebuild, that is exactly the window a rebuild opens, every time.
+      //
+      // Conversations first, notes last: the small, high-value indexes come back
+      // in seconds and the long vault walk runs behind them.
+
+      // Phase 1: Backfill existing conversations (idempotent, resumable)
+      await this.queue.startConversationIndex();
 
       // Phase 2: Backfill existing traces (from migration)
       await this.queue.startTraceIndex();
 
-      // Phase 3: Backfill existing conversations
-      // Runs after notes and traces; idempotent and resumable on interrupt
-      await this.queue.startConversationIndex();
+      // Phase 3: Index all notes - longest by far, so it goes last
+      await this.queue.startFullIndex();
     } catch (error) {
       console.error('[EmbeddingManager] Background indexing failed:', error);
     }

--- a/tests/unit/EmbeddingManagerPhaseOrder.test.ts
+++ b/tests/unit/EmbeddingManagerPhaseOrder.test.ts
@@ -1,0 +1,123 @@
+/**
+ * EmbeddingManager phase-ordering and cache-rebuild recovery tests.
+ *
+ * Two behaviours pinned here:
+ *
+ *  1. Background indexing runs cheapest-first (conversations -> traces ->
+ *     notes). The phases are independent, so the order is free -- and putting
+ *     the multi-hour vault walk first means the few hundred conversations
+ *     behind it have no chat search until it finishes.
+ *  2. A cache rebuild re-derives conversation embeddings. clearAllData() DROPs
+ *     conversation_embeddings on every full rebuild and the JSONL replay does
+ *     not restore them, so without this a mid-session "Nexus: Rebuild cache"
+ *     leaves chat search dead for the rest of the session.
+ */
+
+jest.mock('../../src/services/embeddings/EmbeddingEngine', () => ({
+  EmbeddingEngine: jest.fn().mockImplementation(() => ({
+    dispose: jest.fn().mockResolvedValue(undefined)
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingService', () => ({
+  EmbeddingService: jest.fn().mockImplementation(() => ({
+    isServiceEnabled: jest.fn().mockReturnValue(true),
+    getStats: jest.fn().mockResolvedValue({ noteCount: 0, traceCount: 0, conversationChunkCount: 0 })
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingWatcher', () => ({
+  EmbeddingWatcher: jest.fn().mockImplementation(() => ({ start: jest.fn(), stop: jest.fn() }))
+}));
+
+jest.mock('../../src/services/embeddings/EmbeddingStatusBar', () => ({
+  EmbeddingStatusBar: jest.fn().mockImplementation(() => ({ init: jest.fn(), destroy: jest.fn() }))
+}));
+
+const calls: string[] = [];
+let indexing = false;
+const cancel = jest.fn(() => { indexing = false; });
+
+jest.mock('../../src/services/embeddings/IndexingQueue', () => ({
+  IndexingQueue: jest.fn().mockImplementation(() => ({
+    startFullIndex: jest.fn(async () => { calls.push('notes'); }),
+    startTraceIndex: jest.fn(async () => { calls.push('traces'); }),
+    startConversationIndex: jest.fn(async () => { calls.push('conversations'); }),
+    cancel,
+    destroy: jest.fn(),
+    isIndexing: jest.fn(() => indexing)
+  }))
+}));
+
+jest.mock('../../src/services/embeddings/adapter/createRetrievalDreamService', () => ({
+  createRetrievalDreamService: jest.fn().mockReturnValue(null)
+}));
+
+import { EmbeddingManager } from '../../src/services/embeddings/EmbeddingManager';
+import type { App, Plugin } from 'obsidian';
+import type { SQLiteCacheManager } from '../../src/database/storage/SQLiteCacheManager';
+
+function createManager() {
+  const app = { vault: { adapter: {}, configDir: '.obsidian' } } as unknown as App;
+  const plugin = {
+    settings: { embeddings: { retrievalLearning: false } },
+    addCommand: jest.fn(),
+    registerInterval: jest.fn()
+  } as unknown as Plugin;
+  return new EmbeddingManager(app, plugin, {} as unknown as SQLiteCacheManager, true);
+}
+
+describe('EmbeddingManager background indexing order', () => {
+  beforeEach(() => {
+    calls.length = 0;
+    indexing = false;
+    cancel.mockClear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('indexes conversations before traces, and notes last', async () => {
+    const manager = createManager();
+    manager.initialize();
+
+    jest.advanceTimersByTime(3_000);
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['conversations', 'traces', 'notes']);
+  });
+
+  it('re-derives embeddings after a cache rebuild', async () => {
+    jest.useRealTimers();
+    const manager = createManager();
+    manager.initialize();
+    calls.length = 0;
+
+    await manager.reindexAfterCacheRebuild();
+
+    // Conversations first here too: they are the rows the rebuild actually
+    // destroyed, so they must not queue behind the vault walk.
+    expect(calls[0]).toBe('conversations');
+    expect(calls).toContain('traces');
+    expect(calls).toContain('notes');
+  });
+
+  it('cancels the in-flight walk so the re-index is not swallowed by isRunning', async () => {
+    jest.useRealTimers();
+    const manager = createManager();
+    manager.initialize();
+    indexing = true;          // the long note walk is running
+    calls.length = 0;
+
+    await manager.reindexAfterCacheRebuild();
+
+    // Without the cancel(), every phase would early-return on isRunning and the
+    // rebuild would silently leave conversation embeddings at zero.
+    expect(cancel).toHaveBeenCalled();
+    expect(calls[0]).toBe('conversations');
+  });
+});

--- a/tests/unit/EmbeddingManagerShutdownTimer.test.ts
+++ b/tests/unit/EmbeddingManagerShutdownTimer.test.ts
@@ -112,6 +112,9 @@ describe('EmbeddingManager deferred background indexing', () => {
     jest.advanceTimersByTime(3_000);
     await Promise.resolve();
 
-    expect(startFullIndex).toHaveBeenCalled();
+    // Conversations are the first phase (cheapest-first ordering), so this is
+    // the call that proves the timer fired. Asserting on the note phase would
+    // only prove the whole chain had drained.
+    expect(startConversationIndex).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Two halves of the same defect: after any full cache rebuild, chat search was dead for hours — or for the rest of the session.

`SQLiteMaintenanceService.clearAllData()` DROPs `conversation_embeddings` and clears `embedding_backfill_state` at the start of every `fullRebuild`. Note and trace embeddings are **untouched**, so a rebuild destroys exactly one index — the smallest and most valuable one — and then made it wait the longest to come back.

## 1. Phase ordering

`runBackgroundIndexing` awaited notes → traces → conversations.

Verified the phases are independent before touching the order: `ConversationIndexer` reads only `conversations` / `messages` / `embedding_backfill_state`, `TraceIndexer` only `memory_traces` and its own metadata, and the note phase walks the vault. Nothing reads another phase's output, so the ordering was incidental — but on a vault with 18,197 notes it queued a few hundred conversations behind a multi-hour walk.

Measured live on a real vault: **~62 notes/min**, so **~5 hours** before the conversation phase could even start.

Now conversations → traces → notes. Cheapest first, longest last.

## 2. Cache-rebuild recovery

Re-derivation was designed in — `clearAllData` also clears `embedding_backfill_state` so the backfill restarts — but only on the **next plugin load**. A mid-session "Nexus: Rebuild cache" left conversation embeddings at zero with nothing to rebuild them, because `cache-rebuilt` had exactly one subscriber in the entire codebase: the notes index (`ServiceDefinitions.ts:244`).

The embedding manager now subscribes too, wired in `PluginLifecycleManager` via `registerEvent` so the ref drops on unload.

`reindexAfterCacheRebuild()` **cancels the in-flight walk before restarting.** The phases are gated on `isRunning`, so a re-index requested during the long note walk would otherwise early-return and silently do nothing — which is precisely why this could not be shipped as a bare subscription. `cancel()` does not set the queue's `destroyed` flag (#360), which is what makes the restart legal.

### Deliberately not done

**`cache-rebuilt` is not fired from the startup rebuild path.** At startup the event has no subscribers — embeddings initialize only after `waitForQueryReady()`, well after the rebuild runs — so adding the trigger there would be a no-op that reads like coverage. The reordering above already covers the startup case. Only the mid-session rebuild needed the signal.

## Tests

3 new tests, all of which fail against the old code (verified by stashing the source, not assumed):

- phases run `['conversations', 'traces', 'notes']` in that order
- a cache rebuild re-derives, conversations first
- the re-index cancels the in-flight walk, so it is not swallowed by `isRunning`

Also retargets the shutdown-timer test's positive control, which asserted the note phase had started — true when notes ran first, wrong now. It now asserts on the conversation phase, which is what proves the timer fired.

## Gate

- `npx tsc --noEmit --skipLibCheck` — 0 errors
- `npx jest --runInBand` — **4916 passed, 0 failed**, 37 skipped
- `npm run build` — exit 0 (checked via file, not through a pipe), mobile scan `clean: no Node built-in is statically reachable from init`

Follow-up to #360, which made the `cancel()` semantics this relies on correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)