### PR TITLE
chore: remove dead recreateCorruptedDatabase wrapper

### DIFF
--- a/src/database/storage/SQLiteCacheManager.ts
+++ b/src/database/storage/SQLiteCacheManager.ts
@@ -359,25 +359,6 @@ export class SQLiteCacheManager implements IStorageBackend, ISQLiteCacheManager 
   }
 
   /**
-   * Recreate database after corruption detected
-   * Deletes corrupt file and creates fresh database
-   */
-  private async recreateCorruptedDatabase(): Promise<void> {
-    const sqlite3 = this.getSqlite3OrThrow();
-    if (this.db) {
-      try {
-        this.bridge.close(this.db);
-      } catch {
-        void 0;
-      }
-      this.db = null;
-    }
-
-    this.db = await this.persistenceService.recreateCorruptedDatabase(sqlite3, SCHEMA_SQL);
-    this.hasUnsavedData = false;
-  }
-
-  /**
    * Save database to file using sqlite3_js_db_export
    */
   private async saveToFile(): Promise<void> {


### PR DESCRIPTION
`SQLiteCacheManager.recreateCorruptedDatabase()` (private, was line 365) had **zero callers**.

Real corruption recovery lives in `SQLitePersistenceService.loadDatabase()`, which calls its own `recreateCorruptedDatabase()` on both the failed-load and failed-integrity-check paths. That is a *different* method which happens to share the name — which is exactly what made the dead wrapper look reachable in a grep.

Verified before removing: after deletion there are no remaining references to the identifier anywhere in `SQLiteCacheManager.ts`, and every other hit in `src/` resolves to the `SQLitePersistenceService` method or a doc comment mentioning it.

## Gate

- `npx tsc --noEmit --skipLibCheck` — 0 errors
- `npx jest --runInBand` — **4913 passed, 0 failed**, 37 skipped
- `npm run build` — exit 0 (checked via file, not through a pipe), mobile scan `clean: no Node built-in is statically reachable from init`

Spotted during the #342 corrupt-cache investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)