### PR TITLE
fix: log when the storage adapter is missing at embedding init

### DIFF
--- a/src/core/PluginLifecycleManager.ts
+++ b/src/core/PluginLifecycleManager.ts
@@ -232,6 +232,17 @@ export class PluginLifecycleManager {
                             const adapter = await this.config.serviceManager?.getService<HybridStorageAdapter>('hybridStorageAdapter');
                             if (adapter) {
                                 await this.initializeEmbeddingsWhenReady(adapter);
+                            } else {
+                                // Falling through silently here is indistinguishable from
+                                // "embeddings are still starting up" — this timer is the only
+                                // thing that ever constructs EmbeddingManager, so if the
+                                // adapter is missing they never initialize and nothing says
+                                // why. That absence of a signal reads as a slow boot, which
+                                // is precisely how it gets misdiagnosed. Say it out loud.
+                                console.error(
+                                    '[PluginLifecycleManager] hybridStorageAdapter unavailable after startup delay; ' +
+                                    'embeddings will not initialize for this session'
+                                );
                             }
                         } catch (err) {
                             console.error('[PluginLifecycleManager] Background SQLite initialization failed:', err);


### PR DESCRIPTION
## What

Adds an `else` branch to the deferred embedding kick-off in `PluginLifecycleManager.startBackgroundInitialization()`. When `getService('hybridStorageAdapter')` returns undefined, the code previously fell through with no log and no side effect.

## Why

That timer is the **only** thing that ever constructs `EmbeddingManager`. If the adapter is missing, embeddings never initialize for the whole session and nothing records why.

The missing signal is the real hazard. Embeddings legitimately take **~10s** to appear after a `plugin:reload` — the 3s timer is scheduled at the *end* of a ten-step await chain, and its callback then awaits `waitForQueryReady()`. So `embeddingManager === undefined` already looks like a slow boot. Without a log, a genuine failure and normal startup latency are indistinguishable.

Measured on a real vault (18k notes):

| | clean reload | 3 stacked reloads |
|---|---|---|
| `isInitialized` | ~4s | ~6s |
| `embeddingManager` present | ~10s | ~16s |

This ambiguity already caused one misdiagnosis in review — a premature probe read the absent manager as "the timer never fires" and a bisect appeared to confirm it as a pre-existing bug. There is no such bug; both reload paths recover. This log line is what would have settled it immediately.

## Scope

Log-only. No behaviour on the success path changes.

## Testing

- `npx tsc --noEmit --skipLibCheck` — exit 0
- `npx eslint src/core/PluginLifecycleManager.ts` — exit 0
- `npx jest --runInBand` — exit 0, 4916 passed / 37 skipped
- `npm run build` — exit 0, `main.js` 4.73 MB (under the 5 MB ceiling); new message confirmed present in the bundle (not tree-shaken)

No unit test: constructing `PluginLifecycleManager` requires ~10 collaborators, which is a disproportionate mock surface for a single log line on a branch that is unreachable in current wiring. The branch's presence in the built bundle is verified instead.

The `else` branch is **not** exercised live — it does not fire in current wiring, which is the point. The success path was re-verified live across five `plugin:reload`s: zero errors, embeddings initializing normally each time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)