### PR TITLE
Add GLM 5.3 Flash to the OpenRouter registry (Qwen3.8 Flash held back)

### DIFF
--- a/.claude/skills/nexus-model-updates/protocols/verify-model.md
+++ b/.claude/skills/nexus-model-updates/protocols/verify-model.md
@@ -70,7 +70,7 @@ structure, through a live call, to tool use.
 - Anti-pattern: reporting "added and tested" when only the unit lane ran. The
   unit lane reads the same literal you just wrote.
 - Anti-pattern: treating a smoke failure as a bad model id before ruling out the
-  two impostors in `references/smoke-harness.md`. Most first failures are one of
+  impostors in `references/smoke-harness.md`. Most first failures are one of
   them.
 - Anti-pattern: pasting credentials, tokens or `.env` contents into a report.
 

--- a/.claude/skills/nexus-model-updates/references/smoke-harness.md
+++ b/.claude/skills/nexus-model-updates/references/smoke-harness.md
@@ -61,7 +61,7 @@ gateway reporting the upstream model it routed to, for instance — fails the
 assertion on a call that actually succeeded. Read the failure message before
 concluding the id is bad.
 
-## The two impostors
+## The three impostors
 Before treating a failure as a bad id or a bad key:
 
 1. **Token starvation on a reasoning model.** The lane sends a small output-token
@@ -78,9 +78,17 @@ Before treating a failure as a bad id or a bad key:
    same treatment, and the symptom is a parameter-rejection error, not a
    model-not-found error.
 
-Network or DNS failures in a sandboxed session are a third category and mean the
-run never reached the provider. Re-run with network access rather than recording
-a failure.
+3. **Upstream saturation on a just-launched gateway model.** The adapter
+   surfaces this as an opaque `generation failed: Provider returned error`,
+   which reads like a bad id. Reproduce the call with curl against the gateway
+   directly and read the error body: a 429 whose metadata names the upstream
+   provider's shared pool means the id is fine and the launch-day pool is
+   saturated. Retry with backoff — these typically clear within minutes — rather
+   than re-spelling the id or touching the entry.
+
+Network or DNS failures in a sandboxed session are a fourth category and mean
+the run never reached the provider. Re-run with network access rather than
+recording a failure.
 
 ## What a pass does not mean
 It returned text. It did not call a tool, hold a multi-turn conversation, or

--- a/.claude/skills/nexus-model-updates/refinement-log.md
+++ b/.claude/skills/nexus-model-updates/refinement-log.md
@@ -37,3 +37,21 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   default; deleted every model id, price and baseline; re-verified every
   remaining claim against source and handed eval-harness content to
   `nexus-model-eval`. | Files: the whole skill.
+
+- 2026-08-27 | Adding `z-ai/glm-5.3-flash` and `qwen/qwen3.8-flash` to the
+  OpenRouter registry, the Qwen smoke run failed with an opaque
+  `generation failed: Provider returned error` that looked like a bad id but was
+  a 429 from Alibaba's saturated shared pool (the model had launched the day
+  before); a direct curl exposed the error body and a retry with backoff
+  passed. | Added a third impostor — upstream saturation on a just-launched
+  gateway model, diagnose via direct curl, retry with backoff — and reworded
+  verify-model's anti-pattern to not hardcode the impostor count. | Files:
+  `references/smoke-harness.md`, `protocols/verify-model.md`.
+
+- 2026-08-27 | Commenting out the Qwen3.8 Flash entry (held back for upstream
+  reliability, per the user) made the gate report a phantom entry missing every
+  field: the brace walker counted braces inside `//` comments. | Added
+  `mask_line_comments()` in `check_model_registry.py` — blanks line comments
+  (outside quotes) with spaces before parsing, preserving offsets so line
+  numbers stay true. Commented-out entries are now a legitimate registry
+  state. | Files: `scripts/check_model_registry.py`.

--- a/.claude/skills/nexus-model-updates/scripts/check_model_registry.py
+++ b/.claude/skills/nexus-model-updates/scripts/check_model_registry.py
@@ -152,8 +152,23 @@ class Registry:
         self.runtime_discovery = False
 
 
+def mask_line_comments(text: str) -> str:
+    """Blank out `//` comments (outside single quotes) with spaces.
+
+    A registry may carry a whole entry commented out — held back rather than
+    deleted. Without masking, the brace walker counts the commented braces and
+    reports a phantom entry missing every field. Spaces preserve offsets so
+    reported line numbers stay true.
+    """
+    out = []
+    for line in text.split("\n"):
+        kept = strip_trailing_comment(line)
+        out.append(kept + " " * (len(line) - len(kept)))
+    return "\n".join(out)
+
+
 def parse_registry(path: Path, provider_dir: str) -> Registry | None:
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = mask_line_comments(path.read_text(encoding="utf-8", errors="replace"))
     decl = REGISTRY_DECL.search(text)
     if not decl:
         return None

--- a/.cline/skills/nexus-model-updates/protocols/verify-model.md
+++ b/.cline/skills/nexus-model-updates/protocols/verify-model.md
@@ -70,7 +70,7 @@ structure, through a live call, to tool use.
 - Anti-pattern: reporting "added and tested" when only the unit lane ran. The
   unit lane reads the same literal you just wrote.
 - Anti-pattern: treating a smoke failure as a bad model id before ruling out the
-  two impostors in `references/smoke-harness.md`. Most first failures are one of
+  impostors in `references/smoke-harness.md`. Most first failures are one of
   them.
 - Anti-pattern: pasting credentials, tokens or `.env` contents into a report.
 

--- a/.cline/skills/nexus-model-updates/references/smoke-harness.md
+++ b/.cline/skills/nexus-model-updates/references/smoke-harness.md
@@ -61,7 +61,7 @@ gateway reporting the upstream model it routed to, for instance — fails the
 assertion on a call that actually succeeded. Read the failure message before
 concluding the id is bad.
 
-## The two impostors
+## The three impostors
 Before treating a failure as a bad id or a bad key:
 
 1. **Token starvation on a reasoning model.** The lane sends a small output-token
@@ -78,9 +78,17 @@ Before treating a failure as a bad id or a bad key:
    same treatment, and the symptom is a parameter-rejection error, not a
    model-not-found error.
 
-Network or DNS failures in a sandboxed session are a third category and mean the
-run never reached the provider. Re-run with network access rather than recording
-a failure.
+3. **Upstream saturation on a just-launched gateway model.** The adapter
+   surfaces this as an opaque `generation failed: Provider returned error`,
+   which reads like a bad id. Reproduce the call with curl against the gateway
+   directly and read the error body: a 429 whose metadata names the upstream
+   provider's shared pool means the id is fine and the launch-day pool is
+   saturated. Retry with backoff — these typically clear within minutes — rather
+   than re-spelling the id or touching the entry.
+
+Network or DNS failures in a sandboxed session are a fourth category and mean
+the run never reached the provider. Re-run with network access rather than
+recording a failure.
 
 ## What a pass does not mean
 It returned text. It did not call a tool, hold a multi-turn conversation, or

--- a/.cline/skills/nexus-model-updates/refinement-log.md
+++ b/.cline/skills/nexus-model-updates/refinement-log.md
@@ -37,3 +37,21 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   default; deleted every model id, price and baseline; re-verified every
   remaining claim against source and handed eval-harness content to
   `nexus-model-eval`. | Files: the whole skill.
+
+- 2026-08-27 | Adding `z-ai/glm-5.3-flash` and `qwen/qwen3.8-flash` to the
+  OpenRouter registry, the Qwen smoke run failed with an opaque
+  `generation failed: Provider returned error` that looked like a bad id but was
+  a 429 from Alibaba's saturated shared pool (the model had launched the day
+  before); a direct curl exposed the error body and a retry with backoff
+  passed. | Added a third impostor — upstream saturation on a just-launched
+  gateway model, diagnose via direct curl, retry with backoff — and reworded
+  verify-model's anti-pattern to not hardcode the impostor count. | Files:
+  `references/smoke-harness.md`, `protocols/verify-model.md`.
+
+- 2026-08-27 | Commenting out the Qwen3.8 Flash entry (held back for upstream
+  reliability, per the user) made the gate report a phantom entry missing every
+  field: the brace walker counted braces inside `//` comments. | Added
+  `mask_line_comments()` in `check_model_registry.py` — blanks line comments
+  (outside quotes) with spaces before parsing, preserving offsets so line
+  numbers stay true. Commented-out entries are now a legitimate registry
+  state. | Files: `scripts/check_model_registry.py`.

--- a/.cline/skills/nexus-model-updates/scripts/check_model_registry.py
+++ b/.cline/skills/nexus-model-updates/scripts/check_model_registry.py
@@ -152,8 +152,23 @@ class Registry:
         self.runtime_discovery = False
 
 
+def mask_line_comments(text: str) -> str:
+    """Blank out `//` comments (outside single quotes) with spaces.
+
+    A registry may carry a whole entry commented out — held back rather than
+    deleted. Without masking, the brace walker counts the commented braces and
+    reports a phantom entry missing every field. Spaces preserve offsets so
+    reported line numbers stay true.
+    """
+    out = []
+    for line in text.split("\n"):
+        kept = strip_trailing_comment(line)
+        out.append(kept + " " * (len(line) - len(kept)))
+    return "\n".join(out)
+
+
 def parse_registry(path: Path, provider_dir: str) -> Registry | None:
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = mask_line_comments(path.read_text(encoding="utf-8", errors="replace"))
     decl = REGISTRY_DECL.search(text)
     if not decl:
         return None

--- a/.codex/skills/nexus-model-updates/protocols/verify-model.md
+++ b/.codex/skills/nexus-model-updates/protocols/verify-model.md
@@ -70,7 +70,7 @@ structure, through a live call, to tool use.
 - Anti-pattern: reporting "added and tested" when only the unit lane ran. The
   unit lane reads the same literal you just wrote.
 - Anti-pattern: treating a smoke failure as a bad model id before ruling out the
-  two impostors in `references/smoke-harness.md`. Most first failures are one of
+  impostors in `references/smoke-harness.md`. Most first failures are one of
   them.
 - Anti-pattern: pasting credentials, tokens or `.env` contents into a report.
 

--- a/.codex/skills/nexus-model-updates/references/smoke-harness.md
+++ b/.codex/skills/nexus-model-updates/references/smoke-harness.md
@@ -61,7 +61,7 @@ gateway reporting the upstream model it routed to, for instance — fails the
 assertion on a call that actually succeeded. Read the failure message before
 concluding the id is bad.
 
-## The two impostors
+## The three impostors
 Before treating a failure as a bad id or a bad key:
 
 1. **Token starvation on a reasoning model.** The lane sends a small output-token
@@ -78,9 +78,17 @@ Before treating a failure as a bad id or a bad key:
    same treatment, and the symptom is a parameter-rejection error, not a
    model-not-found error.
 
-Network or DNS failures in a sandboxed session are a third category and mean the
-run never reached the provider. Re-run with network access rather than recording
-a failure.
+3. **Upstream saturation on a just-launched gateway model.** The adapter
+   surfaces this as an opaque `generation failed: Provider returned error`,
+   which reads like a bad id. Reproduce the call with curl against the gateway
+   directly and read the error body: a 429 whose metadata names the upstream
+   provider's shared pool means the id is fine and the launch-day pool is
+   saturated. Retry with backoff — these typically clear within minutes — rather
+   than re-spelling the id or touching the entry.
+
+Network or DNS failures in a sandboxed session are a fourth category and mean
+the run never reached the provider. Re-run with network access rather than
+recording a failure.
 
 ## What a pass does not mean
 It returned text. It did not call a tool, hold a multi-turn conversation, or

--- a/.codex/skills/nexus-model-updates/refinement-log.md
+++ b/.codex/skills/nexus-model-updates/refinement-log.md
@@ -37,3 +37,21 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   default; deleted every model id, price and baseline; re-verified every
   remaining claim against source and handed eval-harness content to
   `nexus-model-eval`. | Files: the whole skill.
+
+- 2026-08-27 | Adding `z-ai/glm-5.3-flash` and `qwen/qwen3.8-flash` to the
+  OpenRouter registry, the Qwen smoke run failed with an opaque
+  `generation failed: Provider returned error` that looked like a bad id but was
+  a 429 from Alibaba's saturated shared pool (the model had launched the day
+  before); a direct curl exposed the error body and a retry with backoff
+  passed. | Added a third impostor — upstream saturation on a just-launched
+  gateway model, diagnose via direct curl, retry with backoff — and reworded
+  verify-model's anti-pattern to not hardcode the impostor count. | Files:
+  `references/smoke-harness.md`, `protocols/verify-model.md`.
+
+- 2026-08-27 | Commenting out the Qwen3.8 Flash entry (held back for upstream
+  reliability, per the user) made the gate report a phantom entry missing every
+  field: the brace walker counted braces inside `//` comments. | Added
+  `mask_line_comments()` in `check_model_registry.py` — blanks line comments
+  (outside quotes) with spaces before parsing, preserving offsets so line
+  numbers stay true. Commented-out entries are now a legitimate registry
+  state. | Files: `scripts/check_model_registry.py`.

--- a/.codex/skills/nexus-model-updates/scripts/check_model_registry.py
+++ b/.codex/skills/nexus-model-updates/scripts/check_model_registry.py
@@ -152,8 +152,23 @@ class Registry:
         self.runtime_discovery = False
 
 
+def mask_line_comments(text: str) -> str:
+    """Blank out `//` comments (outside single quotes) with spaces.
+
+    A registry may carry a whole entry commented out — held back rather than
+    deleted. Without masking, the brace walker counts the commented braces and
+    reports a phantom entry missing every field. Spaces preserve offsets so
+    reported line numbers stay true.
+    """
+    out = []
+    for line in text.split("\n"):
+        kept = strip_trailing_comment(line)
+        out.append(kept + " " * (len(line) - len(kept)))
+    return "\n".join(out)
+
+
 def parse_registry(path: Path, provider_dir: str) -> Registry | None:
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = mask_line_comments(path.read_text(encoding="utf-8", errors="replace"))
     decl = REGISTRY_DECL.search(text)
     if not decl:
         return None

--- a/.skills/nexus-model-updates/protocols/verify-model.md
+++ b/.skills/nexus-model-updates/protocols/verify-model.md
@@ -70,7 +70,7 @@ structure, through a live call, to tool use.
 - Anti-pattern: reporting "added and tested" when only the unit lane ran. The
   unit lane reads the same literal you just wrote.
 - Anti-pattern: treating a smoke failure as a bad model id before ruling out the
-  two impostors in `references/smoke-harness.md`. Most first failures are one of
+  impostors in `references/smoke-harness.md`. Most first failures are one of
   them.
 - Anti-pattern: pasting credentials, tokens or `.env` contents into a report.
 

--- a/.skills/nexus-model-updates/references/smoke-harness.md
+++ b/.skills/nexus-model-updates/references/smoke-harness.md
@@ -61,7 +61,7 @@ gateway reporting the upstream model it routed to, for instance — fails the
 assertion on a call that actually succeeded. Read the failure message before
 concluding the id is bad.
 
-## The two impostors
+## The three impostors
 Before treating a failure as a bad id or a bad key:
 
 1. **Token starvation on a reasoning model.** The lane sends a small output-token
@@ -78,9 +78,17 @@ Before treating a failure as a bad id or a bad key:
    same treatment, and the symptom is a parameter-rejection error, not a
    model-not-found error.
 
-Network or DNS failures in a sandboxed session are a third category and mean the
-run never reached the provider. Re-run with network access rather than recording
-a failure.
+3. **Upstream saturation on a just-launched gateway model.** The adapter
+   surfaces this as an opaque `generation failed: Provider returned error`,
+   which reads like a bad id. Reproduce the call with curl against the gateway
+   directly and read the error body: a 429 whose metadata names the upstream
+   provider's shared pool means the id is fine and the launch-day pool is
+   saturated. Retry with backoff — these typically clear within minutes — rather
+   than re-spelling the id or touching the entry.
+
+Network or DNS failures in a sandboxed session are a fourth category and mean
+the run never reached the provider. Re-run with network access rather than
+recording a failure.
 
 ## What a pass does not mean
 It returned text. It did not call a tool, hold a multi-turn conversation, or

--- a/.skills/nexus-model-updates/refinement-log.md
+++ b/.skills/nexus-model-updates/refinement-log.md
@@ -37,3 +37,21 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   default; deleted every model id, price and baseline; re-verified every
   remaining claim against source and handed eval-harness content to
   `nexus-model-eval`. | Files: the whole skill.
+
+- 2026-08-27 | Adding `z-ai/glm-5.3-flash` and `qwen/qwen3.8-flash` to the
+  OpenRouter registry, the Qwen smoke run failed with an opaque
+  `generation failed: Provider returned error` that looked like a bad id but was
+  a 429 from Alibaba's saturated shared pool (the model had launched the day
+  before); a direct curl exposed the error body and a retry with backoff
+  passed. | Added a third impostor — upstream saturation on a just-launched
+  gateway model, diagnose via direct curl, retry with backoff — and reworded
+  verify-model's anti-pattern to not hardcode the impostor count. | Files:
+  `references/smoke-harness.md`, `protocols/verify-model.md`.
+
+- 2026-08-27 | Commenting out the Qwen3.8 Flash entry (held back for upstream
+  reliability, per the user) made the gate report a phantom entry missing every
+  field: the brace walker counted braces inside `//` comments. | Added
+  `mask_line_comments()` in `check_model_registry.py` — blanks line comments
+  (outside quotes) with spaces before parsing, preserving offsets so line
+  numbers stay true. Commented-out entries are now a legitimate registry
+  state. | Files: `scripts/check_model_registry.py`.

--- a/.skills/nexus-model-updates/scripts/check_model_registry.py
+++ b/.skills/nexus-model-updates/scripts/check_model_registry.py
@@ -152,8 +152,23 @@ class Registry:
         self.runtime_discovery = False
 
 
+def mask_line_comments(text: str) -> str:
+    """Blank out `//` comments (outside single quotes) with spaces.
+
+    A registry may carry a whole entry commented out — held back rather than
+    deleted. Without masking, the brace walker counts the commented braces and
+    reports a phantom entry missing every field. Spaces preserve offsets so
+    reported line numbers stay true.
+    """
+    out = []
+    for line in text.split("\n"):
+        kept = strip_trailing_comment(line)
+        out.append(kept + " " * (len(line) - len(kept)))
+    return "\n".join(out)
+
+
 def parse_registry(path: Path, provider_dir: str) -> Registry | None:
-    text = path.read_text(encoding="utf-8", errors="replace")
+    text = mask_line_comments(path.read_text(encoding="utf-8", errors="replace"))
     decl = REGISTRY_DECL.search(text)
     if not decl:
         return None

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -245,6 +245,24 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
     }
   },
   {
+    // OpenRouter's model page advertises a 1.31M window, but the top serving
+    // provider caps at 1,048,576 — claim the cap, not the aspiration.
+    provider: 'openrouter',
+    name: 'GLM 5.3 Flash',
+    apiName: 'z-ai/glm-5.3-flash',
+    contextWindow: 1048576,
+    maxTokens: 131072,
+    inputCostPerMillion: 0.075,
+    outputCostPerMillion: 0.25,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
     provider: 'openrouter',
     name: 'GLM 5V Turbo',
     apiName: 'z-ai/glm-5v-turbo',
@@ -711,6 +729,26 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
       supportsThinking: true
     }
   },
+  // Qwen3.8 Flash is held back until its upstream capacity stabilizes: on
+  // 2026-08-27 (launch week) Alibaba's shared pool 429'd 33 of 37 eval
+  // scenarios. The id, metadata and a live smoke pass are verified — re-enable
+  // once the endpoint is reliably reachable.
+  // {
+  //   provider: 'openrouter',
+  //   name: 'Qwen3.8 Flash',
+  //   apiName: 'qwen/qwen3.8-flash',
+  //   contextWindow: 1000000,
+  //   maxTokens: 131072,
+  //   inputCostPerMillion: 0.15,
+  //   outputCostPerMillion: 0.47,
+  //   capabilities: {
+  //     supportsJSON: true,
+  //     supportsImages: true,
+  //     supportsFunctions: true,
+  //     supportsStreaming: true,
+  //     supportsThinking: true
+  //   }
+  // },
 ];
 
 export const OPENROUTER_DEFAULT_MODEL = 'openai/gpt-5.6-sol';


### PR DESCRIPTION
## Summary
- Adds **GLM 5.3 Flash** (`z-ai/glm-5.3-flash`) to the OpenRouter model registry: 1,048,576 context / 131,072 max output, $0.075 in / $0.25 out per million, all five capability flags true per OpenRouter's live listing. Context is claimed at the top serving provider's cap rather than the model page's advertised 1.31M.
- **Qwen3.8 Flash** (`qwen/qwen3.8-flash`) is included but commented out: id, metadata, and a live smoke pass are verified, but Alibaba's launch-week shared pool 429'd 33 of 37 eval scenarios, so it's held back until upstream capacity is reliable. Re-adding is uncommenting the block.
- Skill refinements from the session (source in `.skills/`, mirrors synced): a third smoke-lane impostor (upstream saturation on a just-launched gateway model) documented in `smoke-harness.md`, and `check_model_registry.py` now masks `//` line comments before parsing so a commented-out entry no longer reports as a phantom entry.

## Verification
- Registry gate clean across all 13 registries (pre-existing Claude 1M variant-pair warnings only)
- `ModelRegistry.test.ts` 30/30; full `npm run build` and `tsc --noEmit` pass
- Live smoke through the real adapter: both ids pass
- Eval grade (mock surface, 2026-08-27): GLM 5.3 Flash **97% attributed** (35/36; one charged failure was a malformed CLI string, one fixture-bug excluded and flagged separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)