### PR TITLE
Fix eval move scenario to expect the schema's newPath param

### DIFF
--- a/.claude/skills/nexus-eval-harness/references/scenario-contract.md
+++ b/.claude/skills/nexus-eval-harness/references/scenario-contract.md
@@ -74,6 +74,13 @@ result it was supposed to get looks identical to one that works.
   case-insensitively as substrings of the actual value, and nested objects match
   partially. Assert the path on the unwrapped domain call when you care about
   arguments.
+- **Expected param names must be the schema's names, not normalizer aliases.**
+  The generated catalog advertises only the production tool's declared schema;
+  a model shown it will never produce an alias the normalizer merely accepts
+  (e.g. `destination` for `storageManager_move`, whose schema requires
+  `newPath`). An alias in `params` fails every model identically — the tell for
+  this whole class of fixture bug. Check the tool's `getSchema()` in
+  `src/agents/` before naming a param.
 - **Rounds are consumed in order** unless `allowReorder: true`, which only
   requires that every expected call appears somewhere in the exchange. Reach for
   it whenever the order is genuinely free (search-then-read versus

--- a/.claude/skills/nexus-eval-harness/refinement-log.md
+++ b/.claude/skills/nexus-eval-harness/refinement-log.md
@@ -26,3 +26,14 @@ configure-a-run, debug-a-run, extend-the-harness, self-refine), `references/`
 `scripts/check_scenarios.py`, which derives the scenario field list from
 `tests/eval/types.ts` and the tool names from `tests/eval/fixtures/tools.ts` and
 fails on the selector-blind `getTools` trap. | every file in this skill.
+
+- 2026-08-27 | `read-then-write-then-move` expected `storageManager_move` param
+  `destination` — a normalizer alias the generated catalog never advertises;
+  the production schema requires `newPath`. Three models (glm-5.3-flash,
+  deepseek-v4-pro-0813, gemini-3.7-flash) failed it identically with correct
+  calls. | Changed the expectation to `newPath: archive/` (substring match
+  keeps the target-name freedom) and added a scenario-contract rule: expected
+  param names must be schema names, not normalizer aliases — identical failure
+  across models is the tell. Verified: glm-5.3-flash passes first attempt, 0
+  retries. | Files: `tests/eval/scenarios/multi-turn.eval.yaml`,
+  `references/scenario-contract.md`.

--- a/.cline/skills/nexus-eval-harness/references/scenario-contract.md
+++ b/.cline/skills/nexus-eval-harness/references/scenario-contract.md
@@ -74,6 +74,13 @@ result it was supposed to get looks identical to one that works.
   case-insensitively as substrings of the actual value, and nested objects match
   partially. Assert the path on the unwrapped domain call when you care about
   arguments.
+- **Expected param names must be the schema's names, not normalizer aliases.**
+  The generated catalog advertises only the production tool's declared schema;
+  a model shown it will never produce an alias the normalizer merely accepts
+  (e.g. `destination` for `storageManager_move`, whose schema requires
+  `newPath`). An alias in `params` fails every model identically — the tell for
+  this whole class of fixture bug. Check the tool's `getSchema()` in
+  `src/agents/` before naming a param.
 - **Rounds are consumed in order** unless `allowReorder: true`, which only
   requires that every expected call appears somewhere in the exchange. Reach for
   it whenever the order is genuinely free (search-then-read versus

--- a/.cline/skills/nexus-eval-harness/refinement-log.md
+++ b/.cline/skills/nexus-eval-harness/refinement-log.md
@@ -26,3 +26,14 @@ configure-a-run, debug-a-run, extend-the-harness, self-refine), `references/`
 `scripts/check_scenarios.py`, which derives the scenario field list from
 `tests/eval/types.ts` and the tool names from `tests/eval/fixtures/tools.ts` and
 fails on the selector-blind `getTools` trap. | every file in this skill.
+
+- 2026-08-27 | `read-then-write-then-move` expected `storageManager_move` param
+  `destination` — a normalizer alias the generated catalog never advertises;
+  the production schema requires `newPath`. Three models (glm-5.3-flash,
+  deepseek-v4-pro-0813, gemini-3.7-flash) failed it identically with correct
+  calls. | Changed the expectation to `newPath: archive/` (substring match
+  keeps the target-name freedom) and added a scenario-contract rule: expected
+  param names must be schema names, not normalizer aliases — identical failure
+  across models is the tell. Verified: glm-5.3-flash passes first attempt, 0
+  retries. | Files: `tests/eval/scenarios/multi-turn.eval.yaml`,
+  `references/scenario-contract.md`.

--- a/.codex/skills/nexus-eval-harness/references/scenario-contract.md
+++ b/.codex/skills/nexus-eval-harness/references/scenario-contract.md
@@ -74,6 +74,13 @@ result it was supposed to get looks identical to one that works.
   case-insensitively as substrings of the actual value, and nested objects match
   partially. Assert the path on the unwrapped domain call when you care about
   arguments.
+- **Expected param names must be the schema's names, not normalizer aliases.**
+  The generated catalog advertises only the production tool's declared schema;
+  a model shown it will never produce an alias the normalizer merely accepts
+  (e.g. `destination` for `storageManager_move`, whose schema requires
+  `newPath`). An alias in `params` fails every model identically — the tell for
+  this whole class of fixture bug. Check the tool's `getSchema()` in
+  `src/agents/` before naming a param.
 - **Rounds are consumed in order** unless `allowReorder: true`, which only
   requires that every expected call appears somewhere in the exchange. Reach for
   it whenever the order is genuinely free (search-then-read versus

--- a/.codex/skills/nexus-eval-harness/refinement-log.md
+++ b/.codex/skills/nexus-eval-harness/refinement-log.md
@@ -26,3 +26,14 @@ configure-a-run, debug-a-run, extend-the-harness, self-refine), `references/`
 `scripts/check_scenarios.py`, which derives the scenario field list from
 `tests/eval/types.ts` and the tool names from `tests/eval/fixtures/tools.ts` and
 fails on the selector-blind `getTools` trap. | every file in this skill.
+
+- 2026-08-27 | `read-then-write-then-move` expected `storageManager_move` param
+  `destination` — a normalizer alias the generated catalog never advertises;
+  the production schema requires `newPath`. Three models (glm-5.3-flash,
+  deepseek-v4-pro-0813, gemini-3.7-flash) failed it identically with correct
+  calls. | Changed the expectation to `newPath: archive/` (substring match
+  keeps the target-name freedom) and added a scenario-contract rule: expected
+  param names must be schema names, not normalizer aliases — identical failure
+  across models is the tell. Verified: glm-5.3-flash passes first attempt, 0
+  retries. | Files: `tests/eval/scenarios/multi-turn.eval.yaml`,
+  `references/scenario-contract.md`.

--- a/.skills/nexus-eval-harness/references/scenario-contract.md
+++ b/.skills/nexus-eval-harness/references/scenario-contract.md
@@ -74,6 +74,13 @@ result it was supposed to get looks identical to one that works.
   case-insensitively as substrings of the actual value, and nested objects match
   partially. Assert the path on the unwrapped domain call when you care about
   arguments.
+- **Expected param names must be the schema's names, not normalizer aliases.**
+  The generated catalog advertises only the production tool's declared schema;
+  a model shown it will never produce an alias the normalizer merely accepts
+  (e.g. `destination` for `storageManager_move`, whose schema requires
+  `newPath`). An alias in `params` fails every model identically — the tell for
+  this whole class of fixture bug. Check the tool's `getSchema()` in
+  `src/agents/` before naming a param.
 - **Rounds are consumed in order** unless `allowReorder: true`, which only
   requires that every expected call appears somewhere in the exchange. Reach for
   it whenever the order is genuinely free (search-then-read versus

--- a/.skills/nexus-eval-harness/refinement-log.md
+++ b/.skills/nexus-eval-harness/refinement-log.md
@@ -26,3 +26,14 @@ configure-a-run, debug-a-run, extend-the-harness, self-refine), `references/`
 `scripts/check_scenarios.py`, which derives the scenario field list from
 `tests/eval/types.ts` and the tool names from `tests/eval/fixtures/tools.ts` and
 fails on the selector-blind `getTools` trap. | every file in this skill.
+
+- 2026-08-27 | `read-then-write-then-move` expected `storageManager_move` param
+  `destination` — a normalizer alias the generated catalog never advertises;
+  the production schema requires `newPath`. Three models (glm-5.3-flash,
+  deepseek-v4-pro-0813, gemini-3.7-flash) failed it identically with correct
+  calls. | Changed the expectation to `newPath: archive/` (substring match
+  keeps the target-name freedom) and added a scenario-contract rule: expected
+  param names must be schema names, not normalizer aliases — identical failure
+  across models is the tell. Verified: glm-5.3-flash passes first attempt, 0
+  retries. | Files: `tests/eval/scenarios/multi-turn.eval.yaml`,
+  `references/scenario-contract.md`.

--- a/tests/eval/scenarios/multi-turn.eval.yaml
+++ b/tests/eval/scenarios/multi-turn.eval.yaml
@@ -28,7 +28,11 @@
         - name: storageManager_move
           params:
             path: notes/summary.md
-            destination: archive/
+            # The production schema (storageManager/tools/move.ts) requires
+            # `newPath`; `destination` is only a normalizer alias the generated
+            # catalog never advertises. Substring match accepts any target
+            # under archive/.
+            newPath: archive/
       mockResponses:
         storageManager_move:
           success: true


### PR DESCRIPTION
## Summary
- `read-then-write-then-move` expected `storageManager_move` param `destination` — a normalizer alias the auto-generated tool catalog never advertises. The production schema (`src/agents/storageManager/tools/move.ts`) requires `newPath`, so every model shown the schema produced `newPath` and failed identically (glm-5.3-flash, deepseek-v4-pro-0813, gemini-3.7-flash — all with correct calls).
- Expectation changed to `newPath: archive/`; domain params are substring-matched, so any target under `archive/` passes without pinning a filename.
- Adds a scenario-contract rule to the `nexus-eval-harness` skill: expected param names must be schema names, never normalizer aliases — identical failure across models is the tell. Source in `.skills/`, mirrors synced.

## Verification
- `check_scenarios.py` clean (0 errors)
- One real run of the scenario against `openrouter=z-ai/glm-5.3-flash`: **passed, 0 retries**, transcript shows `{"path": "notes/summary.md", "newPath": "archive/summary.md"}` — the same model failed this scenario before the fix, so the flip is attributable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)