### PR TITLE
Use the shared history-aware message builder in every compat adapter

### DIFF
--- a/src/services/llm/adapters/groq/GroqAdapter.ts
+++ b/src/services/llm/adapters/groq/GroqAdapter.ts
@@ -20,6 +20,7 @@ import { extractStreamErrorMessage } from '../../streaming/streamErrorFrames';
 import { GROQ_MODELS, GROQ_DEFAULT_MODEL } from './GroqModels';
 import {
   buildBearerJsonHeaders,
+  buildMessagesWithConversationHistory,
   mapOpenAiCompatFinishReason,
   convertFunctionTools
 } from '../shared/OpenAICompatHelpers';
@@ -101,24 +102,6 @@ export class GroqAdapter extends BaseAdapter {
   }
 
   /**
-   * Resolve the outgoing message list. Tool continuations arrive as
-   * options.conversationHistory (with the system message stripped by
-   * buildToolContinuation, which expects the adapter to re-add it); dropping
-   * that history sends a continuation with no tool calls or results, and the
-   * model answers an empty conversation with an empty reply.
-   */
-  private resolveMessages(prompt: string, options?: GenerateOptions): Array<Record<string, unknown>> {
-    if (!options?.conversationHistory || options.conversationHistory.length === 0) {
-      return this.buildMessages(prompt, options?.systemPrompt);
-    }
-    let messages = options.conversationHistory;
-    if (options.systemPrompt && !messages.some(m => m.role === 'system')) {
-      messages = [{ role: 'system', content: options.systemPrompt }, ...messages];
-    }
-    return messages;
-  }
-
-  /**
    * Generate streaming response using async generator
    * Uses unified stream processing with automatic tool call accumulation
    */
@@ -131,7 +114,7 @@ export class GroqAdapter extends BaseAdapter {
         headers: buildBearerJsonHeaders(this.apiKey),
         body: JSON.stringify({
           model: options?.model || this.currentModel,
-          messages: this.resolveMessages(prompt, options),
+          messages: buildMessagesWithConversationHistory(prompt, options),
           temperature: options?.temperature,
           max_completion_tokens: options?.maxTokens,
           top_p: options?.topP,
@@ -256,7 +239,7 @@ export class GroqAdapter extends BaseAdapter {
 
     const chatParams: ChatCompletionParams = {
       model,
-      messages: this.resolveMessages(prompt, options),
+      messages: buildMessagesWithConversationHistory(prompt, options),
       temperature: options?.temperature,
       max_completion_tokens: options?.maxTokens,
       top_p: options?.topP,

--- a/src/services/llm/adapters/perplexity/PerplexityAdapter.ts
+++ b/src/services/llm/adapters/perplexity/PerplexityAdapter.ts
@@ -16,6 +16,7 @@ import {
   SearchResult
 } from '../types';
 import { extractStreamErrorMessage } from '../../streaming/streamErrorFrames';
+import { buildMessagesWithConversationHistory } from '../shared/OpenAICompatHelpers';
 import { PERPLEXITY_MODELS, PERPLEXITY_DEFAULT_MODEL } from './PerplexityModels';
 import { WebSearchUtils } from '../../utils/WebSearchUtils';
 import { mapOpenAiCompatFinishReason } from '../shared/OpenAICompatHelpers';
@@ -307,7 +308,7 @@ export class PerplexityAdapter extends BaseAdapter {
     const model = options?.model || this.currentModel;
     const requestBody: PerplexityRequestBody = {
       model,
-      messages: this.buildMessages(prompt, options?.systemPrompt),
+      messages: buildMessagesWithConversationHistory(prompt, options),
       temperature: options?.temperature,
       max_tokens: options?.maxTokens,
       top_p: options?.topP,

--- a/src/services/llm/adapters/requesty/RequestyAdapter.ts
+++ b/src/services/llm/adapters/requesty/RequestyAdapter.ts
@@ -207,7 +207,7 @@ export class RequestyAdapter extends BaseAdapter {
   private async generateWithChatCompletions(prompt: string, options?: GenerateOptions): Promise<LLMResponse> {
     const requestBody: Record<string, unknown> = {
       model: options?.model || this.currentModel,
-      messages: this.buildMessages(prompt, options?.systemPrompt),
+      messages: buildMessagesWithConversationHistory(prompt, options),
       temperature: options?.temperature,
       max_tokens: options?.maxTokens,
       response_format: options?.jsonMode ? { type: 'json_object' } : undefined,


### PR DESCRIPTION
## Summary
Follow-up to #368, from auditing every adapter for the dropped-`conversationHistory` defect:
- **Requesty** non-streaming path and **Perplexity** both paths now use `buildMessagesWithConversationHistory` — latent gaps only (Requesty's chat/streaming path already used the helper; Perplexity has no tool-capable models today), but each was one model-flag change away from the Groq silent-blank bug.
- **Groq**'s private `resolveMessages` duplicated the shared helper; both call sites now import it. Behavior identical, pinned by the adapter tests updated in #369.

Audit result for the rest: OpenRouter/OpenAI/Anthropic/Google/Copilot/Ollama/LM Studio/WebLLM consume history; DeepSeek and Mistral use the shared helper; Gemini CLI has functions off by design. The one remaining suspect is the Claude Code CLI adapter (supportsFunctions true, spawns per-request with no history) — flagged separately for in-app verification.

## Verification
Full build (lint, tsc, esbuild) green; GroqAdapter, ModelRegistry, and AdapterRegistry test lanes pass (51 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)