### PR TITLE
feat(models): add Claude 5 family to the Claude Code provider, default to Sonnet 5

### DIFF
--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeAdapter.ts
@@ -15,6 +15,7 @@ import {
   LLMProviderError
 } from '../types';
 import { ModelRegistry } from '../ModelRegistry';
+import { ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL } from './AnthropicClaudeCodeModels';
 import { getPrimaryServerKey } from '../../../../constants/branding';
 
 type ClaudeCodeToolCall = NonNullable<StreamChunk['toolCalls']>[number];
@@ -34,7 +35,7 @@ export class AnthropicClaudeCodeAdapter extends BaseAdapter {
   private activeProcess: DesktopChildProcess | null = null;
 
   constructor(private vault: Vault) {
-    super('claude-code-local-auth', 'claude-sonnet-4-6', 'claude-code://local', false);
+    super('claude-code-local-auth', ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL, 'claude-code://local', false);
     this.initializeCache();
   }
 

--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
@@ -19,10 +19,58 @@ export const ANTHROPIC_CLAUDE_CODE_MODELS: ModelSpec[] = [
   },
   {
     provider: 'anthropic-claude-code',
+    name: 'Claude Sonnet 5',
+    apiName: 'claude-sonnet-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
     name: 'Claude Sonnet 4.6',
     apiName: 'claude-sonnet-4-6',
     contextWindow: 200000,
     maxTokens: 64000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
+    name: 'Claude Fable 5',
+    apiName: 'claude-fable-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
+    name: 'Claude Opus 5',
+    apiName: 'claude-opus-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
     inputCostPerMillion: 0,
     outputCostPerMillion: 0,
     capabilities: {
@@ -67,4 +115,4 @@ export const ANTHROPIC_CLAUDE_CODE_MODELS: ModelSpec[] = [
   }
 ];
 
-export const ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-4-6';
+export const ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL = 'claude-sonnet-5';


### PR DESCRIPTION
## Summary
- Adds **Claude Fable 5** (`claude-fable-5`), **Claude Opus 5** (`claude-opus-5`) and **Claude Sonnet 5** (`claude-sonnet-5`) to the `anthropic-claude-code` registry — 1M context / 128k output (numbers mirrored from the vetted API-registry entries), cost 0 since the CLI provider bills through the subscription, all five capability flags true.
- Moves `ANTHROPIC_CLAUDE_CODE_DEFAULT_MODEL` from `claude-sonnet-4-6` to `claude-sonnet-5`.
- Replaces the adapter constructor's hardcoded default-model literal with the registry constant so the two can no longer drift.

## Verification
- All three ids verified **live** through the installed `claude` CLI (2.1.246), each returning a response.
- `check_model_registry.py --repo-root . anthropic-claude-code` clean.
- `AnthropicClaudeCodeAdapter.test.ts` + `ModelRegistry.test.ts` full files: 34 pass, 0 fail.
- `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)