### PR TITLE
feat(models): add Claude Opus 5 to the Anthropic registry, correct Sonnet 5 pricing

### DIFF
--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -42,6 +42,24 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     }
   },
 
+  // Claude Opus 5 (native 1M context, no beta header required)
+  {
+    provider: 'anthropic',
+    name: 'Claude Opus 5',
+    apiName: 'claude-opus-5',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 5.00,
+    outputCostPerMillion: 25.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
   // Claude Opus 4.8
   {
     provider: 'anthropic',
@@ -141,8 +159,9 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     apiName: 'claude-sonnet-5',
     contextWindow: 1000000,
     maxTokens: 128000,
-    inputCostPerMillion: 3.00,
-    outputCostPerMillion: 15.00,
+    // Docs list Sonnet 5 below the 4.6-generation Sonnet price point.
+    inputCostPerMillion: 2.00,
+    outputCostPerMillion: 10.00,
     capabilities: {
       supportsJSON: true,
       supportsImages: true,


### PR DESCRIPTION
## Summary
- Adds **Claude Opus 5** (`claude-opus-5`) to the Anthropic API registry: 1M context, 128K max output, $5 / $25 per MTok — all figures from [Anthropic's models overview](https://platform.claude.com/docs/en/docs/about-claude/models/overview). The registry already had Fable 5 and Sonnet 5 but skipped Opus 5.
- Corrects **Sonnet 5** pricing from $3/$15 to the documented **$2/$10** per MTok.

## Verification
- `claude-opus-5` verified **live** against the Messages API (returned `end_turn` with expected text).
- Registry gate clean (3 pre-existing 1M-variant warnings, untouched).
- `AnthropicAdapter` + `AnthropicThinkingContinuation` + `ModelRegistry` full test files: 47 pass, 0 fail.
- `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)