### PR TITLE
docs(skills): pair API registries with their CLI twins in add-model

### DIFF
--- a/.claude/skills/nexus-model-updates/protocols/add-model.md
+++ b/.claude/skills/nexus-model-updates/protocols/add-model.md
@@ -65,7 +65,24 @@ checked, and proven against the live endpoint.
      src/services/llm/adapters/<provider>
    ```
 
-6. **Run the structural gate.**
+6. **Update the CLI twin registry — or the API one, coming the other way.**
+   Two vendors have *paired* registries that cover the same models through
+   different transports and drift independently:
+
+   | API registry | CLI-backed twin | Twin verification |
+   |---|---|---|
+   | `anthropic/AnthropicModels.ts` | `anthropic-claude-code/AnthropicClaudeCodeModels.ts` | `printf '...' \| claude -p --model <id>` |
+   | `openai/OpenAIModels.ts` | `openai-codex/OpenAICodexModels.ts` | `codex exec --model <id> ...` |
+
+   When you touch either side of a pair, open the other side and decide,
+   per model, whether it belongs there too. The twin's conventions differ:
+   cost is 0 (subscription-billed), and availability must be proven through
+   the *CLI*, not the API — the anti-pattern below still applies, so verify
+   with the twin's own command. Skipping this step is how the Claude 5
+   family sat in the API registry for weeks while the Claude Code provider
+   still topped out at Sonnet 4.6 (fixed 2026-08-27).
+
+7. **Run the structural gate.**
 
    ```bash
    python3 .claude/skills/nexus-model-updates/scripts/check_model_registry.py \
@@ -76,7 +93,7 @@ checked, and proven against the live endpoint.
    providers you did not touch are pre-existing findings, not your regression —
    read them, do not silence them.
 
-7. **Verify.** Go to `verify-model.md`. An entry that has never produced a
+8. **Verify.** Go to `verify-model.md`. An entry that has never produced a
    response from the provider is an assertion, not a model.
 
 ## Guidelines

--- a/.claude/skills/nexus-model-updates/refinement-log.md
+++ b/.claude/skills/nexus-model-updates/refinement-log.md
@@ -55,3 +55,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   (outside quotes) with spaces before parsing, preserving offsets so line
   numbers stay true. Commented-out entries are now a legitimate registry
   state. | Files: `scripts/check_model_registry.py`.
+- 2026-08-27 | The anthropic API registry gained the Claude 5 family while the
+  anthropic-claude-code twin sat at Sonnet 4.6 — nothing in the protocol pairs
+  the two registries, so an API-side update leaves the CLI twin stale until a
+  user notices missing models in the picker. Same exposure for
+  openai / openai-codex. | Added step 6 ("Update the CLI twin registry") to
+  add-model.md: a pairing table (API registry ↔ CLI twin ↔ the twin's own
+  verification command) and the rule that touching either side means deciding,
+  per model, whether the other side gets it too — verified through the twin's
+  transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.

--- a/.cline/skills/nexus-model-updates/protocols/add-model.md
+++ b/.cline/skills/nexus-model-updates/protocols/add-model.md
@@ -65,7 +65,24 @@ checked, and proven against the live endpoint.
      src/services/llm/adapters/<provider>
    ```
 
-6. **Run the structural gate.**
+6. **Update the CLI twin registry — or the API one, coming the other way.**
+   Two vendors have *paired* registries that cover the same models through
+   different transports and drift independently:
+
+   | API registry | CLI-backed twin | Twin verification |
+   |---|---|---|
+   | `anthropic/AnthropicModels.ts` | `anthropic-claude-code/AnthropicClaudeCodeModels.ts` | `printf '...' \| claude -p --model <id>` |
+   | `openai/OpenAIModels.ts` | `openai-codex/OpenAICodexModels.ts` | `codex exec --model <id> ...` |
+
+   When you touch either side of a pair, open the other side and decide,
+   per model, whether it belongs there too. The twin's conventions differ:
+   cost is 0 (subscription-billed), and availability must be proven through
+   the *CLI*, not the API — the anti-pattern below still applies, so verify
+   with the twin's own command. Skipping this step is how the Claude 5
+   family sat in the API registry for weeks while the Claude Code provider
+   still topped out at Sonnet 4.6 (fixed 2026-08-27).
+
+7. **Run the structural gate.**
 
    ```bash
    python3 .claude/skills/nexus-model-updates/scripts/check_model_registry.py \
@@ -76,7 +93,7 @@ checked, and proven against the live endpoint.
    providers you did not touch are pre-existing findings, not your regression —
    read them, do not silence them.
 
-7. **Verify.** Go to `verify-model.md`. An entry that has never produced a
+8. **Verify.** Go to `verify-model.md`. An entry that has never produced a
    response from the provider is an assertion, not a model.
 
 ## Guidelines

--- a/.cline/skills/nexus-model-updates/refinement-log.md
+++ b/.cline/skills/nexus-model-updates/refinement-log.md
@@ -55,3 +55,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   (outside quotes) with spaces before parsing, preserving offsets so line
   numbers stay true. Commented-out entries are now a legitimate registry
   state. | Files: `scripts/check_model_registry.py`.
+- 2026-08-27 | The anthropic API registry gained the Claude 5 family while the
+  anthropic-claude-code twin sat at Sonnet 4.6 — nothing in the protocol pairs
+  the two registries, so an API-side update leaves the CLI twin stale until a
+  user notices missing models in the picker. Same exposure for
+  openai / openai-codex. | Added step 6 ("Update the CLI twin registry") to
+  add-model.md: a pairing table (API registry ↔ CLI twin ↔ the twin's own
+  verification command) and the rule that touching either side means deciding,
+  per model, whether the other side gets it too — verified through the twin's
+  transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.

--- a/.codex/skills/nexus-model-updates/protocols/add-model.md
+++ b/.codex/skills/nexus-model-updates/protocols/add-model.md
@@ -65,7 +65,24 @@ checked, and proven against the live endpoint.
      src/services/llm/adapters/<provider>
    ```
 
-6. **Run the structural gate.**
+6. **Update the CLI twin registry — or the API one, coming the other way.**
+   Two vendors have *paired* registries that cover the same models through
+   different transports and drift independently:
+
+   | API registry | CLI-backed twin | Twin verification |
+   |---|---|---|
+   | `anthropic/AnthropicModels.ts` | `anthropic-claude-code/AnthropicClaudeCodeModels.ts` | `printf '...' \| claude -p --model <id>` |
+   | `openai/OpenAIModels.ts` | `openai-codex/OpenAICodexModels.ts` | `codex exec --model <id> ...` |
+
+   When you touch either side of a pair, open the other side and decide,
+   per model, whether it belongs there too. The twin's conventions differ:
+   cost is 0 (subscription-billed), and availability must be proven through
+   the *CLI*, not the API — the anti-pattern below still applies, so verify
+   with the twin's own command. Skipping this step is how the Claude 5
+   family sat in the API registry for weeks while the Claude Code provider
+   still topped out at Sonnet 4.6 (fixed 2026-08-27).
+
+7. **Run the structural gate.**
 
    ```bash
    python3 .claude/skills/nexus-model-updates/scripts/check_model_registry.py \
@@ -76,7 +93,7 @@ checked, and proven against the live endpoint.
    providers you did not touch are pre-existing findings, not your regression —
    read them, do not silence them.
 
-7. **Verify.** Go to `verify-model.md`. An entry that has never produced a
+8. **Verify.** Go to `verify-model.md`. An entry that has never produced a
    response from the provider is an assertion, not a model.
 
 ## Guidelines

--- a/.codex/skills/nexus-model-updates/refinement-log.md
+++ b/.codex/skills/nexus-model-updates/refinement-log.md
@@ -55,3 +55,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   (outside quotes) with spaces before parsing, preserving offsets so line
   numbers stay true. Commented-out entries are now a legitimate registry
   state. | Files: `scripts/check_model_registry.py`.
+- 2026-08-27 | The anthropic API registry gained the Claude 5 family while the
+  anthropic-claude-code twin sat at Sonnet 4.6 — nothing in the protocol pairs
+  the two registries, so an API-side update leaves the CLI twin stale until a
+  user notices missing models in the picker. Same exposure for
+  openai / openai-codex. | Added step 6 ("Update the CLI twin registry") to
+  add-model.md: a pairing table (API registry ↔ CLI twin ↔ the twin's own
+  verification command) and the rule that touching either side means deciding,
+  per model, whether the other side gets it too — verified through the twin's
+  transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.

--- a/.skills/nexus-model-updates/protocols/add-model.md
+++ b/.skills/nexus-model-updates/protocols/add-model.md
@@ -65,7 +65,24 @@ checked, and proven against the live endpoint.
      src/services/llm/adapters/<provider>
    ```
 
-6. **Run the structural gate.**
+6. **Update the CLI twin registry — or the API one, coming the other way.**
+   Two vendors have *paired* registries that cover the same models through
+   different transports and drift independently:
+
+   | API registry | CLI-backed twin | Twin verification |
+   |---|---|---|
+   | `anthropic/AnthropicModels.ts` | `anthropic-claude-code/AnthropicClaudeCodeModels.ts` | `printf '...' \| claude -p --model <id>` |
+   | `openai/OpenAIModels.ts` | `openai-codex/OpenAICodexModels.ts` | `codex exec --model <id> ...` |
+
+   When you touch either side of a pair, open the other side and decide,
+   per model, whether it belongs there too. The twin's conventions differ:
+   cost is 0 (subscription-billed), and availability must be proven through
+   the *CLI*, not the API — the anti-pattern below still applies, so verify
+   with the twin's own command. Skipping this step is how the Claude 5
+   family sat in the API registry for weeks while the Claude Code provider
+   still topped out at Sonnet 4.6 (fixed 2026-08-27).
+
+7. **Run the structural gate.**
 
    ```bash
    python3 .claude/skills/nexus-model-updates/scripts/check_model_registry.py \
@@ -76,7 +93,7 @@ checked, and proven against the live endpoint.
    providers you did not touch are pre-existing findings, not your regression —
    read them, do not silence them.
 
-7. **Verify.** Go to `verify-model.md`. An entry that has never produced a
+8. **Verify.** Go to `verify-model.md`. An entry that has never produced a
    response from the provider is an assertion, not a model.
 
 ## Guidelines

--- a/.skills/nexus-model-updates/refinement-log.md
+++ b/.skills/nexus-model-updates/refinement-log.md
@@ -55,3 +55,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   (outside quotes) with spaces before parsing, preserving offsets so line
   numbers stay true. Commented-out entries are now a legitimate registry
   state. | Files: `scripts/check_model_registry.py`.
+- 2026-08-27 | The anthropic API registry gained the Claude 5 family while the
+  anthropic-claude-code twin sat at Sonnet 4.6 — nothing in the protocol pairs
+  the two registries, so an API-side update leaves the CLI twin stale until a
+  user notices missing models in the picker. Same exposure for
+  openai / openai-codex. | Added step 6 ("Update the CLI twin registry") to
+  add-model.md: a pairing table (API registry ↔ CLI twin ↔ the twin's own
+  verification command) and the rule that touching either side means deciding,
+  per model, whether the other side gets it too — verified through the twin's
+  transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.


### PR DESCRIPTION
## Summary
- Adds step 6 to `nexus-model-updates/protocols/add-model.md`: when touching `anthropic` or `openai` model registries, open the CLI-backed twin (`anthropic-claude-code` / `openai-codex`) and decide per model whether it belongs there too — verified through the twin's own CLI command, cost 0 (subscription-billed).
- Motivating drift: the Claude 5 family reached the API registry while the Claude Code provider still topped out at Sonnet 4.6 (fixed today in #372/#373).
- Refinement log entry added; synced to all three mirrors.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)