### PR TITLE
Fix center-aligned thinking text on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -6166,6 +6166,14 @@ body.is-mobile .message-content {
     line-height: 1.5;
 }
 
+/* Thinking block - same left-alignment guard as .message-content; it is a
+   sibling of .message-content inside the bubble, so it needs its own rule */
+body.is-mobile .message-reasoning,
+body.is-mobile .message-reasoning-summary,
+body.is-mobile .message-reasoning-content {
+    text-align: left;
+}
+
 /* Mobile: conversation action buttons always visible */
 body.is-mobile .conversation-actions {
     opacity: 0.7;


### PR DESCRIPTION
## Summary

On mobile, the collapsible "Thinking" block in chat rendered its text center-aligned instead of left-aligned.

Obsidian's mobile stylesheet centers text inside chat bubbles. The plugin already counteracts this for `.message-content` with an explicit `text-align: left` override under `body.is-mobile`, but the Thinking block (`.message-reasoning`, a sibling of `.message-content` inside the bubble) never received the same guard, so it stayed centered on phones.

## Changes

- Added a `text-align: left` rule for `.message-reasoning`, `.message-reasoning-summary`, and `.message-reasoning-content` under `body.is-mobile`, placed alongside the existing `.message-content` left-alignment guard in `styles.css`.

Desktop is unaffected — the centering only occurs under Obsidian's mobile styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D7s7HcgjMW1GiEWgGDtdv3

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7s7HcgjMW1GiEWgGDtdv3)_