### PR TITLE
Fix the flaky tool ticker and stream the goal as its text

### DIFF
--- a/src/ui/chat/ChatView.ts
+++ b/src/ui/chat/ChatView.ts
@@ -996,9 +996,13 @@ export class ChatView extends ItemView {
       this.messageDisplay.updateMessageContent(messageId, content);
       this.toolEventCoordinator.clearToolNameCache();
     } else {
+      // NOTE: no producer currently emits (isComplete=false, isIncremental=false)
+      // — deltas auto-start the parser via updateStreamingChunk. Do NOT hang
+      // per-turn setup off this branch (the tool ticker's re-subscribe once
+      // lived here and silently never ran); turn brackets belong in
+      // handleLoadingStateChanged.
       this.streamingController.startStreaming(messageId);
       this.streamingController.updateStreamingChunk(messageId, content);
-      this.toolEventCoordinator.ensureListening();
     }
   }
 
@@ -1022,8 +1026,19 @@ export class ChatView extends ItemView {
     // covers normal completion, aborts, and errors uniformly.
     if (loading) {
       this.workingIndicatorController.begin();
+      // Re-arm the tool ticker for THIS turn. The previous turn's completion
+      // unsubscribed the ToolEventCoordinator from the state machine
+      // (clearToolNameCache), and the old re-subscribe lived in a streaming
+      // branch that never fires — so from the second turn on, no tool status
+      // ever reached the bar. This bracket fires for every generation path
+      // (send, retry, alternative), making the subscription unconditional.
+      this.toolEventCoordinator.beginTurn();
     } else {
       this.workingIndicatorController.end();
+      // Uniform teardown: MessageManager's finally block funnels completion,
+      // abort AND error through here, so an errored turn (which never emits
+      // isComplete) can no longer leave a stale "Running…" label behind.
+      this.toolEventCoordinator.clearToolNameCache();
     }
 
     if (this.chatInput) {

--- a/src/ui/chat/components/toolStatusLine.ts
+++ b/src/ui/chat/components/toolStatusLine.ts
@@ -4,11 +4,35 @@ import type { ToolStatusEntry } from '../types/ToolStatus';
 
 export type { ToolStatusEntry };
 
+/**
+ * Single-line status ticker that STREAMS its text word-by-word, the way model
+ * output streams — no ellipsis, no clipping. When the revealed text outgrows
+ * the row, the line follows the newest word (scrolls left) so the reader is
+ * always looking at the words being "typed".
+ *
+ * Sequencing contract: an entry always finishes — full reveal plus a short
+ * dwell — before the next entry replaces it, no matter how mistimed the
+ * incoming events are. While an entry plays, later entries collapse into a
+ * single queued slot (latest wins), so the line never lags behind a fast
+ * batch by more than one entry. A same-text update that only changes tense
+ * (the goal flipping present→past) restyles the current line in place
+ * instead of re-rolling it.
+ */
 export class ToolStatusLine {
+  // Word-streaming cadence: ~11 words/s. A typical one-sentence goal
+  // (8–12 words) plays in about a second; the 200-char coordinator cap
+  // (~35 words) tops out around 3s.
+  private static readonly WORD_MS = 90;
+  // Minimum time a fully revealed entry holds the line before a queued
+  // entry may replace it — fast tool batches stay legible.
+  private static readonly DWELL_MS = 450;
+  // Matches the CSS exit transition on .tool-status-text-*.exiting.
+  private static readonly EXIT_MS = 200;
+
   private currentSlot: HTMLElement | null = null;
-  private lastUpdate = 0;
+  private currentEntry: ToolStatusEntry | null = null;
   private queuedEntry: ToolStatusEntry | null = null;
-  private pendingTimeout: number | null = null;
+  private animating = false;
   private timeouts: ManagedTimeoutTracker;
 
   constructor(private readonly slot: HTMLElement, component: Component) {
@@ -16,56 +40,121 @@ export class ToolStatusLine {
   }
 
   public update(text: string, state: ToolStatusEntry['state']): void {
-    const entry = { text, state };
-    const elapsed = Date.now() - this.lastUpdate;
+    const entry: ToolStatusEntry = { text, state };
+    // Compare against where the line is headed: the queued entry if one is
+    // waiting, else what is currently playing/showing.
+    const target = this.queuedEntry ?? this.currentEntry;
 
-    if (this.lastUpdate !== 0 && elapsed < 400) {
-      this.queuedEntry = entry;
-      if (!this.pendingTimeout) {
-        this.pendingTimeout = this.timeouts.schedule(() => {
-          this.pendingTimeout = null;
-          if (this.queuedEntry) {
-            const queued = this.queuedEntry;
-            this.queuedEntry = null;
-            this.forceUpdate(queued);
-          }
-        }, 400 - elapsed);
+    if (target && target.text === text) {
+      if (target.state === state) {
+        return; // exact duplicate — never re-roll the same line
+      }
+      if (this.queuedEntry) {
+        this.queuedEntry = entry; // upgrade the queued entry's tense
+      } else {
+        this.restyleCurrent(state); // tense flip on the visible line, in place
       }
       return;
     }
 
-    this.forceUpdate(entry);
+    if (this.animating) {
+      // The playing entry must finish its reveal + dwell first; superseded
+      // intermediates collapse into this single slot.
+      this.queuedEntry = entry;
+      return;
+    }
+
+    this.play(entry);
   }
 
   public clear(): void {
-    this.pendingTimeout = null;
     this.timeouts.clear();
     this.queuedEntry = null;
-    this.lastUpdate = 0;
-    if (this.currentSlot) {
-      this.currentSlot.remove();
-      this.currentSlot = null;
+    this.currentEntry = null;
+    this.currentSlot = null;
+    this.animating = false;
+    // Remove every slot, including any mid-exit one whose scheduled removal
+    // was just cancelled by timeouts.clear().
+    const host = this.slot as HTMLElement & { empty?: () => void };
+    if (typeof host.empty === 'function') {
+      host.empty();
     }
   }
 
-  private forceUpdate(entry: ToolStatusEntry): void {
-    this.lastUpdate = Date.now();
+  /** Swap the tense class on the visible line without re-rolling it. */
+  private restyleCurrent(state: ToolStatusEntry['state']): void {
+    if (!this.currentEntry || !this.currentSlot) return;
+    const previous = this.currentEntry.state;
+    if (previous === state) return;
+    this.currentEntry = { ...this.currentEntry, state };
+    this.currentSlot.removeClass(`tool-status-text-${previous}`);
+    this.currentSlot.addClass(`tool-status-text-${state}`);
+  }
+
+  private play(entry: ToolStatusEntry): void {
+    this.animating = true;
+    this.currentEntry = entry;
 
     if (this.currentSlot) {
       const oldSlot = this.currentSlot;
       oldSlot.classList.add('exiting');
-      this.timeouts.schedule(() => oldSlot.remove(), 200);
+      this.timeouts.schedule(() => oldSlot.remove(), ToolStatusLine.EXIT_MS);
     }
 
     const nextSlot = this.slot.createDiv({
       cls: `tool-status-text-${entry.state} entering`,
-      text: entry.text,
     });
-
     this.currentSlot = nextSlot;
     this.timeouts.schedule(() => {
       nextSlot.removeClass('entering');
       nextSlot.addClass('active');
     }, 100);
+
+    if (this.prefersReducedMotion()) {
+      nextSlot.textContent = entry.text;
+      this.finishReveal();
+      return;
+    }
+
+    const words = entry.text.split(' ');
+    let revealed = 0;
+    const step = (): void => {
+      // clear() or a newer play() detaches this slot — stop streaming into it.
+      if (this.currentSlot !== nextSlot) return;
+      revealed++;
+      nextSlot.textContent = words.slice(0, revealed).join(' ');
+      // Follow the words: once the line overflows the row, keep the newest
+      // word in view instead of clipping the tail.
+      nextSlot.scrollLeft = nextSlot.scrollWidth;
+      if (revealed >= words.length) {
+        this.finishReveal();
+      } else {
+        this.timeouts.schedule(step, ToolStatusLine.WORD_MS);
+      }
+    };
+    step();
+  }
+
+  /** Full text is on screen — dwell, then hand the line to the queued entry. */
+  private finishReveal(): void {
+    this.timeouts.schedule(() => {
+      this.animating = false;
+      const next = this.queuedEntry;
+      if (!next) return;
+      this.queuedEntry = null;
+      if (this.currentEntry && next.text === this.currentEntry.text) {
+        this.restyleCurrent(next.state);
+        return;
+      }
+      this.play(next);
+    }, ToolStatusLine.DWELL_MS);
+  }
+
+  private prefersReducedMotion(): boolean {
+    try {
+      return window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/ui/chat/components/toolStatusLine.ts
+++ b/src/ui/chat/components/toolStatusLine.ts
@@ -20,8 +20,8 @@ export type { ToolStatusEntry };
  */
 export class ToolStatusLine {
   // Word-streaming cadence: ~11 words/s. A typical one-sentence goal
-  // (8–12 words) plays in about a second; the 200-char coordinator cap
-  // (~35 words) tops out around 3s.
+  // (8–12 words) plays in about a second; goal text is uncapped, so a
+  // longer one simply streams longer.
   private static readonly WORD_MS = 90;
   // Minimum time a fully revealed entry holds the line before a queued
   // entry may replace it — fast tool batches stay legible.

--- a/src/ui/chat/controllers/StreamingController.ts
+++ b/src/ui/chat/controllers/StreamingController.ts
@@ -96,8 +96,17 @@ export class StreamingController {
    */
   finalizeStreaming(messageId: string, finalContent: string): void {
     const streamingState = this.streamingStates.get(messageId);
+    // Drop the entry synchronously and unconditionally: getCurrentMessageId()
+    // reports the last key of this map, and a finalized turn must never stay
+    // "current". The old cleanup only ran after an async render AND only when
+    // the message element was still in the DOM — a mid-stream conversation
+    // switch or reconcile leaked the key forever, after which
+    // ToolStatusBarController silently dropped every later turn's
+    // present-tense tool status as a messageId mismatch.
+    this.streamingStates.delete(messageId);
+
     const messageElement = this.containerEl.querySelector(`[data-message-id="${messageId}"]`);
-    
+
     if (streamingState && messageElement) {
       const contentElement = messageElement.querySelector('.message-bubble .message-content');
 
@@ -108,13 +117,8 @@ export class StreamingController {
           contentElement as HTMLElement,
           this.app,
           this.component
-        ).then(() => {
-          // Clean up streaming state
-          this.streamingStates.delete(messageId);
-        }).catch(error => {
+        ).catch(error => {
           console.error('[StreamingController] Error finalizing streaming:', error);
-          // Clean up anyway
-          this.streamingStates.delete(messageId);
         });
       }
     }

--- a/src/ui/chat/coordinators/ToolEventCoordinator.ts
+++ b/src/ui/chat/coordinators/ToolEventCoordinator.ts
@@ -27,8 +27,17 @@ type ToolCallLike = NonNullable<ToolEventPayload['toolCall']>;
 type ToolEventData = ToolEventPayload;
 
 export class ToolEventCoordinator {
+  // Longest goal we embed in a status label. The status line also ellipsizes
+  // via CSS; this cap just keeps pathological strings out of the DOM.
+  private static readonly GOAL_MAX_LENGTH = 140;
+
   private unsubscribe: (() => void) | null = null;
   private hideTimer: number | null = null;
+  // The `goal` sentence from the current turn's useTools context contract
+  // (a required parameter of every useTools call — "what you are trying to
+  // accomplish right now"). Appended to tool status labels so the ticker
+  // reads "Reading notes.md — Find last week's meeting notes".
+  private currentGoal: string | null = null;
 
   constructor(
     private controller: ToolStatusBarController,
@@ -51,10 +60,32 @@ export class ToolEventCoordinator {
       this.unsubscribe();
       this.unsubscribe = null;
     }
-    this.stateManager.clear();
+    // clearStates, NOT clear(): clear() also wipes the state manager's
+    // listener array, which would silently kill any other subscriber.
+    this.stateManager.clearStates();
+    this.currentGoal = null;
     // Hide the status bar after a short delay so the user can see the
     // final completed/failed status before it disappears.
     this.scheduleHide(2000);
+  }
+
+  /**
+   * Bracket the start of a generation turn: cancel the previous turn's
+   * pending hide, drop its stale status text and per-turn state, and
+   * re-subscribe to the state manager (clearToolNameCache unsubscribed at
+   * the end of the previous turn).
+   *
+   * ChatView calls this from its loading-state bracket (the same hook that
+   * arms the gap ticker), which fires for every generation path — send,
+   * retry, alternative — so the subscription provably exists for every
+   * turn, not just the first.
+   */
+  beginTurn(): void {
+    this.cancelHide();
+    this.controller.getStatusBar().clearStatus();
+    this.stateManager.clearStates();
+    this.currentGoal = null;
+    this.ensureListening();
   }
 
   /**
@@ -127,6 +158,9 @@ export class ToolEventCoordinator {
 
       if (isUseTools && parameters && typeof parameters === 'object') {
         const params = parameters as Record<string, unknown>;
+        // The useTools context contract requires a `goal` sentence — surface
+        // it as a suffix on this turn's status labels.
+        this.captureGoal(params.goal);
         const innerCalls: Array<{ agent: string; tool: string; parameters?: Record<string, unknown> }> =
           typeof params.tool === 'string'
             ? parseCliForDisplay(params.tool)
@@ -249,6 +283,12 @@ export class ToolEventCoordinator {
     const normalizedName = rawName.replace(/_/g, '.');
     if (normalizedName === 'useTools' || normalizedName === 'getTools' ||
         normalizedName.endsWith('.useTools') || normalizedName.endsWith('.getTools')) {
+      // The wrapper event is filtered, but its parameters carry the turn's
+      // `goal` — grab it before dropping the event so the execution path
+      // (which never re-sends the wrapper params) still gets goal suffixes.
+      if (normalizedName === 'useTools' || normalizedName.endsWith('.useTools')) {
+        this.captureGoalFromEventData(data);
+      }
       return;
     }
 
@@ -308,7 +348,39 @@ export class ToolEventCoordinator {
 
     const text = formatToolStepLabel(step, tense);
     if (text) {
-      this.controller.pushStatus(messageId, { text, state: tense });
+      // Suffix the turn's goal ("Reading a.md — Find the meeting notes") so
+      // the ticker says WHY, not just which tool. The status line ellipsizes,
+      // so an over-long goal degrades to a truncated single line.
+      const display = this.currentGoal ? `${text} — ${this.currentGoal}` : text;
+      this.controller.pushStatus(messageId, { text: display, state: tense });
+    }
+  }
+
+  /** Remember a meaningful goal string for the active turn (trimmed, capped). */
+  private captureGoal(value: unknown): void {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    this.currentGoal = trimmed.length > ToolEventCoordinator.GOAL_MAX_LENGTH
+      ? `${trimmed.slice(0, ToolEventCoordinator.GOAL_MAX_LENGTH - 1).trimEnd()}…`
+      : trimmed;
+  }
+
+  /** Extract a `goal` from a wrapper event's parameters (object or JSON string). */
+  private captureGoalFromEventData(data: ToolEventData): void {
+    let parameters: unknown = data?.parameters;
+    if (parameters === undefined) {
+      parameters = this.extractToolParameters(data?.toolCall);
+    }
+    if (typeof parameters === 'string') {
+      try {
+        parameters = JSON.parse(parameters);
+      } catch {
+        return;
+      }
+    }
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      this.captureGoal((parameters as Record<string, unknown>).goal);
     }
   }
 

--- a/src/ui/chat/coordinators/ToolEventCoordinator.ts
+++ b/src/ui/chat/coordinators/ToolEventCoordinator.ts
@@ -27,13 +27,6 @@ type ToolCallLike = NonNullable<ToolEventPayload['toolCall']>;
 type ToolEventData = ToolEventPayload;
 
 export class ToolEventCoordinator {
-  // Sanity cap on the goal text. Display is NOT clipped — ToolStatusLine
-  // streams the words and follows them past the row edge — so this only
-  // bounds pathological input: 200 chars ≈ 35 words ≈ 3s of streaming, the
-  // most the line should ever be held by a single entry. The useTools
-  // contract asks for 1–3 sentences, so real goals sit well under it.
-  private static readonly GOAL_MAX_LENGTH = 200;
-
   private unsubscribe: (() => void) | null = null;
   private hideTimer: number | null = null;
   // The `goal` sentence from the current turn's useTools context contract
@@ -374,14 +367,16 @@ export class ToolEventCoordinator {
     this.controller.pushStatus(messageId, { text: display, state: tense });
   }
 
-  /** Remember a meaningful goal string for the active turn (trimmed, capped). */
+  /**
+   * Remember a meaningful goal string for the active turn (trimmed).
+   * Deliberately uncapped: ToolStatusLine streams the words and follows
+   * them past the row edge, so length costs display time, never clipping.
+   */
   private captureGoal(value: unknown): void {
     if (typeof value !== 'string') return;
     const trimmed = value.trim();
     if (!trimmed) return;
-    this.currentGoal = trimmed.length > ToolEventCoordinator.GOAL_MAX_LENGTH
-      ? `${trimmed.slice(0, ToolEventCoordinator.GOAL_MAX_LENGTH - 1).trimEnd()}…`
-      : trimmed;
+    this.currentGoal = trimmed;
   }
 
   /** Extract a `goal` from a wrapper event's parameters (object or JSON string). */

--- a/src/ui/chat/coordinators/ToolEventCoordinator.ts
+++ b/src/ui/chat/coordinators/ToolEventCoordinator.ts
@@ -27,9 +27,12 @@ type ToolCallLike = NonNullable<ToolEventPayload['toolCall']>;
 type ToolEventData = ToolEventPayload;
 
 export class ToolEventCoordinator {
-  // Longest goal we embed in a status label. The status line also ellipsizes
-  // via CSS; this cap just keeps pathological strings out of the DOM.
-  private static readonly GOAL_MAX_LENGTH = 140;
+  // Sanity cap on the goal text. Display is NOT clipped — ToolStatusLine
+  // streams the words and follows them past the row edge — so this only
+  // bounds pathological input: 200 chars ≈ 35 words ≈ 3s of streaming, the
+  // most the line should ever be held by a single entry. The useTools
+  // contract asks for 1–3 sentences, so real goals sit well under it.
+  private static readonly GOAL_MAX_LENGTH = 200;
 
   private unsubscribe: (() => void) | null = null;
   private hideTimer: number | null = null;
@@ -330,7 +333,7 @@ export class ToolEventCoordinator {
     this.cancelHide();
     const { state, messageId } = event;
 
-    const tense: 'present' | 'past' | 'failed' =
+    let tense: 'present' | 'past' | 'failed' =
       state.phase === 'completed' ? 'past'
       : state.phase === 'failed' ? 'failed'
       : 'present';
@@ -347,13 +350,28 @@ export class ToolEventCoordinator {
     };
 
     const text = formatToolStepLabel(step, tense);
-    if (text) {
-      // Suffix the turn's goal ("Reading a.md — Find the meeting notes") so
-      // the ticker says WHY, not just which tool. The status line ellipsizes,
-      // so an over-long goal degrades to a truncated single line.
-      const display = this.currentGoal ? `${text} — ${this.currentGoal}` : text;
-      this.controller.pushStatus(messageId, { text: display, state: tense });
+    if (!text) return;
+
+    // Goal-only display: when the turn's useTools call carried a goal, show
+    // THAT instead of the per-tool label. The row's character budget (from
+    // styles.css geometry at ~0.50em/char) is ~48–58 chars on a phone and
+    // ~37 on a narrow desktop pane; a parameterized tool prefix like
+    // "Reading meeting-notes.md — " alone eats up to half of it, so the
+    // tool name is dropped, not suffixed. Failures are the exception —
+    // "Failed to run Move" is actionable in a way the goal is not — and
+    // turns without a goal (direct calls, provider-executed tools) keep the
+    // per-tool labels as the fallback.
+    let display = text;
+    if (this.currentGoal && tense !== 'failed') {
+      display = this.currentGoal;
+      // Hold the working shimmer while other steps of the batch are still
+      // active: every step now renders the same goal text, and flipping
+      // present→past→present per step would only make the line flicker.
+      if (tense === 'past' && this.stateManager.getActiveToolCalls(messageId).length > 0) {
+        tense = 'present';
+      }
     }
+    this.controller.pushStatus(messageId, { text: display, state: tense });
   }
 
   /** Remember a meaningful goal string for the active turn (trimmed, capped). */

--- a/src/ui/chat/services/ToolCallStateManager.ts
+++ b/src/ui/chat/services/ToolCallStateManager.ts
@@ -85,14 +85,15 @@ export class ToolCallStateManager {
   ): boolean {
     // Look up by exact ID first, then check for ID correlation.
     // Execution path appends `_N` suffix (e.g., call_abc_0) while detection
-    // path uses the raw LLM ID (call_abc). Match if either is a prefix of
-    // the other so they share state instead of creating duplicates.
+    // path uses the raw LLM ID (call_abc). Match only when one ID is the
+    // other plus a `_<index>` suffix so they share state instead of creating
+    // duplicates.
     let existing = this.states.get(toolCallId);
     let resolvedId = toolCallId;
 
     if (!existing) {
       for (const [id, state] of this.states) {
-        if (id.startsWith(toolCallId) || toolCallId.startsWith(id)) {
+        if (ToolCallStateManager.isBatchStepVariant(id, toolCallId)) {
           existing = state;
           resolvedId = id; // Use the existing entry's ID as canonical
           break;
@@ -172,6 +173,19 @@ export class ToolCallStateManager {
     };
   }
 
+  /**
+   * True when one ID is the other plus a `_<index>` batch-step suffix —
+   * detection registers the raw LLM ID (`call_abc`) while execution appends
+   * the step index (`call_abc_0`). Anchoring the match at that suffix
+   * boundary keeps `call_abc_1` from swallowing `call_abc_10`, which a bare
+   * mutual-prefix test would cross-match, silently merging two distinct
+   * calls and suppressing the later one's status labels.
+   */
+  private static isBatchStepVariant(a: string, b: string): boolean {
+    const [longer, shorter] = a.length >= b.length ? [a, b] : [b, a];
+    return longer.startsWith(shorter) && /^_\d+$/.test(longer.slice(shorter.length));
+  }
+
   /** Clear all state for a message (call when streaming ends) */
   clearMessage(messageId: string): void {
     const ids = this.messageToolCalls.get(messageId);
@@ -183,7 +197,18 @@ export class ToolCallStateManager {
     }
   }
 
-  /** Clear all state (call on dispose) */
+  /**
+   * Clear per-turn tool call state while KEEPING listeners subscribed.
+   * This is the between-turns reset: wiping the listener array here would
+   * silently kill every subscriber (the status bar goes dark from the next
+   * turn on), so only clear() — reserved for dispose — may do that.
+   */
+  clearStates(): void {
+    this.states.clear();
+    this.messageToolCalls.clear();
+  }
+
+  /** Clear all state AND listeners (call on dispose only) */
   clear(): void {
     this.states.clear();
     this.messageToolCalls.clear();

--- a/styles.css
+++ b/styles.css
@@ -8436,8 +8436,13 @@ body.is-mobile .nexus-task-board-shell {
 .tool-status-text-failed {
   position: absolute;
   inset: 0;
-  display: flex;
-  align-items: center;
+  /* Single line, centered via line-height (matches .tool-status-slot height —
+     the old flex centering defeated text-overflow) and ellipsized so a long
+     label + goal suffix truncates instead of blowing out the row. */
+  line-height: 1.46em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   transition: transform 0.2s ease-out, opacity 0.2s ease-out;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -8436,13 +8436,13 @@ body.is-mobile .nexus-task-board-shell {
 .tool-status-text-failed {
   position: absolute;
   inset: 0;
-  /* Single line, centered via line-height (matches .tool-status-slot height —
-     the old flex centering defeated text-overflow) and ellipsized so a long
-     label + goal suffix truncates instead of blowing out the row. */
+  /* Single line, centered via line-height (matches .tool-status-slot height).
+     No ellipsis: ToolStatusLine streams the text word-by-word and follows the
+     newest word via scrollLeft when the line outgrows the row, so overflow
+     stays hidden but nothing is truncated. */
   line-height: 1.46em;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
   transition: transform 0.2s ease-out, opacity 0.2s ease-out;
 }
 

--- a/tests/unit/ChatViewToolTickerWiring.test.ts
+++ b/tests/unit/ChatViewToolTickerWiring.test.ts
@@ -1,0 +1,75 @@
+/**
+ * ChatView tool ticker wiring — source-level guard.
+ *
+ * The tool ticker regression this protects against: ToolEventCoordinator
+ * unsubscribes from the state machine at every turn end (clearToolNameCache),
+ * and its re-subscribe (ensureListening/beginTurn) once lived in a streaming
+ * branch that no producer ever hits — so the ticker went dark from the second
+ * turn on, while the coordinator's unit tests (which call the re-subscribe
+ * manually) stayed green.
+ *
+ * ChatView cannot be instantiated under Jest (ItemView + full plugin wiring),
+ * so this guard asserts the wiring at the source level: the turn brackets in
+ * handleLoadingStateChanged — the only hook that provably fires for every
+ * generation path — must own the coordinator's begin/end lifecycle.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CHAT_VIEW_PATH = path.join(__dirname, '../../src/ui/chat/ChatView.ts');
+
+/** Extract a method body from the source by brace matching. */
+function extractMethod(source: string, signature: RegExp): string {
+  const match = signature.exec(source);
+  if (!match) {
+    throw new Error(`Method matching ${signature} not found in ChatView.ts`);
+  }
+  const start = source.indexOf('{', match.index);
+  let depth = 0;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`Unbalanced braces after ${signature}`);
+}
+
+describe('ChatView — tool ticker turn brackets (source guard)', () => {
+  const source = fs.readFileSync(CHAT_VIEW_PATH, 'utf8');
+  const loadingHandler = extractMethod(
+    source,
+    /private handleLoadingStateChanged\s*\(/
+  );
+
+  it('re-arms the coordinator on loading start (beginTurn)', () => {
+    // Both turn tickers arm together: the in-bubble gap ticker and the tool
+    // status subscription. If beginTurn leaves this bracket, the tool ticker
+    // dies after the first completed turn — see the pipeline integration test
+    // "second turn — beginTurn() re-arms the pipeline".
+    const loadingBranch = loadingHandler.split(/\belse\b/)[0];
+    expect(loadingBranch).toContain('workingIndicatorController.begin()');
+    expect(loadingBranch).toContain('toolEventCoordinator.beginTurn()');
+  });
+
+  it('tears the coordinator down on loading end (clearToolNameCache)', () => {
+    // Loading-end fires from MessageManager's finally block — completion,
+    // abort AND error — so teardown here cannot be skipped by errored turns.
+    const elseBranch = loadingHandler.slice(loadingHandler.search(/\belse\b/));
+    expect(elseBranch).toContain('toolEventCoordinator.clearToolNameCache()');
+  });
+
+  it('does not hang the re-subscribe off the unreachable streaming branch', () => {
+    // No producer emits (isComplete=false, isIncremental=false); that branch
+    // of handleStreamingUpdate must not be the ticker's lifeline again.
+    const streamingHandler = extractMethod(
+      source,
+      /private handleStreamingUpdate\s*\(/
+    );
+    expect(streamingHandler).not.toContain('ensureListening');
+  });
+});

--- a/tests/unit/StreamingControllerCurrentMessageId.test.ts
+++ b/tests/unit/StreamingControllerCurrentMessageId.test.ts
@@ -1,0 +1,96 @@
+/**
+ * StreamingController — getCurrentMessageId staleness regression.
+ *
+ * ToolStatusBarController drops every present-tense tool status whose
+ * messageId differs from StreamingController.getCurrentMessageId(). That id
+ * is derived from the streamingStates map, so a finalized turn whose entry
+ * is not removed poisons the filter: every later turn's "Running…" labels
+ * are silently discarded.
+ *
+ * The old cleanup ran only after an async markdown render AND only when the
+ * message element was still in the DOM — a mid-stream conversation switch or
+ * reconcile leaked the entry forever. finalizeStreaming must drop the entry
+ * synchronously and unconditionally.
+ */
+
+jest.mock('../../src/ui/chat/utils/MarkdownRenderer', () => ({
+  MarkdownRenderer: {
+    initializeStreamingParser: jest.fn(() => ({ mock: 'streaming-state' })),
+    writeStreamingChunk: jest.fn(),
+    finalizeStreamingContent: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+import { StreamingController } from '../../src/ui/chat/controllers/StreamingController';
+import { MarkdownRenderer } from '../../src/ui/chat/utils/MarkdownRenderer';
+import type { App, Component } from 'obsidian';
+
+interface FakeContentEl {
+  getAttribute: () => string | null;
+  parentElement: null;
+}
+
+function makeHarness() {
+  const contentEl: FakeContentEl = {
+    getAttribute: () => null,
+    parentElement: null,
+  };
+  const messageEl = {
+    querySelector: jest.fn(() => contentEl),
+  };
+  // Toggle to simulate the message element disappearing from the DOM
+  // (conversation switch, reconcile) before finalize runs.
+  const dom = { present: true };
+  const containerEl = {
+    querySelector: jest.fn(() => (dom.present ? messageEl : null)),
+  };
+
+  const controller = new StreamingController(
+    containerEl as unknown as HTMLElement,
+    {} as App,
+    {} as Component
+  );
+
+  return { controller, dom, containerEl };
+}
+
+describe('StreamingController — getCurrentMessageId lifecycle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('reports the streaming message while active and null after finalize', () => {
+    const { controller } = makeHarness();
+
+    controller.startStreaming('msg-1');
+    expect(controller.getCurrentMessageId()).toBe('msg-1');
+
+    controller.finalizeStreaming('msg-1', 'done');
+    // Synchronous: no await on the markdown finalize promise needed.
+    expect(controller.getCurrentMessageId()).toBeNull();
+  });
+
+  it('drops the entry even when the message element left the DOM (leak regression)', () => {
+    const { controller, dom } = makeHarness();
+
+    controller.startStreaming('msg-1');
+    expect(controller.getCurrentMessageId()).toBe('msg-1');
+
+    // Message element is gone by the time the turn finalizes
+    dom.present = false;
+    controller.finalizeStreaming('msg-1', 'done');
+
+    // Before the fix this entry leaked forever and msg-1 stayed "current",
+    // making the status bar filter drop every later turn's present-tense
+    // tool labels.
+    expect(controller.getCurrentMessageId()).toBeNull();
+    expect(MarkdownRenderer.finalizeStreamingContent).not.toHaveBeenCalled();
+  });
+
+  it('finalize on an unknown message is a safe no-op', () => {
+    const { controller } = makeHarness();
+
+    expect(() => controller.finalizeStreaming('never-streamed', 'x')).not.toThrow();
+    expect(controller.getCurrentMessageId()).toBeNull();
+  });
+});

--- a/tests/unit/ToolCallStateManager.test.ts
+++ b/tests/unit/ToolCallStateManager.test.ts
@@ -248,6 +248,61 @@ describe('ToolCallStateManager — clearMessage()', () => {
   });
 });
 
+describe('ToolCallStateManager — clearStates()', () => {
+  it('clears per-turn state but KEEPS listeners subscribed', () => {
+    const sm = new ToolCallStateManager();
+    const listener = jest.fn();
+    sm.onStateChange(listener);
+
+    sm.transition('msg-1', 'tc-1', 'detected');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    sm.clearStates();
+    expect(sm.getState('tc-1')).toBeUndefined();
+    expect(sm.getActiveToolCalls('msg-1')).toEqual([]);
+
+    // The between-turns reset must NOT kill subscribers — that is exactly
+    // the bug that made the tool ticker go dark from the second turn on.
+    sm.transition('msg-2', 'tc-2', 'detected');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('ToolCallStateManager — suffix-boundary correlation', () => {
+  it('does NOT cross-match step 1 with step 10 (a bare prefix test would)', () => {
+    const sm = new ToolCallStateManager();
+
+    sm.transition('msg-1', 'call_b_1', 'completed', { rawName: 'read' }, { success: true });
+
+    // 'call_b_10' starts with 'call_b_1' but the remainder is '0', not '_N' —
+    // it is a distinct batch step and must get its own lifecycle.
+    const result = sm.transition('msg-1', 'call_b_10', 'started', { rawName: 'write' });
+    expect(result).toBe(true);
+    expect(sm.getState('call_b_10')?.phase).toBe('started');
+    expect(sm.getState('call_b_1')?.phase).toBe('completed');
+  });
+
+  it('does not correlate IDs that merely share a character prefix', () => {
+    const sm = new ToolCallStateManager();
+
+    sm.transition('msg-1', 'call_abc', 'completed', undefined, { success: true });
+
+    const result = sm.transition('msg-1', 'call_abcdef', 'started');
+    expect(result).toBe(true);
+    expect(sm.getState('call_abcdef')?.phase).toBe('started');
+  });
+
+  it('still correlates a base ID with its _<index> suffixed variant', () => {
+    const sm = new ToolCallStateManager();
+
+    sm.transition('msg-1', 'call_abc', 'detected', { rawName: 'read' });
+    sm.transition('msg-1', 'call_abc_0', 'started');
+
+    expect(sm.getState('call_abc')?.phase).toBe('started');
+    expect(sm.getState('call_abc_0')).toBeUndefined(); // shares the canonical entry
+  });
+});
+
 describe('ToolCallStateManager — clear()', () => {
   it('removes all state and listeners', () => {
     const sm = new ToolCallStateManager();

--- a/tests/unit/ToolEventCoordinator.test.ts
+++ b/tests/unit/ToolEventCoordinator.test.ts
@@ -849,9 +849,9 @@ describe('ToolEventCoordinator — goal-only status labels', () => {
     expect(entry.state).toBe('past');
   });
 
-  it('caps a pathologically long goal', () => {
+  it('passes a long goal through uncapped and untruncated', () => {
     const { coordinator, controller } = makeCoordinator();
-    const longGoal = 'Investigate '.repeat(30).trim(); // > 200 chars
+    const longGoal = 'Investigate '.repeat(30).trim(); // ~360 chars
 
     coordinator.handleToolCallsDetected('msg-1', [
       {
@@ -863,9 +863,10 @@ describe('ToolEventCoordinator — goal-only status labels', () => {
       },
     ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
 
+    // ToolStatusLine streams and follows the words, so length costs display
+    // time, never clipping — the coordinator must not shorten the text.
     const [, entry] = controller.pushStatus.mock.calls[0];
-    expect(entry.text.length).toBeLessThanOrEqual(200);
-    expect(entry.text.endsWith('…')).toBe(true);
+    expect(entry.text).toBe(longGoal);
   });
 
   it('resets the goal on beginTurn so it does not bleed into the next turn', () => {

--- a/tests/unit/ToolEventCoordinator.test.ts
+++ b/tests/unit/ToolEventCoordinator.test.ts
@@ -708,8 +708,8 @@ describe('ToolEventCoordinator — beginTurn', () => {
   });
 });
 
-describe('ToolEventCoordinator — goal suffix on status labels', () => {
-  it('appends the useTools goal to unwrapped inner-call labels', () => {
+describe('ToolEventCoordinator — goal-only status labels', () => {
+  it('shows the useTools goal INSTEAD of the per-tool label', () => {
     const { coordinator, controller } = makeCoordinator();
 
     coordinator.handleToolCallsDetected('msg-1', [
@@ -730,7 +730,7 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
 
     expect(controller.pushStatus).toHaveBeenCalledTimes(1);
     const [, entry] = controller.pushStatus.mock.calls[0];
-    expect(entry.text).toMatch(/ — Find last week's meeting notes$/);
+    expect(entry.text).toBe('Find last week\'s meeting notes');
     expect(entry.state).toBe('present');
   });
 
@@ -754,7 +754,7 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
 
     expect(controller.pushStatus).toHaveBeenCalledTimes(1);
     const [, entry] = controller.pushStatus.mock.calls[0];
-    expect(entry.text).toMatch(/ — Reorganize the archive$/);
+    expect(entry.text).toBe('Reorganize the archive');
   });
 
   it('captures the goal from wrapper toolCall arguments (JSON string parameters)', () => {
@@ -778,10 +778,10 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
     });
 
     const [, entry] = controller.pushStatus.mock.calls[0];
-    expect(entry.text).toMatch(/ — Summarize the vault$/);
+    expect(entry.text).toBe('Summarize the vault');
   });
 
-  it('leaves labels untouched when the useTools call has no meaningful goal', () => {
+  it('falls back to per-tool labels when the useTools call has no meaningful goal', () => {
     const { coordinator, controller } = makeCoordinator();
 
     coordinator.handleToolCallsDetected('msg-1', [
@@ -795,12 +795,63 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
     ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
 
     const [, entry] = controller.pushStatus.mock.calls[0];
-    expect(entry.text).not.toContain('—');
+    expect(entry.text).toMatch(/Running|Read/i);
   });
 
-  it('caps an over-long goal with an ellipsis', () => {
+  it('keeps the actionable tool label on failure instead of the goal', () => {
     const { coordinator, controller } = makeCoordinator();
-    const longGoal = 'Investigate '.repeat(30).trim(); // > 140 chars
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_f',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({ goal: 'Tidy the archive', tool: 'storage move --source a.md --target b.md' }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    coordinator.handleToolExecutionCompleted('msg-1', 'call_f_0', null, false, 'permission denied');
+
+    const [, entry] = controller.pushStatus.mock.calls[controller.pushStatus.mock.calls.length - 1];
+    expect(entry.state).toBe('failed');
+    expect(entry.text).toMatch(/Failed to run/i);
+    expect(entry.text).not.toContain('Tidy the archive');
+  });
+
+  it('holds the working tense while other batch steps are still active, then flips to past', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_batch',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({
+            goal: 'Reorganize the archive',
+            tool: 'storage move --source a.md --target b.md, content read --file-path b.md',
+          }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    // First inner step completes — the second is still active, so the line
+    // must NOT flicker to past-tense mid-batch.
+    coordinator.handleToolExecutionCompleted('msg-1', 'call_batch_0', {}, true);
+    let [, entry] = controller.pushStatus.mock.calls[controller.pushStatus.mock.calls.length - 1];
+    expect(entry.text).toBe('Reorganize the archive');
+    expect(entry.state).toBe('present');
+
+    // Last step completes — now the goal settles into past tense.
+    coordinator.handleToolExecutionCompleted('msg-1', 'call_batch_1', {}, true);
+    [, entry] = controller.pushStatus.mock.calls[controller.pushStatus.mock.calls.length - 1];
+    expect(entry.text).toBe('Reorganize the archive');
+    expect(entry.state).toBe('past');
+  });
+
+  it('caps a pathologically long goal', () => {
+    const { coordinator, controller } = makeCoordinator();
+    const longGoal = 'Investigate '.repeat(30).trim(); // > 200 chars
 
     coordinator.handleToolCallsDetected('msg-1', [
       {
@@ -813,9 +864,8 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
     ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
 
     const [, entry] = controller.pushStatus.mock.calls[0];
-    const suffix = entry.text.split(' — ')[1];
-    expect(suffix.endsWith('…')).toBe(true);
-    expect(suffix.length).toBeLessThanOrEqual(140);
+    expect(entry.text.length).toBeLessThanOrEqual(200);
+    expect(entry.text.endsWith('…')).toBe(true);
   });
 
   it('resets the goal on beginTurn so it does not bleed into the next turn', () => {
@@ -839,6 +889,7 @@ describe('ToolEventCoordinator — goal suffix on status labels', () => {
 
     const [, entry] = controller.pushStatus.mock.calls[0];
     expect(entry.text).not.toContain('Old goal');
+    expect(entry.text).toMatch(/Running|Read/i);
   });
 });
 

--- a/tests/unit/ToolEventCoordinator.test.ts
+++ b/tests/unit/ToolEventCoordinator.test.ts
@@ -638,5 +638,207 @@ describe('ToolEventCoordinator — clearToolNameCache delegates to state manager
     coordinator.clearToolNameCache();
     expect(stateManager.getState('tool-1')).toBeUndefined();
   });
+
+  it('does NOT wipe other state manager listeners (clearStates, not clear)', () => {
+    const { coordinator, stateManager } = makeCoordinator();
+
+    const otherListener = jest.fn();
+    stateManager.onStateChange(otherListener);
+
+    coordinator.clearToolNameCache();
+
+    // A second subscriber must survive the between-turns reset
+    stateManager.transition('msg-2', 'tool-2', 'detected', { rawName: 'read' });
+    expect(otherListener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ToolEventCoordinator — beginTurn', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('re-subscribes after clearToolNameCache so the next turn reaches the status bar', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    // Turn 1
+    coordinator.handleToolExecutionStarted('msg-1', { id: 'call-t1', name: 'contentManager_read' });
+    expect(controller.pushStatus).toHaveBeenCalledTimes(1);
+
+    // Turn 1 ends — coordinator unsubscribes
+    coordinator.clearToolNameCache();
+
+    // Turn 2 begins via the ChatView loading bracket
+    coordinator.beginTurn();
+
+    coordinator.handleToolExecutionStarted('msg-2', { id: 'call-t2', name: 'storageManager_list' });
+    expect(controller.pushStatus).toHaveBeenCalledTimes(2);
+    const [, entry] = controller.pushStatus.mock.calls[1];
+    expect(entry.state).toBe('present');
+  });
+
+  it('clears the previous turn status text and its per-turn state immediately', () => {
+    const { coordinator, controller, stateManager } = makeCoordinator();
+    const statusBar = { clearStatus: jest.fn() };
+    controller.getStatusBar.mockReturnValue(statusBar);
+
+    coordinator.handleToolExecutionStarted('msg-1', { id: 'call-old', name: 'contentManager_read' });
+    coordinator.clearToolNameCache();
+
+    coordinator.beginTurn();
+
+    expect(statusBar.clearStatus).toHaveBeenCalledTimes(1);
+    expect(stateManager.getState('call-old')).toBeUndefined();
+  });
+
+  it('cancels the pending 2s hide from the previous turn', () => {
+    const { coordinator, controller } = makeCoordinator();
+    const statusBar = { clearStatus: jest.fn() };
+    controller.getStatusBar.mockReturnValue(statusBar);
+
+    coordinator.handleToolExecutionStarted('msg-1', { id: 'call-hide', name: 'contentManager_read' });
+    coordinator.clearToolNameCache();
+
+    jest.advanceTimersByTime(500);
+    coordinator.beginTurn(); // clears once, synchronously
+    statusBar.clearStatus.mockClear();
+
+    jest.advanceTimersByTime(5000);
+    // The delayed hide must NOT fire on top of the new turn
+    expect(statusBar.clearStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('ToolEventCoordinator — goal suffix on status labels', () => {
+  it('appends the useTools goal to unwrapped inner-call labels', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_goal',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({
+            workspaceId: 'default',
+            sessionId: 's1',
+            memory: 'none yet',
+            goal: 'Find last week\'s meeting notes',
+            tool: 'content read --file-path notes.md',
+          }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    expect(controller.pushStatus).toHaveBeenCalledTimes(1);
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    expect(entry.text).toMatch(/ — Find last week's meeting notes$/);
+    expect(entry.state).toBe('present');
+  });
+
+  it('captures the goal from the filtered execution wrapper event (object parameters)', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    // DirectToolExecutor fires the wrapper started event first; it is filtered
+    // from the status bar but must still hand over the goal.
+    coordinator.handleToolEvent('msg-1', 'started', {
+      id: 'wrap-1',
+      name: 'useTools',
+      parameters: { goal: 'Reorganize the archive', tool: 'storage move' },
+    });
+    expect(controller.pushStatus).not.toHaveBeenCalled();
+
+    coordinator.handleToolExecutionStarted('msg-1', {
+      id: 'wrap-1_0',
+      name: 'storageManager_move',
+      parameters: { source: 'a.md', target: 'b.md' },
+    });
+
+    expect(controller.pushStatus).toHaveBeenCalledTimes(1);
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    expect(entry.text).toMatch(/ — Reorganize the archive$/);
+  });
+
+  it('captures the goal from wrapper toolCall arguments (JSON string parameters)', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    coordinator.handleToolEvent('msg-1', 'started', {
+      id: 'wrap-2',
+      name: 'toolManager_useTools',
+      toolCall: {
+        id: 'wrap-2',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({ goal: 'Summarize the vault', tool: 'content read' }),
+        },
+      },
+    });
+
+    coordinator.handleToolExecutionStarted('msg-1', {
+      id: 'wrap-2_0',
+      name: 'contentManager_read',
+    });
+
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    expect(entry.text).toMatch(/ — Summarize the vault$/);
+  });
+
+  it('leaves labels untouched when the useTools call has no meaningful goal', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_nogoal',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({ goal: '   ', tool: 'content read --file-path x.md' }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    expect(entry.text).not.toContain('—');
+  });
+
+  it('caps an over-long goal with an ellipsis', () => {
+    const { coordinator, controller } = makeCoordinator();
+    const longGoal = 'Investigate '.repeat(30).trim(); // > 140 chars
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_long',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({ goal: longGoal, tool: 'content read --file-path x.md' }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    const suffix = entry.text.split(' — ')[1];
+    expect(suffix.endsWith('…')).toBe(true);
+    expect(suffix.length).toBeLessThanOrEqual(140);
+  });
+
+  it('resets the goal on beginTurn so it does not bleed into the next turn', () => {
+    const { coordinator, controller } = makeCoordinator();
+
+    coordinator.handleToolCallsDetected('msg-1', [
+      {
+        id: 'call_g1',
+        function: {
+          name: 'toolManager_useTools',
+          arguments: JSON.stringify({ goal: 'Old goal', tool: 'content read --file-path x.md' }),
+        },
+      },
+    ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+
+    coordinator.clearToolNameCache();
+    coordinator.beginTurn();
+    controller.pushStatus.mockClear();
+
+    coordinator.handleToolExecutionStarted('msg-2', { id: 'call_g2', name: 'contentManager_read' });
+
+    const [, entry] = controller.pushStatus.mock.calls[0];
+    expect(entry.text).not.toContain('Old goal');
+  });
 });
 

--- a/tests/unit/ToolStatusLine.test.ts
+++ b/tests/unit/ToolStatusLine.test.ts
@@ -1,0 +1,161 @@
+/**
+ * ToolStatusLine — word-streaming ticker behavior.
+ *
+ * The line streams entries word-by-word (no ellipsis; it follows the newest
+ * word past the row edge via scrollLeft) and guarantees an entry finishes —
+ * full reveal plus dwell — before the next replaces it, however mistimed the
+ * incoming events are. While one entry plays, later ones collapse into a
+ * single queued slot (latest wins). A same-text tense flip restyles the
+ * visible line in place instead of re-rolling it.
+ */
+
+import { Component, createMockElement } from 'obsidian';
+import { ToolStatusLine } from '../../src/ui/chat/components/toolStatusLine';
+
+const WORD_MS = 90;
+const DWELL_MS = 450;
+
+function makeLine() {
+  const slot = createMockElement('div');
+  const component = new Component();
+  const line = new ToolStatusLine(slot, component);
+  const createdSlots = () =>
+    (slot.createDiv as jest.Mock).mock.results.map(r => r.value as HTMLElement);
+  return { slot, line, createdSlots };
+}
+
+describe('ToolStatusLine — word streaming', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('reveals the text word by word at the streaming cadence', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('one two three', 'present');
+
+    const [el] = createdSlots();
+    expect(el.textContent).toBe('one');
+
+    jest.advanceTimersByTime(WORD_MS);
+    expect(el.textContent).toBe('one two');
+
+    jest.advanceTimersByTime(WORD_MS);
+    expect(el.textContent).toBe('one two three');
+  });
+
+  it('follows the newest word by scrolling the line as it streams', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('alpha beta', 'present');
+    const [el] = createdSlots();
+
+    // scrollWidth is undefined on the mock; the behavior under test is that
+    // every reveal step re-anchors scrollLeft to scrollWidth.
+    (el as unknown as { scrollWidth: number }).scrollWidth = 500;
+    jest.advanceTimersByTime(WORD_MS);
+    expect((el as unknown as { scrollLeft: number }).scrollLeft).toBe(500);
+  });
+
+  it('ignores an exact duplicate instead of re-rolling the line', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('same text', 'present');
+    jest.advanceTimersByTime(WORD_MS * 2 + DWELL_MS);
+
+    line.update('same text', 'present');
+    jest.advanceTimersByTime(WORD_MS * 2 + DWELL_MS);
+
+    expect(createdSlots()).toHaveLength(1);
+  });
+});
+
+describe('ToolStatusLine — finish before moving on', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('lets the current entry finish its reveal + dwell before the next plays, even when the next arrives immediately', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('alpha beta', 'present');
+    line.update('gamma', 'present'); // arrives mid-reveal — mistimed on purpose
+
+    // Still streaming the first entry
+    jest.advanceTimersByTime(WORD_MS - 1);
+    expect(createdSlots()).toHaveLength(1);
+    const [first] = createdSlots();
+
+    // First entry completes its words…
+    jest.advanceTimersByTime(1);
+    expect(first.textContent).toBe('alpha beta');
+    expect(createdSlots()).toHaveLength(1);
+
+    // …and only after the dwell does the queued entry take the line.
+    jest.advanceTimersByTime(DWELL_MS - 1);
+    expect(createdSlots()).toHaveLength(1);
+    jest.advanceTimersByTime(1);
+
+    const slots = createdSlots();
+    expect(slots).toHaveLength(2);
+    expect(slots[1].textContent).toBe('gamma');
+  });
+
+  it('collapses superseded intermediates: only the latest queued entry plays', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('first entry', 'present');
+    line.update('second entry', 'present');
+    line.update('third entry', 'present');
+
+    // Play out the first entry (2 words) + dwell, then the queued one fully.
+    jest.advanceTimersByTime(WORD_MS + DWELL_MS + WORD_MS * 2 + DWELL_MS);
+
+    const slots = createdSlots();
+    expect(slots).toHaveLength(2);
+    expect(slots[1].textContent).toBe('third entry');
+  });
+
+  it('restyles a same-text tense flip in place instead of re-rolling', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('Reorganize the archive', 'present');
+    jest.advanceTimersByTime(WORD_MS * 3 + DWELL_MS);
+
+    line.update('Reorganize the archive', 'past');
+
+    expect(createdSlots()).toHaveLength(1);
+    const [el] = createdSlots();
+    expect(el.removeClass).toHaveBeenCalledWith('tool-status-text-present');
+    expect(el.addClass).toHaveBeenCalledWith('tool-status-text-past');
+  });
+});
+
+describe('ToolStatusLine — clear', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('stops a stream mid-reveal and empties the host slot', () => {
+    const { slot, line, createdSlots } = makeLine();
+
+    line.update('one two three four', 'present');
+    const [el] = createdSlots();
+    expect(el.textContent).toBe('one');
+
+    line.clear();
+    expect(slot.empty).toHaveBeenCalled();
+
+    // Cancelled: no further words are written
+    jest.advanceTimersByTime(WORD_MS * 5);
+    expect(el.textContent).toBe('one');
+  });
+
+  it('starts fresh after clear', () => {
+    const { line, createdSlots } = makeLine();
+
+    line.update('before clear', 'present');
+    line.clear();
+
+    line.update('after clear', 'present');
+    const slots = createdSlots();
+    expect(slots[slots.length - 1].textContent).toBe('after');
+  });
+});

--- a/tests/unit/ToolStatusPipeline.integration.test.ts
+++ b/tests/unit/ToolStatusPipeline.integration.test.ts
@@ -493,6 +493,99 @@ describe('ToolStatusPipeline — integration', () => {
   });
 
   // ------------------------------------------------------------------
+  // 7b. Regression: the ticker must survive into the second turn
+  // ------------------------------------------------------------------
+  describe('second turn — beginTurn() re-arms the pipeline (regression)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('full two-turn flow: turn 1 events → turn end → turn 2 events still reach the bar', () => {
+      const { coordinator, entries, streaming } = createPipeline({ messageId: null });
+
+      // ---- Turn 1 (ChatView calls beginTurn on loading=true) ----
+      coordinator.beginTurn();
+      coordinator.handleToolExecutionStarted('msg-1', {
+        id: 'turn1_call',
+        name: 'contentManager_read',
+      });
+      coordinator.handleToolExecutionCompleted('msg-1', 'turn1_call', {}, true);
+      expect(entries).toHaveLength(2);
+
+      // ---- Turn 1 ends (ChatView calls clearToolNameCache on loading=false) ----
+      coordinator.clearToolNameCache();
+
+      // ---- Turn 2 ----
+      streaming.setMessageId(null); // new turn, nothing streaming yet
+      coordinator.beginTurn();
+
+      coordinator.handleToolCallsDetected('msg-2', [
+        {
+          id: 'turn2_call',
+          function: { name: 'contentManager_read', arguments: '{"filePath":"b.md"}' },
+        },
+      ] as Parameters<typeof coordinator.handleToolCallsDetected>[1]);
+      coordinator.handleToolExecutionStarted('msg-2', {
+        id: 'turn2_call_0',
+        name: 'contentManager_read',
+        parameters: { filePath: 'b.md' },
+      });
+      coordinator.handleToolExecutionCompleted('msg-2', 'turn2_call_0', {}, true);
+
+      // Turn 2 produced its own detected → started → completed sequence.
+      // Before the fix, the coordinator stayed unsubscribed after turn 1 and
+      // NONE of these reached the status bar.
+      expect(entries.length).toBe(5);
+      expect(entries[2].state).toBe('present');
+      expect(entries[4].state).toBe('past');
+      expect(entries[4].text).toMatch(/Ran|Read/i);
+    });
+
+    it('turn 2 works even when turn 1 never fired a tool event', () => {
+      const { coordinator, entries } = createPipeline({ messageId: null });
+
+      // Turn 1: pure-text turn, no tools — but the turn end still clears
+      coordinator.beginTurn();
+      coordinator.clearToolNameCache();
+
+      // Turn 2: tool-first turn
+      coordinator.beginTurn();
+      coordinator.handleToolExecutionStarted('msg-2', {
+        id: 'call_after_quiet_turn',
+        name: 'storageManager_list',
+      });
+
+      expect(entries).toHaveLength(1);
+      expect(entries[0].state).toBe('present');
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // 7c. Batch-step ID correlation stays anchored at the suffix boundary
+  // ------------------------------------------------------------------
+  describe('large batch — step 10 is not swallowed by step 1', () => {
+    it('keeps call_x_10 distinct from a terminal call_x_1', () => {
+      const { coordinator, entries, stateManager } = createPipeline({ messageId: null });
+
+      coordinator.handleToolExecutionStarted('msg-1', { id: 'call_x_1', name: 'contentManager_read' });
+      coordinator.handleToolExecutionCompleted('msg-1', 'call_x_1', {}, true);
+
+      // Step 10 arrives with an ID that PREFIX-matches step 1's ID. A bare
+      // prefix correlation merged it into the terminal call_x_1 entry and its
+      // status never showed.
+      coordinator.handleToolExecutionStarted('msg-1', { id: 'call_x_10', name: 'storageManager_move' });
+
+      expect(stateManager.getState('call_x_10')?.phase).toBe('started');
+      expect(stateManager.getState('call_x_1')?.phase).toBe('completed');
+      expect(entries[entries.length - 1].state).toBe('present');
+    });
+  });
+
+  // ------------------------------------------------------------------
   // 8. Subagent filter — messageId mismatch
   // ------------------------------------------------------------------
   describe('subagent filter — messageId mismatch', () => {


### PR DESCRIPTION
## Why

The tool status ticker went dark after the first completed turn — noticeably on mobile, where the chat view is rarely recreated — and even when alive it identified tools without conveying what the turn was trying to do.

## Root cause

`clearToolNameCache()` unsubscribes the `ToolEventCoordinator` from the tool-call state machine at every turn end, and the matching re-subscribe (`ensureListening()`) lived in a `handleStreamingUpdate` branch no producer ever reaches — every emission is either a delta `(false, true)` or a completion `(true, false)`. From turn two on, tool events fired into an empty listener list. The pipeline tests called `ensureListening()` manually, so the suite stayed green while the app broke.

## What changed

**Lifecycle (the flakiness):**
- `ChatView` brackets the coordinator with loading state: `beginTurn()` on start (re-subscribe, cancel pending hide, clear stale text/state), `clearToolNameCache()` on end — fired from `MessageManager`'s `finally`, so send/retry/alternative/abort/error all tear down uniformly.
- The between-turns reset uses a new `ToolCallStateManager.clearStates()` instead of `clear()`, which was wiping the listener array out from under every subscriber.
- `StreamingController.finalizeStreaming()` drops its `streamingStates` entry synchronously and unconditionally; the old async, DOM-conditional cleanup leaked entries, and a stale `getCurrentMessageId()` made the status bar filter silently discard later turns' present-tense labels.
- Tool-call ID correlation is anchored at a `_<index>` suffix boundary so `call_x_1` can't swallow `call_x_10` in 11+-step batches.

**Display (what the ticker says):**
- The ticker shows the `useTools` `goal` sentence instead of per-tool labels. Sized by the row's real character budget (~48–58 chars on a phone, ~37 on a narrow desktop pane at ~0.50em/char), where a parameterized tool prefix like `Reading meeting-notes.md — ` alone eats up to half a phone row. Goal-less turns fall back to tool labels; failures still say "Failed to run X".
- `ToolStatusLine` streams its text word-by-word (~11 words/s) with no ellipsis, following the newest word past the row edge via `scrollLeft`. An entry always finishes its reveal plus a short dwell before the next replaces it; superseded intermediates collapse into one queued slot (latest wins); a same-text tense flip restyles in place instead of re-rolling. Reduced-motion users get full text immediately.
- Goal text is uncapped — length costs display time, never clipping.

## Verification

- Full Jest suite: 399 suites / 4979 tests green; `npm run lint` (ESLint + mobile reachability gate) and `tsc --noEmit` clean.
- New regression guards: a two-turn pipeline integration test driving the exact ChatView call sequence (fails on the old code), a source-level wiring test pinning `beginTurn`/`clearToolNameCache` to the loading brackets and banning the re-subscribe from the unreachable branch, `StreamingController` staleness tests, ID-boundary correlation tests, and `ToolStatusLine` streaming/sequencing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144nXDCi3gUiG61ibMD54wc

---
_Generated by [Claude Code](https://claude.ai/code/session_0144nXDCi3gUiG61ibMD54wc)_