### PR TITLE
feat(models): add Claude Fable 5.1 to Anthropic, Claude Code, OpenRouter and Requesty

### DIFF
--- a/.claude/skills/nexus-model-updates/references/registry-anatomy.md
+++ b/.claude/skills/nexus-model-updates/references/registry-anatomy.md
@@ -111,3 +111,5 @@ Field-level questions the type does not answer:
 | Not sure whether tools are supported | Not a guess — go back to the provider's docs |
 | Model needs a beta header | `betaHeaders`, not a capability flag |
 | Two entries would share an id | Only where the adapter disambiguates; otherwise one entry |
+| Gateway sibling uses a dash (or dot) in its version | Not evidence — a gateway's separator varies per model; read this model's own listing |
+| Gateway catalog unreachable (egress-blocked, keyless lookup fails) | Ask the user for the gateway's model page; a screenshot of its id and price is a published listing |

--- a/.claude/skills/nexus-model-updates/refinement-log.md
+++ b/.claude/skills/nexus-model-updates/refinement-log.md
@@ -64,3 +64,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   verification command) and the rule that touching either side means deciding,
   per model, whether the other side gets it too — verified through the twin's
   transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.
+- 2026-09-02 | Adding Claude Fable 5.1: both gateway catalogs were
+  egress-blocked from the remote session, and the Requesty registry's own
+  header ("dashed upstream slugs") plus every Claude sibling pointed at
+  `claude-fable-5-1`, while Requesty's listing (supplied by the user as a
+  screenshot) publishes `anthropic/claude-fable-5.1`. A sibling's separator
+  would have produced a confidently spelled 404. | Added two lookup rows to
+  registry-anatomy: a sibling's separator is not evidence, and an unreachable
+  catalog means asking the user for the listing page rather than stopping. |
+  Files: `references/registry-anatomy.md`.

--- a/.cline/skills/nexus-model-updates/references/registry-anatomy.md
+++ b/.cline/skills/nexus-model-updates/references/registry-anatomy.md
@@ -111,3 +111,5 @@ Field-level questions the type does not answer:
 | Not sure whether tools are supported | Not a guess — go back to the provider's docs |
 | Model needs a beta header | `betaHeaders`, not a capability flag |
 | Two entries would share an id | Only where the adapter disambiguates; otherwise one entry |
+| Gateway sibling uses a dash (or dot) in its version | Not evidence — a gateway's separator varies per model; read this model's own listing |
+| Gateway catalog unreachable (egress-blocked, keyless lookup fails) | Ask the user for the gateway's model page; a screenshot of its id and price is a published listing |

--- a/.cline/skills/nexus-model-updates/refinement-log.md
+++ b/.cline/skills/nexus-model-updates/refinement-log.md
@@ -64,3 +64,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   verification command) and the rule that touching either side means deciding,
   per model, whether the other side gets it too — verified through the twin's
   transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.
+- 2026-09-02 | Adding Claude Fable 5.1: both gateway catalogs were
+  egress-blocked from the remote session, and the Requesty registry's own
+  header ("dashed upstream slugs") plus every Claude sibling pointed at
+  `claude-fable-5-1`, while Requesty's listing (supplied by the user as a
+  screenshot) publishes `anthropic/claude-fable-5.1`. A sibling's separator
+  would have produced a confidently spelled 404. | Added two lookup rows to
+  registry-anatomy: a sibling's separator is not evidence, and an unreachable
+  catalog means asking the user for the listing page rather than stopping. |
+  Files: `references/registry-anatomy.md`.

--- a/.codex/skills/nexus-model-updates/references/registry-anatomy.md
+++ b/.codex/skills/nexus-model-updates/references/registry-anatomy.md
@@ -111,3 +111,5 @@ Field-level questions the type does not answer:
 | Not sure whether tools are supported | Not a guess — go back to the provider's docs |
 | Model needs a beta header | `betaHeaders`, not a capability flag |
 | Two entries would share an id | Only where the adapter disambiguates; otherwise one entry |
+| Gateway sibling uses a dash (or dot) in its version | Not evidence — a gateway's separator varies per model; read this model's own listing |
+| Gateway catalog unreachable (egress-blocked, keyless lookup fails) | Ask the user for the gateway's model page; a screenshot of its id and price is a published listing |

--- a/.codex/skills/nexus-model-updates/refinement-log.md
+++ b/.codex/skills/nexus-model-updates/refinement-log.md
@@ -64,3 +64,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   verification command) and the rule that touching either side means deciding,
   per model, whether the other side gets it too — verified through the twin's
   transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.
+- 2026-09-02 | Adding Claude Fable 5.1: both gateway catalogs were
+  egress-blocked from the remote session, and the Requesty registry's own
+  header ("dashed upstream slugs") plus every Claude sibling pointed at
+  `claude-fable-5-1`, while Requesty's listing (supplied by the user as a
+  screenshot) publishes `anthropic/claude-fable-5.1`. A sibling's separator
+  would have produced a confidently spelled 404. | Added two lookup rows to
+  registry-anatomy: a sibling's separator is not evidence, and an unreachable
+  catalog means asking the user for the listing page rather than stopping. |
+  Files: `references/registry-anatomy.md`.

--- a/.skills/nexus-model-updates/references/registry-anatomy.md
+++ b/.skills/nexus-model-updates/references/registry-anatomy.md
@@ -111,3 +111,5 @@ Field-level questions the type does not answer:
 | Not sure whether tools are supported | Not a guess — go back to the provider's docs |
 | Model needs a beta header | `betaHeaders`, not a capability flag |
 | Two entries would share an id | Only where the adapter disambiguates; otherwise one entry |
+| Gateway sibling uses a dash (or dot) in its version | Not evidence — a gateway's separator varies per model; read this model's own listing |
+| Gateway catalog unreachable (egress-blocked, keyless lookup fails) | Ask the user for the gateway's model page; a screenshot of its id and price is a published listing |

--- a/.skills/nexus-model-updates/refinement-log.md
+++ b/.skills/nexus-model-updates/refinement-log.md
@@ -64,3 +64,12 @@ Append-only record of changes made by `protocols/self-refine.md`. Newest on top.
   verification command) and the rule that touching either side means deciding,
   per model, whether the other side gets it too — verified through the twin's
   transport, cost 0 on the CLI side. | Files: `protocols/add-model.md`.
+- 2026-09-02 | Adding Claude Fable 5.1: both gateway catalogs were
+  egress-blocked from the remote session, and the Requesty registry's own
+  header ("dashed upstream slugs") plus every Claude sibling pointed at
+  `claude-fable-5-1`, while Requesty's listing (supplied by the user as a
+  screenshot) publishes `anthropic/claude-fable-5.1`. A sibling's separator
+  would have produced a confidently spelled 404. | Added two lookup rows to
+  registry-anatomy: a sibling's separator is not evidence, and an unreachable
+  catalog means asking the user for the listing page rather than stopping. |
+  Files: `references/registry-anatomy.md`.

--- a/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
+++ b/src/services/llm/adapters/anthropic-claude-code/AnthropicClaudeCodeModels.ts
@@ -51,6 +51,22 @@ export const ANTHROPIC_CLAUDE_CODE_MODELS: ModelSpec[] = [
   },
   {
     provider: 'anthropic-claude-code',
+    name: 'Claude Fable 5.1',
+    apiName: 'claude-fable-5-1',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 0,
+    outputCostPerMillion: 0,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'anthropic-claude-code',
     name: 'Claude Fable 5',
     apiName: 'claude-fable-5',
     contextWindow: 1000000,

--- a/src/services/llm/adapters/anthropic/AnthropicModels.ts
+++ b/src/services/llm/adapters/anthropic/AnthropicModels.ts
@@ -24,6 +24,24 @@ export const ANTHROPIC_MODELS: ModelSpec[] = [
     }
   },
 
+  // Claude Fable 5.1 (native 1M context, 128k output; thinking is always on)
+  {
+    provider: 'anthropic',
+    name: 'Claude Fable 5.1',
+    apiName: 'claude-fable-5-1',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+
   // Claude Fable 5
   {
     provider: 'anthropic',

--- a/src/services/llm/adapters/openrouter/OpenRouterModels.ts
+++ b/src/services/llm/adapters/openrouter/OpenRouterModels.ts
@@ -109,6 +109,22 @@ export const OPENROUTER_MODELS: ModelSpec[] = [
   },
   {
     provider: 'openrouter',
+    name: 'Claude Fable 5.1',
+    apiName: 'anthropic/claude-fable-5.1',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
+  {
+    provider: 'openrouter',
     name: 'Claude Fable 5',
     apiName: 'anthropic/claude-fable-5',
     contextWindow: 1000000,

--- a/src/services/llm/adapters/requesty/RequestyModels.ts
+++ b/src/services/llm/adapters/requesty/RequestyModels.ts
@@ -153,6 +153,23 @@ export const REQUESTY_MODELS: ModelSpec[] = [
   },
 
   // Anthropic models via Requesty (dashed upstream slugs)
+  // Requesty lists this one with a dotted version, unlike its dashed Claude siblings.
+  {
+    provider: 'requesty',
+    name: 'Claude Fable 5.1',
+    apiName: 'anthropic/claude-fable-5.1',
+    contextWindow: 1000000,
+    maxTokens: 128000,
+    inputCostPerMillion: 10.00,
+    outputCostPerMillion: 50.00,
+    capabilities: {
+      supportsJSON: true,
+      supportsImages: true,
+      supportsFunctions: true,
+      supportsStreaming: true,
+      supportsThinking: true
+    }
+  },
   {
     provider: 'requesty',
     name: 'Claude Fable 5',


### PR DESCRIPTION
## Summary

Adds Claude Fable 5.1, released 2026-09-01, to four provider registries. No provider default moves.

| Provider | Slug | Context / output | Price per MTok |
|---|---|---|---|
| Anthropic API | `claude-fable-5-1` | 1M / 128K | $10 / $50 |
| Claude Code (CLI) | `claude-fable-5-1` | 1M / 128K | 0 (subscription-billed) |
| OpenRouter | `anthropic/claude-fable-5.1` | 1M / 128K | $10 / $50 |
| Requesty | `anthropic/claude-fable-5.1` | 1M / 128K | $10 / $50 |

All five capability flags are set. The Anthropic adapter's adaptive-thinking predicate already matches the new id, and the adapter never sends forced `tool_choice`, which Fable 5.1 rejects.

Requesty publishes a dotted version for this model while its Claude siblings in the same registry are dashed; the entry uses the slug as listed and carries a comment saying so.

Also records the session's lesson in the `nexus-model-updates` skill (a gateway sibling's slug separator is not evidence; an unreachable catalog means asking for the listing page) and syncs the skill mirrors.

## Verification

- Registry structural gate: clean on all four registries (the three Anthropic duplicate-id warnings are the pre-existing 1M variant pairs).
- Lint, typecheck, full production build: pass.
- Full Jest suite: 4979 passed, 39 skipped, 0 failed.
- `claude-fable-5-1` verified live through the installed Claude CLI.
- The Anthropic API, OpenRouter and Requesty ids were not smoke-tested live from this environment (no keys; gateways egress-blocked). Gateway slugs and prices were taken from each gateway's own model listing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzYGGs2GKJtE8Tmsp8jPHH

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzYGGs2GKJtE8Tmsp8jPHH)_