### PR TITLE
fix(cli): give tools/call its own ten-minute timeout

### DIFF
--- a/cli/mcpLineClient.ts
+++ b/cli/mcpLineClient.ts
@@ -54,15 +54,41 @@ export function parseJsonRpcResponse(line: string): JsonRpcResponse | null {
     return response;
 }
 
+export const DEFAULT_TIMEOUT_MS = 20_000;
+/** Ten minutes: long enough for an image edit or a slow generation model. */
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 600_000;
+
+/**
+ * Read a positive integer millisecond override from the environment; anything
+ * else (unset, empty, NaN, zero, negative) yields undefined so the default holds.
+ */
+export function parseTimeoutEnv(raw: string | undefined): number | undefined {
+    if (!raw) return undefined;
+    const value = Number(raw);
+    return Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
+}
+
 export class McpLineClient {
     private socket: Socket | null = null;
     private nextId = 1;
     private readonly pending = new Map<number, Pending>();
     private buffer = '';
     private readonly timeoutMs: number;
+    private readonly toolCallTimeoutMs: number;
 
-    constructor(private readonly socketPath: string, opts: { timeoutMs?: number } = {}) {
-        this.timeoutMs = opts.timeoutMs ?? 20000;
+    /**
+     * `timeoutMs` bounds the handshake and discovery calls, which answer from
+     * memory. `toolCallTimeoutMs` bounds `tools/call`, which may be waiting on a
+     * provider: an image edit or a slow model can take well over a minute, and
+     * a 20-second client timeout used to abandon a call the plugin then finished
+     * anyway (the image landed in the vault after the CLI had already errored).
+     */
+    constructor(
+        private readonly socketPath: string,
+        opts: { timeoutMs?: number; toolCallTimeoutMs?: number } = {}
+    ) {
+        this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+        this.toolCallTimeoutMs = opts.toolCallTimeoutMs ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
     }
 
     connect(): Promise<void> {
@@ -113,15 +139,15 @@ export class McpLineClient {
         this.pending.clear();
     }
 
-    private request(method: string, params?: unknown): Promise<unknown> {
+    private request(method: string, params?: unknown, timeoutMs: number = this.timeoutMs): Promise<unknown> {
         if (!this.socket) return Promise.reject(new Error('not connected'));
         const id = this.nextId++;
         const payload = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
         return new Promise((resolve, reject) => {
             const timer = setTimeout(() => {
                 this.pending.delete(id);
-                reject(new Error(`Timeout after ${this.timeoutMs}ms waiting for "${method}"`));
-            }, this.timeoutMs);
+                reject(new Error(`Timeout after ${timeoutMs}ms waiting for "${method}"`));
+            }, timeoutMs);
             this.pending.set(id, {
                 resolve: (v) => { clearTimeout(timer); resolve(v); },
                 reject: (e) => { clearTimeout(timer); reject(e); },
@@ -149,7 +175,7 @@ export class McpLineClient {
     }
 
     callTool(name: string, args: Record<string, unknown>): Promise<McpToolResult> {
-        return this.request('tools/call', { name, arguments: args }) as Promise<McpToolResult>;
+        return this.request('tools/call', { name, arguments: args }, this.toolCallTimeoutMs) as Promise<McpToolResult>;
     }
 
     close(): void {

--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -13,7 +13,7 @@
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { McpLineClient, McpToolResult } from './mcpLineClient';
+import { McpLineClient, McpToolResult, parseTimeoutEnv } from './mcpLineClient';
 import { playbooksDir, parseFrontmatter, listPlaybooks } from './playbooks';
 import {
     hydrateToolContentArgv,
@@ -151,6 +151,8 @@ CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
   --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
+                          (a tool call may run up to 10 minutes — image edits and
+                          slow models take a while; $NEXUS_CLI_TOOL_TIMEOUT_MS overrides)
   --json                  print the raw JSON result
   --dry-run               print the reconstructed request; do not connect or execute
 
@@ -235,7 +237,9 @@ EXAMPLES
 
 async function withClient<T>(vaultName: string | undefined, fn: (c: McpLineClient) => Promise<T>): Promise<T> {
     const vault = resolveVault(vaultName);
-    const client = new McpLineClient(vault.path);
+    const client = new McpLineClient(vault.path, {
+        toolCallTimeoutMs: parseTimeoutEnv(process.env.NEXUS_CLI_TOOL_TIMEOUT_MS)
+    });
     await client.connect();
     try {
         await client.initialize();

--- a/guide/nexus-cli.md
+++ b/guide/nexus-cli.md
@@ -104,6 +104,15 @@ The vault name lives in the socket name, so selection happens at call time:
 3. exactly one vault open → used automatically.
 4. multiple open, none specified → error listing them (run `nexus vaults`).
 
+## Timeouts
+
+The handshake and discovery calls answer from memory and time out after 20
+seconds. A tool call (`nexus use …`) may be waiting on a provider — an image
+edit or a slow generation model can take a minute or more — so it is allowed
+up to **10 minutes**. Set `NEXUS_CLI_TOOL_TIMEOUT_MS` to change that budget for
+a shell/session. The plugin keeps running a call the CLI has given up on, so a
+timed-out image or file write can still land in the vault afterwards.
+
 ## Platform notes
 
 | Platform | Transport | Install |

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,7 +7,7 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "72acd9eeb1c076bc";
+export const NEXUS_CLI_ASSETS_HASH = "12f4a7babd7333df";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
@@ -38,14 +38,29 @@ function parseJsonRpcResponse(line) {
   }
   return response;
 }
+var DEFAULT_TIMEOUT_MS = 2e4;
+var DEFAULT_TOOL_CALL_TIMEOUT_MS = 6e5;
+function parseTimeoutEnv(raw) {
+  if (!raw) return void 0;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : void 0;
+}
 var McpLineClient = class {
+  /**
+   * \`timeoutMs\` bounds the handshake and discovery calls, which answer from
+   * memory. \`toolCallTimeoutMs\` bounds \`tools/call\`, which may be waiting on a
+   * provider: an image edit or a slow model can take well over a minute, and
+   * a 20-second client timeout used to abandon a call the plugin then finished
+   * anyway (the image landed in the vault after the CLI had already errored).
+   */
   constructor(socketPath, opts = {}) {
     this.socketPath = socketPath;
     this.socket = null;
     this.nextId = 1;
     this.pending = /* @__PURE__ */ new Map();
     this.buffer = "";
-    this.timeoutMs = opts.timeoutMs ?? 2e4;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.toolCallTimeoutMs = opts.toolCallTimeoutMs ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
   }
   connect() {
     return new Promise((resolve, reject) => {
@@ -90,15 +105,15 @@ var McpLineClient = class {
     for (const p of this.pending.values()) p.reject(err);
     this.pending.clear();
   }
-  request(method, params) {
+  request(method, params, timeoutMs = this.timeoutMs) {
     if (!this.socket) return Promise.reject(new Error("not connected"));
     const id = this.nextId++;
     const payload = JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\\n";
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pending.delete(id);
-        reject(new Error(\`Timeout after \${this.timeoutMs}ms waiting for "\${method}"\`));
-      }, this.timeoutMs);
+        reject(new Error(\`Timeout after \${timeoutMs}ms waiting for "\${method}"\`));
+      }, timeoutMs);
       this.pending.set(id, {
         resolve: (v) => {
           clearTimeout(timer);
@@ -128,7 +143,7 @@ var McpLineClient = class {
     return this.request("tools/list", {});
   }
   callTool(name, args) {
-    return this.request("tools/call", { name, arguments: args });
+    return this.request("tools/call", { name, arguments: args }, this.toolCallTimeoutMs);
   }
   close() {
     this.socket?.end();
@@ -602,6 +617,8 @@ CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` 
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
   --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
+                          (a tool call may run up to 10 minutes \\u2014 image edits and
+                          slow models take a while; $NEXUS_CLI_TOOL_TIMEOUT_MS overrides)
   --json                  print the raw JSON result
   --dry-run               print the reconstructed request; do not connect or execute
 
@@ -685,7 +702,9 @@ EXAMPLES
 }
 async function withClient(vaultName, fn) {
   const vault = resolveVault(vaultName);
-  const client = new McpLineClient(vault.path);
+  const client = new McpLineClient(vault.path, {
+    toolCallTimeoutMs: parseTimeoutEnv(process.env.NEXUS_CLI_TOOL_TIMEOUT_MS)
+  });
   await client.connect();
   try {
     await client.initialize();

--- a/tests/unit/mcpLineClient.test.ts
+++ b/tests/unit/mcpLineClient.test.ts
@@ -24,3 +24,96 @@ describe('parseJsonRpcResponse', () => {
         expect(parseJsonRpcResponse(input)).toBeNull();
     });
 });
+
+import { createServer, Server } from 'node:net';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    DEFAULT_TIMEOUT_MS,
+    DEFAULT_TOOL_CALL_TIMEOUT_MS,
+    McpLineClient,
+    parseTimeoutEnv,
+} from '../../cli/mcpLineClient';
+
+describe('parseTimeoutEnv', () => {
+    it.each([
+        [undefined, undefined],
+        ['', undefined],
+        ['abc', undefined],
+        ['0', undefined],
+        ['-5', undefined],
+        ['1500', 1500],
+        ['1500.9', 1500],
+    ])('parses %p as %p', (raw, expected) => {
+        expect(parseTimeoutEnv(raw)).toBe(expected);
+    });
+});
+
+describe('McpLineClient timeouts', () => {
+    /**
+     * A fake Nexus socket server: answers initialize immediately and delays
+     * tools/call by `toolDelayMs`, so the two timeouts can be told apart.
+     */
+    function startServer(toolDelayMs: number): { server: Server; socketPath: string; dir: string } {
+        const dir = mkdtempSync(join(tmpdir(), 'nexus-cli-'));
+        const socketPath = join(dir, 'nexus.sock');
+        const server = createServer((socket) => {
+            let buffer = '';
+            socket.on('data', (chunk) => {
+                buffer += chunk.toString('utf8');
+                let idx: number;
+                while ((idx = buffer.indexOf('\n')) >= 0) {
+                    const line = buffer.slice(0, idx);
+                    buffer = buffer.slice(idx + 1);
+                    if (!line.trim()) continue;
+                    const msg = JSON.parse(line) as { id?: number; method: string };
+                    if (msg.id === undefined) continue; // notification
+                    const reply = JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { method: msg.method } }) + '\n';
+                    if (msg.method === 'tools/call') {
+                        setTimeout(() => socket.write(reply), toolDelayMs);
+                    } else {
+                        socket.write(reply);
+                    }
+                }
+            });
+        });
+        server.listen(socketPath);
+        return { server, socketPath, dir };
+    }
+
+    it('defaults to a short handshake timeout and a ten-minute tool-call timeout', () => {
+        expect(DEFAULT_TIMEOUT_MS).toBe(20_000);
+        expect(DEFAULT_TOOL_CALL_TIMEOUT_MS).toBe(600_000);
+    });
+
+    it('lets a tools/call outlive the handshake timeout', async () => {
+        const { server, socketPath, dir } = startServer(120);
+        const client = new McpLineClient(socketPath, { timeoutMs: 40, toolCallTimeoutMs: 2_000 });
+        try {
+            await client.connect();
+            await client.initialize();
+            const result = await client.callTool('toolManager_useTools', {});
+            expect(result).toEqual({ method: 'tools/call' });
+        } finally {
+            client.close();
+            server.close();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('still times out a tools/call that exceeds the tool-call budget, naming the method', async () => {
+        const { server, socketPath, dir } = startServer(500);
+        const client = new McpLineClient(socketPath, { timeoutMs: 40, toolCallTimeoutMs: 60 });
+        try {
+            await client.connect();
+            await client.initialize();
+            await expect(client.callTool('toolManager_useTools', {}))
+                .rejects.toThrow('Timeout after 60ms waiting for "tools/call"');
+        } finally {
+            client.close();
+            server.close();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Why

The CLI's socket client applied one 20-second timeout to every JSON-RPC request, including `tools/call`. An image edit through `nexus use … prompt generate-image` reported `Timeout after 20000ms waiting for "tools/call"` while the plugin finished the call anyway and the image landed in the vault about a minute later. Any tool that waits on a provider (image edits, slow models, large ingests) hits the same wall.

The MCP path is not affected by this bug: `connector.js` applies no timeout of its own, so a tool call over MCP is bounded only by the host client (Claude Code defaults to hours and exposes `MCP_TOOL_TIMEOUT`; the MCP TypeScript SDK client defaults to 60 seconds). Internal chat has no tool-call timeout either, only the adapters' own HTTP budgets (120 s generation, 180 s edits).

## What

- `McpLineClient` gets a second budget: `timeoutMs` (20 s) still bounds `initialize` and `tools/list`, which answer from memory; `toolCallTimeoutMs` (10 minutes) bounds `tools/call`.
- `NEXUS_CLI_TOOL_TIMEOUT_MS` overrides the tool-call budget. `parseTimeoutEnv` accepts only a positive number; anything else keeps the default.
- `--help` and `guide/nexus-cli.md` document the budget, the override, and that the plugin keeps running a call the CLI has given up on.
- `src/utils/cliAssets.ts` regenerated from the rebuilt CLI bundle.

## Verification

- `tests/unit/mcpLineClient.test.ts`: `parseTimeoutEnv` table; a fake socket server that answers the handshake immediately and delays `tools/call`, proving a tool call outlives a 40 ms handshake timeout and that a call past the tool budget still fails naming the method.
- Full Jest suite: 5052 passed, 0 failed, 37 skipped, including the shipped-docs gate over the guide change. CLI `tsc`, ESLint, full production build: pass.
- Reloaded in the running Obsidian (`dev:errors` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)