### PR TITLE
feat(cli): select the vault by working directory

### DIFF
--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -37,6 +37,9 @@ import {
     VaultSocket,
     formatAvailableVaults,
     isOwnUnixSocket,
+    readVaultNotes,
+    resolveVaultByCwd,
+    toRealPath,
 } from './vaultDiscovery';
 
 // Transport endpoints mirror connector.ts exactly:
@@ -74,11 +77,18 @@ function resolveVault(requested?: string): VaultSocket {
         return { name: s, path: p };
     }
     const sockets = listVaultSockets();
-    if (sockets.length === 1) return sockets[0];
     if (sockets.length === 0) {
         throw new Error('No open Nexus vaults found. Is Obsidian running with Nexus? Or pass --vault <name>.');
     }
-    throw new Error(`Multiple vaults open: ${sockets.map((x) => x.name).join(', ')}. Pass --vault <name>.`);
+    // Running from inside a vault's folder selects that vault. Each plugin publishes its
+    // folder beside its socket; the innermost containing folder wins when vaults nest.
+    const byCwd = resolveVaultByCwd(toRealPath(process.cwd()), readVaultNotes(sockets));
+    if (byCwd) return byCwd;
+    if (sockets.length === 1) return sockets[0];
+    throw new Error(
+        `Multiple vaults open: ${sockets.map((x) => x.name).join(', ')}. ` +
+        'Run from inside a vault folder to select it, or pass --vault <name>.'
+    );
 }
 
 function printToolResult(result: McpToolResult, asJson: boolean): number {
@@ -119,7 +129,7 @@ function buildUsage(): string {
     // should answer the immediate follow-up question: which value can I pass to --vault?
     let availableVaultLines: string;
     try {
-        availableVaultLines = formatAvailableVaults(listVaultSockets());
+        availableVaultLines = formatAvailableVaults(readVaultNotes(listVaultSockets()));
     } catch (error) {
         availableVaultLines = `  (could not enumerate: ${(error as Error).message})`;
     }
@@ -141,7 +151,7 @@ COMMANDS
                                      tools, in one call. \`nexus playbook\` lists them.
   nexus context [--json]             What this vault remembers for the CLI: current
                                      session and its workspace (read-only)
-  nexus vaults                       List open Nexus vaults (live sockets)
+  nexus vaults                       List open Nexus vaults (live sockets + vault folder)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
 
@@ -166,7 +176,8 @@ CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
                           to switch. \`nexus context\` shows both.
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
-  --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
+  --vault <name>          target a vault (else: $NEXUS_VAULT; else the open vault whose
+                          folder contains the current directory; else the single open one)
                           (a tool call may run up to 10 minutes — image edits and
                           slow models take a while; $NEXUS_CLI_TOOL_TIMEOUT_MS overrides)
   --json                  print the raw JSON result
@@ -238,7 +249,7 @@ GOTCHAS
     list of errors before touching disk); \`base analyze\` runs it and returns the rows
     a user would see.
   • No open vault → the socket is absent; open Obsidian with Nexus. Multiple open →
-    pass --vault <name>.
+    run from inside a vault's folder (cwd selects it) or pass --vault <name>.
 
 TOOL CATALOG
   Core agents (always on): content, storage, search, canvas, task, memory, prompt, ingest.
@@ -316,7 +327,9 @@ async function main(): Promise<number> {
             process.stdout.write('No open Nexus vaults. Is Obsidian running with Nexus enabled?\n');
             return 0;
         }
-        for (const s of sockets) process.stdout.write(`${s.name}\t${s.path}\n`);
+        for (const s of readVaultNotes(sockets)) {
+            process.stdout.write(`${s.name}\t${s.path}${s.basePath ? `\t${s.basePath}` : ''}\n`);
+        }
         return 0;
     }
 

--- a/cli/vaultDiscovery.ts
+++ b/cli/vaultDiscovery.ts
@@ -6,29 +6,149 @@
  * reports ENOTDIR, so Windows enumeration uses the built-in PowerShell file
  * system provider. The command is fixed and receives no user-controlled text.
  */
-import { lstatSync, readdirSync } from 'node:fs';
+import { lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import * as nodePath from 'node:path';
 
 export const NAME_PREFIX = 'nexus_mcp_';
 export const UNIX_SOCK_DIR = '/tmp';
 export const UNIX_SUFFIX = '.sock';
 export const WIN_PIPE_DIR = '\\\\.\\pipe\\';
+/** The sidecar note a running plugin writes beside its socket. */
+export const NOTE_SUFFIX = '.json';
 
 export interface VaultSocket {
     name: string;
     path: string;
 }
 
+/**
+ * A live endpoint plus what its plugin published about itself. `basePath` is
+ * the vault's absolute folder; absent when the plugin wrote no note (mobile,
+ * an older plugin, or an unreadable note).
+ */
+export interface VaultEntry extends VaultSocket {
+    basePath?: string;
+}
+
 /** Format live endpoints for the dynamic section in `nexus --help`. */
-export function formatAvailableVaults(sockets: readonly VaultSocket[]): string {
+export function formatAvailableVaults(sockets: readonly VaultEntry[]): string {
     if (sockets.length === 0) {
         return '  (none detected — open Obsidian with Nexus enabled)';
     }
 
     const nameWidth = Math.max(...sockets.map((socket) => socket.name.length));
+    const pathWidth = Math.max(...sockets.map((socket) => socket.path.length));
     return sockets
-        .map((socket) => `  ${socket.name.padEnd(nameWidth)}  ${socket.path}`)
+        .map((socket) => {
+            const line = `  ${socket.name.padEnd(nameWidth)}  ${socket.path}`;
+            return socket.basePath ? `${line.padEnd(nameWidth + pathWidth + 4)}  ${socket.basePath}` : line;
+        })
         .join('\n');
+}
+
+/**
+ * Where the plugin for this socket publishes `{ vaultName, basePath }`.
+ *
+ * Beside the socket on Unix (`/tmp/nexus_mcp_<vault>.json`). The Windows pipe
+ * namespace holds no files, so there it lives under the temp directory. Mirrors
+ * `buildVaultNotePath` in src/constants/branding.ts — MUST stay identical.
+ */
+export function vaultNotePath(
+    socket: VaultSocket,
+    platform: NodeJS.Platform = process.platform,
+    tempDir: string = tmpdir()
+): string {
+    if (platform === 'win32') {
+        return `${tempDir.replace(/[\\/]+$/, '')}\\${NAME_PREFIX}${socket.name}${NOTE_SUFFIX}`;
+    }
+    return socket.path.endsWith(UNIX_SUFFIX)
+        ? `${socket.path.slice(0, -UNIX_SUFFIX.length)}${NOTE_SUFFIX}`
+        : `${socket.path}${NOTE_SUFFIX}`;
+}
+
+/** Parse a note's text; undefined for anything that is not exactly the published shape. */
+export function parseVaultNote(raw: string): { vaultName: string; basePath: string } | undefined {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
+    if (typeof parsed !== 'object' || parsed === null) return undefined;
+    const { vaultName, basePath } = parsed as { vaultName?: unknown; basePath?: unknown };
+    if (typeof vaultName !== 'string' || typeof basePath !== 'string' || basePath.length === 0) {
+        return undefined;
+    }
+    return { vaultName, basePath };
+}
+
+/**
+ * Attach each live socket's published folder. Only sockets already listed are
+ * consulted, so a note whose plugin is gone is never seen; a missing, unreadable
+ * or malformed note simply leaves `basePath` unset. The folder is resolved to
+ * its real path (symlinks, on-disk casing) so it compares cleanly with a cwd
+ * resolved the same way.
+ */
+export function readVaultNotes(
+    sockets: readonly VaultSocket[],
+    platform: NodeJS.Platform = process.platform,
+    tempDir: string = tmpdir()
+): VaultEntry[] {
+    return sockets.map((socket) => {
+        let raw: string;
+        try {
+            raw = readFileSync(vaultNotePath(socket, platform, tempDir), 'utf8');
+        } catch {
+            return { ...socket };
+        }
+        const note = parseVaultNote(raw);
+        if (!note) return { ...socket };
+        return { ...socket, basePath: toRealPath(note.basePath) };
+    });
+}
+
+/** Canonicalise a path for comparison; falls back to the input when it cannot be resolved. */
+export function toRealPath(target: string): string {
+    try {
+        return realpathSync.native(target);
+    } catch {
+        return target;
+    }
+}
+
+/**
+ * Pick the vault whose folder contains `cwd`, innermost first.
+ *
+ * Pure: reads nothing from disk. Both sides are normalised with the platform's
+ * path rules, and containment is separator-aware, so `/x/Code` does not claim
+ * `/x/CodeOther`. When vault folders nest, the longest (innermost) match wins,
+ * because that is the vault the caller is most specifically inside. Windows
+ * paths compare case-insensitively. Entries with no `basePath` never match.
+ */
+export function resolveVaultByCwd(
+    cwd: string,
+    entries: readonly VaultEntry[],
+    platform: NodeJS.Platform = process.platform
+): VaultEntry | undefined {
+    const p = platform === 'win32' ? nodePath.win32 : nodePath.posix;
+    const fold = (value: string) => (platform === 'win32' ? value.toLowerCase() : value);
+    const here = fold(p.resolve(cwd));
+
+    let best: VaultEntry | undefined;
+    let bestLength = -1;
+    for (const entry of entries) {
+        if (!entry.basePath) continue;
+        const base = fold(p.resolve(entry.basePath));
+        const prefix = base.endsWith(p.sep) ? base : `${base}${p.sep}`;
+        const contains = here === base || here.startsWith(prefix);
+        if (contains && base.length > bestLength) {
+            best = entry;
+            bestLength = base.length;
+        }
+    }
+    return best;
 }
 
 const WINDOWS_PIPE_LIST_SCRIPT = "Get-ChildItem -LiteralPath '\\\\.\\pipe\\' -Name";

--- a/src/constants/branding.ts
+++ b/src/constants/branding.ts
@@ -85,3 +85,30 @@ export function getPrimaryIpcPath(vaultName: string, isWindows: boolean): string
     const sanitized = sanitizeVaultName(vaultName);
     return buildIpcPath(sanitized, isWindows, PIPE_NAME_PREFIXES.current);
 }
+
+/**
+ * Where a running plugin publishes its vault's folder for the CLI.
+ *
+ * Sits beside the socket on Unix (`/tmp/nexus_mcp_<vault>.json`). The Windows
+ * pipe namespace holds no files, so there it goes under the temp directory the
+ * caller passes (`os.tmpdir()`, i.e. %TEMP%). `cli/vaultDiscovery.ts` mirrors
+ * this shape and must stay identical.
+ */
+export function buildVaultNotePath(
+    sanitizedVaultName: string,
+    isWindows: boolean,
+    windowsTempDir: string
+): string {
+    const fileName = `${PIPE_NAME_PREFIXES.current}_${sanitizedVaultName}.json`;
+    return isWindows
+        ? `${windowsTempDir.replace(/[\\/]+$/, '')}\\${fileName}`
+        : `/tmp/${fileName}`;
+}
+
+export function getPrimaryVaultNotePath(
+    vaultName: string,
+    isWindows: boolean,
+    windowsTempDir: string
+): string {
+    return buildVaultNotePath(sanitizeVaultName(vaultName), isWindows, windowsTempDir);
+}

--- a/src/server/services/ServerConfiguration.ts
+++ b/src/server/services/ServerConfiguration.ts
@@ -6,7 +6,8 @@
 import { App } from 'obsidian';
 import { sanitizeVaultName } from '../../utils/vaultUtils';
 import { logger } from '../../utils/logger';
-import { getPrimaryServerKey, getPrimaryIpcPath } from '../../constants/branding';
+import { desktopRequire } from '../../utils/desktopRequire';
+import { getPrimaryServerKey, getPrimaryIpcPath, getPrimaryVaultNotePath } from '../../constants/branding';
 
 export interface ServerConfigurationOptions {
     serverName?: string;
@@ -112,6 +113,36 @@ export class ServerConfiguration {
      */
     getIPCPath(): string {
         return getPrimaryIpcPath(this.vaultName, this.isWindows());
+    }
+
+    /**
+     * Where this server publishes `{ vaultName, basePath }` for the CLI so a
+     * `nexus` run from inside the vault folder can pick this vault without
+     * `--vault`. Beside the socket on Unix; under %TEMP% on Windows, where the
+     * pipe namespace holds no files.
+     */
+    getVaultNotePath(): string {
+        const isWindows = this.isWindows();
+        const tempDir = isWindows ? desktopRequire<typeof import('os')>('os').tmpdir() : '';
+        return getPrimaryVaultNotePath(this.vaultName, isWindows, tempDir);
+    }
+
+    /**
+     * The vault's absolute folder on disk, or null when the adapter cannot say
+     * (mobile, or a non-filesystem adapter). Callers must treat null as "do not
+     * publish" rather than guess.
+     */
+    getVaultBasePath(): string | null {
+        try {
+            const adapter = this.app.vault.adapter as { getBasePath?: () => string };
+            if (typeof adapter.getBasePath !== 'function') {
+                return null;
+            }
+            const basePath = adapter.getBasePath();
+            return typeof basePath === 'string' && basePath.length > 0 ? basePath : null;
+        } catch {
+            return null;
+        }
     }
 
     /**

--- a/src/server/transport/IPCTransportManager.ts
+++ b/src/server/transport/IPCTransportManager.ts
@@ -42,6 +42,18 @@ interface OwnedSocket {
 }
 
 /**
+ * The vault note is a plain file at a path every instance of this vault shares,
+ * so it has exactly the socket's ownership problem and is tracked the same way.
+ */
+type OwnedNote = OwnedSocket;
+
+/** What the note says. `cli/vaultDiscovery.ts` parses this shape. */
+interface VaultNote {
+    vaultName: string;
+    basePath: string;
+}
+
+/**
  * How long teardown waits on a single client before giving up on it. A client
  * that has not disconnected cleanly can leave close() pending indefinitely,
  * which would stall restartServer().
@@ -64,6 +76,8 @@ export class IPCTransportManager {
     private currentTransport: StdioServerTransport | null = null;
     /** The socket file we created, so teardown never deletes someone else's. */
     private ownedSocket: OwnedSocket | null = null;
+    /** The vault note we wrote beside the socket; same ownership rule. */
+    private ownedNote: OwnedNote | null = null;
 
     constructor(
         private configuration: ServerConfiguration,
@@ -329,11 +343,70 @@ export class IPCTransportManager {
             }
         }
 
+        this.publishVaultNote();
+
         this.ipcServer = server;
         this.isRunning = true;
-        
+
         logger.systemLog(`IPC server started on path: ${ipcPath}`);
         resolve(server);
+    }
+
+    /**
+     * Tell the CLI which folder this vault lives in, so `nexus` run from inside
+     * it needs no `--vault`. Written only once the socket is listening, so a
+     * note always describes a vault the CLI can reach; removed with the socket.
+     *
+     * The note is only ever an assertion of fact. With no filesystem adapter
+     * (mobile, or anything that cannot name a folder) nothing is written, and a
+     * stale note from an earlier run is cleared rather than left to mislead.
+     *
+     * Owner-only, like the socket: created 0o600 after unlinking whatever was
+     * there, because writeFile's mode applies only on create and a stale note
+     * could have been born wider.
+     */
+    private publishVaultNote(): void {
+        // Runs inside the 'listening' callback: nothing here may throw, or the
+        // transport would come up with an uncaught exception behind it.
+        let notePath: string;
+        let fs: typeof import('fs');
+        try {
+            notePath = this.configuration.getVaultNotePath();
+            fs = desktopRequire<typeof import('fs')>('fs');
+        } catch (error) {
+            logger.systemError(error as Error, 'Vault Note Path');
+            return;
+        }
+
+        try {
+            fs.unlinkSync(notePath);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                logger.systemError(error as Error, 'Vault Note Cleanup');
+            }
+        }
+
+        const basePath = this.configuration.getVaultBasePath();
+        if (!basePath) {
+            this.ownedNote = null;
+            return;
+        }
+
+        const note: VaultNote = {
+            vaultName: this.configuration.getSanitizedVaultName(),
+            basePath
+        };
+
+        try {
+            fs.writeFileSync(notePath, JSON.stringify(note), { encoding: 'utf8', mode: 0o600 });
+            if (!this.configuration.isWindows()) {
+                fs.chmodSync(notePath, 0o600);
+            }
+            this.ownedNote = this.readSocketIdentity(notePath);
+        } catch (error) {
+            logger.systemError(error as Error, 'Vault Note Write');
+            this.ownedNote = null;
+        }
     }
 
     /**
@@ -359,6 +432,7 @@ export class IPCTransportManager {
     async stopTransport(): Promise<void> {
         const hasWork = this.ipcServer !== null
             || this.ownedSocket !== null
+            || this.ownedNote !== null
             || this.currentTransport !== null
             || this.activeConnections.size > 0;
         if (!hasWork) {
@@ -370,6 +444,7 @@ export class IPCTransportManager {
         try {
             await this.closeActiveConnections();
             await this.releaseOwnedSocket();
+            await this.releaseOwnedNote();
 
             logger.systemLog('IPC transport stopped successfully');
         } catch (error) {
@@ -504,7 +579,53 @@ export class IPCTransportManager {
     }
 
     /**
-     * Stat the socket file for its identity, or null if it is not there.
+     * Remove the vault note, but only while it is still the one we wrote.
+     *
+     * Same hazard as the socket: on a hot reload the successor has already
+     * rewritten the note at this shared path by the time we get here, and
+     * deleting by name would take the successor's note with it — leaving its
+     * vault invisible to a cwd-based `nexus` until the next reload. So the note
+     * goes only when its identity matches what we wrote AND nothing is listening
+     * on the IPC path any more (our own listener closed first, so a live one is
+     * a successor's). Runs on every platform: a named pipe has no file, but the
+     * note under %TEMP% is a file all the same.
+     */
+    private async releaseOwnedNote(): Promise<void> {
+        const owned = this.ownedNote;
+        this.ownedNote = null;
+
+        if (!owned) {
+            return;
+        }
+
+        const current = this.readSocketIdentity(owned.path);
+        if (!current) {
+            return;
+        }
+
+        if (!this.isSameSocketFile(current, owned)) {
+            logger.systemLog(`Leaving the vault note at ${owned.path} alone — it belongs to another instance now`);
+            return;
+        }
+
+        if (await this.isSocketLive(this.configuration.getIPCPath())) {
+            logger.systemLog(`Leaving the vault note at ${owned.path} alone — another instance is listening`);
+            return;
+        }
+
+        try {
+            const fs = desktopRequire<typeof import('fs')>('fs').promises;
+            await fs.unlink(owned.path);
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                logger.systemError(error as Error, 'Vault Note Cleanup');
+            }
+        }
+    }
+
+    /**
+     * Stat a file for its identity, or null if it is not there. Used for the
+     * socket and for the vault note alike — the check is the same.
      */
     private readSocketIdentity(ipcPath: string): OwnedSocket | null {
         try {
@@ -693,18 +814,26 @@ export class IPCTransportManager {
      * file alone and a human disagrees.
      */
     async forceCleanupSocket(): Promise<void> {
-        if (this.configuration.isWindows()) {
-            return;
+        this.ownedSocket = null;
+        this.ownedNote = null;
+
+        const fs = desktopRequire<typeof import('fs')>('fs').promises;
+        if (!this.configuration.isWindows()) {
+            try {
+                await fs.unlink(this.configuration.getIPCPath());
+                logger.systemLog('Socket force cleaned up successfully');
+            } catch (error) {
+                logger.systemError(error as Error, 'Force Socket Cleanup');
+            }
         }
 
-        this.ownedSocket = null;
-
+        // The note is a file on every platform, pipe or socket.
         try {
-            const fs = desktopRequire<typeof import('fs')>('fs').promises;
-            await fs.unlink(this.configuration.getIPCPath());
-            logger.systemLog('Socket force cleaned up successfully');
+            await fs.unlink(this.configuration.getVaultNotePath());
         } catch (error) {
-            logger.systemError(error as Error, 'Force Socket Cleanup');
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+                logger.systemError(error as Error, 'Force Vault Note Cleanup');
+            }
         }
     }
 }

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,11 +7,33 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "0cc1ae808e1c59cc";
+export const NEXUS_CLI_ASSETS_HASH = "62f9b230e38756c1";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
 "use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
 
 // cli/nexus-cli.ts
 var import_node_fs3 = require("node:fs");
@@ -564,16 +586,81 @@ function suggestVerb(candidate) {
 // cli/vaultDiscovery.ts
 var import_node_fs2 = require("node:fs");
 var import_node_child_process = require("node:child_process");
+var import_node_os2 = require("node:os");
+var nodePath = __toESM(require("node:path"));
 var NAME_PREFIX = "nexus_mcp_";
 var UNIX_SOCK_DIR = "/tmp";
 var UNIX_SUFFIX = ".sock";
 var WIN_PIPE_DIR = "\\\\\\\\.\\\\pipe\\\\";
+var NOTE_SUFFIX = ".json";
 function formatAvailableVaults(sockets) {
   if (sockets.length === 0) {
     return "  (none detected \\u2014 open Obsidian with Nexus enabled)";
   }
   const nameWidth = Math.max(...sockets.map((socket) => socket.name.length));
-  return sockets.map((socket) => \`  \${socket.name.padEnd(nameWidth)}  \${socket.path}\`).join("\\n");
+  const pathWidth = Math.max(...sockets.map((socket) => socket.path.length));
+  return sockets.map((socket) => {
+    const line = \`  \${socket.name.padEnd(nameWidth)}  \${socket.path}\`;
+    return socket.basePath ? \`\${line.padEnd(nameWidth + pathWidth + 4)}  \${socket.basePath}\` : line;
+  }).join("\\n");
+}
+function vaultNotePath(socket, platform = process.platform, tempDir = (0, import_node_os2.tmpdir)()) {
+  if (platform === "win32") {
+    return \`\${tempDir.replace(/[\\\\/]+$/, "")}\\\\\${NAME_PREFIX}\${socket.name}\${NOTE_SUFFIX}\`;
+  }
+  return socket.path.endsWith(UNIX_SUFFIX) ? \`\${socket.path.slice(0, -UNIX_SUFFIX.length)}\${NOTE_SUFFIX}\` : \`\${socket.path}\${NOTE_SUFFIX}\`;
+}
+function parseVaultNote(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return void 0;
+  }
+  if (typeof parsed !== "object" || parsed === null) return void 0;
+  const { vaultName, basePath } = parsed;
+  if (typeof vaultName !== "string" || typeof basePath !== "string" || basePath.length === 0) {
+    return void 0;
+  }
+  return { vaultName, basePath };
+}
+function readVaultNotes(sockets, platform = process.platform, tempDir = (0, import_node_os2.tmpdir)()) {
+  return sockets.map((socket) => {
+    let raw;
+    try {
+      raw = (0, import_node_fs2.readFileSync)(vaultNotePath(socket, platform, tempDir), "utf8");
+    } catch {
+      return { ...socket };
+    }
+    const note = parseVaultNote(raw);
+    if (!note) return { ...socket };
+    return { ...socket, basePath: toRealPath(note.basePath) };
+  });
+}
+function toRealPath(target) {
+  try {
+    return import_node_fs2.realpathSync.native(target);
+  } catch {
+    return target;
+  }
+}
+function resolveVaultByCwd(cwd, entries, platform = process.platform) {
+  const p = platform === "win32" ? nodePath.win32 : nodePath.posix;
+  const fold = (value) => platform === "win32" ? value.toLowerCase() : value;
+  const here = fold(p.resolve(cwd));
+  let best;
+  let bestLength = -1;
+  for (const entry of entries) {
+    if (!entry.basePath) continue;
+    const base = fold(p.resolve(entry.basePath));
+    const prefix = base.endsWith(p.sep) ? base : \`\${base}\${p.sep}\`;
+    const contains = here === base || here.startsWith(prefix);
+    if (contains && base.length > bestLength) {
+      best = entry;
+      bestLength = base.length;
+    }
+  }
+  return best;
 }
 var WINDOWS_PIPE_LIST_SCRIPT = "Get-ChildItem -LiteralPath '\\\\\\\\.\\\\pipe\\\\' -Name";
 var SAFE_PIPE_NAME = /^nexus_mcp_[a-z0-9_-]+$/;
@@ -647,11 +734,15 @@ function resolveVault(requested) {
     return { name: s, path: p };
   }
   const sockets = listVaultSockets();
-  if (sockets.length === 1) return sockets[0];
   if (sockets.length === 0) {
     throw new Error("No open Nexus vaults found. Is Obsidian running with Nexus? Or pass --vault <name>.");
   }
-  throw new Error(\`Multiple vaults open: \${sockets.map((x) => x.name).join(", ")}. Pass --vault <name>.\`);
+  const byCwd = resolveVaultByCwd(toRealPath(process.cwd()), readVaultNotes(sockets));
+  if (byCwd) return byCwd;
+  if (sockets.length === 1) return sockets[0];
+  throw new Error(
+    \`Multiple vaults open: \${sockets.map((x) => x.name).join(", ")}. Run from inside a vault folder to select it, or pass --vault <name>.\`
+  );
 }
 function printToolResult(result, asJson) {
   if (asJson) {
@@ -677,7 +768,7 @@ function buildUsage() {
   }
   let availableVaultLines;
   try {
-    availableVaultLines = formatAvailableVaults(listVaultSockets());
+    availableVaultLines = formatAvailableVaults(readVaultNotes(listVaultSockets()));
   } catch (error) {
     availableVaultLines = \`  (could not enumerate: \${error.message})\`;
   }
@@ -698,7 +789,7 @@ COMMANDS
                                      tools, in one call. \\\`nexus playbook\\\` lists them.
   nexus context [--json]             What this vault remembers for the CLI: current
                                      session and its workspace (read-only)
-  nexus vaults                       List open Nexus vaults (live sockets)
+  nexus vaults                       List open Nexus vaults (live sockets + vault folder)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
 
@@ -723,7 +814,8 @@ CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` 
                           to switch. \\\`nexus context\\\` shows both.
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
-  --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
+  --vault <name>          target a vault (else: $NEXUS_VAULT; else the open vault whose
+                          folder contains the current directory; else the single open one)
                           (a tool call may run up to 10 minutes \\u2014 image edits and
                           slow models take a while; $NEXUS_CLI_TOOL_TIMEOUT_MS overrides)
   --json                  print the raw JSON result
@@ -795,7 +887,7 @@ GOTCHAS
     list of errors before touching disk); \\\`base analyze\\\` runs it and returns the rows
     a user would see.
   \\u2022 No open vault \\u2192 the socket is absent; open Obsidian with Nexus. Multiple open \\u2192
-    pass --vault <name>.
+    run from inside a vault's folder (cwd selects it) or pass --vault <name>.
 
 TOOL CATALOG
   Core agents (always on): content, storage, search, canvas, task, memory, prompt, ingest.
@@ -864,8 +956,10 @@ Run \\\`nexus --help\\\` for the manual.
       process.stdout.write("No open Nexus vaults. Is Obsidian running with Nexus enabled?\\n");
       return 0;
     }
-    for (const s of sockets) process.stdout.write(\`\${s.name}	\${s.path}
+    for (const s of readVaultNotes(sockets)) {
+      process.stdout.write(\`\${s.name}	\${s.path}\${s.basePath ? \`	\${s.basePath}\` : ""}
 \`);
+    }
     return 0;
   }
   if (cmd === "doctor") {

--- a/tests/integration/ipcSocketOwnership.test.ts
+++ b/tests/integration/ipcSocketOwnership.test.ts
@@ -42,18 +42,27 @@ function uniqueSocketPath(): string {
   return socketPath;
 }
 
-function createConfiguration(ipcPath: string): ServerConfiguration {
+/** The sidecar note lives beside the socket: `<path minus .sock>.json`. */
+function noteFor(ipcPath: string): string {
+  return ipcPath.replace(/\.sock$/, '.json');
+}
+
+function createConfiguration(ipcPath: string, basePath: string | null = null): ServerConfiguration {
   return {
     isWindows: () => false,
     getIPCPath: () => ipcPath,
+    getVaultNotePath: () => noteFor(ipcPath),
+    getVaultBasePath: () => basePath,
+    getSanitizedVaultName: () => 'test-vault',
     getServerInfo: () => ({ name: 'test', version: '1.0' }),
     getServerOptions: () => ({}),
   } as unknown as ServerConfiguration;
 }
 
-function createTransportManager(ipcPath: string): IPCTransportManager {
+function createTransportManager(ipcPath: string, basePath: string | null = null): IPCTransportManager {
+  createdPaths.push(noteFor(ipcPath));
   const manager = new IPCTransportManager(
-    createConfiguration(ipcPath),
+    createConfiguration(ipcPath, basePath),
     {} as unknown as StdioTransportManager
   );
   openManagers.push(manager);
@@ -286,5 +295,99 @@ describeOnPosix('IPC socket ownership across a reload', () => {
     await expect(canConnect(ipcPath)).resolves.toBe(true);
 
     await manager.stopTransport();
+  });
+});
+
+/**
+ * The vault note is how a `nexus` run from inside a vault folder finds its
+ * vault. It shares the socket's path (minus the suffix) and therefore the
+ * socket's ownership hazard, so it is written and released alongside it.
+ */
+describeOnPosix('IPC vault note beside the socket', () => {
+  afterEach(async () => {
+    for (const manager of openManagers.splice(0)) {
+      manager.closeListener();
+      await manager.stopTransport().catch(() => undefined);
+    }
+    for (const server of openServers.splice(0)) {
+      await closeDirectly(server);
+    }
+    for (const createdPath of createdPaths.splice(0)) {
+      try {
+        fs.unlinkSync(createdPath);
+      } catch {
+        // Already gone, which is the usual case.
+      }
+    }
+  });
+
+  it('publishes { vaultName, basePath } owner-only once listening, and removes it on stop', async () => {
+    const ipcPath = uniqueSocketPath();
+    const notePath = noteFor(ipcPath);
+
+    const manager = createTransportManager(ipcPath, '/vaults/Test Vault');
+    expect(fs.existsSync(notePath)).toBe(false);
+
+    await manager.startTransport();
+
+    expect(fs.existsSync(notePath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(notePath, 'utf8'))).toEqual({
+      vaultName: 'test-vault',
+      basePath: '/vaults/Test Vault',
+    });
+    expect(fs.statSync(notePath).mode & 0o777).toBe(0o600);
+
+    await manager.stopTransport();
+
+    expect(fs.existsSync(notePath)).toBe(false);
+  });
+
+  it('writes no note when the adapter cannot name a folder, and clears a stale one', async () => {
+    const ipcPath = uniqueSocketPath();
+    const notePath = noteFor(ipcPath);
+    fs.writeFileSync(notePath, JSON.stringify({ vaultName: 'test-vault', basePath: '/gone' }));
+
+    const manager = createTransportManager(ipcPath, null);
+    await manager.startTransport();
+
+    expect(fs.existsSync(notePath)).toBe(false);
+
+    await manager.stopTransport();
+  });
+
+  it('overwrites a stale note from an earlier run rather than trusting it', async () => {
+    const ipcPath = uniqueSocketPath();
+    const notePath = noteFor(ipcPath);
+    fs.writeFileSync(notePath, JSON.stringify({ vaultName: 'test-vault', basePath: '/old/place' }), { mode: 0o644 });
+
+    const manager = createTransportManager(ipcPath, '/new/place');
+    await manager.startTransport();
+
+    expect(JSON.parse(fs.readFileSync(notePath, 'utf8')).basePath).toBe('/new/place');
+    expect(fs.statSync(notePath).mode & 0o777).toBe(0o600);
+
+    await manager.stopTransport();
+  });
+
+  it('leaves the successor’s note alone when the predecessor tears down late', async () => {
+    const ipcPath = uniqueSocketPath();
+    const notePath = noteFor(ipcPath);
+
+    const predecessor = createTransportManager(ipcPath, '/vaults/Test Vault');
+    await predecessor.startTransport();
+    predecessor.closeListener();
+
+    const successor = createTransportManager(ipcPath, '/vaults/Test Vault');
+    await successor.startTransport();
+    const successorNote = identityOf(notePath);
+    expect(successorNote).not.toBeNull();
+
+    await predecessor.stopTransport();
+
+    expect(fs.existsSync(notePath)).toBe(true);
+    expect(identityOf(notePath)).toEqual(successorNote);
+
+    await successor.stopTransport();
+    expect(fs.existsSync(notePath)).toBe(false);
   });
 });

--- a/tests/unit/IPCTransportManager.test.ts
+++ b/tests/unit/IPCTransportManager.test.ts
@@ -76,6 +76,9 @@ function createMockConfiguration() {
   return {
     isWindows: jest.fn().mockReturnValue(false),
     getIPCPath: jest.fn().mockReturnValue('/tmp/test-nexus.sock'),
+    getVaultNotePath: jest.fn().mockReturnValue('/tmp/test-nexus.json'),
+    getVaultBasePath: jest.fn().mockReturnValue(null),
+    getSanitizedVaultName: jest.fn().mockReturnValue('test-nexus'),
     getServerInfo: jest.fn().mockReturnValue({ name: 'test', version: '1.0' }),
     getServerOptions: jest.fn().mockReturnValue({}),
   } as unknown as ServerConfiguration;

--- a/tests/unit/nexusVaultDiscovery.test.ts
+++ b/tests/unit/nexusVaultDiscovery.test.ts
@@ -1,5 +1,17 @@
 import { spawnSync } from 'node:child_process';
-import { formatAvailableVaults, listVaultSockets, parseWindowsPipeListing } from '../../cli/vaultDiscovery';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+    formatAvailableVaults,
+    listVaultSockets,
+    parseVaultNote,
+    parseWindowsPipeListing,
+    readVaultNotes,
+    resolveVaultByCwd,
+    vaultNotePath,
+    VaultEntry,
+} from '../../cli/vaultDiscovery';
 
 jest.mock('node:child_process', () => ({
     spawnSync: jest.fn(),
@@ -106,5 +118,142 @@ describe('Nexus vault help formatting', () => {
             '  notes           /tmp/nexus_mcp_notes.sock',
             '  research-vault  /tmp/nexus_mcp_research-vault.sock',
         ].join('\n'));
+    });
+
+    it('adds the vault folder as a third column where a note was published', () => {
+        expect(formatAvailableVaults([
+            { name: 'notes', path: '/tmp/nexus_mcp_notes.sock', basePath: '/Users/me/Notes' },
+            { name: 'research-vault', path: '/tmp/nexus_mcp_research-vault.sock' },
+        ])).toBe([
+            '  notes           /tmp/nexus_mcp_notes.sock           /Users/me/Notes',
+            '  research-vault  /tmp/nexus_mcp_research-vault.sock',
+        ].join('\n'));
+    });
+});
+
+describe('Nexus vault note path', () => {
+    it('sits beside the socket on Unix, swapping .sock for .json', () => {
+        expect(vaultNotePath({ name: 'code', path: '/tmp/nexus_mcp_code.sock' }, 'darwin', '/ignored'))
+            .toBe('/tmp/nexus_mcp_code.json');
+        expect(vaultNotePath({ name: 'code', path: '/tmp/nexus_mcp_code.sock' }, 'linux', '/ignored'))
+            .toBe('/tmp/nexus_mcp_code.json');
+    });
+
+    it('lives under %TEMP% on Windows because the pipe namespace holds no files', () => {
+        const socket = { name: 'code', path: '\\\\.\\pipe\\nexus_mcp_code' };
+        expect(vaultNotePath(socket, 'win32', 'C:\\Users\\me\\AppData\\Local\\Temp'))
+            .toBe('C:\\Users\\me\\AppData\\Local\\Temp\\nexus_mcp_code.json');
+        // A trailing separator on the temp dir must not double up.
+        expect(vaultNotePath(socket, 'win32', 'C:\\Temp\\'))
+            .toBe('C:\\Temp\\nexus_mcp_code.json');
+    });
+});
+
+describe('Nexus vault note parsing', () => {
+    it('accepts exactly the published shape', () => {
+        expect(parseVaultNote('{"vaultName":"code","basePath":"/Users/me/Code"}'))
+            .toEqual({ vaultName: 'code', basePath: '/Users/me/Code' });
+    });
+
+    it.each([
+        ['not json', '{nope'],
+        ['a bare string', '"/Users/me/Code"'],
+        ['null', 'null'],
+        ['missing basePath', '{"vaultName":"code"}'],
+        ['empty basePath', '{"vaultName":"code","basePath":""}'],
+        ['non-string basePath', '{"vaultName":"code","basePath":42}'],
+    ])('ignores %s', (_label, raw) => {
+        expect(parseVaultNote(raw)).toBeUndefined();
+    });
+});
+
+describe('Nexus vault notes beside live sockets', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'nexus-vault-notes-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('attaches basePath from a readable note and leaves it unset for a missing or corrupt one', () => {
+        const withNote = { name: 'code', path: join(dir, 'nexus_mcp_code.sock') };
+        const corrupt = { name: 'notes', path: join(dir, 'nexus_mcp_notes.sock') };
+        const missing = { name: 'work', path: join(dir, 'nexus_mcp_work.sock') };
+        writeFileSync(join(dir, 'nexus_mcp_code.json'), JSON.stringify({ vaultName: 'code', basePath: dir }));
+        writeFileSync(join(dir, 'nexus_mcp_notes.json'), '{not json');
+
+        const entries = readVaultNotes([withNote, corrupt, missing], 'darwin');
+
+        expect(entries).toHaveLength(3);
+        expect(entries[0]).toMatchObject({ name: 'code', path: withNote.path });
+        expect(entries[0].basePath).toBeDefined();
+        expect(entries[1]).toEqual({ ...corrupt });
+        expect(entries[2]).toEqual({ ...missing });
+    });
+
+    it('never surfaces a note that has no live socket behind it', () => {
+        // The plugin for `orphan` is gone; only its note remains.
+        writeFileSync(join(dir, 'nexus_mcp_orphan.json'), JSON.stringify({ vaultName: 'orphan', basePath: dir }));
+        const live = { name: 'code', path: join(dir, 'nexus_mcp_code.sock') };
+
+        const entries = readVaultNotes([live], 'darwin');
+
+        expect(entries.map((entry) => entry.name)).toEqual(['code']);
+    });
+});
+
+describe('Nexus vault selection by working directory', () => {
+    const code: VaultEntry = { name: 'code', path: '/tmp/nexus_mcp_code.sock', basePath: '/Users/me/Code' };
+    const nested: VaultEntry = {
+        name: 'plugin',
+        path: '/tmp/nexus_mcp_plugin.sock',
+        basePath: '/Users/me/Code/.obsidian/plugins/nexus',
+    };
+    const notes: VaultEntry = { name: 'notes', path: '/tmp/nexus_mcp_notes.sock', basePath: '/Users/me/Notes' };
+    const silent: VaultEntry = { name: 'mobile', path: '/tmp/nexus_mcp_mobile.sock' };
+
+    it('picks the vault whose folder contains the cwd', () => {
+        expect(resolveVaultByCwd('/Users/me/Code/src', [notes, code, silent], 'darwin')).toBe(code);
+    });
+
+    it('matches the vault folder itself, not only its children', () => {
+        expect(resolveVaultByCwd('/Users/me/Code', [notes, code], 'darwin')).toBe(code);
+        expect(resolveVaultByCwd('/Users/me/Code/', [notes, code], 'darwin')).toBe(code);
+    });
+
+    it('prefers the innermost vault when folders nest, whatever the order', () => {
+        const cwd = '/Users/me/Code/.obsidian/plugins/nexus/src';
+        expect(resolveVaultByCwd(cwd, [code, nested], 'darwin')).toBe(nested);
+        expect(resolveVaultByCwd(cwd, [nested, code], 'darwin')).toBe(nested);
+        // Above the nested vault but inside the outer one: the outer wins.
+        expect(resolveVaultByCwd('/Users/me/Code/docs', [nested, code], 'darwin')).toBe(code);
+    });
+
+    it('returns undefined when no vault folder contains the cwd', () => {
+        expect(resolveVaultByCwd('/Users/me/Elsewhere', [notes, code, silent], 'darwin')).toBeUndefined();
+        expect(resolveVaultByCwd('/Users/me/Code', [silent], 'darwin')).toBeUndefined();
+        expect(resolveVaultByCwd('/Users/me/Code', [], 'darwin')).toBeUndefined();
+    });
+
+    it('is separator-aware: /x/Code does not claim /x/CodeOther', () => {
+        expect(resolveVaultByCwd('/Users/me/CodeOther', [code], 'darwin')).toBeUndefined();
+        expect(resolveVaultByCwd('/Users/me/CodeOther/src', [code], 'darwin')).toBeUndefined();
+    });
+
+    it('normalises redundant path segments before comparing', () => {
+        expect(resolveVaultByCwd('/Users/me/Notes/../Code/./src', [notes, code], 'darwin')).toBe(code);
+    });
+
+    it('compares Windows paths with Windows rules: backslashes and case-insensitive', () => {
+        const winVault: VaultEntry = {
+            name: 'code',
+            path: '\\\\.\\pipe\\nexus_mcp_code',
+            basePath: 'C:\\Users\\Me\\Code',
+        };
+        expect(resolveVaultByCwd('c:\\users\\me\\code\\src', [winVault], 'win32')).toBe(winVault);
+        expect(resolveVaultByCwd('C:\\Users\\Me\\CodeOther', [winVault], 'win32')).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary

When the `nexus` CLI is run from a folder inside a running vault's folder, it targets that vault with no `--vault` flag. With several vaults open this is the common case for an agent working inside a vault, and it needs no state anywhere.

**Plugin side.** When the IPC socket starts listening, the transport publishes a sidecar note beside it — `/tmp/nexus_mcp_<vault>.json` on macOS/Linux, `%TEMP%\nexus_mcp_<vault>.json` on Windows (the pipe namespace holds no files) — containing `{ vaultName, basePath }`. It is written owner-only (0600) after unlinking any stale note, and only when the adapter can actually name a folder; otherwise nothing is written. Teardown removes it under the same two-layer guard the socket already uses (identity match **and** no live listener on the IPC path), so a hot reload never deletes the successor's note (#337). Base path and note path come from two new methods on `ServerConfiguration`, which already holds `app` — no constructor changes.

**CLI side.** `resolveVault` order is now:

```
--vault  →  $NEXUS_VAULT  →  innermost open vault whose folder contains cwd  →  single open vault  →  error
```

The matcher is pure and separator-aware (`/x/Code` does not claim `/x/CodeOther`), realpath-normalised on both sides, case-folded on Windows, and picks the innermost folder when vaults nest. A note with no live socket is never consulted; a missing or malformed note just leaves the entry unmatched. `nexus vaults` and `--help` show the vault folder when known, and the multi-vault error now says how to select one.

PR 3 of `docs/plans/session-sticky-context-plan.md`. Refs #214.

## Verification

- `node scripts/build-cli.mjs` and `npm run build` green (lint incl. mobile lint, tsc, esbuild, connector); `src/utils/cliAssets.ts` regenerated and committed.
- `npm run test`: 405 suites passed, 5096 tests passed, 0 failed. Adds 18 unit tests (`nexusVaultDiscovery`) and 4 real-socket integration tests (`ipcSocketOwnership`), including "leaves the successor's note alone".
- Live, CLI half, against four open vaults with a temporary hand-written note: cwd inside the `code` vault → `nexus doctor` connected to `code` with no flag; from `~` → the multi-vault error; from a sibling `CodeOther` folder → no match; `nexus vaults` / `--help` show the folder column. Temporary note removed.
- Live, plugin half (note appears on reload, disappears on unload): pending — the `code` vault's plugin folder is the main checkout, so it will be checked after merge.

## Notes for review

- `forceCleanupSocket` now runs on Windows as well, removing only the note (it was a no-op there before; its sole caller is `ServerLifecycleManager`).
- `nexus vaults` prints a third tab-separated column only for rows that have a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)