### PR TITLE
feat(session): remember a session's workspace after the first call (#214)

### DIFF
--- a/cli-first-tool-schemas.json
+++ b/cli-first-tool-schemas.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-08T20:49:25.172Z",
+  "generatedAt": "2026-09-12T15:56:20.428Z",
   "selector": "--help",
   "toolCount": 80,
   "agentCount": 14,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -368,6 +368,7 @@ export default defineConfig([
             "src/database/migration/CacheBackendMigration.ts", // removes code-controlled cache.db conflict siblings
             "src/database/migration/LegacyArchiver.ts",        // renames legacy storage folder to archive path
             "src/services/artifacts/ArtifactJobStore.ts",
+            "src/services/session/SessionBindingsStore.ts", // session-bindings.json under resolvePluginStorageRoot().dataRoot; path is code-controlled (#214)
             "src/services/storage/SnapshotArchiveService.ts",
             "src/services/llm/utils/CacheManager.ts",
             "src/services/llm/utils/Logger.ts",

--- a/schemas/5.18.6/cli-tools.json
+++ b/schemas/5.18.6/cli-tools.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-09-08T20:49:25.172Z",
+  "generatedAt": "2026-09-12T15:56:20.428Z",
   "selector": "--help",
   "toolCount": 80,
   "agentCount": 14,

--- a/schemas/5.18.6/mcp-tools.json
+++ b/schemas/5.18.6/mcp-tools.json
@@ -1,22 +1,22 @@
 {
   "schemaVersion": 1,
   "nexusVersion": "5.18.6",
-  "generatedAt": "2026-09-08T20:49:25.172Z",
+  "generatedAt": "2026-09-12T15:56:20.428Z",
   "toolCount": 2,
   "tools": [
     {
       "name": "toolManager_getTools",
-      "description": "REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.\nThis returns CLI-oriented command metadata for the tools you need next.\nSend workspaceId, sessionId, memory, goal, and constraints at the top level.\nUse one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.\nDo not send a nested \"context\" object or legacy \"request\" array.\n\nWorkflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands\nKnown-good example: {\"workspaceId\":\"default\",\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available storage tools.\",\"tool\":\"storage move, content read\"}\nExample selectors: tool=\"--help\", tool=\"storage\", tool=\"storage move\", tool=\"storage move, content read\"\n\nAgents:\ncontent: [read,write,replace,insert,setProperty,removeProperty]\nstorage: [list,createFolder,move,copy,archive,open]\nsearch: [content,directory,memory,queryNotes]\nmemory: [createState,listStates,loadState,updateState,archiveState,createWorkspace,listWorkspaces,searchWorkspaces,loadWorkspace,updateWorkspace,archiveWorkspace,run]\nprompt: [list,get,create,update,archive,listModels,execute,generateImage,generateAudio,generateVideo,checkGeneratedArtifact,subagent]\ncanvas: [read,write,update,list]\nbase: [read,write,update,list,analyze]\ntask: [createProject,listProjects,updateProject,archiveProject,create,list,open,update,move,query,linkNote]\ningest: [run,capabilities]\nelevenlabs: [listVoices,soundEffects,generateMusic]\ncomposer: [compose,listFormats]\nweb: [open,capture-markdown,capture-png,capture-pdf,links]\nskills: [listSkills,loadSkill,createSkill,updateSkill,archiveSkill,syncSkills]\ndata: [runPython,listCapabilities]\n\nExisting workspaces: not listed here. The getTools RESULT carries the live list — read \"workspaces\" there and pass one of those exact names. Never infer a workspace name from the user's wording.",
+      "description": "REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.\nThis returns CLI-oriented command metadata for the tools you need next.\nSend sessionId, memory, goal, and constraints at the top level.\nThe workspace is remembered per session: the first useTools call of a fresh session passes \"workspaceId\" once (\"default\" or an exact name from the workspaces list this call returns) or runs \"memory load-workspace\"; later calls inherit it. Omit \"workspaceId\" unless you are deliberately switching. getTools itself never needs it.\nUse one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.\nDo not send a nested \"context\" object or legacy \"request\" array.\n\nWorkflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands\nKnown-good example: {\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available storage tools.\",\"tool\":\"storage move, content read\"}\nExample selectors: tool=\"--help\", tool=\"storage\", tool=\"storage move\", tool=\"storage move, content read\"\n\nAgents:\ncontent: [read,write,replace,insert,setProperty,removeProperty]\nstorage: [list,createFolder,move,copy,archive,open]\nsearch: [content,directory,memory,queryNotes]\nmemory: [createState,listStates,loadState,updateState,archiveState,createWorkspace,listWorkspaces,searchWorkspaces,loadWorkspace,updateWorkspace,archiveWorkspace,run]\nprompt: [list,get,create,update,archive,listModels,execute,generateImage,generateAudio,generateVideo,checkGeneratedArtifact,subagent]\ncanvas: [read,write,update,list]\nbase: [read,write,update,list,analyze]\ntask: [createProject,listProjects,updateProject,archiveProject,create,list,open,update,move,query,linkNote]\ningest: [run,capabilities]\nelevenlabs: [listVoices,soundEffects,generateMusic]\ncomposer: [compose,listFormats]\nweb: [open,capture-markdown,capture-png,capture-pdf,links]\nskills: [listSkills,loadSkill,createSkill,updateSkill,archiveSkill,syncSkills]\ndata: [runPython,listCapabilities]\n\nExisting workspaces: not listed here. The getTools RESULT carries the live list — read \"workspaces\" there and pass one of those exact names. Never infer a workspace name from the user's wording.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list this call returns."
+            "description": "Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. Discovery never needs it — a fresh session names its workspace on its first useTools call (\"default\" for the global workspace, or an exact value from the workspaces list this call returns). An empty string is read as omitted, never as \"default\"."
           },
           "sessionId": {
             "type": "string",
-            "description": "Stable human-readable session name for this chat. Required. Reuse the same value for every getTools/useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently."
+            "description": "Stable human-readable session name for this chat. Reuse the same value for every getTools/useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session."
           },
           "memory": {
             "type": "string",
@@ -36,8 +36,6 @@
           }
         },
         "required": [
-          "workspaceId",
-          "sessionId",
           "memory",
           "goal",
           "tool"
@@ -46,17 +44,17 @@
     },
     {
       "name": "toolManager_useTools",
-      "description": "Execute one or more CLI-style tool commands from the top-level \"tool\" field. Known-good example: {\"workspaceId\":\"default\",\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available workspaces.\",\"tool\":\"memory list-workspaces\"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. Separate multiple commands with a top-level comma outside quotes (\"cmd1, cmd2\"); commas inside quoted values stay literal and never split commands. For multiline content, wrap the value in quotes — literal newlines and escaped ones like \"# Title\\n\\nBody\" both work, and any double quote inside the value must be escaped as \\\". Never flatten multiline content to one line; quoting is enough. For content heavy on backslashes, quotes, or length (code, Windows paths, LaTeX, regex), skip CLI escaping entirely: put the text in the optional top-level \"values\" map and reference it from the tool string as @key (unquoted). Values are substituted after parsing with no escape processing, so the content arrives exactly as written. Quote the token (\"@key\") to pass literal text instead, and reference every declared key. Example: {\"tool\": \"content write --path snippet.md --content @body\", \"values\": {\"body\": \"const re = /\\\\d+/;\"}}. When you already know several files you want to read, batch them as comma-separated \"content read\" commands in ONE call with strategy \"parallel\" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.",
+      "description": "Execute one or more CLI-style tool commands from the top-level \"tool\" field. Known-good example: {\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available workspaces.\",\"tool\":\"memory list-workspaces\"}. The workspace is remembered per session: a fresh session passes \"workspaceId\" once (\"default\" or an exact name from getTools) or loads one with \"memory load-workspace\"; every later call in that session inherits it, so omit \"workspaceId\" unless you are deliberately switching. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. Separate multiple commands with a top-level comma outside quotes (\"cmd1, cmd2\"); commas inside quoted values stay literal and never split commands. For multiline content, wrap the value in quotes — literal newlines and escaped ones like \"# Title\\n\\nBody\" both work, and any double quote inside the value must be escaped as \\\". Never flatten multiline content to one line; quoting is enough. For content heavy on backslashes, quotes, or length (code, Windows paths, LaTeX, regex), skip CLI escaping entirely: put the text in the optional top-level \"values\" map and reference it from the tool string as @key (unquoted). Values are substituted after parsing with no escape processing, so the content arrives exactly as written. Quote the token (\"@key\") to pass literal text instead, and reference every declared key. Example: {\"tool\": \"content write --path snippet.md --content @body\", \"values\": {\"body\": \"const re = /\\\\d+/;\"}}. When you already know several files you want to read, batch them as comma-separated \"content read\" commands in ONE call with strategy \"parallel\" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools."
+            "description": "Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. A fresh session must pass it once (or run \"memory load-workspace\") before other commands — \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools. An empty string is read as omitted, never as \"default\"."
           },
           "sessionId": {
             "type": "string",
-            "description": "Stable human-readable session name for this chat. Required. Reuse the same value for every useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently."
+            "description": "Stable human-readable session name for this chat. Reuse the same value for every useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session."
           },
           "memory": {
             "type": "string",
@@ -98,8 +96,6 @@
           }
         },
         "required": [
-          "workspaceId",
-          "sessionId",
           "memory",
           "goal",
           "tool"

--- a/src/agents/toolManager/services/ToolBatchExecutionService.ts
+++ b/src/agents/toolManager/services/ToolBatchExecutionService.ts
@@ -3,6 +3,7 @@ import { IAgent } from '../../interfaces/IAgent';
 import { CommonResult } from '../../../types';
 import { NormalizedUseToolParams, ToolCallParams, ToolCallResult, ToolContext, UseToolResult } from '../types';
 import { getErrorMessage } from '../../../utils/errorUtils';
+import { logger } from '../../../utils/logger';
 import { getNexusPlugin } from '../../../utils/pluginLocator';
 import { WorkspaceService } from '../../../services/WorkspaceService';
 import { matchWorkspaces } from '../../memoryManager/services/WorkspaceMatcher';
@@ -20,6 +21,19 @@ interface NexusPluginLike {
   services?: { workspaceService?: WorkspaceService };
   getService?<T>(name: string, timeoutMs?: number): Promise<T | null>;
 }
+
+/**
+ * The slice of SessionContextManager bind point 2 needs (#214). Structural so
+ * this service does not import the manager module.
+ */
+interface SessionBinderLike {
+  canonicalizeWorkspaceId(value: string): Promise<string>;
+  bindSessionWorkspaceById(internalSessionId: string, workspaceId: string): void;
+}
+
+/** Agent + tool slug of the one command that binds a session by loading a workspace. */
+const LOAD_WORKSPACE_AGENT = 'memoryManager';
+const LOAD_WORKSPACE_TOOL = 'loadWorkspace';
 
 export interface ToolManagerWorkspaceInfo {
   name: string;
@@ -462,6 +476,10 @@ export class ToolBatchExecutionService {
         result.error = toolResult.error;
       }
 
+      if (toolResult.success && agentName === LOAD_WORKSPACE_AGENT && toolSlug === LOAD_WORKSPACE_TOOL) {
+        await this.bindSessionToLoadedWorkspace(context, toolResult);
+      }
+
       if (toolResult.success) {
         const toolResultPayload = {
           ...(toolResult as unknown as Record<string, unknown>)
@@ -501,6 +519,64 @@ export class ToolBatchExecutionService {
         error: `Error executing ${agentName}_${toolSlug}: ${getErrorMessage(error)}`
       };
     }
+  }
+
+  /**
+   * Bind point 2 (#214): a successful `memory load-workspace` binds the
+   * session to the workspace ACTUALLY loaded — which, on a near-miss, is the
+   * resolved match, not the string the caller typed (that string is what used
+   * to mint phantom `ws_<typo>/` stores when filed under verbatim).
+   *
+   * Reads the raw tool result before executeCall strips `workspaceContext`:
+   * `workspaceContext.workspaceId` is already the canonical id. The
+   * `resolution.resolvedTo.name` / `data.context.name` fallbacks cover a
+   * result without it (the system guides workspace) and are canonicalised.
+   * Only the internal session id is in hand here, so the bind goes by id.
+   * Best-effort: a missing manager or lookup failure is logged, never thrown.
+   */
+  private async bindSessionToLoadedWorkspace(context: ToolContext, toolResult: CommonResult): Promise<void> {
+    if (!context.sessionId) {
+      return;
+    }
+    try {
+      const binder = await this.getSessionBinder();
+      if (!binder) {
+        return;
+      }
+
+      const raw = toolResult as unknown as Record<string, unknown>;
+      const workspaceContext = raw.workspaceContext as { workspaceId?: unknown } | undefined;
+      const resolution = raw.resolution as { resolvedTo?: { id?: unknown; name?: unknown } } | undefined;
+      const data = raw.data as { context?: { name?: unknown } } | undefined;
+
+      const fromContext = typeof workspaceContext?.workspaceId === 'string' ? workspaceContext.workspaceId : undefined;
+      const fromResolution = typeof resolution?.resolvedTo?.id === 'string'
+        ? resolution.resolvedTo.id
+        : typeof resolution?.resolvedTo?.name === 'string' ? resolution.resolvedTo.name : undefined;
+      const fromName = typeof data?.context?.name === 'string' ? data.context.name : undefined;
+
+      const candidate = fromContext ?? fromResolution ?? fromName;
+      if (!candidate || candidate === 'Unknown') {
+        return;
+      }
+
+      const workspaceId = await binder.canonicalizeWorkspaceId(candidate);
+      binder.bindSessionWorkspaceById(context.sessionId, workspaceId);
+    } catch (error) {
+      logger.systemWarn(`[ToolBatchExecutionService] load-workspace bind skipped: ${getErrorMessage(error)}`);
+    }
+  }
+
+  private async getSessionBinder(): Promise<SessionBinderLike | null> {
+    const plugin = getNexusPlugin(this.app) as NexusPluginLike | null;
+    if (!plugin?.getService) {
+      return null;
+    }
+    const manager = await plugin.getService<SessionBinderLike>('sessionContextManager');
+    if (!manager || typeof manager.bindSessionWorkspaceById !== 'function') {
+      return null;
+    }
+    return manager;
   }
 
   private applyContextDefaults(

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -643,9 +643,9 @@ function isMeaningfulContextValue(value: unknown): boolean {
 }
 
 // sessionId carries a valid silent default (auto-session), and an absent or
-// empty workspaceId is refused outright by normalizeContext — see
-// WORKSPACE_ID_REQUIRED_MESSAGE. So blank is never this function's business;
-// only a present, non-empty placeholder is junk.
+// empty workspaceId is either inherited from the session's bind upstream or
+// refused by normalizeContext — see WORKSPACE_ID_REQUIRED_MESSAGE. So blank is
+// never this function's business; only a present, non-empty placeholder is junk.
 function isPlaceholderJunk(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   if (value.trim().length === 0) return false;
@@ -655,8 +655,8 @@ function isPlaceholderJunk(value: unknown): boolean {
 /**
  * Collect predictable steering for a useTools context block.
  * - memory + goal: hard-required (empty or placeholder → steer).
- * - workspaceId: requiredness is enforced once, in normalizeContext; here we
- *   only steer a present-but-junk value.
+ * - workspaceId: "bound or explicit" is enforced once, in normalizeContext;
+ *   here we only steer a present-but-junk value.
  * - sessionId: defaults silently; steer only if present-but-junk.
  * Pure — no agent registry needed, so the eval harness can call it directly.
  */
@@ -680,7 +680,7 @@ export function collectContextContractViolations(
   if (isPlaceholderJunk(params.workspaceId)) {
     violations.push({
       field: 'workspaceId',
-      message: 'The "workspaceId" looks like a placeholder. Use "default" for the global workspace, or an exact workspace name or ID from getTools — it is required, so there is nothing to fall back to.',
+      message: 'The "workspaceId" looks like a placeholder. Use "default" for the global workspace, or an exact workspace name or ID from getTools — or omit it to keep the workspace this session already uses.',
     });
   }
   if (isPlaceholderJunk(params.sessionId)) {
@@ -743,34 +743,37 @@ function normalizeVerbatimValues(raw: unknown): Record<string, string> | undefin
 }
 
 // ---------------------------------------------------------------------------
-// workspaceId requiredness (#214)
+// workspaceId: pass it once, it is remembered (#214)
 //
-// `workspaceId` is in the `required` array of both envelope schemas, and on the
-// MCP path that array IS enforced at runtime (ValidationService → validateParams
-// → "Missing required parameter: workspaceId"). But `required` only asks whether
-// the key is PRESENT, so `workspaceId: ""` sailed through and the old
-// `params.workspaceId || 'default'` here quietly filed the call under the global
-// workspace — a caller whose template rendered to empty behaved completely
-// differently from one that omitted the field, and its traces, sessions and
-// states landed somewhere it never asked for.
+// A session's workspace is bound by the first useTools call that names one
+// (or by a successful `memory load-workspace`) and inherited by every later
+// call in that session — ToolExecutionStrategy.processSession resolves
+//   explicit on this call → the session's last bind → UNBOUND
+// and writes the winner onto `params.workspaceId` before this normalizer runs.
+// `workspaceId` is therefore no longer in the `required` array of either
+// envelope schema: a call that omits it is the normal case after the first.
 //
-// So: empty, blank and absent all fail the same way, and they fail HERE because
-// schema `required` is documentation plus CLI-normalizer hints, not validation.
-// There is no session stickiness to fall back on (see #214) — nothing remembers
-// the workspace a session was already working in, so a silent default is a guess
-// dressed up as a decision. Surrounding whitespace is trimmed rather than
-// refused: ` default ` is unambiguous, and trimming keeps it from reaching the
-// repository guard as a distinct path segment.
+// What reaches this function is the RESOLVED value, so an empty one means the
+// session has never been bound. That still fails, and fails HERE, because the
+// alternative is the bug #214 reports: the old `params.workspaceId || 'default'`
+// quietly filed an unbound call under the global workspace, and a caller whose
+// template rendered `workspaceId: ""` behaved differently from one that omitted
+// the field while its traces, sessions and states landed somewhere it never
+// asked for. Empty, blank and absent all mean UNBOUND; none of them means
+// 'default'. Surrounding whitespace is trimmed rather than refused: ` default `
+// is unambiguous, and trimming keeps it from reaching the repository guard as
+// a distinct path segment.
 // ---------------------------------------------------------------------------
 
 export const WORKSPACE_ID_REQUIRED_MESSAGE =
-  '"workspaceId" is required and must not be empty. Pass "default" for the global workspace, '
-  + 'or an exact workspace name or id from the availableWorkspaces list returned by getTools. '
-  + 'An empty string is not treated as "default" — it is rejected, exactly like omitting the field.';
+  'This session has no workspace yet. Pass "workspaceId" once — "default" for the global workspace, '
+  + 'or an exact name/id from availableWorkspaces — or load one with "memory load-workspace"; '
+  + 'later calls in this session inherit it.';
 
 /**
- * Resolve the envelope's workspaceId, or throw a recoverable steering error.
- * @param raw - The caller-supplied top-level workspaceId
+ * Accept the session's resolved workspaceId, or throw the recoverable
+ * "pass it once" steer when the session is still unbound.
+ * @param raw - The resolved top-level workspaceId (explicit or inherited)
  * @returns The trimmed workspace identifier
  */
 export function normalizeRequiredWorkspaceId(raw: unknown): string {

--- a/src/agents/toolManager/tools/getTools.ts
+++ b/src/agents/toolManager/tools/getTools.ts
@@ -60,12 +60,13 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
     const lines = [
       'REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.',
       'This returns CLI-oriented command metadata for the tools you need next.',
-      'Send workspaceId, sessionId, memory, goal, and constraints at the top level.',
+      'Send sessionId, memory, goal, and constraints at the top level.',
+      'The workspace is remembered per session: the first useTools call of a fresh session passes "workspaceId" once ("default" or an exact name from the workspaces list this call returns) or runs "memory load-workspace"; later calls inherit it. Omit "workspaceId" unless you are deliberately switching. getTools itself never needs it.',
       'Use one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.',
       'Do not send a nested "context" object or legacy "request" array.',
       '',
       'Workflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands',
-      'Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available storage tools.","tool":"storage move, content read"}',
+      'Known-good example: {"sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available storage tools.","tool":"storage move, content read"}',
       'Example selectors: tool="--help", tool="storage", tool="storage move", tool="storage move, content read"',
       '',
       'Agents:'
@@ -243,11 +244,11 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
       properties: {
         workspaceId: {
           type: 'string',
-          description: 'Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as "default". Pass "default" for the global workspace, or an exact value from the availableWorkspaces list this call returns.'
+          description: 'Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. Discovery never needs it — a fresh session names its workspace on its first useTools call ("default" for the global workspace, or an exact value from the workspaces list this call returns). An empty string is read as omitted, never as "default".'
         },
         sessionId: {
           type: 'string',
-          description: 'Stable human-readable session name for this chat. Required. Reuse the same value for every getTools/useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently.'
+          description: 'Stable human-readable session name for this chat. Reuse the same value for every getTools/useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session.'
         },
         memory: {
           type: 'string',
@@ -266,7 +267,10 @@ export class GetToolsTool implements ITool<GetToolsParams, GetToolsResult> {
           description: 'CLI-style selector string. Supports one or more selectors separated by commas. Examples: "--help", "storage", "storage move", "storage move, content read".'
         }
       },
-      required: ['workspaceId', 'sessionId', 'memory', 'goal', 'tool']
+      // workspaceId and sessionId are deliberately NOT required (#214) — see the
+      // matching note in useTools.getParameterSchema. Discovery is often a
+      // session's first call, before any workspace has been chosen.
+      required: ['memory', 'goal', 'tool']
     };
   }
 

--- a/src/agents/toolManager/tools/useTools.ts
+++ b/src/agents/toolManager/tools/useTools.ts
@@ -28,7 +28,7 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
   ) {
     this.slug = 'useTools';
     this.name = 'Use Tools';
-    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"workspaceId":"default","sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. '
+    this.description = 'Execute one or more CLI-style tool commands from the top-level "tool" field. Known-good example: {"sessionId":"workspace setup","memory":"Summarize work so far.","goal":"Inspect available workspaces.","tool":"memory list-workspaces"}. The workspace is remembered per session: a fresh session passes "workspaceId" once ("default" or an exact name from getTools) or loads one with "memory load-workspace"; every later call in that session inherits it, so omit "workspaceId" unless you are deliberately switching. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. '
       + CLI_BATCHING_RULE + ' '
       + CLI_MULTILINE_RULE + ' '
       + CLI_VALUES_RULE + ' Example: ' + CLI_VALUES_EXAMPLE
@@ -63,11 +63,11 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
       properties: {
         workspaceId: {
           type: 'string',
-          description: 'Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as "default". Pass "default" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools.'
+          description: 'Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. A fresh session must pass it once (or run "memory load-workspace") before other commands — "default" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools. An empty string is read as omitted, never as "default".'
         },
         sessionId: {
           type: 'string',
-          description: 'Stable human-readable session name for this chat. Required. Reuse the same value for every useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently.'
+          description: 'Stable human-readable session name for this chat. Reuse the same value for every useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session.'
         },
         memory: {
           type: 'string',
@@ -107,7 +107,13 @@ export class UseToolTool implements ITool<UseToolParams, UseToolResult> {
             + ' Keys use letters, digits, "_" or "-". Example: ' + CLI_VALUES_EXAMPLE
         }
       },
-      required: ['workspaceId', 'sessionId', 'memory', 'goal', 'tool']
+      // workspaceId and sessionId are deliberately NOT required (#214): the
+      // workspace is inherited from the session's bind after the first call,
+      // and on the MCP path `required` IS enforced (ValidationService), so
+      // listing it would force every call to restate it. Requiredness of the
+      // FIRST call is enforced where it can see the session — in
+      // ToolCliNormalizer.normalizeRequiredWorkspaceId — not by the schema.
+      required: ['memory', 'goal', 'tool']
     };
   }
 

--- a/src/core/services/ServiceDefinitions.ts
+++ b/src/core/services/ServiceDefinitions.ts
@@ -10,7 +10,7 @@
  */
 
 import type { App, Plugin, PluginManifest } from 'obsidian';
-import { Events, Platform } from 'obsidian';
+import { Events, normalizePath, Platform } from 'obsidian';
 import type { ServiceManager } from '../ServiceManager';
 import type { Settings } from '../../settings';
 import type { IStorageAdapter } from '../../database/interfaces/IStorageAdapter';
@@ -272,10 +272,24 @@ export const CORE_SERVICE_DEFINITIONS: ServiceDefinition[] = [
         dependencies: ['workspaceService', 'memoryService', 'sessionService'],
         create: defineService(async (context) => {
             const { SessionContextManager } = await import('../../services/SessionContextManager');
+            const { VaultSessionBindingsStore, SESSION_BINDINGS_FILE_NAME } = await import('../../services/session/SessionBindingsStore');
+            const { resolvePluginStorageRoot } = await import('../../database/storage/PluginStoragePathResolver');
             const sessionService = await context.serviceManager.getService<SessionService>('sessionService');
+            const workspaceService = await context.serviceManager.getService<WorkspaceService>('workspaceService');
 
             const manager = new SessionContextManager();
             manager.setSessionService(sessionService);
+            // Canonical ids for binds and handle partitions (#214), the same
+            // lookup ToolCallTraceService uses for traces.
+            manager.setWorkspaceResolver(workspaceService);
+            // Session bindings live in the plugin's own data folder inside the
+            // vault — resolved, never a literal root — so a handle's workspace
+            // and session survive a plugin reload.
+            const { dataRoot } = resolvePluginStorageRoot(context.app, context.plugin);
+            manager.setBindingsStore(new VaultSessionBindingsStore(
+                context.app.vault.adapter,
+                normalizePath(`${dataRoot}/${SESSION_BINDINGS_FILE_NAME}`)
+            ));
             return manager;
         })
     },

--- a/src/handlers/interfaces/IRequestHandlerServices.ts
+++ b/src/handlers/interfaces/IRequestHandlerServices.ts
@@ -169,6 +169,14 @@ export interface IRequestContext {
     sessionId: string;
     fullToolName: string;
     sessionContextManager?: SessionContextManager;
+    /**
+     * `clientInfo.name` from the connection's MCP `initialize` handshake
+     * (`Server.getClientVersion()`), e.g. `'nexus-cli'`. Undefined when the
+     * SDK has no client info. Attached by RequestHandlerFactory so
+     * connection-specific policy (the CLI's current-session default, plan
+     * PR 2) can key off who is calling without a new wire-level field.
+     */
+    clientName?: string;
 }
 
 export interface ISchemaEnhancementService {

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -43,7 +43,34 @@ interface ToolExecutionRequest {
         name: string;
         arguments: Record<string, unknown>;
     };
+    /** Attached by RequestHandlerFactory from the connection's initialize handshake. */
+    clientName?: string;
 }
+
+/** The envelope fields processSession reads and rewrites. */
+type SessionEnvelopeParams = Record<string, unknown> & {
+    context?: { sessionId?: string; workspaceId?: string; [key: string]: unknown };
+    sessionId?: string;
+    workspaceId?: string;
+    workspaceContext?: { workspaceId?: string; [key: string]: unknown };
+};
+
+/**
+ * What processSession decided about the workspace, carried to bind point 1.
+ * `handle` is the caller-supplied session id (friendly name or standard id) —
+ * the key a later call will present again — not the internal id.
+ */
+interface WorkspaceBindingIntent {
+    handle: string;
+    displayHandle?: string;
+    workspaceId: string;
+    explicit: boolean;
+}
+
+/** Tool names on the two-tool surface, as the strategy sees them after the prefix split. */
+const TOOL_MANAGER_AGENT = 'toolManager';
+const USE_TOOLS = 'useTools';
+const GET_TOOLS = 'getTools';
 
 interface ToolExecutionResponse {
     content: Array<{
@@ -73,16 +100,17 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
 
     async handle(request: ToolExecutionRequest): Promise<ToolExecutionResponse> {
         const startTime = Date.now();
-        let context: (IRequestContext & { sessionInfo: SessionInfo }) | undefined;
+        let context: (IRequestContext & { sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }) | undefined;
         let success = false;
         let result: ToolExecutionResult;
-        
+
         try {
             context = await this.buildRequestContext(request);
             const processedParams = await this.processParameters(context);
             result = await this.executeTool(context, processedParams);
             success = true;
-            
+            this.bindWorkspaceFromResult(context, result);
+
             // Trigger response capture callback if available
             if (this.onToolResponse) {
                 try {
@@ -174,7 +202,9 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         }
     }
 
-    private async buildRequestContext(request: ToolExecutionRequest): Promise<IRequestContext & { sessionInfo: SessionInfo }> {
+    private async buildRequestContext(
+        request: ToolExecutionRequest
+    ): Promise<IRequestContext & { sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }> {
         const { name: fullToolName, arguments: parsedArgs } = request.params;
 
         if (!parsedArgs) {
@@ -188,11 +218,7 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         // MCP requires tool names match ^[a-zA-Z0-9_-]{1,64}$ (no dots allowed)
         let agentName: string;
         let tool: string;
-        let params: Record<string, unknown> & {
-            context?: { sessionId?: string; workspaceId?: string; [key: string]: unknown };
-            sessionId?: string;
-            workspaceContext?: { workspaceId?: string; [key: string]: unknown };
-        };
+        let params: SessionEnvelopeParams;
 
         // Check if this is a toolManager tool (toolManager_getTools or toolManager_useTool)
         if (fullToolName.startsWith('toolManager_')) {
@@ -215,58 +241,10 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             }
         }
 
-        // Use SessionContextManager for unified session handling instead of separate SessionService
-        const sessionId = params.context?.sessionId || params.sessionId;
+        const { sessionInfo, workspaceBinding } = await this.processSession(params, agentName, tool);
 
-        let sessionInfo: SessionInfo;
-        if (this.sessionContextManager && sessionId) {
-            try {
-                const validationResult = await this.sessionContextManager.validateSessionId(
-                    sessionId,
-                    typeof params.memory === 'string' ? params.memory : undefined,
-                    typeof params.workspaceId === 'string'
-                        ? params.workspaceId
-                        : params.context?.workspaceId
-                );
-                const isNonStandardId = validationResult.displaySessionIdChanged;
-                
-                sessionInfo = {
-                    sessionId: validationResult.id,
-                    isNewSession: validationResult.created,
-                    isNonStandardId: isNonStandardId,
-                    originalSessionId: isNonStandardId ? sessionId : undefined,
-                    displaySessionId: validationResult.displaySessionId,
-                    displaySessionIdChanged: validationResult.displaySessionIdChanged
-                };
-                
-                // Update params with validated session ID (both locations for compatibility)
-                if (params.context) {
-                    params.context.sessionId = validationResult.id;
-                    params.context.sessionName = validationResult.displaySessionId;
-                }
-                params.sessionId = validationResult.id;
-                params._displaySessionId = validationResult.displaySessionId;
-            } catch (error) {
-                logger.systemWarn(`SessionContextManager validation failed: ${getErrorMessage(error)}. Falling back to SessionService`);
-                // Fallback to original SessionService if SessionContextManager fails
-                sessionInfo = await this.dependencies.sessionService.processSessionId(sessionId);
-                if (params.context) {
-                    params.context.sessionId = sessionInfo.sessionId;
-                }
-                params.sessionId = sessionInfo.sessionId;
-            }
-        } else {
-            // Fallback to original SessionService if no SessionContextManager or sessionId
-            // processSessionId handles undefined by generating a new session ID
-            sessionInfo = await this.dependencies.sessionService.processSessionId(sessionId);
-            if (params.context) {
-                params.context.sessionId = sessionInfo.sessionId;
-            }
-            params.sessionId = sessionInfo.sessionId;
-        }
-        
         const shouldInjectInstructions = this.dependencies.sessionService.shouldInjectInstructions(
-            sessionInfo.sessionId, 
+            sessionInfo.sessionId,
             this.sessionContextManager
         );
 
@@ -276,12 +254,164 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             params,
             sessionId: sessionInfo.sessionId,
             fullToolName,
+            clientName: request.clientName,
             sessionContextManager: this.sessionContextManager,
             sessionInfo: {
                 ...sessionInfo,
                 shouldInjectInstructions
-            }
+            },
+            ...(workspaceBinding ? { workspaceBinding } : {})
         };
+    }
+
+    /**
+     * Resolve the session and the workspace it runs in, in that order of
+     * dependency: the handle partition (`"<workspaceId>::<handle>"`) needs the
+     * workspace, so the workspace is settled FIRST (#214):
+     *
+     *   workspaceId:  explicit on this call  →  handle's last bind  →  UNBOUND
+     *
+     * UNBOUND is not an error here. `useTools` is left without a workspaceId so
+     * ToolCliNormalizer.normalizeRequiredWorkspaceId throws its "pass it once"
+     * steer; `getTools` is partitioned under 'default' so discovery can be a
+     * session's first call — WITHOUT binding, because nothing was chosen.
+     *
+     * The resolved canonical value is written back onto `params` so
+     * normalizeContext and ToolBatchExecutionService.validateContext can stay
+     * strict and unchanged. Mutates `params` in place, as the caller expects.
+     */
+    private async processSession(
+        params: SessionEnvelopeParams,
+        agentName: string,
+        tool: string
+    ): Promise<{ sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }> {
+        // Use SessionContextManager for unified session handling instead of separate SessionService
+        const sessionId = params.context?.sessionId || params.sessionId;
+
+        if (!this.sessionContextManager || !sessionId) {
+            // Fallback to original SessionService if no SessionContextManager or sessionId
+            // processSessionId handles undefined by generating a new session ID
+            const sessionInfo = await this.dependencies.sessionService.processSessionId(sessionId);
+            if (params.context) {
+                params.context.sessionId = sessionInfo.sessionId;
+            }
+            params.sessionId = sessionInfo.sessionId;
+            return { sessionInfo };
+        }
+
+        const isToolManager = agentName === TOOL_MANAGER_AGENT;
+        let workspaceBinding: WorkspaceBindingIntent | undefined;
+        try {
+            // Legacy `agent_tool` calls carry the envelope under `context`; the
+            // two-tool surface carries it at the top level (normalizeContext
+            // rejects a nested `context` outright).
+            const resolution = await this.sessionContextManager.resolveWorkspaceForSession(
+                params.workspaceId ?? params.context?.workspaceId,
+                sessionId
+            );
+
+            if (resolution.workspaceId) {
+                // Two-tool calls read the top level; legacy calls read `context`.
+                // A legacy call only gets the top-level key canonicalised if it
+                // sent one — injecting a new key into an arbitrary tool's params
+                // is not this method's business.
+                if (isToolManager || !params.context || params.workspaceId !== undefined) {
+                    params.workspaceId = resolution.workspaceId;
+                }
+                if (params.context) {
+                    params.context.workspaceId = resolution.workspaceId;
+                }
+                workspaceBinding = {
+                    handle: sessionId,
+                    workspaceId: resolution.workspaceId,
+                    explicit: resolution.explicit
+                };
+            } else if (isToolManager && tool === USE_TOOLS) {
+                // Leave it absent. Deleting rather than skipping guards against a
+                // caller that sent `workspaceId: ""` — blank must fail exactly
+                // like omitted, not slip past `required` as a present key.
+                delete params.workspaceId;
+            }
+
+            // Only discovery is partitioned under 'default' when unbound. For
+            // everything else the manager's own 'default' parameter applies,
+            // which is today's behaviour for legacy-format calls.
+            const partitionWorkspace = resolution.workspaceId
+                ?? (isToolManager && tool === GET_TOOLS ? 'default' : undefined);
+
+            const validationResult = await this.sessionContextManager.validateSessionId(
+                sessionId,
+                typeof params.memory === 'string' ? params.memory : undefined,
+                partitionWorkspace
+            );
+            const isNonStandardId = validationResult.displaySessionIdChanged;
+
+            const sessionInfo: SessionInfo = {
+                sessionId: validationResult.id,
+                isNewSession: validationResult.created,
+                isNonStandardId: isNonStandardId,
+                originalSessionId: isNonStandardId ? sessionId : undefined,
+                displaySessionId: validationResult.displaySessionId,
+                displaySessionIdChanged: validationResult.displaySessionIdChanged
+            };
+
+            // Update params with validated session ID (both locations for compatibility)
+            if (params.context) {
+                params.context.sessionId = validationResult.id;
+                params.context.sessionName = validationResult.displaySessionId;
+            }
+            params.sessionId = validationResult.id;
+            params._displaySessionId = validationResult.displaySessionId;
+
+            if (workspaceBinding && validationResult.displaySessionId !== sessionId) {
+                workspaceBinding.displayHandle = validationResult.displaySessionId;
+            }
+            return { sessionInfo, workspaceBinding };
+        } catch (error) {
+            logger.systemWarn(`SessionContextManager validation failed: ${getErrorMessage(error)}. Falling back to SessionService`);
+            // Fallback to original SessionService if SessionContextManager fails
+            const sessionInfo = await this.dependencies.sessionService.processSessionId(sessionId);
+            if (params.context) {
+                params.context.sessionId = sessionInfo.sessionId;
+            }
+            params.sessionId = sessionInfo.sessionId;
+            // No bind on the fallback path: the manager that would hold it just failed.
+            return { sessionInfo };
+        }
+    }
+
+    /**
+     * Bind point 1 (#214): an EXPLICIT workspaceId on a `useTools` call whose
+     * result did not fail binds the session's handle to that workspace.
+     *
+     * The check reads the RESULT, not `handle()`'s local `success` flag — that
+     * flag is true for any non-throwing call, including one that returned
+     * `{ success: false }` because validateWorkspaceId rejected the value. An
+     * inherited workspace is not a new choice and never re-binds; `getTools`
+     * never binds because discovery chooses nothing.
+     */
+    private bindWorkspaceFromResult(
+        context: IRequestContext & { workspaceBinding?: WorkspaceBindingIntent },
+        result: ToolExecutionResult
+    ): void {
+        const intent = context.workspaceBinding;
+        if (!this.sessionContextManager || !intent || !intent.explicit) {
+            return;
+        }
+        if (context.agentName !== TOOL_MANAGER_AGENT || context.tool !== USE_TOOLS) {
+            return;
+        }
+        if (!result || result.success === false) {
+            return;
+        }
+        try {
+            this.sessionContextManager.bindHandleWorkspace(intent.handle, intent.workspaceId);
+            if (intent.displayHandle && intent.displayHandle !== intent.handle) {
+                this.sessionContextManager.bindHandleWorkspace(intent.displayHandle, intent.workspaceId);
+            }
+        } catch (error) {
+            logger.systemWarn(`Workspace bind failed for session "${intent.handle}": ${getErrorMessage(error)}`);
+        }
     }
 
     private async processParameters(context: IRequestContext): Promise<EnhancedToolParams> {

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -65,6 +65,13 @@ interface WorkspaceBindingIntent {
     displayHandle?: string;
     workspaceId: string;
     explicit: boolean;
+    /**
+     * What the handle was bound to BEFORE the tool ran. Bind point 1 compares
+     * against this after execution: if the handle moved in between, bind point
+     * 2 (`memory load-workspace` inside the batch) fired during the call and
+     * must win — see bindWorkspaceFromResult.
+     */
+    priorBound?: string;
 }
 
 /** Tool names on the two-tool surface, as the strategy sees them after the prefix split. */
@@ -324,7 +331,8 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
                 workspaceBinding = {
                     handle: sessionId,
                     workspaceId: resolution.workspaceId,
-                    explicit: resolution.explicit
+                    explicit: resolution.explicit,
+                    priorBound: this.sessionContextManager.resolveHandleWorkspace(sessionId)
                 };
             } else if (isToolManager && tool === USE_TOOLS) {
                 // Leave it absent. Deleting rather than skipping guards against a
@@ -389,6 +397,12 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
      * `{ success: false }` because validateWorkspaceId rejected the value. An
      * inherited workspace is not a new choice and never re-binds; `getTools`
      * never binds because discovery chooses nothing.
+     *
+     * Ordering with bind point 2: `nexus use --workspace X -- memory
+     * load-workspace Y` fires BOTH points in one call — the batch service binds
+     * Y while the tool runs, and this method runs after. The loaded workspace
+     * is the more deliberate act and happened later, so it must win: if the
+     * handle's binding moved since processSession snapshotted it, skip.
      */
     private bindWorkspaceFromResult(
         context: IRequestContext & { workspaceBinding?: WorkspaceBindingIntent },
@@ -405,13 +419,35 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             return;
         }
         try {
+            if (this.boundDuringCall(intent.handle, intent.priorBound)) {
+                return;
+            }
             this.sessionContextManager.bindHandleWorkspace(intent.handle, intent.workspaceId);
-            if (intent.displayHandle && intent.displayHandle !== intent.handle) {
+            if (intent.displayHandle && intent.displayHandle !== intent.handle
+                && !this.boundDuringCall(intent.displayHandle, intent.priorBound)) {
                 this.sessionContextManager.bindHandleWorkspace(intent.displayHandle, intent.workspaceId);
             }
         } catch (error) {
             logger.systemWarn(`Workspace bind failed for session "${intent.handle}": ${getErrorMessage(error)}`);
         }
+    }
+
+    /**
+     * True when `handle` is bound to something other than what processSession
+     * saw before execution — i.e. bind point 2 moved it during this call. The
+     * display handle (a renamed friendly id) had no binding of its own before
+     * the call, so the same snapshot serves both: bind point 2 binds every
+     * handle mapped to the session id at once.
+     */
+    private boundDuringCall(handle: string, priorBound: string | undefined): boolean {
+        const current = this.sessionContextManager?.resolveHandleWorkspace(handle);
+        if (current === undefined || current === priorBound) {
+            return false;
+        }
+        logger.systemLog(
+            `Session "${handle}" was bound to workspace ${current} during the call (load-workspace); keeping it over the explicit workspaceId`
+        );
+        return true;
     }
 
     private async processParameters(context: IRequestContext): Promise<EnhancedToolParams> {

--- a/src/server/execution/AgentExecutionManager.ts
+++ b/src/server/execution/AgentExecutionManager.ts
@@ -125,11 +125,25 @@ export class AgentExecutionManager {
         }
 
         try {
+            // Same resolution order as ToolExecutionStrategy.processSession
+            // (explicit → session's last bind → unbound), so the handle partition
+            // never diverges between the MCP path and this direct-form chat
+            // path (#214). Direct-form callers carry the chat's workspace under
+            // `context` (DirectToolExecutor fills it from the chat selection);
+            // the old top-level-only read partitioned every such handle under
+            // 'default'. Only the PARTITION uses the resolved value — the tool
+            // still receives `context.workspaceId` exactly as the chat sent it.
+            const nestedContext = params.context as { workspaceId?: unknown } | undefined;
+            const resolution = await this.sessionContextManager.resolveWorkspaceForSession(
+                params.workspaceId ?? nestedContext?.workspaceId,
+                sessionId
+            );
+
             // Validate session ID - destructure the result to get the actual ID
             const validationResult = await this.sessionContextManager.validateSessionId(
                 sessionId,
                 typeof params.memory === 'string' ? params.memory : undefined,
-                typeof params.workspaceId === 'string' ? params.workspaceId : undefined
+                resolution.workspaceId
             );
             const validatedSessionId = validationResult.id;
             params.sessionId = validatedSessionId;

--- a/src/server/handlers/RequestHandlerFactory.ts
+++ b/src/server/handlers/RequestHandlerFactory.ts
@@ -154,16 +154,37 @@ export class RequestHandlerFactory {
     }
 
     /**
-     * Handle normal tool execution
+     * Handle normal tool execution.
+     *
+     * Each IPC connection has its own MCPSDKServer, and this factory holds it,
+     * so this is the one place that knows WHICH client sent the call. The
+     * client's `initialize` name (the CLI sends `'nexus-cli'`) rides along as a
+     * sibling of `params` — outside the tool arguments, so it can never be
+     * spoofed from the payload or mistaken for a tool parameter — and lands on
+     * `IRequestContext.clientName`.
      */
     private async handleNormalExecution(request: ToolCallRequestLike, parsedArgs: ToolArguments): Promise<MCPResult> {
         return await this.requestRouter.handleRequest('tools/call', {
             ...request,
+            clientName: this.resolveClientName(),
             params: {
                 ...request.params,
                 arguments: parsedArgs
             }
         }) as MCPResult;
+    }
+
+    /**
+     * `Server.getClientVersion()` is undefined until the handshake completes
+     * and on SDK builds that predate it; both read as "unknown client".
+     */
+    private resolveClientName(): string | undefined {
+        try {
+            const name = this.server.getClientVersion?.()?.name;
+            return typeof name === 'string' && name.length > 0 ? name : undefined;
+        } catch {
+            return undefined;
+        }
     }
 
     /**

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -1,5 +1,10 @@
 import { CommonResult } from '../types';
 import type { SessionData } from './session/SessionService';
+import type {
+  PersistedSessionBindings,
+  PersistedSessionHandle,
+  SessionBindingsStore
+} from './session/SessionBindingsStore';
 import { logger } from '../utils/logger';
 import { parseWorkspaceContext } from '../utils/contextUtils';
 import { generateSessionId, isStandardSessionId } from '../utils/sessionUtils';
@@ -33,12 +38,42 @@ interface SessionServiceLike {
 
 export type SessionDeletedListener = (sessionId: string, workspaceId: string) => void;
 
+/**
+ * The slice of WorkspaceService the manager needs to turn a caller-supplied
+ * workspace name into its canonical id. Structural so tests can stub it and
+ * so this file does not import the (heavy) WorkspaceService module.
+ */
+export interface WorkspaceResolverLike {
+  getWorkspaceByNameOrId(identifier: string): Promise<{ id: string } | null>;
+}
+
 export interface SessionValidationResult {
   id: string;
   created: boolean;
   displaySessionId: string;
   displaySessionIdChanged: boolean;
 }
+
+/**
+ * Outcome of resolving which workspace a tool call runs in (#214).
+ * `explicit` is true only when the caller named the workspace on THIS call;
+ * a value inherited from an earlier bind is not a new decision and must not
+ * re-bind (see ToolExecutionStrategy bind point 1).
+ */
+export interface SessionWorkspaceResolution {
+  workspaceId?: string;
+  explicit: boolean;
+}
+
+/** The global workspace id is not a name to look up — it passes through. */
+const GLOBAL_WORKSPACE_ID = 'default';
+
+/**
+ * How long consecutive binding changes are coalesced before one write. A
+ * session's first few calls (getTools, useTools, load-workspace) all mutate
+ * the map within a second or two; one file write per burst is plenty.
+ */
+const BINDINGS_SAVE_DEBOUNCE_MS = 300;
 
 /**
  * SessionContextManager
@@ -70,6 +105,34 @@ export class SessionContextManager {
   // the display-name entry without scanning the whole map.
   private sessionHandleMap: Map<string, { id: string; displaySessionId: string; workspaceId: string }> = new Map();
 
+  // Handle entries restored from session-bindings.json that have not yet been
+  // checked against storage. A restored entry is only trusted once
+  // `sessionService.getAllSessions(entry.workspaceId)` confirms the session
+  // still exists; a session deleted while the plugin was unloaded is dropped
+  // at that point instead of being silently resumed. The check is lazy (on the
+  // handle's first use) rather than at service init because storage is cold
+  // during startup hydration and would report every session as missing.
+  private unverifiedHandleKeys: Set<string> = new Set();
+
+  // Handle → workspace id of the LAST DELIBERATE bind (#214). Distinct from
+  // `sessionContextMap`, which ToolCallTraceService.captureToolCall overwrites
+  // on every call — including unbound discovery calls that ran under
+  // 'default' — so that map records where traces went, not what the caller
+  // chose. Only bindHandleWorkspace / bindSessionWorkspaceById write here.
+  private handleWorkspace: Map<string, string> = new Map();
+
+  // Canonicalises workspace names to ids before a bind or partition, the same
+  // way ToolCallTraceService.resolveWorkspaceId does for traces, so a session's
+  // sessions, states and traces land in one store whether the caller passed
+  // the name or the id.
+  private workspaceResolver: WorkspaceResolverLike | null = null;
+
+  // Persistence for handles + handleWorkspace. Null in tests and before wiring;
+  // every store operation is best-effort and degrades to "pass it once again".
+  private bindingsStore: SessionBindingsStore | null = null;
+  private bindingsSaveTimer: number | null = null;
+  private bindingsRestore: Promise<void> | null = null;
+
   // Disposer for the session-deleted subscription so re-wiring or teardown can
   // unregister cleanly.
   private sessionDeletedUnsubscribe: (() => void) | null = null;
@@ -98,6 +161,194 @@ export class SessionContextManager {
   }
 
   /**
+   * Wire the workspace lookup used to canonicalise names to ids. Optional: with
+   * no resolver, values bind and partition as given (the batch service still
+   * rejects unknown ones with its existing steer).
+   */
+  setWorkspaceResolver(resolver: WorkspaceResolverLike | null): void {
+    this.workspaceResolver = resolver;
+  }
+
+  /**
+   * Wire the persistence store and start restoring what it holds. Restoration
+   * is awaited by the first `validateSessionId` / `resolveWorkspaceForSession`
+   * call, so callers never race the read; a failed read logs and leaves the
+   * manager empty.
+   */
+  setBindingsStore(store: SessionBindingsStore | null): void {
+    this.bindingsStore = store;
+    this.bindingsRestore = store ? this.restorePersistedBindings(store) : null;
+  }
+
+  /** Resolves once the persisted bindings (if any) are loaded into memory. */
+  async ensureBindingsRestored(): Promise<void> {
+    if (this.bindingsRestore) {
+      await this.bindingsRestore;
+    }
+  }
+
+  private async restorePersistedBindings(store: SessionBindingsStore): Promise<void> {
+    let doc: PersistedSessionBindings | null = null;
+    try {
+      doc = await store.load();
+    } catch (error) {
+      logger.systemWarn(`Session bindings restore failed: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    if (!doc) {
+      return;
+    }
+
+    for (const [key, entry] of Object.entries(doc.handles)) {
+      // Never let a stale file clobber a handle the live process already
+      // created — the in-memory entry is newer by definition.
+      if (!this.sessionHandleMap.has(key)) {
+        this.sessionHandleMap.set(key, { ...entry });
+        this.unverifiedHandleKeys.add(key);
+      }
+    }
+    for (const [handle, workspaceId] of Object.entries(doc.handleWorkspace)) {
+      if (!this.handleWorkspace.has(handle)) {
+        this.handleWorkspace.set(handle, workspaceId);
+      }
+    }
+  }
+
+  private snapshotBindings(): PersistedSessionBindings {
+    const handles: Record<string, PersistedSessionHandle> = {};
+    for (const [key, entry] of this.sessionHandleMap.entries()) {
+      handles[key] = { id: entry.id, displaySessionId: entry.displaySessionId, workspaceId: entry.workspaceId };
+    }
+    return {
+      handles,
+      handleWorkspace: Object.fromEntries(this.handleWorkspace.entries())
+    };
+  }
+
+  /**
+   * Coalesce binding changes into one write. Fire-and-forget: a failed write
+   * is logged by the store and the next change retries.
+   */
+  private scheduleBindingsSave(): void {
+    if (!this.bindingsStore) {
+      return;
+    }
+    if (this.bindingsSaveTimer) {
+      window.clearTimeout(this.bindingsSaveTimer);
+    }
+    this.bindingsSaveTimer = window.setTimeout(() => {
+      this.bindingsSaveTimer = null;
+      void this.flushBindings();
+    }, BINDINGS_SAVE_DEBOUNCE_MS);
+  }
+
+  /** Write the current bindings now, cancelling any pending debounced write. */
+  async flushBindings(): Promise<void> {
+    if (this.bindingsSaveTimer) {
+      window.clearTimeout(this.bindingsSaveTimer);
+      this.bindingsSaveTimer = null;
+    }
+    if (!this.bindingsStore) {
+      return;
+    }
+    try {
+      await this.bindingsStore.save(this.snapshotBindings());
+    } catch (error) {
+      logger.systemWarn(`Session bindings save failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Canonicalise a caller-supplied workspace handle to its id. 'default'
+   * passes through; a name or id that resolves becomes the id; anything else
+   * is returned untouched so ToolBatchExecutionService.validateWorkspaceId can
+   * reject it with its did-you-mean steer instead of this method guessing.
+   */
+  async canonicalizeWorkspaceId(value: string): Promise<string> {
+    const trimmed = value.trim();
+    if (trimmed.length === 0 || trimmed === GLOBAL_WORKSPACE_ID || !this.workspaceResolver) {
+      return trimmed;
+    }
+    try {
+      const workspace = await this.workspaceResolver.getWorkspaceByNameOrId(trimmed);
+      return workspace?.id ?? trimmed;
+    } catch (error) {
+      logger.systemWarn(`Workspace lookup failed for "${trimmed}": ${error instanceof Error ? error.message : String(error)}`);
+      return trimmed;
+    }
+  }
+
+  /**
+   * Resolution order for the workspace a call runs in (#214):
+   *   explicit on this call  →  the handle's last deliberate bind  →  unbound.
+   * An empty or blank explicit value counts as absent — `workspaceId: ""` used
+   * to be read as 'default', which is exactly the silent misfiling #214
+   * reports. Callers decide what UNBOUND means for their tool (useTools
+   * fails with the steer; getTools partitions under 'default' without binding).
+   */
+  async resolveWorkspaceForSession(
+    explicitRaw: unknown,
+    sessionHandle?: string
+  ): Promise<SessionWorkspaceResolution> {
+    await this.ensureBindingsRestored();
+
+    const explicit = typeof explicitRaw === 'string' ? explicitRaw.trim() : '';
+    if (explicit.length > 0) {
+      return { workspaceId: await this.canonicalizeWorkspaceId(explicit), explicit: true };
+    }
+
+    const bound = sessionHandle ? this.resolveHandleWorkspace(sessionHandle) : undefined;
+    return { workspaceId: bound, explicit: false };
+  }
+
+  /** The workspace a handle was last deliberately bound to, if any. */
+  resolveHandleWorkspace(handle: string): string | undefined {
+    return this.handleWorkspace.get(handle);
+  }
+
+  /**
+   * Record a deliberate workspace choice for a handle. `workspaceId` should
+   * already be canonical (see canonicalizeWorkspaceId); this method does not
+   * look it up so it can stay synchronous for the batch service's hot path.
+   */
+  bindHandleWorkspace(handle: string, workspaceId: string): void {
+    const trimmedHandle = handle.trim();
+    const trimmedWorkspace = workspaceId.trim();
+    if (!trimmedHandle || !trimmedWorkspace) {
+      logger.systemWarn('Attempted to bind a session handle with an empty handle or workspaceId');
+      return;
+    }
+    if (this.handleWorkspace.get(trimmedHandle) === trimmedWorkspace) {
+      return;
+    }
+    this.handleWorkspace.set(trimmedHandle, trimmedWorkspace);
+    logger.systemLog(`Bound session handle "${trimmedHandle}" to workspace ${trimmedWorkspace}`);
+    this.scheduleBindingsSave();
+  }
+
+  /**
+   * Bind by INTERNAL session id — for callers that only hold the id the
+   * strategy rewrote onto `params.sessionId` (ToolBatchExecutionService's
+   * `load-workspace` bind point). Every friendly handle that maps to this id
+   * is bound, and so is the id itself, so a caller that passes the standard
+   * `s-…` id straight through inherits too.
+   */
+  bindSessionWorkspaceById(internalSessionId: string, workspaceId: string): void {
+    if (!internalSessionId) {
+      return;
+    }
+    this.bindHandleWorkspace(internalSessionId, workspaceId);
+    for (const [key, entry] of this.sessionHandleMap.entries()) {
+      if (entry.id !== internalSessionId) {
+        continue;
+      }
+      const prefix = `${entry.workspaceId}::`;
+      const handle = key.startsWith(prefix) ? key.slice(prefix.length) : key;
+      this.bindHandleWorkspace(handle, workspaceId);
+    }
+  }
+
+  /**
    * Build the partition key used for sessionHandleMap lookups.
    * Friendly handles are unique only within a workspace; the same string in two
    * workspaces must map to two distinct sessions.
@@ -107,18 +358,73 @@ export class SessionContextManager {
   }
 
   /**
+   * Confirm a restored handle's session still exists in storage. Returns the
+   * entry when it does (and marks it trusted), or null after dropping the
+   * entry when the session is gone. A lookup that THROWS keeps the entry
+   * unverified and returns it — a storage hiccup must not rename a live
+   * session to `<handle>-2`.
+   */
+  private async verifyRestoredHandle(
+    key: string,
+    entry: { id: string; displaySessionId: string; workspaceId: string }
+  ): Promise<{ id: string; displaySessionId: string; workspaceId: string } | null> {
+    if (!this.unverifiedHandleKeys.has(key)) {
+      return entry;
+    }
+    if (!this.sessionService?.getAllSessions) {
+      return entry;
+    }
+
+    let sessions: SessionData[];
+    try {
+      sessions = await this.sessionService.getAllSessions(entry.workspaceId);
+    } catch {
+      return entry;
+    }
+
+    if (sessions.some(session => session.id === entry.id)) {
+      // Trust every key that points at this session, not just the one looked up.
+      for (const [otherKey, other] of this.sessionHandleMap.entries()) {
+        if (other.id === entry.id) {
+          this.unverifiedHandleKeys.delete(otherKey);
+        }
+      }
+      return entry;
+    }
+
+    logger.systemLog(`Restored session handle "${key}" points at deleted session ${entry.id}; dropping it`);
+    for (const [otherKey, other] of this.sessionHandleMap.entries()) {
+      if (other.id === entry.id) {
+        this.sessionHandleMap.delete(otherKey);
+        this.unverifiedHandleKeys.delete(otherKey);
+      }
+    }
+    this.scheduleBindingsSave();
+    return null;
+  }
+
+  /**
    * Remove sessionHandleMap entries for a deleted session in a given workspace.
    * Called from the session-deleted listener registered on SessionService.
    */
   evictSessionHandles(sessionId: string, workspaceId = 'default'): void {
+    let removed = false;
     for (const [key, entry] of this.sessionHandleMap.entries()) {
       if (entry.id === sessionId && entry.workspaceId === workspaceId) {
         this.sessionHandleMap.delete(key);
+        this.unverifiedHandleKeys.delete(key);
+        removed = true;
       }
     }
     this.sessionContextMap.delete(sessionId);
     this.sessionActiveSkillsMap.delete(sessionId);
     this.instructedSessions.delete(sessionId);
+    // handleWorkspace is left alone on purpose: the workspace choice belongs
+    // to the handle, not the deleted session. The handle's next call creates a
+    // fresh session in the workspace the caller last chose.
+    if (removed) {
+      this.scheduleBindingsSave();
+    }
   }
   
   /**
@@ -281,6 +587,8 @@ export class SessionContextManager {
     this.sessionContextMap.clear();
     this.sessionActiveSkillsMap.clear();
     this.sessionHandleMap.clear();
+    this.unverifiedHandleKeys.clear();
+    this.handleWorkspace.clear();
     this.instructedSessions.clear();
     this.defaultWorkspaceContext = null;
   }
@@ -288,13 +596,22 @@ export class SessionContextManager {
   /**
    * ServiceContainer-detected cleanup hook. Runs on plugin teardown
    * (ServiceContainer.clear) so the in-memory handle map and session-deleted
-   * subscription do not survive a plugin reload.
+   * subscription do not survive a plugin reload. The persisted bindings DO
+   * survive — that is what lets a returning handle resume its session — so
+   * any pending debounced write is flushed before memory is cleared.
    */
   cleanup(): void {
     if (this.sessionDeletedUnsubscribe) {
       this.sessionDeletedUnsubscribe();
       this.sessionDeletedUnsubscribe = null;
     }
+    if (this.bindingsSaveTimer) {
+      // Snapshot before clearAll() empties the maps; the write itself is
+      // fire-and-forget because Obsidian does not await plugin unload.
+      void this.flushBindings();
+    }
+    this.bindingsStore = null;
+    this.bindingsRestore = null;
     this.clearAll();
   }
   
@@ -320,7 +637,10 @@ export class SessionContextManager {
     sessionDescription?: string,
     workspaceId = 'default'
   ): Promise<SessionValidationResult> {
-    
+    // Handles persisted before the last reload must be in memory before a
+    // lookup, or a returning handle is created anew and renamed `<handle>-2`.
+    await this.ensureBindingsRestored();
+
     // If no session ID is provided, generate a new one in our standard format
     if (!sessionId) {
       logger.systemWarn('Empty sessionId provided for validation, generating a new one');
@@ -336,7 +656,9 @@ export class SessionContextManager {
     
     // If the session ID doesn't match our standard format, it's a friendly name - create session
     if (!isStandardSessionId(sessionId)) {
-      const existingHandle = this.sessionHandleMap.get(this.handleKey(workspaceId, sessionId));
+      const key = this.handleKey(workspaceId, sessionId);
+      const knownHandle = this.sessionHandleMap.get(key);
+      const existingHandle = knownHandle ? await this.verifyRestoredHandle(key, knownHandle) : null;
       if (existingHandle) {
         return {
           id: existingHandle.id,
@@ -349,8 +671,9 @@ export class SessionContextManager {
       const newId = generateSessionId();
       const displaySessionId = await this.createUniqueSessionDisplayName(sessionId, workspaceId);
       const handleEntry = { id: newId, displaySessionId, workspaceId };
-      this.sessionHandleMap.set(this.handleKey(workspaceId, sessionId), handleEntry);
+      this.sessionHandleMap.set(key, handleEntry);
       this.sessionHandleMap.set(this.handleKey(workspaceId, displaySessionId), handleEntry);
+      this.scheduleBindingsSave();
       await this.createAutoSession(newId, displaySessionId, sessionDescription, workspaceId);
       return {
         id: newId,
@@ -430,10 +753,13 @@ export class SessionContextManager {
 
   private async createUniqueSessionDisplayName(baseName: string, workspaceId: string): Promise<string> {
     const usedNames = new Set<string>();
-    for (const entry of this.sessionHandleMap.values()) {
+    for (const [key, entry] of this.sessionHandleMap.entries()) {
       // Only collide names within the same workspace — same handle in two
-      // workspaces is allowed (workspaces are UX scoping).
-      if (entry.workspaceId === workspaceId) {
+      // workspaces is allowed (workspaces are UX scoping). Restored-but-
+      // unverified entries are skipped: if their session still exists the
+      // storage lookup below lists its name anyway, and if it was deleted its
+      // stale display name must not force a `-2` on a fresh handle.
+      if (entry.workspaceId === workspaceId && !this.unverifiedHandleKeys.has(key)) {
         usedNames.add(entry.displaySessionId.toLowerCase());
       }
     }

--- a/src/services/session/SessionBindingsStore.ts
+++ b/src/services/session/SessionBindingsStore.ts
@@ -1,0 +1,137 @@
+import type { DataAdapter } from 'obsidian';
+import { logger } from '../../utils/logger';
+
+/**
+ * A friendly session handle's mapping to its internal session. Mirrors the
+ * `sessionHandleMap` entry shape in SessionContextManager.
+ */
+export interface PersistedSessionHandle {
+  id: string;
+  displaySessionId: string;
+  workspaceId: string;
+}
+
+/**
+ * The on-disk shape of `session-bindings.json` (see
+ * docs/plans/session-sticky-context-plan.md, "Where the state lives").
+ *
+ * - `handles` is keyed `"<workspaceId>::<handle>"`, exactly like the in-memory
+ *   partition map, so a returning handle resumes its session across a plugin
+ *   reload instead of being renamed `<handle>-2`.
+ * - `handleWorkspace` records the LAST DELIBERATE workspace bind per handle
+ *   (#214). It is written only by an explicit `workspaceId` on a successful
+ *   call or a successful `memory load-workspace` — never by trace capture.
+ *
+ * PR 2 of the plan adds a `cliCurrentSession` slot beside these two. The
+ * parser ignores keys it does not know, so adding one is a shape extension,
+ * not a migration.
+ */
+export interface PersistedSessionBindings {
+  handles: Record<string, PersistedSessionHandle>;
+  handleWorkspace: Record<string, string>;
+}
+
+/**
+ * Where SessionContextManager keeps its bindings between reloads. Kept as an
+ * interface so unit tests can hand the manager an in-memory store and the
+ * manager never learns about paths or adapters.
+ */
+export interface SessionBindingsStore {
+  load(): Promise<PersistedSessionBindings | null>;
+  save(doc: PersistedSessionBindings): Promise<void>;
+}
+
+export const SESSION_BINDINGS_FILE_NAME = 'session-bindings.json';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Shape-check a parsed document field by field. A corrupt or foreign file
+ * must degrade to "pass it once again", never to a throw at service init —
+ * this store is bookkeeping, and losing it costs one extra `workspaceId`
+ * per session, not data.
+ */
+export function parsePersistedSessionBindings(raw: unknown): PersistedSessionBindings | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+
+  const handles: Record<string, PersistedSessionHandle> = {};
+  if (isRecord(raw.handles)) {
+    for (const [key, value] of Object.entries(raw.handles)) {
+      if (
+        isRecord(value)
+        && typeof value.id === 'string' && value.id.length > 0
+        && typeof value.displaySessionId === 'string' && value.displaySessionId.length > 0
+        && typeof value.workspaceId === 'string' && value.workspaceId.length > 0
+      ) {
+        handles[key] = {
+          id: value.id,
+          displaySessionId: value.displaySessionId,
+          workspaceId: value.workspaceId
+        };
+      }
+    }
+  }
+
+  const handleWorkspace: Record<string, string> = {};
+  if (isRecord(raw.handleWorkspace)) {
+    for (const [handle, workspaceId] of Object.entries(raw.handleWorkspace)) {
+      if (typeof workspaceId === 'string' && workspaceId.trim().length > 0) {
+        handleWorkspace[handle] = workspaceId;
+      }
+    }
+  }
+
+  return { handles, handleWorkspace };
+}
+
+/**
+ * File-backed store on the vault adapter. The path is resolved by the caller
+ * (`resolvePluginStorageRoot(app, plugin).dataRoot`); this class never
+ * composes a storage root itself. Uses `app.vault.adapter` rather than Node
+ * `fs` because the plugin runs on mobile.
+ */
+export class VaultSessionBindingsStore implements SessionBindingsStore {
+  constructor(
+    private readonly adapter: DataAdapter,
+    private readonly path: string
+  ) {}
+
+  async load(): Promise<PersistedSessionBindings | null> {
+    try {
+      if (!(await this.adapter.exists(this.path))) {
+        return null;
+      }
+      const text = await this.adapter.read(this.path);
+      const parsed = parsePersistedSessionBindings(JSON.parse(text));
+      if (!parsed) {
+        logger.systemWarn(`[SessionBindingsStore] ${this.path} is not a bindings document; starting empty`);
+      }
+      return parsed;
+    } catch (error) {
+      // JSON.parse on a half-written file lands here too. Starting empty is
+      // the correct recovery: the next deliberate bind rewrites the file.
+      logger.systemWarn(
+        `[SessionBindingsStore] Could not read ${this.path}: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return null;
+    }
+  }
+
+  async save(doc: PersistedSessionBindings): Promise<void> {
+    try {
+      const parent = this.path.substring(0, this.path.lastIndexOf('/'));
+      if (parent && !(await this.adapter.exists(parent))) {
+        await this.adapter.mkdir(parent);
+      }
+      await this.adapter.write(this.path, JSON.stringify(doc, null, 2));
+    } catch (error) {
+      logger.systemWarn(
+        `[SessionBindingsStore] Could not write ${this.path}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}

--- a/src/ui/chat/services/SystemPromptBuilder.ts
+++ b/src/ui/chat/services/SystemPromptBuilder.ts
@@ -224,8 +224,13 @@ export class SystemPromptBuilder {
    * Includes tools overview and context parameter instructions
    */
   private buildSessionContext(sessionId?: string, workspaceId?: string, toolCatalog?: ToolCatalogEntry[]): string | null {
-    const effectiveSessionId = sessionId || `session_${Date.now()}`;
-    const effectiveWorkspaceId = workspaceId || 'default';
+    // The chat runtime attaches its own selected workspace and session to every
+    // tool call (DirectToolExecutor), so the model must NOT restate them. A
+    // model that copied `"workspaceId": "default"` from an example here
+    // overrode the user's chat selection and filed the whole session under
+    // the wrong workspace (#214). The values are named for orientation only.
+    const workspaceLabel = workspaceId || 'the global "default" workspace';
+    const sessionLabel = sessionId ? `"${sessionId}"` : 'assigned by the runtime';
 
     let prompt = '<tools_and_context>\n';
 
@@ -234,16 +239,14 @@ export class SystemPromptBuilder {
 - useTools: execute tool calls
 
 Context (REQUIRED in every useTools call):
-- workspaceId: "${effectiveWorkspaceId}"
-- sessionId: "${effectiveSessionId}"
 - memory: brief summary of the conversation so far
 - goal: brief statement of the current objective
 - constraints: (optional) any rules or limits
 
+Workspace and session are already known to the runtime — this chat runs in workspace ${workspaceLabel}, session ${sessionLabel}. Do NOT include "workspaceId" or "sessionId" in tool calls. The only exception: to deliberately switch to a different workspace, pass "workspaceId" once with its exact name (or run "memory load-workspace"); later calls inherit the switch.
+
 Exact getTools payload shape:
 {
-  "workspaceId": "${effectiveWorkspaceId}",
-  "sessionId": "${effectiveSessionId}",
   "memory": "brief summary of the conversation so far",
   "goal": "brief statement of the current objective",
   "constraints": "optional rules or limits",
@@ -252,8 +255,6 @@ Exact getTools payload shape:
 
 Exact useTools payload shape:
 {
-  "workspaceId": "${effectiveWorkspaceId}",
-  "sessionId": "${effectiveSessionId}",
   "memory": "brief summary of the conversation so far",
   "goal": "brief statement of the current objective",
   "constraints": "optional rules or limits",
@@ -284,7 +285,7 @@ CLI string rules:
 
     prompt += `
 Call getTools first to get the exact command metadata, then useTools with correct CLI arguments.
-Keep workspaceId, sessionId, memory, goal, and constraints at the top level exactly as shown.
+Keep memory, goal, and constraints at the top level exactly as shown; leave workspaceId and sessionId out.
 Do not send a nested "context" object.
 Do not send a "calls" array.
 Do not place context fields inside the "tool" string as CLI flags.

--- a/tests/eval/headless/headless.smoke.test.ts
+++ b/tests/eval/headless/headless.smoke.test.ts
@@ -69,12 +69,16 @@ describe('HeadlessAgentStack', () => {
       properties?: Record<string, unknown>;
     };
 
+    // workspaceId/sessionId are present as properties but NOT required (#214):
+    // the workspace is inherited from the session's bind after the first call.
     expect(getToolsSchema.required).toEqual(
-      expect.arrayContaining(['workspaceId', 'sessionId', 'memory', 'goal', 'tool'])
+      expect.arrayContaining(['memory', 'goal', 'tool'])
     );
+    expect(getToolsSchema.required).not.toContain('workspaceId');
     expect(useToolsSchema.required).toEqual(
-      expect.arrayContaining(['workspaceId', 'sessionId', 'memory', 'goal', 'tool'])
+      expect.arrayContaining(['memory', 'goal', 'tool'])
     );
+    expect(useToolsSchema.required).not.toContain('workspaceId');
 
     expect(getToolsSchema.properties).toHaveProperty('workspaceId');
     expect(getToolsSchema.properties).toHaveProperty('sessionId');

--- a/tests/unit/EnvelopeWorkspaceIdRequired.test.ts
+++ b/tests/unit/EnvelopeWorkspaceIdRequired.test.ts
@@ -15,13 +15,21 @@
  *
  * 2. THE SCHEMA CONTRADICTED ITSELF. The parameter description read "Workspace
  *    ID. Optional. Defaults to \"default\"." while the same schema listed the
- *    field as required. Requiredness is the half that is actually enforced —
- *    and with no session stickiness (the other half of #214, deliberately not
- *    implemented) a silent default is a guess, not a decision — so the
- *    description was corrected to match the contract, not the other way round.
+ *    field as required. The description was corrected first; then the other
+ *    half of #214 — session stickiness — landed (docs/plans/
+ *    session-sticky-context-plan.md, PR 1): a session's workspace is bound by
+ *    the first call that names it and inherited by later calls, so
+ *    `workspaceId` LEFT `required` on both schemas. Requiredness of the FIRST
+ *    call is enforced where it can see the session, in the normalizer, after
+ *    ToolExecutionStrategy.processSession has written the inherited value
+ *    back onto `params`.
  *
- * The guard lives in the normalizer because tool parameter schemas are
- * documentation plus CLI-normalizer hints, not runtime validation.
+ * What this file still pins: the normalizer receives the RESOLVED value, and
+ * an empty one (never bound, nothing explicit) fails loudly with the one
+ * "pass it once" steer — blank, whitespace and absent identically — rather
+ * than silently becoming 'default'. The guard lives in the normalizer because
+ * tool parameter schemas are documentation plus CLI-normalizer hints, not
+ * runtime validation.
  */
 import {
   ToolCliNormalizer,
@@ -101,11 +109,17 @@ describe('envelope workspaceId requiredness (#214)', () => {
       ).toThrow(WORKSPACE_ID_REQUIRED_MESSAGE);
     });
 
-    it('says plainly that "" is not read as "default"', () => {
-      // The message has to name the coercion that used to happen, because the
-      // caller most likely to hit this is a template that rendered to empty.
-      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('empty string is not treated as "default"');
+    it('steers toward "pass it once", naming both ways to bind and the inheritance', () => {
+      // The caller most likely to hit this is a fresh session (or a template
+      // that rendered to empty). The steer has to say what to do ONCE — name a
+      // workspace or load one — and that later calls inherit it, or the model
+      // goes back to restating it on every call.
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('no workspace yet');
       expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('"default"');
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toContain('memory load-workspace');
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).toMatch(/inherit/i);
+      // And it must never re-teach the every-call habit.
+      expect(WORKSPACE_ID_REQUIRED_MESSAGE).not.toMatch(/every call/i);
     });
 
     it('never silently substitutes "default" for a blank value', () => {
@@ -179,19 +193,35 @@ describe('envelope workspaceId requiredness (#214)', () => {
       ]
     ];
 
-    it.each(schemas)('%s lists workspaceId as required', (_name, getSchema) => {
+    it.each(schemas)('%s does not list workspaceId or sessionId as required', (_name, getSchema) => {
+      // On the MCP path `required` IS enforced (ValidationService), so listing
+      // either would force every call to restate what the session already
+      // remembers — the exact per-call tax the sticky contract removes.
       const schema = getSchema();
-      expect(schema.required).toContain('workspaceId');
+      expect(schema.required).not.toContain('workspaceId');
+      expect(schema.required).not.toContain('sessionId');
+      expect(schema.required).toEqual(expect.arrayContaining(['memory', 'goal', 'tool']));
     });
 
-    it.each(schemas)('%s no longer describes workspaceId as optional', (_name, getSchema) => {
+    it.each(schemas)('%s describes workspaceId as pass-once-and-inherited, never as defaulting', (_name, getSchema) => {
       const schema = getSchema();
       const properties = schema.properties as Record<string, { description: string }>;
       const description = properties.workspaceId.description;
-      expect(description).toMatch(/required/i);
-      expect(description).not.toMatch(/optional/i);
-      // The specific claim that regressed: "Defaults to \"default\"".
+      expect(description).toMatch(/inherit/i);
+      expect(description).toMatch(/once/i);
+      // The specific claim that regressed: "Defaults to \"default\"". An empty
+      // string must be described as omitted, not as the global workspace.
       expect(description).not.toMatch(/defaults to/i);
+      expect(description).toMatch(/never as "default"/i);
+    });
+
+    it('neither known-good example inlines "workspaceId":"default" any more', () => {
+      // The example is what models copy. `"workspaceId":"default"` in it is how
+      // whole sessions got filed under the global workspace (#214).
+      const useTools = createUseTool().tool;
+      const getTools = new GetToolsTool(new Map<string, IAgent>(), { workspaces: [], customAgents: [], vaultRoot: [] });
+      expect(useTools.description).not.toContain('"workspaceId":"default"');
+      expect(getTools.description).not.toContain('"workspaceId":"default"');
     });
   });
 });

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -1,0 +1,829 @@
+/**
+ * Session-sticky workspace (#214, docs/plans/session-sticky-context-plan.md PR 1).
+ *
+ * The defect: every call had to restate `workspaceId`, and a caller that
+ * copied `"workspaceId":"default"` from an example silently filed a whole
+ * session's traces, sessions and states under the wrong workspace. The fix is
+ * a server-side contract: a session's workspace is bound once — by an explicit
+ * `workspaceId` on a successful `useTools` call, or by a successful
+ * `memory load-workspace` — and inherited by every later call in that
+ * session, persisted in the vault; an unbound session still fails loudly.
+ *
+ * Each block below names the failure it buys. The SessionContextManager is
+ * REAL throughout; only storage (SessionService), the workspace lookup and the
+ * persistence store are stubbed — and none of them supplies the value an
+ * assertion depends on, except where the test is about that stub's data
+ * (persistence round-trip, deleted-session drop).
+ */
+
+import { ToolExecutionStrategy } from '../../src/handlers/strategies/ToolExecutionStrategy';
+import type {
+  IRequestHandlerDependencies,
+  IRequestContext,
+  SessionInfo,
+  ToolExecutionResult
+} from '../../src/handlers/interfaces/IRequestHandlerServices';
+import type { IAgent } from '../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../src/agents/interfaces/ITool';
+import { SessionContextManager } from '../../src/services/SessionContextManager';
+import type { WorkspaceResolverLike } from '../../src/services/SessionContextManager';
+import {
+  parsePersistedSessionBindings,
+  VaultSessionBindingsStore,
+  type PersistedSessionBindings,
+  type SessionBindingsStore
+} from '../../src/services/session/SessionBindingsStore';
+import {
+  ToolCliNormalizer,
+  WORKSPACE_ID_REQUIRED_MESSAGE
+} from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import { UseToolTool } from '../../src/agents/toolManager/tools/useTools';
+import { GetToolsTool } from '../../src/agents/toolManager/tools/getTools';
+import { ToolBatchExecutionService } from '../../src/agents/toolManager/services/ToolBatchExecutionService';
+import { RequestHandlerFactory } from '../../src/server/handlers/RequestHandlerFactory';
+import { AgentExecutionManager } from '../../src/server/execution/AgentExecutionManager';
+import { AgentRegistry } from '../../src/server/services/AgentRegistry';
+import type { RequestRouter } from '../../src/handlers/RequestRouter';
+import type { Server as MCPSDKServer } from '@modelcontextprotocol/sdk/server/index.js';
+import type { App } from 'obsidian';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Two real workspaces plus the global one; `Reserch` is a deliberate near-miss. */
+const WORKSPACES = [
+  { id: 'ws-research-id', name: 'Research' },
+  { id: 'ws-blog-id', name: 'Blog' }
+];
+
+function makeResolver(): WorkspaceResolverLike & { getWorkspaceByNameOrId: jest.Mock } {
+  return {
+    getWorkspaceByNameOrId: jest.fn(async (identifier: string) => {
+      const match = WORKSPACES.find(ws => ws.id === identifier || ws.name.toLowerCase() === identifier.toLowerCase());
+      return match ? { id: match.id } : null;
+    })
+  };
+}
+
+interface SessionServiceStub {
+  getSession: jest.Mock;
+  getAllSessions: jest.Mock;
+  createSession: jest.Mock;
+  updateSession: jest.Mock;
+}
+
+function makeSessionService(): SessionServiceStub {
+  return {
+    getSession: jest.fn().mockResolvedValue(null),
+    getAllSessions: jest.fn().mockResolvedValue([]),
+    createSession: jest.fn().mockResolvedValue(undefined),
+    updateSession: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+/** In-memory store standing in for the vault file. */
+class MemoryBindingsStore implements SessionBindingsStore {
+  doc: PersistedSessionBindings | null = null;
+  saves = 0;
+  async load(): Promise<PersistedSessionBindings | null> {
+    return this.doc ? JSON.parse(JSON.stringify(this.doc)) : null;
+  }
+  async save(doc: PersistedSessionBindings): Promise<void> {
+    this.saves += 1;
+    this.doc = JSON.parse(JSON.stringify(doc));
+  }
+}
+
+function makeManager(options: {
+  sessionService?: SessionServiceStub;
+  resolver?: WorkspaceResolverLike | null;
+  store?: SessionBindingsStore | null;
+} = {}): { manager: SessionContextManager; sessionService: SessionServiceStub } {
+  const sessionService = options.sessionService ?? makeSessionService();
+  const manager = new SessionContextManager();
+  manager.setSessionService(sessionService);
+  manager.setWorkspaceResolver(options.resolver === undefined ? makeResolver() : options.resolver);
+  if (options.store) {
+    manager.setBindingsStore(options.store);
+  }
+  return { manager, sessionService };
+}
+
+/**
+ * A toolManager agent whose useTools/getTools are the REAL tools over a real
+ * ToolCliNormalizer, so the unbound-useTools steer comes from production code
+ * rather than a stub. The batch service is stubbed: it records the context it
+ * was handed and returns whatever the test says the workspace guard decided.
+ */
+function makeToolManagerAgent(batchResult: () => unknown = () => ({ success: true })): {
+  agent: IAgent;
+  batchExecute: jest.Mock;
+} {
+  // Minimal registry so normalizeExecutionCalls can resolve `content read`
+  // and `memory load-workspace` — the normalizer rejects unknown commands.
+  const readTool = {
+    slug: 'read', name: 'Read', description: 'Read a note', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
+  const loadWorkspaceTool = {
+    slug: 'loadWorkspace', name: 'Load Workspace', description: 'Load a workspace', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: { workspace: { type: 'string' } }, required: ['workspace'] }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
+  const stubAgent = (name: string, tool: ITool): IAgent => ({
+    name, description: '', version: '1.0.0',
+    getTools: () => [tool],
+    getTool: (slug: string) => (slug === tool.slug ? tool : undefined),
+    initialize: jest.fn(), executeTool: jest.fn(), setAgentManager: jest.fn()
+  });
+  const registry = new Map<string, IAgent>([
+    ['contentManager', stubAgent('contentManager', readTool)],
+    ['memoryManager', stubAgent('memoryManager', loadWorkspaceTool)]
+  ]);
+  const normalizer = new ToolCliNormalizer(registry);
+  const batchExecute = jest.fn(async () => batchResult());
+  const batchService = { execute: batchExecute } as unknown as ToolBatchExecutionService;
+  const useTools = new UseToolTool(batchService, normalizer);
+  const getTools = new GetToolsTool(registry, { workspaces: [], customAgents: [], vaultRoot: [] });
+  const tools = new Map<string, ITool>([['useTools', useTools], ['getTools', getTools]]);
+  const agent: IAgent = {
+    name: 'toolManager',
+    description: '',
+    version: '1.0.0',
+    getTools: () => Array.from(tools.values()),
+    getTool: (slug: string) => tools.get(slug),
+    initialize: jest.fn(),
+    executeTool: jest.fn(async (slug: string, params: Record<string, unknown>) => {
+      const tool = tools.get(slug);
+      if (!tool) throw new Error(`unknown tool ${slug}`);
+      return tool.execute(params);
+    }),
+    setAgentManager: jest.fn()
+  };
+  return { agent, batchExecute };
+}
+
+interface Captured {
+  result?: ToolExecutionResult;
+  sessionInfo?: SessionInfo;
+}
+
+function makeDeps(captured: Captured): IRequestHandlerDependencies {
+  return {
+    validationService: {
+      validateToolParams: jest.fn(async (params: Record<string, unknown>) => params),
+      validateSessionId: jest.fn(),
+      validateBatchOperations: jest.fn(),
+      validateBatchPaths: jest.fn()
+    },
+    sessionService: {
+      processSessionId: jest.fn(async (sessionId: string | undefined) => ({
+        sessionId: sessionId ?? 's-fallback',
+        isNewSession: false,
+        isNonStandardId: false
+      })),
+      generateSessionId: jest.fn(),
+      isStandardSessionId: jest.fn(),
+      shouldInjectInstructions: jest.fn().mockReturnValue(false)
+    },
+    toolExecutionService: {
+      // Real dispatch into the agent so a thrown normalizer steer propagates
+      // exactly the way ToolExecutionService.executeAgent rethrows it.
+      executeAgent: jest.fn(async (agent: IAgent, tool: string, params: Record<string, unknown>) => {
+        return await agent.executeTool(tool, params) as ToolExecutionResult;
+      })
+    },
+    responseFormatter: {
+      formatToolExecutionResponse: jest.fn((result: ToolExecutionResult, sessionInfo?: SessionInfo) => {
+        captured.result = result;
+        captured.sessionInfo = sessionInfo;
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }),
+      formatSessionInstructions: jest.fn((_id, r) => r),
+      formatErrorResponse: jest.fn((err) => ({ content: [{ type: 'text', text: err.message }] }))
+    },
+    toolListService: {} as never,
+    resourceListService: {} as never,
+    resourceReadService: {} as never,
+    promptsListService: {} as never,
+    toolHelpService: {} as never,
+    schemaEnhancementService: {} as never
+  };
+}
+
+const ENVELOPE = {
+  sessionId: 'nexus-cli',
+  memory: 'Listed the vault and the workspaces.',
+  goal: 'Read one note.'
+};
+
+function useToolsRequest(extra: Record<string, unknown> = {}) {
+  return {
+    params: {
+      name: 'toolManager_useTools',
+      arguments: { ...ENVELOPE, tool: 'content read --path notes/a.md', ...extra }
+    }
+  };
+}
+
+function getToolsRequest(extra: Record<string, unknown> = {}) {
+  return {
+    params: {
+      name: 'toolManager_getTools',
+      arguments: { ...ENVELOPE, tool: '--help', ...extra }
+    }
+  };
+}
+
+function makeStrategy(manager: SessionContextManager, agentFactory = makeToolManagerAgent) {
+  const captured: Captured = {};
+  const { agent, batchExecute } = agentFactory();
+  const strategy = new ToolExecutionStrategy(makeDeps(captured), () => agent, manager);
+  return { strategy, captured, batchExecute };
+}
+
+// ---------------------------------------------------------------------------
+// Resolution order
+// ---------------------------------------------------------------------------
+
+describe('resolution order: explicit → bound → unbound', () => {
+  it('explicit beats bound: a call that names a workspace runs there even when the session is bound elsewhere', async () => {
+    const { manager } = makeManager();
+    manager.bindHandleWorkspace('nexus-cli', 'ws-blog-id');
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+
+    expect(batchExecute).toHaveBeenCalledTimes(1);
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('bound beats nothing: a call with no workspaceId inherits the session\'s bind', async () => {
+    const { manager } = makeManager();
+    manager.bindHandleWorkspace('nexus-cli', 'ws-research-id');
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest());
+
+    expect(batchExecute).toHaveBeenCalledTimes(1);
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('an empty-string workspaceId counts as absent and inherits, exactly like omitting it (#214)', async () => {
+    const { manager } = makeManager();
+    manager.bindHandleWorkspace('nexus-cli', 'ws-research-id');
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: '   ' }));
+
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('unbound useTools fails with the reworded "pass it once" steer and runs nothing', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest());
+
+    expect(batchExecute).not.toHaveBeenCalled();
+    expect(captured.result?.success).toBe(false);
+    expect(captured.result?.error).toContain(WORKSPACE_ID_REQUIRED_MESSAGE);
+    // The steer teaches "once", never the every-call habit it replaces.
+    expect(captured.result?.error).toMatch(/inherit/);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('unbound getTools proceeds, partitions the session under "default", and does NOT bind', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(getToolsRequest());
+
+    expect(captured.result?.success).toBe(true);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'default', name: 'nexus-cli' })
+    );
+    // Discovery chose nothing, so nothing is remembered: the next useTools
+    // still has to name a workspace once.
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('the handle partition follows the resolved workspace, so the same handle in two workspaces is two sessions', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+    await strategy.handle(useToolsRequest({ workspaceId: 'Blog' }));
+
+    const created = sessionService.createSession.mock.calls.map(call => call[0].workspaceId);
+    expect(created).toEqual(['ws-research-id', 'ws-blog-id']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bind point 1 — explicit workspaceId on a useTools call whose result did not fail
+// ---------------------------------------------------------------------------
+
+describe('bind point 1: explicit useTools workspaceId', () => {
+  it('binds the handle when the workspace was explicit and the result did not fail', async () => {
+    const { manager } = makeManager();
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+  });
+
+  it('never binds off a returned { success: false } — a rejected workspace is not a choice', async () => {
+    // handle() sets its local `success = true` for any non-throwing call, so
+    // a bind keyed off that flag would remember the very value the batch
+    // service just refused. The check must read the result.
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager, () =>
+      makeToolManagerAgent(() => ({ success: false, error: 'Invalid workspace "Nope".' }))
+    );
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Nope' }));
+
+    expect(captured.result?.success).toBe(false);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('never binds off a thrown error either', async () => {
+    const { manager } = makeManager();
+    const { strategy } = makeStrategy(manager, () =>
+      makeToolManagerAgent(() => { throw new Error('boom'); })
+    );
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('an inherited workspace is not a new choice: no re-bind, and no bind for getTools', async () => {
+    const { manager } = makeManager();
+    manager.bindHandleWorkspace('nexus-cli', 'ws-research-id');
+    const bind = jest.spyOn(manager, 'bindHandleWorkspace');
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest());
+    await strategy.handle(getToolsRequest({ workspaceId: 'Blog' }));
+
+    expect(bind).not.toHaveBeenCalled();
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+  });
+
+  it('switching is the same gesture as choosing: pass a different value once', async () => {
+    const { manager } = makeManager();
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+    await strategy.handle(useToolsRequest({ workspaceId: 'Blog' }));
+    await strategy.handle(useToolsRequest());
+
+    expect(batchExecute.mock.calls.map(call => call[0].context.workspaceId))
+      .toEqual(['ws-research-id', 'ws-blog-id', 'ws-blog-id']);
+  });
+
+  it('binds the display handle too when the caller\'s handle was renamed, so the renamed name also inherits', async () => {
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValue([{ id: 's-other', workspaceId: 'ws-research-id', name: 'nexus-cli' }]);
+    const { manager } = makeManager({ sessionService });
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+
+    expect(captured.sessionInfo?.displaySessionId).toBe('nexus-cli-2');
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+    expect(manager.resolveHandleWorkspace('nexus-cli-2')).toBe('ws-research-id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bind point 2 — a successful `memory load-workspace` inside a batch
+// ---------------------------------------------------------------------------
+
+describe('bind point 2: memory load-workspace', () => {
+  function makeLoadWorkspaceBatch(loadResult: () => unknown, manager: SessionContextManager) {
+    const loadWorkspace: ITool = {
+      slug: 'loadWorkspace',
+      name: 'Load Workspace',
+      description: '',
+      version: '1.0.0',
+      execute: jest.fn(async () => loadResult()),
+      getParameterSchema: jest.fn().mockReturnValue({}),
+      getResultSchema: jest.fn().mockReturnValue({}),
+      getExecutionPolicy: () => ({ effect: 'read', parallelSafe: true, replay: 'never' } as never)
+    } as unknown as ITool;
+    const memoryManager: IAgent = {
+      name: 'memoryManager',
+      description: '',
+      version: '1.0.0',
+      getTools: () => [loadWorkspace],
+      getTool: (slug: string) => (slug === 'loadWorkspace' ? loadWorkspace : undefined),
+      initialize: jest.fn(),
+      executeTool: jest.fn(),
+      setAgentManager: jest.fn()
+    };
+    // The batch service reaches the manager the way it reaches WorkspaceService:
+    // getNexusPlugin(app) → plugin.getService('sessionContextManager').
+    const app = {
+      plugins: {
+        getPlugin: () => ({
+          getService: async (name: string) => (name === 'sessionContextManager' ? manager : null)
+        })
+      }
+    } as unknown as App;
+    const service = new ToolBatchExecutionService(app, new Map([['memoryManager', memoryManager]]));
+    return { service, execute: loadWorkspace.execute as jest.Mock };
+  }
+
+  const LOADED_RESEARCH = {
+    success: true,
+    data: { context: { name: 'Research', rootFolder: 'Research', recentActivity: [] } },
+    workspaceContext: { workspaceId: 'ws-research-id', workspacePath: [] },
+    resolution: {
+      requested: 'Reserch',
+      autoResolved: true,
+      resolvedTo: { id: 'ws-research-id', name: 'Research' },
+      note: 'No workspace is named Reserch.'
+    }
+  };
+
+  async function run(service: ToolBatchExecutionService, sessionId: string) {
+    return service.execute({
+      context: { workspaceId: 'default', sessionId, memory: 'm', goal: 'g' },
+      calls: [{ agent: 'memoryManager', tool: 'loadWorkspace', params: { workspace: 'Reserch' } }]
+    });
+  }
+
+  it('a near-miss load binds the RESOLVED workspace\'s id, not the typo the caller sent', async () => {
+    const { manager } = makeManager();
+    // Give the internal id a friendly handle so the by-id bind can reach it.
+    const validated = await manager.validateSessionId('nexus-cli', undefined, 'default');
+    const { service } = makeLoadWorkspaceBatch(() => LOADED_RESEARCH, manager);
+
+    const result = await run(service, validated.id);
+
+    expect(result.success).toBe(true);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+    expect(manager.resolveHandleWorkspace(validated.id)).toBe('ws-research-id');
+    expect(manager.resolveHandleWorkspace('Reserch')).toBeUndefined();
+  });
+
+  it('falls back to the resolved name and canonicalises it when the result carries no workspaceContext', async () => {
+    const { manager } = makeManager();
+    const validated = await manager.validateSessionId('nexus-cli', undefined, 'default');
+    const { workspaceContext: _stripped, ...withoutContext } = LOADED_RESEARCH;
+    const { service } = makeLoadWorkspaceBatch(() => ({
+      ...withoutContext,
+      resolution: { ...withoutContext.resolution, resolvedTo: { name: 'Research' } }
+    }), manager);
+
+    await run(service, validated.id);
+
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+  });
+
+  it('a failed load binds nothing', async () => {
+    const { manager } = makeManager();
+    const validated = await manager.validateSessionId('nexus-cli', undefined, 'default');
+    const { service } = makeLoadWorkspaceBatch(() => ({
+      success: false,
+      error: 'Workspace not found',
+      data: { context: { name: 'Unknown', rootFolder: '', recentActivity: [] } }
+    }), manager);
+
+    const result = await run(service, validated.id);
+
+    expect(result.success).toBe(false);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('the bind then feeds resolution: the next call in that session inherits the loaded workspace', async () => {
+    const { manager } = makeManager();
+    const { strategy: first, batchExecute } = makeStrategy(manager);
+    // First call: explicit default so it runs; the batch (stubbed here) is
+    // where load-workspace would execute. Simulate its bind by id.
+    await first.handle(useToolsRequest({ workspaceId: 'default', tool: 'memory load-workspace Reserch' }));
+    const internalId = batchExecute.mock.calls[0][0].context.sessionId as string;
+    manager.bindSessionWorkspaceById(internalId, 'ws-research-id');
+
+    await first.handle(useToolsRequest());
+
+    expect(batchExecute.mock.calls[1][0].context.workspaceId).toBe('ws-research-id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical ids
+// ---------------------------------------------------------------------------
+
+describe('canonicalisation', () => {
+  it('a name and its id bind to the same canonical id', async () => {
+    const { manager } = makeManager();
+    expect(await manager.canonicalizeWorkspaceId('Research')).toBe('ws-research-id');
+    expect(await manager.canonicalizeWorkspaceId('research')).toBe('ws-research-id');
+    expect(await manager.canonicalizeWorkspaceId('ws-research-id')).toBe('ws-research-id');
+  });
+
+  it('"default" passes through without a lookup', async () => {
+    const resolver = makeResolver();
+    const { manager } = makeManager({ resolver });
+    expect(await manager.canonicalizeWorkspaceId(' default ')).toBe('default');
+    expect(resolver.getWorkspaceByNameOrId).not.toHaveBeenCalled();
+  });
+
+  it('an unresolvable value stays raw so the batch service can reject it with its steer', async () => {
+    const { manager } = makeManager();
+    expect(await manager.canonicalizeWorkspaceId('Nope')).toBe('Nope');
+  });
+
+  it('a lookup that throws degrades to the raw value instead of failing the call', async () => {
+    const resolver: WorkspaceResolverLike = {
+      getWorkspaceByNameOrId: jest.fn().mockRejectedValue(new Error('storage cold'))
+    };
+    const { manager } = makeManager({ resolver });
+    expect(await manager.canonicalizeWorkspaceId('Research')).toBe('Research');
+  });
+
+  it('the handle partition and the bind both use the canonical id, whichever spelling the caller used', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+    await strategy.handle(useToolsRequest({ workspaceId: 'ws-research-id', sessionId: 'other' }));
+
+    expect(sessionService.createSession.mock.calls.map(call => call[0].workspaceId))
+      .toEqual(['ws-research-id', 'ws-research-id']);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+    expect(manager.resolveHandleWorkspace('other')).toBe('ws-research-id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe('persistence: session-bindings.json', () => {
+  it('handles and bindings round-trip through the store, and a restored handle resumes its session (no -2)', async () => {
+    const store = new MemoryBindingsStore();
+    const sessionService = makeSessionService();
+    const { manager: before } = makeManager({ store, sessionService });
+    const { strategy } = makeStrategy(before);
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Research' }));
+    const firstId = sessionService.createSession.mock.calls[0][0].id as string;
+    await before.flushBindings();
+
+    expect(store.doc?.handleWorkspace['nexus-cli']).toBe('ws-research-id');
+    expect(store.doc?.handles['ws-research-id::nexus-cli']?.id).toBe(firstId);
+
+    // "Reload": a fresh manager over the same store. Storage still lists the
+    // session, so the handle must resume it — this is the exact scenario that
+    // used to rename the CLI's session to nexus-cli-2 on every plugin reload.
+    const afterService = makeSessionService();
+    afterService.getAllSessions.mockImplementation(async (workspaceId: string) =>
+      workspaceId === 'ws-research-id' ? [{ id: firstId, workspaceId, name: 'nexus-cli' }] : []
+    );
+    const { manager: after } = makeManager({ store, sessionService: afterService });
+
+    expect(await after.resolveWorkspaceForSession(undefined, 'nexus-cli'))
+      .toEqual({ workspaceId: 'ws-research-id', explicit: false });
+    const resumed = await after.validateSessionId('nexus-cli', undefined, 'ws-research-id');
+    expect(resumed.id).toBe(firstId);
+    expect(resumed.created).toBe(false);
+    expect(resumed.displaySessionId).toBe('nexus-cli');
+    expect(afterService.createSession).not.toHaveBeenCalled();
+  });
+
+  it('a restored handle whose session was deleted is dropped, and the handle gets a fresh session', async () => {
+    const store = new MemoryBindingsStore();
+    store.doc = {
+      handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
+      handleWorkspace: { 'nexus-cli': 'default' }
+    };
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValue([]); // deleted while unloaded
+    const { manager } = makeManager({ store, sessionService });
+
+    const result = await manager.validateSessionId('nexus-cli', undefined, 'default');
+
+    expect(result.created).toBe(true);
+    expect(result.id).not.toBe('s-20260101000000');
+    // Not renamed either: the stale display name must not force a suffix.
+    expect(result.displaySessionId).toBe('nexus-cli');
+    await manager.flushBindings();
+    expect(store.doc?.handles['default::nexus-cli']?.id).toBe(result.id);
+  });
+
+  it('a storage lookup that throws keeps the restored handle rather than renaming a live session', async () => {
+    const store = new MemoryBindingsStore();
+    store.doc = {
+      handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
+      handleWorkspace: {}
+    };
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockRejectedValue(new Error('storage cold'));
+    const { manager } = makeManager({ store, sessionService });
+
+    const result = await manager.validateSessionId('nexus-cli', undefined, 'default');
+
+    expect(result.id).toBe('s-20260101000000');
+    expect(result.created).toBe(false);
+  });
+
+  it('a corrupt file loads as empty without throwing', async () => {
+    const adapter = {
+      exists: jest.fn().mockResolvedValue(true),
+      read: jest.fn().mockResolvedValue('{ not json'),
+      write: jest.fn(),
+      mkdir: jest.fn()
+    };
+    const store = new VaultSessionBindingsStore(adapter as never, '.obsidian/plugins/nexus/data/session-bindings.json');
+
+    await expect(store.load()).resolves.toBeNull();
+
+    const { manager } = makeManager({ store });
+    await expect(manager.resolveWorkspaceForSession(undefined, 'nexus-cli'))
+      .resolves.toEqual({ workspaceId: undefined, explicit: false });
+  });
+
+  it('a foreign or half-typed document is filtered field by field, never trusted wholesale', () => {
+    expect(parsePersistedSessionBindings(null)).toBeNull();
+    expect(parsePersistedSessionBindings([])).toBeNull();
+    expect(parsePersistedSessionBindings({
+      handles: { ok: { id: 'a', displaySessionId: 'b', workspaceId: 'c' }, bad: { id: 1 } },
+      handleWorkspace: { h: 'ws', blank: '   ', wrong: 7 },
+      cliCurrentSession: 'nexus-cli' // PR 2's slot: ignored, not fatal
+    })).toEqual({
+      handles: { ok: { id: 'a', displaySessionId: 'b', workspaceId: 'c' } },
+      handleWorkspace: { h: 'ws' }
+    });
+  });
+
+  it('writes are debounced into one save per burst and flushed on cleanup', async () => {
+    jest.useFakeTimers();
+    try {
+      const store = new MemoryBindingsStore();
+      const { manager } = makeManager({ store });
+
+      manager.bindHandleWorkspace('a', 'ws-research-id');
+      manager.bindHandleWorkspace('b', 'ws-blog-id');
+      manager.bindHandleWorkspace('c', 'default');
+      expect(store.saves).toBe(0);
+
+      await jest.advanceTimersByTimeAsync(1000);
+      expect(store.saves).toBe(1);
+      expect(Object.keys(store.doc?.handleWorkspace ?? {})).toEqual(['a', 'b', 'c']);
+
+      manager.bindHandleWorkspace('d', 'default');
+      manager.cleanup();
+      await Promise.resolve();
+      expect(store.saves).toBe(2);
+      expect(store.doc?.handleWorkspace.d).toBe('default');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('the vault store creates the data folder and writes through the adapter, never Node fs', async () => {
+    const files = new Map<string, string>();
+    const dirs = new Set<string>();
+    const adapter = {
+      exists: jest.fn(async (p: string) => files.has(p) || dirs.has(p)),
+      read: jest.fn(async (p: string) => files.get(p) ?? ''),
+      write: jest.fn(async (p: string, data: string) => { files.set(p, data); }),
+      mkdir: jest.fn(async (p: string) => { dirs.add(p); })
+    };
+    const path = '.obsidian/plugins/nexus/data/session-bindings.json';
+    const store = new VaultSessionBindingsStore(adapter as never, path);
+
+    await store.save({ handles: {}, handleWorkspace: { 'nexus-cli': 'ws-research-id' } });
+
+    expect(adapter.mkdir).toHaveBeenCalledWith('.obsidian/plugins/nexus/data');
+    expect(await store.load()).toEqual({ handles: {}, handleWorkspace: { 'nexus-cli': 'ws-research-id' } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clientName — the per-connection hook PR 2 keys the CLI default off
+// ---------------------------------------------------------------------------
+
+describe('clientName from the MCP initialize handshake', () => {
+  function captureToolsCall(getClientVersion: (() => { name: string; version: string } | undefined) | undefined) {
+    const handlers = new Map<string, (request: unknown) => Promise<unknown>>();
+    const server = {
+      setRequestHandler: jest.fn((schema: { shape?: { method?: { value?: string } } }, handler: (r: unknown) => Promise<unknown>) => {
+        // The SDK schemas expose the literal method under shape.method.value.
+        handlers.set(schema.shape?.method?.value ?? String(handlers.size), handler);
+      }),
+      ...(getClientVersion ? { getClientVersion } : {})
+    } as unknown as MCPSDKServer;
+    const handleRequest = jest.fn(async () => ({ content: [] }));
+    const router = { handleRequest } as unknown as RequestRouter;
+    new RequestHandlerFactory(server, router).initializeHandlers();
+    const toolsCall = handlers.get('tools/call');
+    if (!toolsCall) throw new Error('tools/call handler was not registered');
+    return { toolsCall, handleRequest };
+  }
+
+  it('attaches clientName from getClientVersion(), outside the tool arguments', async () => {
+    const { toolsCall, handleRequest } = captureToolsCall(() => ({ name: 'nexus-cli', version: '0.1.0' }));
+
+    await toolsCall({ params: { name: 'toolManager_getTools', arguments: { tool: '--help' } } });
+
+    const routed = handleRequest.mock.calls[0] as unknown as [string, Record<string, unknown>];
+    expect(routed[0]).toBe('tools/call');
+    expect(routed[1].clientName).toBe('nexus-cli');
+    expect((routed[1].params as { arguments: Record<string, unknown> }).arguments).not.toHaveProperty('clientName');
+  });
+
+  it('is absent when the SDK has no client info, and when the method itself is missing', async () => {
+    const noInfo = captureToolsCall(() => undefined);
+    await noInfo.toolsCall({ params: { name: 'toolManager_getTools', arguments: { tool: '--help' } } });
+    expect((noInfo.handleRequest.mock.calls[0] as unknown as [string, Record<string, unknown>])[1].clientName).toBeUndefined();
+
+    const noMethod = captureToolsCall(undefined);
+    await noMethod.toolsCall({ params: { name: 'toolManager_getTools', arguments: { tool: '--help' } } });
+    expect((noMethod.handleRequest.mock.calls[0] as unknown as [string, Record<string, unknown>])[1].clientName).toBeUndefined();
+  });
+
+  it('is threaded onto IRequestContext by the strategy', async () => {
+    const { manager } = makeManager();
+    const { strategy } = makeStrategy(manager);
+    const build = (strategy as unknown as {
+      buildRequestContext(request: unknown): Promise<IRequestContext>;
+    }).buildRequestContext.bind(strategy);
+
+    const withName = await build({ ...getToolsRequest(), clientName: 'nexus-cli' });
+    const withoutName = await build(getToolsRequest());
+
+    expect(withName.clientName).toBe('nexus-cli');
+    expect(withoutName.clientName).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AgentExecutionManager — the direct-form chat path uses the same resolution
+// ---------------------------------------------------------------------------
+
+describe('AgentExecutionManager.processSessionContext shares the resolution order', () => {
+  function makeDirectFormManager(manager: SessionContextManager) {
+    const tool = {
+      slug: 'runStub',
+      name: 'stub',
+      description: '',
+      version: '1.0.0',
+      execute: jest.fn(async () => ({ success: true })),
+      getParameterSchema: jest.fn(),
+      getResultSchema: jest.fn()
+    } as unknown as ITool;
+    const agent: IAgent = {
+      name: 'stubAgent',
+      description: '',
+      version: '1.0.0',
+      getTools: () => [tool],
+      getTool: (slug: string) => (slug === 'runStub' ? tool : undefined),
+      initialize: jest.fn(),
+      executeTool: jest.fn(async () => ({ success: true })),
+      setAgentManager: jest.fn()
+    };
+    const registry = new AgentRegistry();
+    (registry as unknown as { registerAgent: (a: IAgent) => void }).registerAgent(agent);
+    return new AgentExecutionManager(registry, manager);
+  }
+
+  it('partitions a direct-form chat handle under the chat\'s context.workspaceId, not silently under default', async () => {
+    // DirectToolExecutor fills `context.workspaceId` from the chat selection;
+    // the old top-level-only read ignored it and filed every such handle
+    // under 'default'.
+    const { manager, sessionService } = makeManager();
+    const aem = makeDirectFormManager(manager);
+
+    await aem.executeAgentTool('stubAgent', 'runStub', {
+      sessionId: 'chat handle',
+      context: { sessionId: 'chat handle', workspaceId: 'Research' }
+    });
+
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'chat handle', workspaceId: 'ws-research-id' })
+    );
+  });
+
+  it('falls back to the handle\'s bind when the call names no workspace at all', async () => {
+    const { manager, sessionService } = makeManager();
+    manager.bindHandleWorkspace('chat handle', 'ws-blog-id');
+    const aem = makeDirectFormManager(manager);
+
+    await aem.executeAgentTool('stubAgent', 'runStub', { sessionId: 'chat handle' });
+
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'ws-blog-id' })
+    );
+  });
+});

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -115,8 +115,14 @@ function makeManager(options: {
  * ToolCliNormalizer, so the unbound-useTools steer comes from production code
  * rather than a stub. The batch service is stubbed: it records the context it
  * was handed and returns whatever the test says the workspace guard decided.
+ * `batchResult` receives the batch params so a test can act mid-execution the
+ * way the real service does (bind point 2 fires inside `execute`).
  */
-function makeToolManagerAgent(batchResult: () => unknown = () => ({ success: true })): {
+type BatchParams = Parameters<ToolBatchExecutionService['execute']>[0];
+
+function makeToolManagerAgent(
+  batchResult: (params: BatchParams) => unknown = () => ({ success: true })
+): {
   agent: IAgent;
   batchExecute: jest.Mock;
 } {
@@ -145,7 +151,7 @@ function makeToolManagerAgent(batchResult: () => unknown = () => ({ success: tru
     ['memoryManager', stubAgent('memoryManager', loadWorkspaceTool)]
   ]);
   const normalizer = new ToolCliNormalizer(registry);
-  const batchExecute = jest.fn(async () => batchResult());
+  const batchExecute = jest.fn(async (params: BatchParams) => batchResult(params));
   const batchService = { execute: batchExecute } as unknown as ToolBatchExecutionService;
   const useTools = new UseToolTool(batchService, normalizer);
   const getTools = new GetToolsTool(registry, { workspaces: [], customAgents: [], vaultRoot: [] });
@@ -516,6 +522,22 @@ describe('bind point 2: memory load-workspace', () => {
     await first.handle(useToolsRequest());
 
     expect(batchExecute.mock.calls[1][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('when both bind points fire in one call, the loaded workspace wins over the explicit workspaceId', async () => {
+    // `nexus use --workspace Blog -- memory load-workspace Research`: bind
+    // point 2 binds Research while the batch runs; bind point 1 runs after
+    // and must not overwrite it with Blog — loading is the more deliberate
+    // act and it happened later in the same call.
+    const { manager } = makeManager();
+    const { strategy } = makeStrategy(manager, () => makeToolManagerAgent((params) => {
+      manager.bindSessionWorkspaceById(params.context.sessionId as string, 'ws-research-id');
+      return { success: true };
+    }));
+
+    await strategy.handle(useToolsRequest({ workspaceId: 'Blog', tool: 'memory load-workspace Research' }));
+
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
   });
 });
 

--- a/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
+++ b/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
@@ -110,6 +110,10 @@ function makeContextManager(overrides: Partial<SessionContextManager> = {}): Ses
       return trimmed ? { workspaceId: trimmed, explicit: true } : { workspaceId: undefined, explicit: false };
     }),
     bindHandleWorkspace: jest.fn(),
+    // Nothing bound before or after the call, so bind point 1 never sees a
+    // mid-call load-workspace bind here (that ordering is pinned in
+    // SessionStickyWorkspace.test.ts).
+    resolveHandleWorkspace: jest.fn().mockReturnValue(undefined),
     applyWorkspaceContext: jest.fn((_id: string, p: Record<string, unknown>) => p),
     updateFromResult: jest.fn(),
     updateSessionDescription: jest.fn(),

--- a/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
+++ b/tests/unit/ToolExecutionStrategy.buildRequestContext.test.ts
@@ -103,6 +103,13 @@ function makeDeps(captured: CapturedExecution): IRequestHandlerDependencies {
 function makeContextManager(overrides: Partial<SessionContextManager> = {}): SessionContextManager {
   return {
     validateSessionId: jest.fn(),
+    // Identity resolution: an explicit value is used as-is, nothing is bound.
+    // The resolution order itself is covered in SessionStickyWorkspace.test.ts.
+    resolveWorkspaceForSession: jest.fn(async (explicit: unknown) => {
+      const trimmed = typeof explicit === 'string' ? explicit.trim() : '';
+      return trimmed ? { workspaceId: trimmed, explicit: true } : { workspaceId: undefined, explicit: false };
+    }),
+    bindHandleWorkspace: jest.fn(),
     applyWorkspaceContext: jest.fn((_id: string, p: Record<string, unknown>) => p),
     updateFromResult: jest.fn(),
     updateSessionDescription: jest.fn(),

--- a/tests/unit/connector.session.test.ts
+++ b/tests/unit/connector.session.test.ts
@@ -15,16 +15,22 @@
  *
  * That connector path was dead (no callers) and has been removed; the live
  * MCP path is `ToolExecutionStrategy.processSession`, which calls the same
- * 3-arg `validateSessionId(sessionId, memory, workspaceId)` seam. The
- * tests remain as a direct contract pin on
- * `SessionContextManager.validateSessionId` under those inputs.
+ * 3-arg `validateSessionId(sessionId, memory, workspaceId)` seam. No live
+ * path synthesizes the literal 'Default Session' any more — here it is just
+ * a friendly handle like any other — so these tests remain as a direct
+ * contract pin on `SessionContextManager.validateSessionId`: a friendly
+ * handle creates one session, is reused on the next call, carries `memory`
+ * as the description, and is partitioned under the supplied workspace.
  *
- * Backend-reviewer flag (preserved verbatim): the friendly-name
- * workspaceId is passed straight through to the validator, so a model
- * that sends `workspaceId: "Engineering"` will get a session bound to
- * the literal name "Engineering" rather than its resolved UUID. The
- * test below documents the current behavior; it is not asserted to
- * be desired or undesired.
+ * Backend-reviewer flag, now resolved upstream: `validateSessionId` still
+ * passes a friendly-name workspaceId straight through (it is the partition
+ * key, not a lookup), but the live callers — `processSession` and
+ * `AgentExecutionManager.processSessionContext` — canonicalise the value via
+ * `SessionContextManager.resolveWorkspaceForSession` BEFORE calling it, so a
+ * model that sends `workspaceId: "Engineering"` is partitioned under that
+ * workspace's id. The last test pins the seam's pass-through so the
+ * canonicalisation is known to live in exactly one place (#214;
+ * tests/unit/SessionStickyWorkspace.test.ts covers it).
  */
 
 import { SessionContextManager } from '../../src/services/SessionContextManager';
@@ -129,13 +135,11 @@ describe("connector session resolution — 'Default Session' default + 3-arg val
     );
   });
 
-  it('documents current behavior: friendly-name workspaceId is passed straight through to createSession', async () => {
-    // Backend-reviewer flag: the connector does not resolve a friendly
-    // workspace handle (e.g., "Engineering") to its UUID before calling
-    // validateSessionId. As a result, the resulting session is bound
-    // to the literal name as its workspaceId. This test pins that
-    // behavior; whether it is desired is a product decision, not a
-    // test concern.
+  it('passes the workspaceId it is given straight through to createSession (canonicalisation is the caller\'s job)', async () => {
+    // validateSessionId treats workspaceId as the partition key and never
+    // looks it up. The live callers canonicalise first (see the docblock);
+    // pinning the pass-through here keeps that lookup in one place instead
+    // of letting a second copy grow inside the validator.
     const manager = new SessionContextManager();
     const sessionService = makeSessionService();
     manager.setSessionService(sessionService);

--- a/tool-schemas.json
+++ b/tool-schemas.json
@@ -1,22 +1,22 @@
 {
   "schemaVersion": 1,
   "nexusVersion": "5.18.6",
-  "generatedAt": "2026-09-08T20:49:25.172Z",
+  "generatedAt": "2026-09-12T15:56:20.428Z",
   "toolCount": 2,
   "tools": [
     {
       "name": "toolManager_getTools",
-      "description": "REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.\nThis returns CLI-oriented command metadata for the tools you need next.\nSend workspaceId, sessionId, memory, goal, and constraints at the top level.\nUse one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.\nDo not send a nested \"context\" object or legacy \"request\" array.\n\nWorkflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands\nKnown-good example: {\"workspaceId\":\"default\",\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available storage tools.\",\"tool\":\"storage move, content read\"}\nExample selectors: tool=\"--help\", tool=\"storage\", tool=\"storage move\", tool=\"storage move, content read\"\n\nAgents:\ncontent: [read,write,replace,insert,setProperty,removeProperty]\nstorage: [list,createFolder,move,copy,archive,open]\nsearch: [content,directory,memory,queryNotes]\nmemory: [createState,listStates,loadState,updateState,archiveState,createWorkspace,listWorkspaces,searchWorkspaces,loadWorkspace,updateWorkspace,archiveWorkspace,run]\nprompt: [list,get,create,update,archive,listModels,execute,generateImage,generateAudio,generateVideo,checkGeneratedArtifact,subagent]\ncanvas: [read,write,update,list]\nbase: [read,write,update,list,analyze]\ntask: [createProject,listProjects,updateProject,archiveProject,create,list,open,update,move,query,linkNote]\ningest: [run,capabilities]\nelevenlabs: [listVoices,soundEffects,generateMusic]\ncomposer: [compose,listFormats]\nweb: [open,capture-markdown,capture-png,capture-pdf,links]\nskills: [listSkills,loadSkill,createSkill,updateSkill,archiveSkill,syncSkills]\ndata: [runPython,listCapabilities]\n\nExisting workspaces: not listed here. The getTools RESULT carries the live list — read \"workspaces\" there and pass one of those exact names. Never infer a workspace name from the user's wording.",
+      "description": "REQUIRED FIRST STEP: You MUST call getTools BEFORE calling useTools.\nThis returns CLI-oriented command metadata for the tools you need next.\nSend sessionId, memory, goal, and constraints at the top level.\nThe workspace is remembered per session: the first useTools call of a fresh session passes \"workspaceId\" once (\"default\" or an exact name from the workspaces list this call returns) or runs \"memory load-workspace\"; later calls inherit it. Omit \"workspaceId\" unless you are deliberately switching. getTools itself never needs it.\nUse one stable human-readable session name for the conversation. Reuse that same sessionId value for every getTools/useTools call in the chat; do not invent a new sessionId per tool or per saved state. Nexus stores an internal UUID silently.\nDo not send a nested \"context\" object or legacy \"request\" array.\n\nWorkflow: 1) Call getTools with one or more selectors → 2) Call useTools with one or more CLI-style commands\nKnown-good example: {\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available storage tools.\",\"tool\":\"storage move, content read\"}\nExample selectors: tool=\"--help\", tool=\"storage\", tool=\"storage move\", tool=\"storage move, content read\"\n\nAgents:\ncontent: [read,write,replace,insert,setProperty,removeProperty]\nstorage: [list,createFolder,move,copy,archive,open]\nsearch: [content,directory,memory,queryNotes]\nmemory: [createState,listStates,loadState,updateState,archiveState,createWorkspace,listWorkspaces,searchWorkspaces,loadWorkspace,updateWorkspace,archiveWorkspace,run]\nprompt: [list,get,create,update,archive,listModels,execute,generateImage,generateAudio,generateVideo,checkGeneratedArtifact,subagent]\ncanvas: [read,write,update,list]\nbase: [read,write,update,list,analyze]\ntask: [createProject,listProjects,updateProject,archiveProject,create,list,open,update,move,query,linkNote]\ningest: [run,capabilities]\nelevenlabs: [listVoices,soundEffects,generateMusic]\ncomposer: [compose,listFormats]\nweb: [open,capture-markdown,capture-png,capture-pdf,links]\nskills: [listSkills,loadSkill,createSkill,updateSkill,archiveSkill,syncSkills]\ndata: [runPython,listCapabilities]\n\nExisting workspaces: not listed here. The getTools RESULT carries the live list — read \"workspaces\" there and pass one of those exact names. Never infer a workspace name from the user's wording.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list this call returns."
+            "description": "Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. Discovery never needs it — a fresh session names its workspace on its first useTools call (\"default\" for the global workspace, or an exact value from the workspaces list this call returns). An empty string is read as omitted, never as \"default\"."
           },
           "sessionId": {
             "type": "string",
-            "description": "Stable human-readable session name for this chat. Required. Reuse the same value for every getTools/useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently."
+            "description": "Stable human-readable session name for this chat. Reuse the same value for every getTools/useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session."
           },
           "memory": {
             "type": "string",
@@ -36,8 +36,6 @@
           }
         },
         "required": [
-          "workspaceId",
-          "sessionId",
           "memory",
           "goal",
           "tool"
@@ -46,17 +44,17 @@
     },
     {
       "name": "toolManager_useTools",
-      "description": "Execute one or more CLI-style tool commands from the top-level \"tool\" field. Known-good example: {\"workspaceId\":\"default\",\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available workspaces.\",\"tool\":\"memory list-workspaces\"}. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. Separate multiple commands with a top-level comma outside quotes (\"cmd1, cmd2\"); commas inside quoted values stay literal and never split commands. For multiline content, wrap the value in quotes — literal newlines and escaped ones like \"# Title\\n\\nBody\" both work, and any double quote inside the value must be escaped as \\\". Never flatten multiline content to one line; quoting is enough. For content heavy on backslashes, quotes, or length (code, Windows paths, LaTeX, regex), skip CLI escaping entirely: put the text in the optional top-level \"values\" map and reference it from the tool string as @key (unquoted). Values are substituted after parsing with no escape processing, so the content arrives exactly as written. Quote the token (\"@key\") to pass literal text instead, and reference every declared key. Example: {\"tool\": \"content write --path snippet.md --content @body\", \"values\": {\"body\": \"const re = /\\\\d+/;\"}}. When you already know several files you want to read, batch them as comma-separated \"content read\" commands in ONE call with strategy \"parallel\" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.",
+      "description": "Execute one or more CLI-style tool commands from the top-level \"tool\" field. Known-good example: {\"sessionId\":\"workspace setup\",\"memory\":\"Summarize work so far.\",\"goal\":\"Inspect available workspaces.\",\"tool\":\"memory list-workspaces\"}. The workspace is remembered per session: a fresh session passes \"workspaceId\" once (\"default\" or an exact name from getTools) or loads one with \"memory load-workspace\"; every later call in that session inherits it, so omit \"workspaceId\" unless you are deliberately switching. Use one stable human-readable session name for the conversation; reuse that same sessionId value for every useTools call so traces and saved states attach to the current session. Nexus stores the internal UUID silently. Separate multiple commands with a top-level comma outside quotes (\"cmd1, cmd2\"); commas inside quoted values stay literal and never split commands. For multiline content, wrap the value in quotes — literal newlines and escaped ones like \"# Title\\n\\nBody\" both work, and any double quote inside the value must be escaped as \\\". Never flatten multiline content to one line; quoting is enough. For content heavy on backslashes, quotes, or length (code, Windows paths, LaTeX, regex), skip CLI escaping entirely: put the text in the optional top-level \"values\" map and reference it from the tool string as @key (unquoted). Values are substituted after parsing with no escape processing, so the content arrives exactly as written. Quote the token (\"@key\") to pass literal text instead, and reference every declared key. Example: {\"tool\": \"content write --path snippet.md --content @body\", \"values\": {\"body\": \"const re = /\\\\d+/;\"}}. When you already know several files you want to read, batch them as comma-separated \"content read\" commands in ONE call with strategy \"parallel\" — do not issue a separate useTools call per file. IMPORTANT: You MUST call getTools first to inspect the exact command signatures before calling this tool.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "workspaceId": {
             "type": "string",
-            "description": "Workspace name or ID. Required, and must be non-empty — an empty string is rejected, not read as \"default\". Pass \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools."
+            "description": "Workspace name or ID. Pass it once to choose or switch the workspace for this session; later calls in the same session inherit it, so omit it otherwise. A fresh session must pass it once (or run \"memory load-workspace\") before other commands — \"default\" for the global workspace, or an exact value from the availableWorkspaces list returned by getTools. An empty string is read as omitted, never as \"default\"."
           },
           "sessionId": {
             "type": "string",
-            "description": "Stable human-readable session name for this chat. Required. Reuse the same value for every useTools call so traces and saved states attach to the current session; Nexus stores the internal UUID silently."
+            "description": "Stable human-readable session name for this chat. Reuse the same value for every useTools call so traces, saved states and the remembered workspace attach to the current session; Nexus stores the internal UUID silently. Omit it only when the runtime already supplies the session."
           },
           "memory": {
             "type": "string",
@@ -98,8 +96,6 @@
           }
         },
         "required": [
-          "workspaceId",
-          "sessionId",
           "memory",
           "goal",
           "tool"


### PR DESCRIPTION
Part of #214 — PR 1 of `docs/plans/session-sticky-context-plan.md`. Stacked on #384 (base: `chore/remove-connector-calltool`).

## Summary

A session's workspace is chosen **once** and inherited by every later call in that session — for MCP, the CLI and native chat alike — and the binding lives in the vault so it survives a plugin reload.

- **Resolution** (`ToolExecutionStrategy.processSession`): `explicit on this call → the handle's last deliberate bind → UNBOUND`. Values are canonicalised to workspace ids via `WorkspaceService.getWorkspaceByNameOrId` (the same lookup `ToolCallTraceService` uses), so name and id land in one store. `workspaceId: ""` counts as omitted, never as `default`.
- **Bind point 1**: an explicit `workspaceId` on a `useTools` call whose *result* did not fail binds the handle. Reads the result, not the strategy's success flag, so a rejected workspace never sticks. Inherited values never re-bind; `getTools` never binds.
- **Bind point 2**: a successful `memory load-workspace` binds the session to the workspace actually loaded (the resolved match on a near-miss, not the typo). When both bind points fire in one call, the loaded workspace wins.
- **UNBOUND**: `useTools` fails with a reworded "pass it once" steer that names both ways to bind; `getTools` proceeds under `default` without binding, so discovery can be a session's first call.
- **Persistence**: `session-bindings.json` under `resolvePluginStorageRoot(app, plugin).dataRoot`, via the vault adapter (mobile-safe). Holds the handle→session map and the handle→workspace binds. Restored handles resume their session (no more `nexus-cli-2` on every reload) and are verified lazily against storage, so a session deleted while unloaded is dropped rather than resumed. Writes are debounced (300 ms) and flushed on `cleanup()`.
- **Schemas / prompts**: `workspaceId` and `sessionId` leave `required` on both envelope schemas (on the MCP path `required` *is* enforced, so keeping them would force every call to restate them); descriptions and the known-good examples no longer inline `"workspaceId":"default"`; the chat system prompt tells the model to omit both ids since the runtime supplies them. Catalog regenerated.
- **`clientName`**: `RequestHandlerFactory` attaches the connection's `initialize` name (`Server.getClientVersion()`) to `IRequestContext`, outside the tool arguments — the hook PR 2 keys the CLI's current-session default off.
- **`AgentExecutionManager`** (direct-form chat calls) uses the same resolution order for the handle partition so MCP and chat never diverge.

## Test plan

- [x] `npm run test` — 5108 passed / 0 failed (baseline 5073); new `tests/unit/SessionStickyWorkspace.test.ts` (34 tests) exercises the real `SessionContextManager` and `ToolExecutionStrategy` with stubbed storage
- [x] Red/green: dropping the `success === false` guard → 1 red; inverting resolution order → 3 red; removing the bind-order guard → 1 red
- [x] `npm run build` — exit 0, tree clean afterwards
- [ ] Live after merge (the `code` vault's plugin folder is the checkout): `nexus --vault code use --workspace default --session nexus-cli ... -- memory list-workspaces`, then the same without `--workspace`, reload the plugin, repeat; inspect `.obsidian/plugins/claudesidian-mcp/data/session-bindings.json`

## Known limit

If a handle is already bound to Y, and one call passes explicit X *and* loads Y again, bind point 2 is a no-op (value unchanged) so bind point 1 rebinds to X. Detecting that needs the batch result; left for PR 2 if it matters in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
