### PR TITLE
feat(cli): remember the CLI's session per vault and stop restating context (#214)

### DIFF
--- a/cli/agents-snippet.md
+++ b/cli/agents-snippet.md
@@ -12,6 +12,12 @@ offline and instant, so read it before your first command instead of guessing.
   Drill down: `nexus tools storage list` = one tool's full arg schema.
 - **Execute:** `nexus use --memory "<what you're doing>" --goal "<objective>" -- <agent command --flags>`.
   `--memory`/`--goal` are **required** on every `use`.
+- **Context is remembered:** add `--session <name> --workspace <name>` to the
+  **first** `use` of a task (or run `memory load-workspace <name>`), then omit
+  both — later calls continue that session and inherit its workspace. A session
+  that never chose a workspace fails with "This session has no workspace yet";
+  choose once, never pass `default` as a placeholder. `nexus context` shows what
+  the vault remembers.
 - **Multiline content:** keep Markdown/YAML and embedded quotes out of shell
   argv. After `--`, swap any value-taking flag for its transport form:
   `--<flag>-stdin` (piped input) or `--<flag>-file <local-path>` — e.g.

--- a/cli/commandLine.ts
+++ b/cli/commandLine.ts
@@ -59,7 +59,7 @@ export const MISPLACEABLE_CONTEXT_FLAGS = new Set([
     'memory', 'goal', 'constraints', 'operation-id', 'vault', 'session', 'json', 'dry-run',
 ]);
 
-export const VERBS = ['tools', 'use', 'playbook', 'vaults', 'doctor', 'help'];
+export const VERBS = ['tools', 'use', 'playbook', 'context', 'vaults', 'doctor', 'help'];
 
 export interface PartitionedUseArgv {
     outerArgv: string[];

--- a/cli/context.ts
+++ b/cli/context.ts
@@ -1,0 +1,97 @@
+/**
+ * `nexus context` — parse and render what the vault remembers for the CLI.
+ * Pure, unit-testable; the socket work lives in nexus-cli.ts.
+ *
+ * The server answers a `resources/read` of `nexus://context` with a JSON
+ * snapshot (src/handlers/services/CliContextResource.ts). This module is the
+ * CLI-side mirror of that shape: keep the two in step.
+ */
+
+export const NEXUS_CONTEXT_RESOURCE_URI = 'nexus://context';
+
+export interface ContextSnapshot {
+    vault: string | null;
+    defaultSessionHandle: string;
+    cliSession: {
+        handle: string;
+        displaySessionId: string | null;
+        workspace: { id: string; name?: string } | null;
+    } | null;
+}
+
+interface ResourceReadResultLike {
+    contents?: Array<{ uri?: string; text?: string; mimeType?: string }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Pull the snapshot out of a `resources/read` result. Throws on anything but
+ * the documented shape — a wrong server version must fail loudly rather
+ * than print "none" for a session that is in fact remembered.
+ */
+export function parseContextSnapshot(result: unknown): ContextSnapshot {
+    const contents = (result as ResourceReadResultLike | null)?.contents;
+    const entry = Array.isArray(contents) ? contents.find((c) => typeof c?.text === 'string') : undefined;
+    if (!entry || typeof entry.text !== 'string') {
+        throw new Error(`Unexpected reply to ${NEXUS_CONTEXT_RESOURCE_URI}: no text content. Is the Nexus plugin up to date?`);
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(entry.text) as unknown;
+    } catch {
+        throw new Error(`Unexpected reply to ${NEXUS_CONTEXT_RESOURCE_URI}: not JSON.`);
+    }
+    if (!isRecord(parsed) || typeof parsed.defaultSessionHandle !== 'string' || !('cliSession' in parsed)) {
+        throw new Error(`Unexpected reply to ${NEXUS_CONTEXT_RESOURCE_URI}: missing fields.`);
+    }
+    const session = parsed.cliSession;
+    if (session !== null && (!isRecord(session) || typeof session.handle !== 'string')) {
+        throw new Error(`Unexpected reply to ${NEXUS_CONTEXT_RESOURCE_URI}: malformed cliSession.`);
+    }
+    const workspace = isRecord(session) ? session.workspace : null;
+    return {
+        vault: typeof parsed.vault === 'string' ? parsed.vault : null,
+        defaultSessionHandle: parsed.defaultSessionHandle,
+        cliSession: isRecord(session)
+            ? {
+                handle: session.handle as string,
+                displaySessionId: typeof session.displaySessionId === 'string' ? session.displaySessionId : null,
+                workspace: isRecord(workspace) && typeof workspace.id === 'string'
+                    ? { id: workspace.id, ...(typeof workspace.name === 'string' ? { name: workspace.name } : {}) }
+                    : null,
+            }
+            : null,
+    };
+}
+
+/** Human-readable rendering; `--json` prints the snapshot itself instead. */
+export function formatContextSnapshot(snapshot: ContextSnapshot): string {
+    const lines: string[] = [];
+    lines.push(`Vault:      ${snapshot.vault ?? '(unknown)'}`);
+
+    const session = snapshot.cliSession;
+    if (!session) {
+        lines.push(`Session:    none — the next CLI call runs as "${snapshot.defaultSessionHandle}".`);
+        lines.push('            Pass --session <name> once to choose one; later calls continue it.');
+        lines.push('Workspace:  unbound — pass --workspace <name> once, or run `memory load-workspace <name>`.');
+        return lines.join('\n') + '\n';
+    }
+
+    const renamed = session.displaySessionId && session.displaySessionId !== session.handle
+        ? `  (display name: ${session.displaySessionId})`
+        : '';
+    lines.push(`Session:    ${session.handle}${renamed}`);
+
+    if (session.workspace) {
+        const { id, name } = session.workspace;
+        lines.push(`Workspace:  ${name && name !== id ? `${name}  (${id})` : id}`);
+    } else {
+        lines.push('Workspace:  unbound — pass --workspace <name> once, or run `memory load-workspace <name>`.');
+    }
+    lines.push('');
+    lines.push('Calls without --session/--workspace use these. Pass a different value once to switch.');
+    return lines.join('\n') + '\n';
+}

--- a/cli/envelope.ts
+++ b/cli/envelope.ts
@@ -1,0 +1,63 @@
+/**
+ * Envelope builders for the nexus CLI — pure, side-effect-free, unit-testable.
+ *
+ * One rule (#214, docs/plans/session-sticky-context-plan.md PR 2): the CLI
+ * sends `workspaceId` / `sessionId` ONLY when the caller passed the flag. It
+ * used to fill `workspaceId: 'default'` and `sessionId: 'nexus-cli'` when
+ * they were absent, which put a second source of defaults outside the vault
+ * and — the `'default'` half — filed unbound sessions under the global
+ * workspace silently. The server owns both defaults now: the workspace is
+ * inherited from the session's bind (or the call fails with the "pass it
+ * once" steer), and the session is the vault's remembered CLI session, else
+ * `nexus-cli`.
+ */
+
+export type ParsedFlags = Record<string, string | boolean>;
+
+export interface ContextEnvelope {
+    workspaceId?: string;
+    sessionId?: string;
+}
+
+/** Only keys whose flag was actually given, so an absent flag is an absent key. */
+export function contextFromFlags(flags: ParsedFlags): ContextEnvelope {
+    const envelope: ContextEnvelope = {};
+    if (typeof flags.workspace === 'string') envelope.workspaceId = flags.workspace;
+    if (typeof flags.session === 'string') envelope.sessionId = flags.session;
+    return envelope;
+}
+
+/** `nexus tools [selector]` — getTools validates memory/goal too, so discovery auto-fills them. */
+export function buildToolsEnvelope(flags: ParsedFlags, selector: string): Record<string, unknown> {
+    return {
+        tool: selector,
+        ...contextFromFlags(flags),
+        memory: typeof flags.memory === 'string' ? flags.memory : 'Discovering available Nexus tools.',
+        goal: typeof flags.goal === 'string' ? flags.goal : `Inspect "${selector}" tools.`,
+    };
+}
+
+/** `nexus playbook <name>` — the context shared by its list-workspaces and getTools calls. */
+export function buildPlaybookEnvelope(flags: ParsedFlags, name: string): Record<string, unknown> {
+    return {
+        ...contextFromFlags(flags),
+        memory: `Loading the "${name}" playbook.`,
+        goal: `Prepare to run the ${name} task.`,
+    };
+}
+
+/**
+ * `nexus use ... -- <command>` — memory and goal are the caller's; the caller
+ * has already rejected the command when either is missing.
+ */
+export function buildUseEnvelope(flags: ParsedFlags, command: string, memory: string, goal: string): Record<string, unknown> {
+    const args: Record<string, unknown> = {
+        tool: command,
+        ...contextFromFlags(flags),
+        memory,
+        goal,
+    };
+    if (typeof flags.constraints === 'string') args.constraints = flags.constraints;
+    if (typeof flags['operation-id'] === 'string') args.operationId = flags['operation-id'];
+    return args;
+}

--- a/cli/mcpLineClient.ts
+++ b/cli/mcpLineClient.ts
@@ -178,6 +178,11 @@ export class McpLineClient {
         return this.request('tools/call', { name, arguments: args }, this.toolCallTimeoutMs) as Promise<McpToolResult>;
     }
 
+    /** Standard MCP `resources/read`; used for the server-answered `nexus://context` view. */
+    readResource(uri: string): Promise<unknown> {
+        return this.request('resources/read', { uri });
+    }
+
     close(): void {
         this.socket?.end();
         this.socket?.destroy();

--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -4,17 +4,22 @@
  *
  * Discover:  nexus tools [selector]
  * Execute:   nexus use --memory "…" --goal "…" -- <agent action --flags>
- * Inspect:   nexus vaults | nexus doctor
+ * Inspect:   nexus context | nexus vaults | nexus doctor
  *
  * It connects to the same unix socket connector.js uses (/tmp/nexus_mcp_<vault>.sock),
  * speaks the two-tool protocol (toolManager_getTools / toolManager_useTools), prints the
  * result, and exits. Spike scope per docs/plans/local-cli-agent-bridge-plan.md §9 step 1:
  * self-contained (node builtins only), macOS/Linux sockets only.
+ *
+ * The CLI holds no state and fills no defaults (#214): `--workspace` and `--session`
+ * are sent only when given, and the server remembers them per vault — pass each once.
  */
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { McpLineClient, McpToolResult, parseTimeoutEnv } from './mcpLineClient';
 import { playbooksDir, parseFrontmatter, listPlaybooks } from './playbooks';
+import { buildPlaybookEnvelope, buildToolsEnvelope, buildUseEnvelope } from './envelope';
+import { NEXUS_CONTEXT_RESOURCE_URI, formatContextSnapshot, parseContextSnapshot } from './context';
 import {
     hydrateToolContentArgv,
     parseOuterArgs,
@@ -134,6 +139,8 @@ COMMANDS
   nexus use [context] -- <command>    EXECUTE a tool (useTools). See CONTEXT below.
   nexus playbook [name]              Task primer: recipe + your workspaces + preloaded
                                      tools, in one call. \`nexus playbook\` lists them.
+  nexus context [--json]             What this vault remembers for the CLI: current
+                                     session and its workspace (read-only)
   nexus vaults                       List open Nexus vaults (live sockets)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
@@ -146,8 +153,16 @@ CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
   --memory "<text>"       REQUIRED — rolling summary of what you've done/learned
   --goal "<text>"         REQUIRED — this call's objective, one sentence
                           (empty or placeholder like "N/A" is REJECTED with a steer)
-  --workspace <id>        scope for traces/memory (default: "default")
-  --session <name>        continuity across calls (default: "nexus-cli"; keep it stable)
+  --workspace <name|id>   PASS ONCE — the vault remembers it per session. A fresh
+                          session must choose: pass --workspace once, or run
+                          \`memory load-workspace <name>\`; every later call in that
+                          session inherits it. Nothing defaults silently: an unbound
+                          session's \`use\` fails with a steer (only \`memory
+                          list-workspaces\` / \`memory load-workspace\` run unbound).
+  --session <name>        PASS ONCE — the vault remembers the CLI's current session.
+                          Omit it and the CLI continues where it left off (or runs as
+                          "nexus-cli" if it never chose). Pass a different name once
+                          to switch. \`nexus context\` shows both.
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
   --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
@@ -204,6 +219,15 @@ GOTCHAS
     --dryRun, and typos like --vualt fail with a suggestion instead of silently
     doing nothing. Tool flags are only recognized after \`--\`.
   • --memory/--goal are enforced — send real values or the call is rejected.
+  • "This session has no workspace yet" means choose once: \`--workspace <name>\` on
+    this call, or \`memory load-workspace <name>\` in its own call (not batched with
+    other commands). Then drop --workspace; the session inherits it. Repeating
+    --workspace on every call is harmless but unnecessary. \`--workspace default\`
+    is the global workspace — pass it deliberately, never as a placeholder.
+  • --session works the same way: choose once, then omit. Two different --session
+    names are two different sessions with their own remembered workspace.
+    \`nexus context\` shows what the current vault remembers; a plugin reload
+    keeps it.
   • Media generation is async — \`prompt generate-image\` / \`generate-audio\` /
     \`generate-video\` return a job; poll \`prompt check-generated-artifact "<job-id>"\`.
   • States: the AI gets archive (reversible), not delete.
@@ -227,10 +251,13 @@ ${playbookLines}
 
 EXAMPLES
   nexus tools "content read, search content"
-  nexus use --memory "auditing notes" --goal "read today's daily" -- content read --path Daily/2026-07-17.md --start-line 1
-  nexus use --vault "My Notes" --memory "smoke test" --goal "list vault root" -- storage list
-  nexus use --dry-run --memory "resuming research" --goal "load workspace" -- memory load-workspace "NeuroAI Mapping" --limit 1
+  # first call of a fresh session: choose the session and workspace ONCE...
+  nexus use --session daily-audit --workspace "My Notes" --memory "auditing notes" --goal "read today's daily" -- content read --path Daily/2026-07-17.md --start-line 1
+  # ...then omit both; this call runs in daily-audit / "My Notes"
+  nexus use --memory "read today's daily; checking the root" --goal "list vault root" -- storage list
+  nexus use --vault "My Notes" --dry-run --memory "resuming research" --goal "load workspace" -- memory load-workspace "NeuroAI Mapping" --limit 1
   nexus use --memory "reviewing saved views" --goal "see what the Tasks base returns" -- base analyze "Bases/Tasks.base" --limit 20
+  nexus context
   nexus playbook vault-work
 `;
 }
@@ -307,15 +334,18 @@ async function main(): Promise<number> {
         //   nexus tools storage move, content read -> multiple tools, full schemas each
         const selector = positionals.slice(1).join(' ') || '--help';
         return withClient(vaultFlag, async (client) => {
-            // getTools validates memory/goal too — auto-fill for discovery so callers need not pass them.
-            const result = await client.callTool('toolManager_getTools', {
-                tool: selector,
-                workspaceId: typeof flags.workspace === 'string' ? flags.workspace : 'default',
-                sessionId: typeof flags.session === 'string' ? flags.session : 'nexus-cli',
-                memory: typeof flags.memory === 'string' ? flags.memory : 'Discovering available Nexus tools.',
-                goal: typeof flags.goal === 'string' ? flags.goal : `Inspect "${selector}" tools.`,
-            });
+            const result = await client.callTool('toolManager_getTools', buildToolsEnvelope(flags, selector));
             return printToolResult(result, asJson);
+        });
+    }
+
+    if (cmd === 'context') {
+        // Read-only: what THIS vault remembers for the CLI (current session and
+        // its workspace). Answered by the server over a standard resources/read.
+        return withClient(vaultFlag, async (client) => {
+            const snapshot = parseContextSnapshot(await client.readResource(NEXUS_CONTEXT_RESOURCE_URI));
+            process.stdout.write(asJson ? JSON.stringify(snapshot, null, 2) + '\n' : formatContextSnapshot(snapshot));
+            return 0;
         });
     }
 
@@ -357,12 +387,10 @@ async function main(): Promise<number> {
         const preamble = existsSync(preamblePath) ? readFileSync(preamblePath, 'utf8').trim() : '';
         if (preamble) process.stdout.write(preamble + '\n\n');
 
-        const ctx = {
-            workspaceId: typeof flags.workspace === 'string' ? flags.workspace : 'default',
-            sessionId: typeof flags.session === 'string' ? flags.session : 'nexus-cli',
-            memory: `Loading the "${name}" playbook.`,
-            goal: `Prepare to run the ${name} task.`,
-        };
+        // `memory list-workspaces` is one of the two commands the server runs
+        // for a session that has not chosen a workspace yet, so this works on a
+        // fresh session with no --workspace.
+        const ctx = buildPlaybookEnvelope(flags, name);
         try {
             // Fetch live parts BEFORE printing them, so a mid-stream failure falls back
             // cleanly instead of duplicating half-printed sections.
@@ -422,15 +450,7 @@ async function main(): Promise<number> {
             );
             return 2;
         }
-        const args: Record<string, unknown> = {
-            tool: command,
-            workspaceId: typeof flags.workspace === 'string' ? flags.workspace : 'default',
-            sessionId: typeof flags.session === 'string' ? flags.session : 'nexus-cli',
-            memory,
-            goal,
-        };
-        if (typeof flags.constraints === 'string') args.constraints = flags.constraints;
-        if (typeof flags['operation-id'] === 'string') args.operationId = flags['operation-id'];
+        const args = buildUseEnvelope(flags, command, memory, goal);
         if (flags['dry-run'] === true) {
             process.stdout.write('DRY RUN — no vault connection and no tool execution.\n');
             process.stdout.write(JSON.stringify(args, null, 2) + '\n');

--- a/cli/nexus-cli.ts
+++ b/cli/nexus-cli.ts
@@ -158,7 +158,8 @@ CONTEXT (flags on \`use\`; \`tools\` accepts them too. \`playbook\` reads only
                           \`memory load-workspace <name>\`; every later call in that
                           session inherits it. Nothing defaults silently: an unbound
                           session's \`use\` fails with a steer (only \`memory
-                          list-workspaces\` / \`memory load-workspace\` run unbound).
+                          list-workspaces\` / \`load-workspace\` / \`create-workspace\`
+                          run unbound).
   --session <name>        PASS ONCE — the vault remembers the CLI's current session.
                           Omit it and the CLI continues where it left off (or runs as
                           "nexus-cli" if it never chose). Pass a different name once
@@ -221,7 +222,8 @@ GOTCHAS
   • --memory/--goal are enforced — send real values or the call is rejected.
   • "This session has no workspace yet" means choose once: \`--workspace <name>\` on
     this call, or \`memory load-workspace <name>\` in its own call (not batched with
-    other commands). Then drop --workspace; the session inherits it. Repeating
+    other commands; if none fits, \`memory create-workspace\` first, then load it).
+    Then drop --workspace; the session inherits it. Repeating
     --workspace on every call is harmless but unnecessary. \`--workspace default\`
     is the global workspace — pass it deliberately, never as a placeholder.
   • --session works the same way: choose once, then omit. Two different --session
@@ -387,7 +389,7 @@ async function main(): Promise<number> {
         const preamble = existsSync(preamblePath) ? readFileSync(preamblePath, 'utf8').trim() : '';
         if (preamble) process.stdout.write(preamble + '\n\n');
 
-        // `memory list-workspaces` is one of the two commands the server runs
+        // `memory list-workspaces` is one of the three commands the server runs
         // for a session that has not chosen a workspace yet, so this works on a
         // fresh session with no --workspace.
         const ctx = buildPlaybookEnvelope(flags, name);

--- a/guide/nexus-cli.md
+++ b/guide/nexus-cli.md
@@ -72,8 +72,9 @@ switch) and omit it afterwards:
   and every later call in that session inherits it. Nothing defaults silently:
   a session that has not chosen fails with *"This session has no workspace
   yet"* — pass `--workspace` once, or run `memory load-workspace <name>` in
-  its own call. Only `memory list-workspaces` and `memory load-workspace` run
-  before a workspace is chosen. `--workspace default` is the global workspace;
+  its own call. Only `memory list-workspaces`, `memory load-workspace` and
+  `memory create-workspace` run before a workspace is chosen (create one when
+  none fits, then load it). `--workspace default` is the global workspace;
   pass it deliberately, never as a placeholder.
 
 ```

--- a/guide/nexus-cli.md
+++ b/guide/nexus-cli.md
@@ -38,6 +38,7 @@ nexus tools [selector...]           Discover tools. Drill down as far as you wan
                                       nexus tools storage list       one tool, full arg schema
                                       nexus tools "storage list, content read"   several at once
 nexus use [context] -- <command>    Run a CLI-style tool command
+nexus context [--json]              What this vault remembers for the CLI (session, workspace)
 nexus vaults                        List open vaults
 nexus doctor [--vault <name>]       Connect + MCP handshake + tools/list
 nexus --help                        Full usage
@@ -53,9 +54,42 @@ nexus use \
 ```
 
 `--memory` and `--goal` are **required** — Nexus enforces the context contract
-and rejects calls without them. Optional: `--workspace <id>` (default
-`default`), `--session <name>` (default `nexus-cli`; reuse one name per task),
-`--constraints <text>`, `--json` (raw JSON-RPC result).
+and rejects calls without them. Optional: `--constraints <text>`, `--json` (raw
+JSON-RPC result).
+
+### Workspace and session: choose once, it is remembered
+
+`--workspace <name|id>` and `--session <name>` are **pass-once** flags. The
+vault remembers them, so you pass each on the first call of a task (or to
+switch) and omit it afterwards:
+
+- **Session.** With an explicit `--session`, the vault records that handle as
+  the CLI's current session once the call succeeds; every later CLI call with
+  no `--session` continues it. A vault where the CLI never chose runs as
+  `nexus-cli`. Two different names are two different sessions.
+- **Workspace.** A session's workspace is bound by the first successful call
+  that names one (`--workspace`) or by a successful `memory load-workspace`,
+  and every later call in that session inherits it. Nothing defaults silently:
+  a session that has not chosen fails with *"This session has no workspace
+  yet"* — pass `--workspace` once, or run `memory load-workspace <name>` in
+  its own call. Only `memory list-workspaces` and `memory load-workspace` run
+  before a workspace is chosen. `--workspace default` is the global workspace;
+  pass it deliberately, never as a placeholder.
+
+```
+# first call: choose both once
+nexus use --session weekly-review --workspace "Research" \
+  --memory "starting the weekly review" --goal "list this week's dailies" \
+  -- search directory --query "2026-07" --paths "Daily"
+
+# later calls: nothing to repeat
+nexus use --memory "have the list; reading Monday" --goal "read Monday's daily" \
+  -- content read --path Daily/2026-07-13.md --start-line 1
+```
+
+`nexus context` prints what the current vault remembers (vault, current CLI
+session, its workspace). The state lives in the plugin's data folder inside
+the vault and survives a plugin reload; the CLI itself holds nothing.
 
 The `--` delimiter separates CLI context from the tool command. Values after it
 are ordinary shell arguments, so a multiword value needs only one quote layer:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -36,6 +36,14 @@ For a common task, **`nexus playbook <name>`** gives you a ready-to-run recipe
   hoping for vault content — that comes from `nexus use --memory … --goal … -- content read …`.
 - **`--memory` and `--goal` are real and enforced.** You're operating a person's
   live vault; pass a genuine running summary and objective, not placeholders.
+- **`--workspace` and `--session` are pass-once.** The vault remembers them:
+  name a session and choose its workspace on the first call of a task (or run
+  `memory load-workspace <name>`), then omit both — every later call continues
+  that session and inherits its workspace. Nothing defaults silently: a session
+  that never chose a workspace fails with *"This session has no workspace yet"*
+  (only `memory list-workspaces` / `memory load-workspace` run before the
+  choice). Pass a different value once to switch. `nexus context` shows what
+  the vault currently remembers.
 - **You can't escape the vault.** Paths are vault-relative; `..`, `~`, and
   absolute paths are rejected. That's a guardrail, not a bug.
 - **Nothing is destroyed.** The AI gets archive (reversible), not delete.
@@ -48,7 +56,11 @@ For a common task, **`nexus playbook <name>`** gives you a ready-to-run recipe
 nexus tools [selector]              # discover — tool schemas (never vault data)
 nexus use --memory "<what you're doing>" --goal "<objective>" -- \
     <agent command --flags>         # execute — runs one tool, prints the result
+nexus context                       # what this vault remembers: session + workspace
 ```
+
+Add `--session <name> --workspace <name>` to the **first** `use` of a task
+only; the vault remembers both for every call after it.
 
 The `--` delimiter is canonical: context belongs before it; the tool command
 belongs after it. This avoids nested command-string quoting, especially in

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -41,8 +41,8 @@ For a common task, **`nexus playbook <name>`** gives you a ready-to-run recipe
   `memory load-workspace <name>`), then omit both — every later call continues
   that session and inherits its workspace. Nothing defaults silently: a session
   that never chose a workspace fails with *"This session has no workspace yet"*
-  (only `memory list-workspaces` / `memory load-workspace` run before the
-  choice). Pass a different value once to switch. `nexus context` shows what
+  (only `memory list-workspaces` / `load-workspace` / `create-workspace` run
+  before the choice). Pass a different value once to switch. `nexus context` shows what
   the vault currently remembers.
 - **You can't escape the vault.** Paths are vault-relative; `..`, `~`, and
   absolute paths are rejected. That's a guardrail, not a bug.

--- a/skill/playbooks/_preamble.md
+++ b/skill/playbooks/_preamble.md
@@ -6,13 +6,18 @@ so you can go straight to `nexus use` without a separate `nexus tools` call.
 
 **Every playbook starts the same way:**
 
-1. **Pick a workspace and load it.** Choose from *Your workspaces* below and run
-   `nexus use --memory … --goal … -- memory load-workspace "<name>"`. If
-   none fits, create one with `memory create-workspace`. Loading scopes your traces
-   and auto-loads that workspace's task summary. (This playbook only *lists*
-   workspaces — loading is your call, since only you know which one.)
-2. **Thread the workspace** into every following call with `--workspace <name>`
-   (the outer context flag), and keep a stable `--session <name>` for the task.
+1. **Name the session and load a workspace — once.** Choose from *Your
+   workspaces* below and run
+   `nexus use --session <task-name> --memory … --goal … -- memory load-workspace "<name>"`.
+   If none fits, create one with `memory create-workspace`, then load it. Loading
+   scopes your traces, auto-loads that workspace's task summary, and **binds the
+   session to it**. (This playbook only *lists* workspaces — loading is your
+   call, since only you know which one.)
+2. **Then omit `--session` and `--workspace`.** The vault remembers both: every
+   later call continues that session and inherits its workspace. Pass a
+   different value once to switch; `nexus context` shows what is remembered. A
+   session that never chose fails with "This session has no workspace yet" —
+   never pass `default` as a placeholder.
 3. **Always pass real `--memory` and `--goal`** — a running summary and the
    current objective. Placeholders are rejected.
 4. **Checkpoint at milestones** with `memory create-state` so the work is

--- a/skill/playbooks/_preamble.md
+++ b/skill/playbooks/_preamble.md
@@ -12,7 +12,9 @@ so you can go straight to `nexus use` without a separate `nexus tools` call.
    If none fits, create one with `memory create-workspace`, then load it. Loading
    scopes your traces, auto-loads that workspace's task summary, and **binds the
    session to it**. (This playbook only *lists* workspaces — loading is your
-   call, since only you know which one.)
+   call, since only you know which one.) These three — `memory list-workspaces`,
+   `load-workspace`, `create-workspace` — are the only commands that run before
+   a workspace is chosen; each in its own call.
 2. **Then omit `--session` and `--workspace`.** The vault remembers both: every
    later call continues that session and inherits its workspace. Pass a
    different value once to switch; `nexus context` shows what is remembered. A

--- a/skill/playbooks/organize.md
+++ b/skill/playbooks/organize.md
@@ -12,7 +12,8 @@ Unlike `vault-work` (which edits note *bodies*), this moves and files whole note
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above); thread `--workspace`/`--session`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Map the current layout before touching anything.**
    - `storage list --path "<folder>"` — see what's in a folder.
    - `search query-notes --sql "…"` — query frontmatter as a database to *find*
@@ -33,33 +34,30 @@ Unlike `vault-work` (which edits note *bodies*), this moves and files whole note
 ## Worked example — archive old daily notes into a subfolder
 
 ```
-# 1. load the workspace
+# 1. name the session and load the workspace — the only call that needs --session;
+#    loading binds the workspace, so nothing below repeats either flag
 nexus use \
-  --memory "tidying old dailies" --goal "load the journal workspace" \
   --session tidy-dailies \
+  --memory "tidying old dailies" --goal "load the journal workspace" \
   -- memory load-workspace "journal"
 
 # 2. map — which dailies are from 2025? (query frontmatter; --describe to see columns first)
 nexus use \
-  --workspace journal --session tidy-dailies \
   --memory "finding 2025 dailies to archive" --goal "list 2025 daily notes" \
   -- search query-notes --sql "SELECT path FROM notes WHERE path LIKE 'Daily/2025-%' ORDER BY path"
 
 # 3. make the destination folder
 nexus use \
-  --workspace journal --session tidy-dailies \
   --memory "have the 2025 list; creating archive folder" --goal "create Daily/Archive/2025" \
   -- storage create-folder --path Daily/Archive/2025
 
 # 4. move each note (one call per file — verify each)
 nexus use \
-  --workspace journal --session tidy-dailies \
   --memory "moving 2025 dailies into the archive folder" --goal "move 2025-01-03.md" \
   -- storage move --path Daily/2025-01-03.md --new-path Daily/Archive/2025/2025-01-03.md
 
 # 5. checkpoint after the batch
 nexus use \
-  --workspace journal --session tidy-dailies \
   --memory "2025 dailies archived" --goal "checkpoint the reorg" \
   -- memory create-state --name dailies-archived \
   --conversation-context "moved all 2025 daily notes into Daily/Archive/2025" \

--- a/skill/playbooks/prompt.md
+++ b/skill/playbooks/prompt.md
@@ -34,7 +34,8 @@ Full live schema: `nexus tools prompt execute`. Saved prompts: `prompt list`
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above); thread `--workspace`/`--session`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Pick the driver**: write an **inline** `prompt`, or find a **saved** one with
    `prompt list` and pass its name as `customPrompt`.
 3. **Attach the notes** the prompt should see via `contextFiles` (read them first
@@ -60,11 +61,14 @@ the inline JSON stays small.
 
 ## Worked examples
 
+All three examples share one session. Example A is the first call, so it names
+the session and the workspace once; B and C omit both and inherit them.
+
 **A — inline prompt, one note as context, result to stdout:**
 
 ```
 nexus use \
-  --json --workspace research --session prompt-run \
+  --json --session prompt-run --workspace research \
   --memory "summarizing the auth flow note" --goal "get a 3-bullet summary" \
   -- prompt execute --prompts '[{"type":"text","prompt":"Summarize this note in 3 bullets","contextFiles":["Projects/Auth/flow.md"]}]'
 ```
@@ -76,14 +80,13 @@ the **user** message. They are different roles, not alternatives — a request w
 `customPrompt` and no `prompt` sends the model no instruction to act on.
 
 ```
-# find the saved prompt's name
-nexus use --workspace research --session prompt-run \
+# find the saved prompt's name (session + workspace inherited from A)
+nexus use \
   --memory "looking for my weekly-review prompt" --goal "list saved prompts" \
   -- prompt list
 
 # run it over this week's notes and append the output to the review note
 nexus use \
-  --workspace research --session prompt-run \
   --memory "have the daily notes; running weekly-review" --goal "append a weekly review" \
   -- prompt execute --prompts '[{"type":"text","customPrompt":"weekly-review","prompt":"Write the weekly review from the attached daily notes.","contextFiles":["Daily/2026-07-14.md","Daily/2026-07-15.md"],"action":{"type":"append","targetPath":"Reviews/2026-W29.md"}}]'
 ```
@@ -92,11 +95,10 @@ nexus use \
 
 ```
 nexus use \
-  --workspace research --session prompt-run \
   --memory "need a logo asset" --goal "generate a logo image" \
   -- prompt execute --prompts '[{"type":"image","prompt":"a minimalist logo, teal on white","savePath":"Assets/logo.png","aspectRatio":"1:1"}]'
 # then poll:
-nexus use --workspace research --session prompt-run \
+nexus use \
   --memory "waiting on the logo" --goal "check image generation status" \
   -- prompt check-generated-artifact "<job-id>"
 ```

--- a/skill/playbooks/tasks.md
+++ b/skill/playbooks/tasks.md
@@ -13,23 +13,24 @@ the workspace, get or create a project (capture its `projectId`), then add tasks
 
 ## The one thing to get right: workspace vs project
 
-- **Workspace** comes from the **top-level `--workspace <name-or-id>` context
-  flag** — the same flag you pass on every call, set to the workspace you loaded.
-  Task tools read their workspace scope from it automatically. **Do not** put
+- **Workspace** is the one your session is bound to — set once by loading it
+  (`memory load-workspace`) or by passing the top-level `--workspace <name-or-id>`
+  context flag once; every later call in the session inherits it, and task tools
+  read their workspace scope from it automatically. **Do not** put
   `--workspace-id` *inside* the tool string — it's a reserved context field and
   is rejected there.
 - **Project** is identified by a **`projectId`** that `task create-project` (or
   `task list-projects`) returns. Capture it and pass it to task calls as
   `--project-id`.
 
-So: load the workspace → thread `--workspace` on every call → create/find a
-project → capture its `projectId` → create tasks with `--project-id`.
+So: load the workspace once → create/find a project → capture its `projectId`
+→ create tasks with `--project-id`.
 
 ## Protocol
 
-1. **Load the workspace** (spine above); thread `--workspace <name-or-id>` on
-   every following call.
-2. **Get a project.** `task list-projects` (scoped by `--workspace`) to find one,
+1. **Name the session and load the workspace** (spine above) — once; later calls
+   inherit both.
+2. **Get a project.** `task list-projects` (scoped by the session's workspace) to find one,
    or `task create-project --name "<name>"` — note the **projectId** it returns.
 3. **Add tasks.** `task create --project-id <projectId> --title "<title>"` (add
    `--description`, dependencies, etc. — see `nexus tools task create`).
@@ -44,39 +45,35 @@ project → capture its `projectId` → create tasks with `--project-id`.
 ## Worked example — new project, two tasks, one depends on the other
 
 ```
-# 1. load the workspace — thread --workspace (name or id) on every later call
+# 1. name the session and load the workspace — once; loading binds the session
+#    to "product", so no later call repeats --session or --workspace
 nexus use \
-  --memory "planning the launch" --goal "load the product workspace" \
   --session launch-plan \
+  --memory "planning the launch" --goal "load the product workspace" \
   -- memory load-workspace "product"
 
-# 2. create a project — workspace comes from --workspace; capture the projectId
+# 2. create a project — workspace scope is inherited; capture the projectId
 nexus use \
-  --workspace product --session launch-plan \
   --memory "starting the Q3 launch project" --goal "create the Q3 Launch project" \
   -- task create-project --name "Q3 Launch"
 # → result includes the projectId, e.g. "proj_def456"
 
 # 3. add tasks under that project
 nexus use \
-  --workspace product --session launch-plan \
   --memory "adding launch tasks" --goal "create the copy task" \
   -- task create --project-id proj_def456 --title "Write launch copy"
 
 nexus use \
-  --workspace product --session launch-plan \
   --memory "adding the dependent task" --goal "create the publish task" \
   -- task create --project-id proj_def456 --title "Publish blog post"
 
 # 4. see the board (statuses, what's blocked)
 nexus use \
-  --workspace product --session launch-plan \
   --memory "reviewing the launch tasks" --goal "list tasks in the project" \
   -- task list --project-id proj_def456
 
 # 5. checkpoint
 nexus use \
-  --workspace product --session launch-plan \
   --memory "project + tasks created" --goal "checkpoint the setup" \
   -- memory create-state --name launch-tasks-seeded \
   --conversation-context "created Q3 Launch project with copy + publish tasks" \
@@ -91,8 +88,11 @@ Run `nexus tools task create` / `task move` / `task update` for the exact fields
 ## Pitfalls
 
 - **Putting `--workspace-id` inside the tool string** — rejected as a reserved
-  context field. Scope task tools with the top-level `--workspace <name-or-id>`
-  flag instead (the workspace you loaded); it accepts a name *or* an id.
+  context field. Task tools are scoped by the session's workspace — the one you
+  loaded, or the top-level `--workspace <name-or-id>` flag passed once; it
+  accepts a name *or* an id.
+- **"This session has no workspace yet"** — the session never chose. Load one
+  first (step 1); don't answer the steer with `--workspace default`.
 - **Creating tasks with no project** — `task create` needs `--project-id`; make or
   find the project first and capture the id it returns.
 - **`task link-note` needs a real `--note-path`** — a vault-relative path to an

--- a/skill/playbooks/vault-work.md
+++ b/skill/playbooks/vault-work.md
@@ -11,7 +11,8 @@ update it," "answer a question from my notes," "add a section to Y," etc.
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above), thread `--workspace`/`--session`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Find the note(s).** Pick the search that fits:
    - `search content --query "<terms>"` — semantic/keyword over note bodies.
    - `search directory --query "<name>" --paths "<folder>"` — by filename/path.
@@ -34,27 +35,25 @@ update it," "answer a question from my notes," "add a section to Y," etc.
 ## Worked example — add a summary under a heading
 
 ```
-# 1. load the workspace you picked from the list above (--workspace = name or id)
+# 1. name the session and load the workspace you picked from the list above —
+#    this is the only call that needs --session; loading binds the workspace
 nexus use \
-  --memory "starting: summarize the auth notes" --goal "load the research workspace" \
   --session auth-summary \
+  --memory "starting: summarize the auth notes" --goal "load the research workspace" \
   -- memory load-workspace "research"
 
-# 2. find
+# 2. find — no --session/--workspace: the vault remembers auth-summary → research
 nexus use \
-  --workspace research --session auth-summary \
   --memory "looking for the main auth note" --goal "locate the auth flow note" \
   -- search content --query "authentication flow" --limit 5
 
 # 3. read the top hit (search gave a path, not the text)
 nexus use \
-  --workspace research --session auth-summary \
   --memory "found Projects/Auth/flow.md; reading it" --goal "read the auth flow note" \
   -- content read --path Projects/Auth/flow.md --start-line 1
 
 # 4. edit — anchor on exact text pulled from the read
 nexus use \
-  --workspace research --session auth-summary \
   --memory "have the body; inserting a summary" --goal "replace the Summary section" \
   -- content replace --path Projects/Auth/flow.md \
   --start "## Summary" --end "## Details" \
@@ -62,7 +61,6 @@ nexus use \
 
 # 5. checkpoint (create-state needs name + context + task + file/step arrays)
 nexus use \
-  --workspace research --session auth-summary \
   --memory "summary written to flow.md" --goal "checkpoint the finished edit" \
   -- memory create-state --name auth-summary-done \
   --conversation-context "summarized the auth flow note into a Summary section" \
@@ -79,6 +77,11 @@ nexus use \
   `start`/`end`. Copy the anchors verbatim from the read.
 - **Answering a question from `{path, score}`** — read the note; don't fabricate
   from the ranking.
-- **Losing trace scope** — pass `--workspace` on every call, not just the load.
+- **Switching sessions by accident** — a different `--session` name is a
+  different session with its own remembered workspace. Stay on one name per
+  task; `nexus context` shows which one is current.
+- **"This session has no workspace yet"** — this session never chose. Load one
+  (`memory load-workspace`, on its own) or pass `--workspace` once; don't answer
+  it with `--workspace default`.
 - **Writing outside the vault** — `..`/`~`/absolute paths are rejected; keep
   paths vault-relative.

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -767,8 +767,51 @@ function normalizeVerbatimValues(raw: unknown): Record<string, string> | undefin
 
 export const WORKSPACE_ID_REQUIRED_MESSAGE =
   'This session has no workspace yet. Pass "workspaceId" once — "default" for the global workspace, '
-  + 'or an exact name/id from availableWorkspaces — or load one with "memory load-workspace"; '
+  + 'or an exact name/id from availableWorkspaces — or load one with "memory load-workspace" in its own call '
+  + '(it and "memory list-workspaces" are the only commands that run before a workspace is chosen); '
   + 'later calls in this session inherit it.';
+
+/**
+ * The commands an UNBOUND session may run: choosing a workspace needs a way
+ * to see the choices and to make one, and both live behind useTools. Anything
+ * else waits for the choice — see isWorkspaceSelectionOnlyCommand.
+ */
+const WORKSPACE_SELECTION_COMMANDS = new Set(['loadworkspace', 'listworkspaces']);
+
+function normalizeCommandWord(value: string): string {
+  return value.replace(/[-_\s]/g, '').toLowerCase();
+}
+
+/**
+ * True when EVERY command in a useTools `tool` string is a workspace-selection
+ * command (`memory load-workspace`, `memory list-workspaces`).
+ *
+ * Why every, not the first: normalizeContext stamps ONE workspaceId onto the
+ * whole batch. If `memory load-workspace X, content read --path a.md` were
+ * allowed through unbound, the read would run under 'default' while the
+ * session was being bound to X — the exact misfiling #214 reports. A mixed
+ * batch on an unbound session gets the steer and does the load in its own
+ * call first. Tokenises with the same splitter the executor uses, so a quoted
+ * comma inside a value cannot fake a second command.
+ */
+export function isWorkspaceSelectionOnlyCommand(toolString: unknown): boolean {
+  if (typeof toolString !== 'string' || toolString.trim().length === 0) {
+    return false;
+  }
+  const segments = splitTopLevelSegments(toolString);
+  if (segments.length === 0) {
+    return false;
+  }
+  return segments.every(segment => {
+    const tokens = tokenizeWithMeta(segment);
+    if (tokens.length < 2) {
+      return false;
+    }
+    const agent = normalizeCommandWord(tokens[0].value);
+    const tool = normalizeCommandWord(tokens[1].value);
+    return (agent === 'memory' || agent === 'memorymanager') && WORKSPACE_SELECTION_COMMANDS.has(tool);
+  });
+}
 
 /**
  * Accept the session's resolved workspaceId, or throw the recoverable

--- a/src/agents/toolManager/services/ToolCliNormalizer.ts
+++ b/src/agents/toolManager/services/ToolCliNormalizer.ts
@@ -768,15 +768,18 @@ function normalizeVerbatimValues(raw: unknown): Record<string, string> | undefin
 export const WORKSPACE_ID_REQUIRED_MESSAGE =
   'This session has no workspace yet. Pass "workspaceId" once — "default" for the global workspace, '
   + 'or an exact name/id from availableWorkspaces — or load one with "memory load-workspace" in its own call '
-  + '(it and "memory list-workspaces" are the only commands that run before a workspace is chosen); '
+  + '(it, "memory list-workspaces" and "memory create-workspace" are the only commands that run before a workspace is chosen); '
   + 'later calls in this session inherit it.';
 
 /**
  * The commands an UNBOUND session may run: choosing a workspace needs a way
- * to see the choices and to make one, and both live behind useTools. Anything
- * else waits for the choice — see isWorkspaceSelectionOnlyCommand.
+ * to see the choices, to make one when none fits, and to pick one — and all
+ * three live behind useTools. `create-workspace` is not scoped to any
+ * workspace (it makes one), and the guidance says "create, then load", so the
+ * load still does the binding. Anything else waits for the choice — see
+ * isWorkspaceSelectionOnlyCommand.
  */
-const WORKSPACE_SELECTION_COMMANDS = new Set(['loadworkspace', 'listworkspaces']);
+const WORKSPACE_SELECTION_COMMANDS = new Set(['loadworkspace', 'listworkspaces', 'createworkspace']);
 
 function normalizeCommandWord(value: string): string {
   return value.replace(/[-_\s]/g, '').toLowerCase();
@@ -784,7 +787,8 @@ function normalizeCommandWord(value: string): string {
 
 /**
  * True when EVERY command in a useTools `tool` string is a workspace-selection
- * command (`memory load-workspace`, `memory list-workspaces`).
+ * command (`memory load-workspace`, `memory list-workspaces`,
+ * `memory create-workspace`).
  *
  * Why every, not the first: normalizeContext stamps ONE workspaceId onto the
  * whole batch. If `memory load-workspace X, content read --path a.md` were

--- a/src/handlers/RequestRouter.ts
+++ b/src/handlers/RequestRouter.ts
@@ -119,7 +119,9 @@ export class RequestRouter {
             ),
             new ResourceReadStrategy(
                 this.dependencies,
-                this.app
+                this.app,
+                // For the CLI's `nexus://context` read (see CliContextResource).
+                { sessionContextManager: this.sessionContextManager, vaultName: this.vaultName }
             ),
             new PromptsListStrategy(
                 this.dependencies

--- a/src/handlers/services/CliContextResource.ts
+++ b/src/handlers/services/CliContextResource.ts
@@ -1,0 +1,68 @@
+import type { SessionContextManager } from '../../services/SessionContextManager';
+import { CLI_DEFAULT_SESSION_HANDLE } from '../strategies/ToolExecutionStrategy';
+
+/**
+ * `nexus context` (#214, docs/plans/session-sticky-context-plan.md PR 2):
+ * what this vault currently remembers for the CLI — the current session
+ * handle and the workspace that handle is bound to.
+ *
+ * Served as an MCP RESOURCE at a fixed, unlisted URI rather than as a third
+ * tool or a custom JSON-RPC method: `resources/read` already exists on every
+ * connection, the two-tool contract (`getTools`/`useTools`) stays fixed, and
+ * a read has no side effects to gate. It is not returned by `resources/list`
+ * — the URI is for the CLI, not a document for MCP clients to browse.
+ */
+export const NEXUS_CONTEXT_RESOURCE_URI = 'nexus://context';
+
+export interface CliContextSnapshot {
+  /** Sanitized vault name — the value `--vault` accepts. */
+  vault: string | null;
+  /** What a CLI call with no `--session` runs as when nothing is remembered. */
+  defaultSessionHandle: string;
+  /** Null until the CLI has chosen a session with `--session` once. */
+  cliSession: {
+    /** The handle the CLI typed and will present again. */
+    handle: string;
+    /** The display name it resolved to (differs when renamed to `<handle>-2`), if the manager has seen it. */
+    displaySessionId: string | null;
+    /** The handle's last deliberate workspace bind; null means UNBOUND. */
+    workspace: { id: string; name?: string } | null;
+  } | null;
+}
+
+/**
+ * Read-only. Never creates a session, never binds anything, never touches
+ * the store beyond waiting for the restore that `setBindingsStore` started.
+ */
+export async function buildCliContextSnapshot(
+  manager: SessionContextManager | undefined,
+  vaultName: string | undefined
+): Promise<CliContextSnapshot> {
+  const snapshot: CliContextSnapshot = {
+    vault: vaultName ?? null,
+    defaultSessionHandle: CLI_DEFAULT_SESSION_HANDLE,
+    cliSession: null
+  };
+  if (!manager) {
+    return snapshot;
+  }
+
+  await manager.ensureBindingsRestored();
+  const handle = manager.getCliCurrentSession();
+  if (!handle) {
+    return snapshot;
+  }
+
+  const boundWorkspaceId = manager.resolveHandleWorkspace(handle);
+  const workspace = boundWorkspaceId ? await manager.describeWorkspace(boundWorkspaceId) : null;
+  // The handle is partitioned under its bound workspace, or 'default' while
+  // unbound — the same key processSession uses, so this finds the same entry.
+  const described = manager.describeHandle(handle, boundWorkspaceId ?? 'default');
+
+  snapshot.cliSession = {
+    handle,
+    displaySessionId: described?.displaySessionId ?? null,
+    workspace
+  };
+  return snapshot;
+}

--- a/src/handlers/strategies/ResourceReadStrategy.ts
+++ b/src/handlers/strategies/ResourceReadStrategy.ts
@@ -2,6 +2,8 @@ import { App } from 'obsidian';
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { IRequestStrategy } from './IRequestStrategy';
 import { IRequestHandlerDependencies } from '../interfaces/IRequestHandlerServices';
+import type { SessionContextManager } from '../../services/SessionContextManager';
+import { NEXUS_CONTEXT_RESOURCE_URI, buildCliContextSnapshot } from '../services/CliContextResource';
 import { logger } from '../../utils/logger';
 
 interface ResourceReadRequest {
@@ -20,6 +22,12 @@ interface ResourceReadResponse {
     }>;
 }
 
+/** What the strategy needs to answer `nexus://context`; absent in tests and before wiring. */
+export interface ResourceReadStrategyContextSources {
+    sessionContextManager?: SessionContextManager;
+    vaultName?: string;
+}
+
 /**
  * Strategy for handling resource read requests
  * Follows Strategy Pattern for clean request handling
@@ -27,7 +35,8 @@ interface ResourceReadResponse {
 export class ResourceReadStrategy implements IRequestStrategy<ResourceReadRequest, ResourceReadResponse> {
     constructor(
         private dependencies: IRequestHandlerDependencies,
-        private app: App
+        private app: App,
+        private contextSources: ResourceReadStrategyContextSources = {}
     ) {}
 
     canHandle(request: ResourceReadRequest): boolean {
@@ -37,9 +46,9 @@ export class ResourceReadStrategy implements IRequestStrategy<ResourceReadReques
     async handle(request: ResourceReadRequest): Promise<ResourceReadResponse> {
         try {
             logger.systemLog('ResourceReadStrategy: Handling resource read request');
-            
+
             const { uri, uris } = request.params;
-            
+
             // Validate parameters
             if (!uri && (!uris || uris.length === 0)) {
                 throw new McpError(
@@ -47,17 +56,23 @@ export class ResourceReadStrategy implements IRequestStrategy<ResourceReadReques
                     'Either uri or uris parameter is required'
                 );
             }
-            
+
+            // The CLI's read-only context view (`nexus context`). Answered
+            // here, before the vault-file reader, because it is not a file.
+            if (uri === NEXUS_CONTEXT_RESOURCE_URI && !(uris && uris.length > 0)) {
+                return await this.readCliContext();
+            }
+
             // Handle multiple URIs if provided
             if (uris && uris.length > 0) {
                 return await this.dependencies.resourceReadService.readMultipleResources(uris);
             }
-            
+
             // Handle single URI
             if (uri) {
                 return await this.dependencies.resourceReadService.readResource(uri);
             }
-            
+
             throw new McpError(
                 ErrorCode.InvalidParams,
                 'No valid URI provided for resource read'
@@ -69,5 +84,19 @@ export class ResourceReadStrategy implements IRequestStrategy<ResourceReadReques
             logger.systemError(error as Error, 'ResourceReadStrategy');
             throw new McpError(ErrorCode.InternalError, 'Failed to read resource', error);
         }
+    }
+
+    private async readCliContext(): Promise<ResourceReadResponse> {
+        const snapshot = await buildCliContextSnapshot(
+            this.contextSources.sessionContextManager,
+            this.contextSources.vaultName
+        );
+        return {
+            contents: [{
+                uri: NEXUS_CONTEXT_RESOURCE_URI,
+                text: JSON.stringify(snapshot),
+                mimeType: 'application/json'
+            }]
+        };
     }
 }

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -3,6 +3,7 @@ import { IRequestStrategy } from './IRequestStrategy';
 import { IRequestHandlerDependencies, IRequestContext, SessionInfo, ToolExecutionResult } from '../interfaces/IRequestHandlerServices';
 import { IAgent } from '../../agents/interfaces/IAgent';
 import { SessionContextManager } from '../../services/SessionContextManager';
+import { isWorkspaceSelectionOnlyCommand } from '../../agents/toolManager/services/ToolCliNormalizer';
 import { logger } from '../../utils/logger';
 import { getErrorMessage } from '../../utils/errorUtils';
 
@@ -74,10 +75,46 @@ interface WorkspaceBindingIntent {
     priorBound?: string;
 }
 
+/**
+ * What processSession decided about the CLI's current session, carried to
+ * bind point 3. Present only when a CLI connection named a session
+ * EXPLICITLY on this call; an inherited or defaulted handle is not a choice.
+ */
+interface CliSessionBindingIntent {
+    handle: string;
+}
+
+/** Every session-related decision processSession hands back with the SessionInfo. */
+interface SessionResolution {
+    sessionInfo: SessionInfo;
+    workspaceBinding?: WorkspaceBindingIntent;
+    cliSessionBinding?: CliSessionBindingIntent;
+}
+
+type StrategyRequestContext = IRequestContext & {
+    sessionInfo: SessionInfo;
+    workspaceBinding?: WorkspaceBindingIntent;
+    cliSessionBinding?: CliSessionBindingIntent;
+};
+
 /** Tool names on the two-tool surface, as the strategy sees them after the prefix split. */
 const TOOL_MANAGER_AGENT = 'toolManager';
 const USE_TOOLS = 'useTools';
 const GET_TOOLS = 'getTools';
+
+/**
+ * The name the CLI sends as `clientInfo.name` on `initialize`
+ * (cli/mcpLineClient.ts). Only connections that identify this way get the
+ * current-session default and bind point 3; MCP clients and chat never do.
+ */
+export const CLI_CLIENT_NAME = 'nexus-cli';
+
+/**
+ * The handle a CLI call runs under when it names no session AND the vault has
+ * never remembered one. The CLI used to fill this client-side; it is a
+ * default, not a choice, and is never written to `cliCurrentSession`.
+ */
+export const CLI_DEFAULT_SESSION_HANDLE = 'nexus-cli';
 
 interface ToolExecutionResponse {
     content: Array<{
@@ -107,7 +144,7 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
 
     async handle(request: ToolExecutionRequest): Promise<ToolExecutionResponse> {
         const startTime = Date.now();
-        let context: (IRequestContext & { sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }) | undefined;
+        let context: StrategyRequestContext | undefined;
         let success = false;
         let result: ToolExecutionResult;
 
@@ -117,6 +154,7 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             result = await this.executeTool(context, processedParams);
             success = true;
             this.bindWorkspaceFromResult(context, result);
+            this.bindCliSessionFromResult(context, result);
 
             // Trigger response capture callback if available
             if (this.onToolResponse) {
@@ -211,7 +249,7 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
 
     private async buildRequestContext(
         request: ToolExecutionRequest
-    ): Promise<IRequestContext & { sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }> {
+    ): Promise<StrategyRequestContext> {
         const { name: fullToolName, arguments: parsedArgs } = request.params;
 
         if (!parsedArgs) {
@@ -248,7 +286,8 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             }
         }
 
-        const { sessionInfo, workspaceBinding } = await this.processSession(params, agentName, tool);
+        const { sessionInfo, workspaceBinding, cliSessionBinding } =
+            await this.processSession(params, agentName, tool, request.clientName);
 
         const shouldInjectInstructions = this.dependencies.sessionService.shouldInjectInstructions(
             sessionInfo.sessionId,
@@ -267,21 +306,32 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
                 ...sessionInfo,
                 shouldInjectInstructions
             },
-            ...(workspaceBinding ? { workspaceBinding } : {})
+            ...(workspaceBinding ? { workspaceBinding } : {}),
+            ...(cliSessionBinding ? { cliSessionBinding } : {})
         };
     }
 
     /**
-     * Resolve the session and the workspace it runs in, in that order of
-     * dependency: the handle partition (`"<workspaceId>::<handle>"`) needs the
-     * workspace, so the workspace is settled FIRST (#214):
+     * Resolve the session handle, then the workspace it runs in, then validate
+     * the handle inside that workspace — in that order of dependency, because
+     * the handle partition (`"<workspaceId>::<handle>"`) needs the workspace
+     * and the workspace lookup needs the handle (#214):
      *
-     *   workspaceId:  explicit on this call  →  handle's last bind  →  UNBOUND
+     *   sessionId:    explicit  →  cliCurrentSession ?? 'nexus-cli' (CLI connections only)  →  today's fallback
+     *   workspaceId:  explicit  →  handle's last bind                                        →  UNBOUND
+     *
+     * The CLI default is applied only when the connection identified itself
+     * as the CLI on `initialize` (`clientName === CLI_CLIENT_NAME`); MCP
+     * clients and native chat behave exactly as before. Because the workspace
+     * is looked up for the RESOLVED handle, an inherited CLI session inherits
+     * its workspace too.
      *
      * UNBOUND is not an error here. `useTools` is left without a workspaceId so
      * ToolCliNormalizer.normalizeRequiredWorkspaceId throws its "pass it once"
      * steer; `getTools` is partitioned under 'default' so discovery can be a
-     * session's first call — WITHOUT binding, because nothing was chosen.
+     * session's first call — WITHOUT binding, because nothing was chosen. The
+     * same partition-without-bind applies to a `useTools` batch made ONLY of
+     * workspace-selection commands (see resolveUnboundPartition).
      *
      * The resolved canonical value is written back onto `params` so
      * normalizeContext and ToolBatchExecutionService.validateContext can stay
@@ -290,10 +340,23 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
     private async processSession(
         params: SessionEnvelopeParams,
         agentName: string,
-        tool: string
-    ): Promise<{ sessionInfo: SessionInfo; workspaceBinding?: WorkspaceBindingIntent }> {
-        // Use SessionContextManager for unified session handling instead of separate SessionService
-        const sessionId = params.context?.sessionId || params.sessionId;
+        tool: string,
+        clientName?: string
+    ): Promise<SessionResolution> {
+        const explicitSessionRaw = params.context?.sessionId || params.sessionId;
+        const explicitSession = typeof explicitSessionRaw === 'string' && explicitSessionRaw.trim().length > 0
+            ? explicitSessionRaw.trim()
+            : undefined;
+        const isCliConnection = clientName === CLI_CLIENT_NAME;
+
+        let sessionId = explicitSession;
+        if (!sessionId && isCliConnection && this.sessionContextManager) {
+            // Continue where the CLI left off in this vault, or fall back to the
+            // handle the CLI used to fill in client-side. Neither is a choice,
+            // so neither is bound (see bindCliSessionFromResult).
+            await this.sessionContextManager.ensureBindingsRestored();
+            sessionId = this.sessionContextManager.getCliCurrentSession() ?? CLI_DEFAULT_SESSION_HANDLE;
+        }
 
         if (!this.sessionContextManager || !sessionId) {
             // Fallback to original SessionService if no SessionContextManager or sessionId
@@ -307,6 +370,10 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
         }
 
         const isToolManager = agentName === TOOL_MANAGER_AGENT;
+        // Bind point 3 intent: only an EXPLICIT handle on a CLI connection is a
+        // choice. Recorded before execution, acted on after (success gate).
+        const cliSessionBinding: CliSessionBindingIntent | undefined =
+            isCliConnection && explicitSession ? { handle: explicitSession } : undefined;
         let workspaceBinding: WorkspaceBindingIntent | undefined;
         try {
             // Legacy `agent_tool` calls carry the envelope under `context`; the
@@ -334,18 +401,42 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
                     explicit: resolution.explicit,
                     priorBound: this.sessionContextManager.resolveHandleWorkspace(sessionId)
                 };
-            } else if (isToolManager && tool === USE_TOOLS) {
-                // Leave it absent. Deleting rather than skipping guards against a
-                // caller that sent `workspaceId: ""` — blank must fail exactly
-                // like omitted, not slip past `required` as a present key.
-                delete params.workspaceId;
             }
 
-            // Only discovery is partitioned under 'default' when unbound. For
-            // everything else the manager's own 'default' parameter applies,
-            // which is today's behaviour for legacy-format calls.
-            const partitionWorkspace = resolution.workspaceId
-                ?? (isToolManager && tool === GET_TOOLS ? 'default' : undefined);
+            // UNBOUND: what runs anyway, and under which partition. Discovery
+            // always does. So does a `useTools` batch made ENTIRELY of
+            // `memory load-workspace` / `memory list-workspaces` — the only
+            // exemption from the UNBOUND rule. A fresh session has to be able
+            // to see its workspaces and pick one, both of those live behind
+            // useTools, and the steer itself tells the caller to do exactly
+            // this; without the exemption `load-workspace` would need the
+            // workspace it is about to load. It is a partition, not a choice:
+            // no WorkspaceBindingIntent is recorded, so bind point 1 stays
+            // silent, and bind point 2 binds the workspace actually loaded on
+            // success. A MIXED batch does not qualify: normalizeContext stamps
+            // one workspaceId on the whole batch, so the trailing commands
+            // would run under 'default' while the session was being bound
+            // elsewhere — the misfiling #214 is about. It gets the steer.
+            let unboundPartition: string | undefined;
+            if (!resolution.workspaceId && isToolManager) {
+                if (tool === GET_TOOLS) {
+                    unboundPartition = 'default';
+                } else if (tool === USE_TOOLS) {
+                    if (isWorkspaceSelectionOnlyCommand(params.tool)) {
+                        unboundPartition = 'default';
+                        params.workspaceId = unboundPartition;
+                    } else {
+                        // Leave it absent. Deleting rather than skipping guards against a
+                        // caller that sent `workspaceId: ""` — blank must fail exactly
+                        // like omitted, not slip past `required` as a present key.
+                        delete params.workspaceId;
+                    }
+                }
+            }
+
+            // For everything else unbound the manager's own 'default' parameter
+            // applies, which is today's behaviour for legacy-format calls.
+            const partitionWorkspace = resolution.workspaceId ?? unboundPartition;
 
             const validationResult = await this.sessionContextManager.validateSessionId(
                 sessionId,
@@ -374,7 +465,7 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
             if (workspaceBinding && validationResult.displaySessionId !== sessionId) {
                 workspaceBinding.displayHandle = validationResult.displaySessionId;
             }
-            return { sessionInfo, workspaceBinding };
+            return { sessionInfo, workspaceBinding, cliSessionBinding };
         } catch (error) {
             logger.systemWarn(`SessionContextManager validation failed: ${getErrorMessage(error)}. Falling back to SessionService`);
             // Fallback to original SessionService if SessionContextManager fails
@@ -383,8 +474,37 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
                 params.context.sessionId = sessionInfo.sessionId;
             }
             params.sessionId = sessionInfo.sessionId;
-            // No bind on the fallback path: the manager that would hold it just failed.
+            // No bind of any kind on the fallback path: the manager that would hold it just failed.
             return { sessionInfo };
+        }
+    }
+
+    /**
+     * Bind point 3 (#214): an EXPLICIT `--session` on a CLI connection becomes
+     * this vault's `cliCurrentSession` once the call succeeds, so the next CLI
+     * call with no `--session` continues it. Same success rule as bind point 1
+     * — for `useTools` the RESULT must not carry `success: false` (handle()'s
+     * local flag is true for any non-throwing call); for `getTools` any
+     * non-throwing result counts, since discovery has no failure payload of
+     * its own. A thrown call never reaches here. The default and inherited
+     * handles carry no intent and so are never bound.
+     */
+    private bindCliSessionFromResult(
+        context: StrategyRequestContext,
+        result: ToolExecutionResult
+    ): void {
+        const intent = context.cliSessionBinding;
+        if (!this.sessionContextManager || !intent) {
+            return;
+        }
+        if (context.agentName === TOOL_MANAGER_AGENT && context.tool === USE_TOOLS
+            && (!result || result.success === false)) {
+            return;
+        }
+        try {
+            this.sessionContextManager.setCliCurrentSession(intent.handle);
+        } catch (error) {
+            logger.systemWarn(`CLI current-session bind failed for "${intent.handle}": ${getErrorMessage(error)}`);
         }
     }
 

--- a/src/handlers/strategies/ToolExecutionStrategy.ts
+++ b/src/handlers/strategies/ToolExecutionStrategy.ts
@@ -405,12 +405,15 @@ export class ToolExecutionStrategy implements IRequestStrategy<ToolExecutionRequ
 
             // UNBOUND: what runs anyway, and under which partition. Discovery
             // always does. So does a `useTools` batch made ENTIRELY of
-            // `memory load-workspace` / `memory list-workspaces` — the only
-            // exemption from the UNBOUND rule. A fresh session has to be able
-            // to see its workspaces and pick one, both of those live behind
+            // `memory load-workspace` / `memory list-workspaces` /
+            // `memory create-workspace` — the only exemption from the UNBOUND
+            // rule. A fresh session has to be able to see its workspaces,
+            // create one when none fits, and pick one; all three live behind
             // useTools, and the steer itself tells the caller to do exactly
             // this; without the exemption `load-workspace` would need the
-            // workspace it is about to load. It is a partition, not a choice:
+            // workspace it is about to load. Creating is part of choosing and
+            // is scoped to no workspace; the guidance says "create, then
+            // load", so the load still binds. It is a partition, not a choice:
             // no WorkspaceBindingIntent is recorded, so bind point 1 stays
             // silent, and bind point 2 binds the workspace actually loaded on
             // success. A MIXED batch does not qualify: normalizeContext stamps

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -44,7 +44,7 @@ export type SessionDeletedListener = (sessionId: string, workspaceId: string) =>
  * so this file does not import the (heavy) WorkspaceService module.
  */
 export interface WorkspaceResolverLike {
-  getWorkspaceByNameOrId(identifier: string): Promise<{ id: string } | null>;
+  getWorkspaceByNameOrId(identifier: string): Promise<{ id: string; name?: string } | null>;
 }
 
 export interface SessionValidationResult {
@@ -120,6 +120,14 @@ export class SessionContextManager {
   // 'default' — so that map records where traces went, not what the caller
   // chose. Only bindHandleWorkspace / bindSessionWorkspaceById write here.
   private handleWorkspace: Map<string, string> = new Map();
+
+  // The session handle the CLI last chose with an explicit `--session` on a
+  // successful call — "where the CLI left off" in this vault. A CLI call with
+  // no `--session` continues it (ToolExecutionStrategy bind point 3). Null
+  // until the CLI has chosen once; the `'nexus-cli'` fallback the strategy
+  // applies in that case is a default, not a choice, and never lands here.
+  // MCP clients and native chat never read or write this.
+  private cliCurrentSession: string | null = null;
 
   // Canonicalises workspace names to ids before a bind or partition, the same
   // way ToolCallTraceService.resolveWorkspaceId does for traces, so a session's
@@ -212,6 +220,9 @@ export class SessionContextManager {
         this.handleWorkspace.set(handle, workspaceId);
       }
     }
+    if (this.cliCurrentSession === null && doc.cliCurrentSession) {
+      this.cliCurrentSession = doc.cliCurrentSession;
+    }
   }
 
   private snapshotBindings(): PersistedSessionBindings {
@@ -221,8 +232,43 @@ export class SessionContextManager {
     }
     return {
       handles,
-      handleWorkspace: Object.fromEntries(this.handleWorkspace.entries())
+      handleWorkspace: Object.fromEntries(this.handleWorkspace.entries()),
+      cliCurrentSession: this.cliCurrentSession
     };
+  }
+
+  /** The handle the CLI last chose with `--session`, or null if it never has. */
+  getCliCurrentSession(): string | null {
+    return this.cliCurrentSession;
+  }
+
+  /**
+   * Bind point 3 (#214): remember the handle an explicit `--session` named
+   * once the call succeeded. Switching is the same gesture as choosing — pass
+   * a different value once. Idempotent so the every-call case costs no write.
+   */
+  setCliCurrentSession(handle: string): void {
+    const trimmed = handle.trim();
+    if (!trimmed) {
+      logger.systemWarn('Attempted to set the CLI current session to an empty handle');
+      return;
+    }
+    if (this.cliCurrentSession === trimmed) {
+      return;
+    }
+    this.cliCurrentSession = trimmed;
+    logger.systemLog(`CLI current session is now "${trimmed}"`);
+    this.scheduleBindingsSave();
+  }
+
+  /**
+   * The internal session a friendly handle maps to in a workspace, if this
+   * manager has seen it (live or restored). Read-only; used by the
+   * `nexus://context` resource to show the display name a renamed handle got.
+   */
+  describeHandle(handle: string, workspaceId = 'default'): { id: string; displaySessionId: string } | undefined {
+    const entry = this.sessionHandleMap.get(this.handleKey(workspaceId, handle));
+    return entry ? { id: entry.id, displaySessionId: entry.displaySessionId } : undefined;
   }
 
   /**
@@ -275,6 +321,23 @@ export class SessionContextManager {
     } catch (error) {
       logger.systemWarn(`Workspace lookup failed for "${trimmed}": ${error instanceof Error ? error.message : String(error)}`);
       return trimmed;
+    }
+  }
+
+  /**
+   * Best-effort display name for a canonical workspace id ('default' has
+   * none). Read-only; a failed or absent lookup yields undefined.
+   */
+  async describeWorkspace(workspaceId: string): Promise<{ id: string; name?: string }> {
+    const trimmed = workspaceId.trim();
+    if (trimmed.length === 0 || trimmed === GLOBAL_WORKSPACE_ID || !this.workspaceResolver) {
+      return { id: trimmed };
+    }
+    try {
+      const workspace = await this.workspaceResolver.getWorkspaceByNameOrId(trimmed);
+      return workspace?.name ? { id: trimmed, name: workspace.name } : { id: trimmed };
+    } catch {
+      return { id: trimmed };
     }
   }
 
@@ -589,6 +652,7 @@ export class SessionContextManager {
     this.sessionHandleMap.clear();
     this.unverifiedHandleKeys.clear();
     this.handleWorkspace.clear();
+    this.cliCurrentSession = null;
     this.instructedSessions.clear();
     this.defaultWorkspaceContext = null;
   }

--- a/src/services/session/SessionBindingsStore.ts
+++ b/src/services/session/SessionBindingsStore.ts
@@ -21,14 +21,19 @@ export interface PersistedSessionHandle {
  * - `handleWorkspace` records the LAST DELIBERATE workspace bind per handle
  *   (#214). It is written only by an explicit `workspaceId` on a successful
  *   call or a successful `memory load-workspace` — never by trace capture.
+ * - `cliCurrentSession` is the handle the CLI last chose with an explicit
+ *   `--session` on a successful call — this vault's "where the CLI left off".
+ *   A CLI call with no `--session` continues it. Null until the CLI has chosen
+ *   once; the server's `'nexus-cli'` fallback for that case is a default, not
+ *   a bind, and is never written here.
  *
- * PR 2 of the plan adds a `cliCurrentSession` slot beside these two. The
- * parser ignores keys it does not know, so adding one is a shape extension,
- * not a migration.
+ * The parser ignores keys it does not know, so adding a slot is a shape
+ * extension, not a migration.
  */
 export interface PersistedSessionBindings {
   handles: Record<string, PersistedSessionHandle>;
   handleWorkspace: Record<string, string>;
+  cliCurrentSession: string | null;
 }
 
 /**
@@ -85,7 +90,13 @@ export function parsePersistedSessionBindings(raw: unknown): PersistedSessionBin
     }
   }
 
-  return { handles, handleWorkspace };
+  // A blank or non-string value reads as "the CLI has not chosen yet", the
+  // same as a file written before this slot existed.
+  const cliCurrentSession = typeof raw.cliCurrentSession === 'string' && raw.cliCurrentSession.trim().length > 0
+    ? raw.cliCurrentSession.trim()
+    : null;
+
+  return { handles, handleWorkspace, cliCurrentSession };
 }
 
 /**

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,7 +7,7 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "12f4a7babd7333df";
+export const NEXUS_CLI_ASSETS_HASH = "5a6cadfe8840206d";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
@@ -145,6 +145,10 @@ var McpLineClient = class {
   callTool(name, args) {
     return this.request("tools/call", { name, arguments: args }, this.toolCallTimeoutMs);
   }
+  /** Standard MCP \`resources/read\`; used for the server-answered \`nexus://context\` view. */
+  readResource(uri) {
+    return this.request("resources/read", { uri });
+  }
   close() {
     this.socket?.end();
     this.socket?.destroy();
@@ -180,6 +184,98 @@ function listPlaybooks(dir) {
   return (0, import_node_fs.readdirSync)(dir).filter((f) => f.endsWith(".md") && !f.startsWith("_")).map((f) => parseFrontmatter((0, import_node_fs.readFileSync)((0, import_node_path.join)(dir, f), "utf8")).meta).filter((m) => m.name);
 }
 
+// cli/envelope.ts
+function contextFromFlags(flags) {
+  const envelope = {};
+  if (typeof flags.workspace === "string") envelope.workspaceId = flags.workspace;
+  if (typeof flags.session === "string") envelope.sessionId = flags.session;
+  return envelope;
+}
+function buildToolsEnvelope(flags, selector) {
+  return {
+    tool: selector,
+    ...contextFromFlags(flags),
+    memory: typeof flags.memory === "string" ? flags.memory : "Discovering available Nexus tools.",
+    goal: typeof flags.goal === "string" ? flags.goal : \`Inspect "\${selector}" tools.\`
+  };
+}
+function buildPlaybookEnvelope(flags, name) {
+  return {
+    ...contextFromFlags(flags),
+    memory: \`Loading the "\${name}" playbook.\`,
+    goal: \`Prepare to run the \${name} task.\`
+  };
+}
+function buildUseEnvelope(flags, command, memory, goal) {
+  const args = {
+    tool: command,
+    ...contextFromFlags(flags),
+    memory,
+    goal
+  };
+  if (typeof flags.constraints === "string") args.constraints = flags.constraints;
+  if (typeof flags["operation-id"] === "string") args.operationId = flags["operation-id"];
+  return args;
+}
+
+// cli/context.ts
+var NEXUS_CONTEXT_RESOURCE_URI = "nexus://context";
+function isRecord2(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function parseContextSnapshot(result) {
+  const contents = result?.contents;
+  const entry = Array.isArray(contents) ? contents.find((c) => typeof c?.text === "string") : void 0;
+  if (!entry || typeof entry.text !== "string") {
+    throw new Error(\`Unexpected reply to \${NEXUS_CONTEXT_RESOURCE_URI}: no text content. Is the Nexus plugin up to date?\`);
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(entry.text);
+  } catch {
+    throw new Error(\`Unexpected reply to \${NEXUS_CONTEXT_RESOURCE_URI}: not JSON.\`);
+  }
+  if (!isRecord2(parsed) || typeof parsed.defaultSessionHandle !== "string" || !("cliSession" in parsed)) {
+    throw new Error(\`Unexpected reply to \${NEXUS_CONTEXT_RESOURCE_URI}: missing fields.\`);
+  }
+  const session = parsed.cliSession;
+  if (session !== null && (!isRecord2(session) || typeof session.handle !== "string")) {
+    throw new Error(\`Unexpected reply to \${NEXUS_CONTEXT_RESOURCE_URI}: malformed cliSession.\`);
+  }
+  const workspace = isRecord2(session) ? session.workspace : null;
+  return {
+    vault: typeof parsed.vault === "string" ? parsed.vault : null,
+    defaultSessionHandle: parsed.defaultSessionHandle,
+    cliSession: isRecord2(session) ? {
+      handle: session.handle,
+      displaySessionId: typeof session.displaySessionId === "string" ? session.displaySessionId : null,
+      workspace: isRecord2(workspace) && typeof workspace.id === "string" ? { id: workspace.id, ...typeof workspace.name === "string" ? { name: workspace.name } : {} } : null
+    } : null
+  };
+}
+function formatContextSnapshot(snapshot) {
+  const lines = [];
+  lines.push(\`Vault:      \${snapshot.vault ?? "(unknown)"}\`);
+  const session = snapshot.cliSession;
+  if (!session) {
+    lines.push(\`Session:    none \\u2014 the next CLI call runs as "\${snapshot.defaultSessionHandle}".\`);
+    lines.push("            Pass --session <name> once to choose one; later calls continue it.");
+    lines.push("Workspace:  unbound \\u2014 pass --workspace <name> once, or run \`memory load-workspace <name>\`.");
+    return lines.join("\\n") + "\\n";
+  }
+  const renamed = session.displaySessionId && session.displaySessionId !== session.handle ? \`  (display name: \${session.displaySessionId})\` : "";
+  lines.push(\`Session:    \${session.handle}\${renamed}\`);
+  if (session.workspace) {
+    const { id, name } = session.workspace;
+    lines.push(\`Workspace:  \${name && name !== id ? \`\${name}  (\${id})\` : id}\`);
+  } else {
+    lines.push("Workspace:  unbound \\u2014 pass --workspace <name> once, or run \`memory load-workspace <name>\`.");
+  }
+  lines.push("");
+  lines.push("Calls without --session/--workspace use these. Pass a different value once to switch.");
+  return lines.join("\\n") + "\\n";
+}
+
 // cli/commandLine.ts
 var CONTEXT_VALUE_FLAGS = /* @__PURE__ */ new Set([
   "memory",
@@ -210,7 +306,7 @@ var MISPLACEABLE_CONTEXT_FLAGS = /* @__PURE__ */ new Set([
   "json",
   "dry-run"
 ]);
-var VERBS = ["tools", "use", "playbook", "vaults", "doctor", "help"];
+var VERBS = ["tools", "use", "playbook", "context", "vaults", "doctor", "help"];
 function editDistance(a, b) {
   const rows = Array.from({ length: a.length + 1 }, (_, i) => {
     const row = new Array(b.length + 1).fill(0);
@@ -600,6 +696,8 @@ COMMANDS
   nexus use [context] -- <command>    EXECUTE a tool (useTools). See CONTEXT below.
   nexus playbook [name]              Task primer: recipe + your workspaces + preloaded
                                      tools, in one call. \\\`nexus playbook\\\` lists them.
+  nexus context [--json]             What this vault remembers for the CLI: current
+                                     session and its workspace (read-only)
   nexus vaults                       List open Nexus vaults (live sockets)
   nexus doctor [--vault <name>]      Connect + handshake; print server info
   nexus --help                       This manual
@@ -612,8 +710,16 @@ CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` 
   --memory "<text>"       REQUIRED \\u2014 rolling summary of what you've done/learned
   --goal "<text>"         REQUIRED \\u2014 this call's objective, one sentence
                           (empty or placeholder like "N/A" is REJECTED with a steer)
-  --workspace <id>        scope for traces/memory (default: "default")
-  --session <name>        continuity across calls (default: "nexus-cli"; keep it stable)
+  --workspace <name|id>   PASS ONCE \\u2014 the vault remembers it per session. A fresh
+                          session must choose: pass --workspace once, or run
+                          \\\`memory load-workspace <name>\\\`; every later call in that
+                          session inherits it. Nothing defaults silently: an unbound
+                          session's \\\`use\\\` fails with a steer (only \\\`memory
+                          list-workspaces\\\` / \\\`memory load-workspace\\\` run unbound).
+  --session <name>        PASS ONCE \\u2014 the vault remembers the CLI's current session.
+                          Omit it and the CLI continues where it left off (or runs as
+                          "nexus-cli" if it never chose). Pass a different name once
+                          to switch. \\\`nexus context\\\` shows both.
   --constraints "<text>"  optional guardrails
   --operation-id <id>     optional stable retry identity; reuse only for the exact same command
   --vault <name>          target a vault (else: the single open one, or $NEXUS_VAULT)
@@ -670,6 +776,15 @@ GOTCHAS
     --dryRun, and typos like --vualt fail with a suggestion instead of silently
     doing nothing. Tool flags are only recognized after \\\`--\\\`.
   \\u2022 --memory/--goal are enforced \\u2014 send real values or the call is rejected.
+  \\u2022 "This session has no workspace yet" means choose once: \\\`--workspace <name>\\\` on
+    this call, or \\\`memory load-workspace <name>\\\` in its own call (not batched with
+    other commands). Then drop --workspace; the session inherits it. Repeating
+    --workspace on every call is harmless but unnecessary. \\\`--workspace default\\\`
+    is the global workspace \\u2014 pass it deliberately, never as a placeholder.
+  \\u2022 --session works the same way: choose once, then omit. Two different --session
+    names are two different sessions with their own remembered workspace.
+    \\\`nexus context\\\` shows what the current vault remembers; a plugin reload
+    keeps it.
   \\u2022 Media generation is async \\u2014 \\\`prompt generate-image\\\` / \\\`generate-audio\\\` /
     \\\`generate-video\\\` return a job; poll \\\`prompt check-generated-artifact "<job-id>"\\\`.
   \\u2022 States: the AI gets archive (reversible), not delete.
@@ -693,10 +808,13 @@ PLAYBOOKS  (nexus playbook <name>)
 
 EXAMPLES
   nexus tools "content read, search content"
-  nexus use --memory "auditing notes" --goal "read today's daily" -- content read --path Daily/2026-07-17.md --start-line 1
-  nexus use --vault "My Notes" --memory "smoke test" --goal "list vault root" -- storage list
-  nexus use --dry-run --memory "resuming research" --goal "load workspace" -- memory load-workspace "NeuroAI Mapping" --limit 1
+  # first call of a fresh session: choose the session and workspace ONCE...
+  nexus use --session daily-audit --workspace "My Notes" --memory "auditing notes" --goal "read today's daily" -- content read --path Daily/2026-07-17.md --start-line 1
+  # ...then omit both; this call runs in daily-audit / "My Notes"
+  nexus use --memory "read today's daily; checking the root" --goal "list vault root" -- storage list
+  nexus use --vault "My Notes" --dry-run --memory "resuming research" --goal "load workspace" -- memory load-workspace "NeuroAI Mapping" --limit 1
   nexus use --memory "reviewing saved views" --goal "see what the Tasks base returns" -- base analyze "Bases/Tasks.base" --limit 20
+  nexus context
   nexus playbook vault-work
 \`;
 }
@@ -759,14 +877,15 @@ Run \\\`nexus --help\\\` for the manual.
   if (cmd === "tools") {
     const selector = positionals.slice(1).join(" ") || "--help";
     return withClient(vaultFlag, async (client) => {
-      const result = await client.callTool("toolManager_getTools", {
-        tool: selector,
-        workspaceId: typeof flags.workspace === "string" ? flags.workspace : "default",
-        sessionId: typeof flags.session === "string" ? flags.session : "nexus-cli",
-        memory: typeof flags.memory === "string" ? flags.memory : "Discovering available Nexus tools.",
-        goal: typeof flags.goal === "string" ? flags.goal : \`Inspect "\${selector}" tools.\`
-      });
+      const result = await client.callTool("toolManager_getTools", buildToolsEnvelope(flags, selector));
       return printToolResult(result, asJson);
+    });
+  }
+  if (cmd === "context") {
+    return withClient(vaultFlag, async (client) => {
+      const snapshot = parseContextSnapshot(await client.readResource(NEXUS_CONTEXT_RESOURCE_URI));
+      process.stdout.write(asJson ? JSON.stringify(snapshot, null, 2) + "\\n" : formatContextSnapshot(snapshot));
+      return 0;
     });
   }
   if (cmd === "playbook") {
@@ -803,12 +922,7 @@ Run \\\`nexus --help\\\` for the manual.
     const preamblePath = (0, import_node_path2.join)(dir, "_preamble.md");
     const preamble = (0, import_node_fs3.existsSync)(preamblePath) ? (0, import_node_fs3.readFileSync)(preamblePath, "utf8").trim() : "";
     if (preamble) process.stdout.write(preamble + "\\n\\n");
-    const ctx = {
-      workspaceId: typeof flags.workspace === "string" ? flags.workspace : "default",
-      sessionId: typeof flags.session === "string" ? flags.session : "nexus-cli",
-      memory: \`Loading the "\${name}" playbook.\`,
-      goal: \`Prepare to run the \${name} task.\`
-    };
+    const ctx = buildPlaybookEnvelope(flags, name);
     try {
       const { workspaces, tools } = await withClient(vaultFlag, async (client) => {
         const ws = await client.callTool("toolManager_useTools", { ...ctx, tool: "memory list-workspaces" });
@@ -874,15 +988,7 @@ Write: nexus use --memory "<what you've done so far>" --goal "<this call's objec
       );
       return 2;
     }
-    const args = {
-      tool: command,
-      workspaceId: typeof flags.workspace === "string" ? flags.workspace : "default",
-      sessionId: typeof flags.session === "string" ? flags.session : "nexus-cli",
-      memory,
-      goal
-    };
-    if (typeof flags.constraints === "string") args.constraints = flags.constraints;
-    if (typeof flags["operation-id"] === "string") args.operationId = flags["operation-id"];
+    const args = buildUseEnvelope(flags, command, memory, goal);
     if (flags["dry-run"] === true) {
       process.stdout.write("DRY RUN \\u2014 no vault connection and no tool execution.\\n");
       process.stdout.write(JSON.stringify(args, null, 2) + "\\n");
@@ -946,6 +1052,14 @@ For a common task, **\`nexus playbook <name>\`** gives you a ready-to-run recipe
   hoping for vault content — that comes from \`nexus use --memory … --goal … -- content read …\`.
 - **\`--memory\` and \`--goal\` are real and enforced.** You're operating a person's
   live vault; pass a genuine running summary and objective, not placeholders.
+- **\`--workspace\` and \`--session\` are pass-once.** The vault remembers them:
+  name a session and choose its workspace on the first call of a task (or run
+  \`memory load-workspace <name>\`), then omit both — every later call continues
+  that session and inherits its workspace. Nothing defaults silently: a session
+  that never chose a workspace fails with *"This session has no workspace yet"*
+  (only \`memory list-workspaces\` / \`memory load-workspace\` run before the
+  choice). Pass a different value once to switch. \`nexus context\` shows what
+  the vault currently remembers.
 - **You can't escape the vault.** Paths are vault-relative; \`..\`, \`~\`, and
   absolute paths are rejected. That's a guardrail, not a bug.
 - **Nothing is destroyed.** The AI gets archive (reversible), not delete.
@@ -958,7 +1072,11 @@ For a common task, **\`nexus playbook <name>\`** gives you a ready-to-run recipe
 nexus tools [selector]              # discover — tool schemas (never vault data)
 nexus use --memory "<what you're doing>" --goal "<objective>" -- \\
     <agent command --flags>         # execute — runs one tool, prints the result
+nexus context                       # what this vault remembers: session + workspace
 \`\`\`
+
+Add \`--session <name> --workspace <name>\` to the **first** \`use\` of a task
+only; the vault remembers both for every call after it.
 
 The \`--\` delimiter is canonical: context belongs before it; the tool command
 belongs after it. This avoids nested command-string quoting, especially in
@@ -1015,6 +1133,12 @@ offline and instant, so read it before your first command instead of guessing.
   Drill down: \`nexus tools storage list\` = one tool's full arg schema.
 - **Execute:** \`nexus use --memory "<what you're doing>" --goal "<objective>" -- <agent command --flags>\`.
   \`--memory\`/\`--goal\` are **required** on every \`use\`.
+- **Context is remembered:** add \`--session <name> --workspace <name>\` to the
+  **first** \`use\` of a task (or run \`memory load-workspace <name>\`), then omit
+  both — later calls continue that session and inherit its workspace. A session
+  that never chose a workspace fails with "This session has no workspace yet";
+  choose once, never pass \`default\` as a placeholder. \`nexus context\` shows what
+  the vault remembers.
 - **Multiline content:** keep Markdown/YAML and embedded quotes out of shell
   argv. After \`--\`, swap any value-taking flag for its transport form:
   \`--<flag>-stdin\` (piped input) or \`--<flag>-file <local-path>\` — e.g.
@@ -1043,13 +1167,18 @@ so you can go straight to \`nexus use\` without a separate \`nexus tools\` call.
 
 **Every playbook starts the same way:**
 
-1. **Pick a workspace and load it.** Choose from *Your workspaces* below and run
-   \`nexus use --memory … --goal … -- memory load-workspace "<name>"\`. If
-   none fits, create one with \`memory create-workspace\`. Loading scopes your traces
-   and auto-loads that workspace's task summary. (This playbook only *lists*
-   workspaces — loading is your call, since only you know which one.)
-2. **Thread the workspace** into every following call with \`--workspace <name>\`
-   (the outer context flag), and keep a stable \`--session <name>\` for the task.
+1. **Name the session and load a workspace — once.** Choose from *Your
+   workspaces* below and run
+   \`nexus use --session <task-name> --memory … --goal … -- memory load-workspace "<name>"\`.
+   If none fits, create one with \`memory create-workspace\`, then load it. Loading
+   scopes your traces, auto-loads that workspace's task summary, and **binds the
+   session to it**. (This playbook only *lists* workspaces — loading is your
+   call, since only you know which one.)
+2. **Then omit \`--session\` and \`--workspace\`.** The vault remembers both: every
+   later call continues that session and inherits its workspace. Pass a
+   different value once to switch; \`nexus context\` shows what is remembered. A
+   session that never chose fails with "This session has no workspace yet" —
+   never pass \`default\` as a placeholder.
 3. **Always pass real \`--memory\` and \`--goal\`** — a running summary and the
    current objective. Placeholders are rejected.
 4. **Checkpoint at milestones** with \`memory create-state\` so the work is
@@ -1082,7 +1211,8 @@ Unlike \`vault-work\` (which edits note *bodies*), this moves and files whole no
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above); thread \`--workspace\`/\`--session\`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Map the current layout before touching anything.**
    - \`storage list --path "<folder>"\` — see what's in a folder.
    - \`search query-notes --sql "…"\` — query frontmatter as a database to *find*
@@ -1103,33 +1233,30 @@ Unlike \`vault-work\` (which edits note *bodies*), this moves and files whole no
 ## Worked example — archive old daily notes into a subfolder
 
 \`\`\`
-# 1. load the workspace
+# 1. name the session and load the workspace — the only call that needs --session;
+#    loading binds the workspace, so nothing below repeats either flag
 nexus use \\
-  --memory "tidying old dailies" --goal "load the journal workspace" \\
   --session tidy-dailies \\
+  --memory "tidying old dailies" --goal "load the journal workspace" \\
   -- memory load-workspace "journal"
 
 # 2. map — which dailies are from 2025? (query frontmatter; --describe to see columns first)
 nexus use \\
-  --workspace journal --session tidy-dailies \\
   --memory "finding 2025 dailies to archive" --goal "list 2025 daily notes" \\
   -- search query-notes --sql "SELECT path FROM notes WHERE path LIKE 'Daily/2025-%' ORDER BY path"
 
 # 3. make the destination folder
 nexus use \\
-  --workspace journal --session tidy-dailies \\
   --memory "have the 2025 list; creating archive folder" --goal "create Daily/Archive/2025" \\
   -- storage create-folder --path Daily/Archive/2025
 
 # 4. move each note (one call per file — verify each)
 nexus use \\
-  --workspace journal --session tidy-dailies \\
   --memory "moving 2025 dailies into the archive folder" --goal "move 2025-01-03.md" \\
   -- storage move --path Daily/2025-01-03.md --new-path Daily/Archive/2025/2025-01-03.md
 
 # 5. checkpoint after the batch
 nexus use \\
-  --workspace journal --session tidy-dailies \\
   --memory "2025 dailies archived" --goal "checkpoint the reorg" \\
   -- memory create-state --name dailies-archived \\
   --conversation-context "moved all 2025 daily notes into Daily/Archive/2025" \\
@@ -1187,7 +1314,8 @@ Full live schema: \`nexus tools prompt execute\`. Saved prompts: \`prompt list\`
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above); thread \`--workspace\`/\`--session\`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Pick the driver**: write an **inline** \`prompt\`, or find a **saved** one with
    \`prompt list\` and pass its name as \`customPrompt\`.
 3. **Attach the notes** the prompt should see via \`contextFiles\` (read them first
@@ -1213,11 +1341,14 @@ the inline JSON stays small.
 
 ## Worked examples
 
+All three examples share one session. Example A is the first call, so it names
+the session and the workspace once; B and C omit both and inherit them.
+
 **A — inline prompt, one note as context, result to stdout:**
 
 \`\`\`
 nexus use \\
-  --json --workspace research --session prompt-run \\
+  --json --session prompt-run --workspace research \\
   --memory "summarizing the auth flow note" --goal "get a 3-bullet summary" \\
   -- prompt execute --prompts '[{"type":"text","prompt":"Summarize this note in 3 bullets","contextFiles":["Projects/Auth/flow.md"]}]'
 \`\`\`
@@ -1229,14 +1360,13 @@ the **user** message. They are different roles, not alternatives — a request w
 \`customPrompt\` and no \`prompt\` sends the model no instruction to act on.
 
 \`\`\`
-# find the saved prompt's name
-nexus use --workspace research --session prompt-run \\
+# find the saved prompt's name (session + workspace inherited from A)
+nexus use \\
   --memory "looking for my weekly-review prompt" --goal "list saved prompts" \\
   -- prompt list
 
 # run it over this week's notes and append the output to the review note
 nexus use \\
-  --workspace research --session prompt-run \\
   --memory "have the daily notes; running weekly-review" --goal "append a weekly review" \\
   -- prompt execute --prompts '[{"type":"text","customPrompt":"weekly-review","prompt":"Write the weekly review from the attached daily notes.","contextFiles":["Daily/2026-07-14.md","Daily/2026-07-15.md"],"action":{"type":"append","targetPath":"Reviews/2026-W29.md"}}]'
 \`\`\`
@@ -1245,11 +1375,10 @@ nexus use \\
 
 \`\`\`
 nexus use \\
-  --workspace research --session prompt-run \\
   --memory "need a logo asset" --goal "generate a logo image" \\
   -- prompt execute --prompts '[{"type":"image","prompt":"a minimalist logo, teal on white","savePath":"Assets/logo.png","aspectRatio":"1:1"}]'
 # then poll:
-nexus use --workspace research --session prompt-run \\
+nexus use \\
   --memory "waiting on the logo" --goal "check image generation status" \\
   -- prompt check-generated-artifact "<job-id>"
 \`\`\`
@@ -1283,23 +1412,24 @@ the workspace, get or create a project (capture its \`projectId\`), then add tas
 
 ## The one thing to get right: workspace vs project
 
-- **Workspace** comes from the **top-level \`--workspace <name-or-id>\` context
-  flag** — the same flag you pass on every call, set to the workspace you loaded.
-  Task tools read their workspace scope from it automatically. **Do not** put
+- **Workspace** is the one your session is bound to — set once by loading it
+  (\`memory load-workspace\`) or by passing the top-level \`--workspace <name-or-id>\`
+  context flag once; every later call in the session inherits it, and task tools
+  read their workspace scope from it automatically. **Do not** put
   \`--workspace-id\` *inside* the tool string — it's a reserved context field and
   is rejected there.
 - **Project** is identified by a **\`projectId\`** that \`task create-project\` (or
   \`task list-projects\`) returns. Capture it and pass it to task calls as
   \`--project-id\`.
 
-So: load the workspace → thread \`--workspace\` on every call → create/find a
-project → capture its \`projectId\` → create tasks with \`--project-id\`.
+So: load the workspace once → create/find a project → capture its \`projectId\`
+→ create tasks with \`--project-id\`.
 
 ## Protocol
 
-1. **Load the workspace** (spine above); thread \`--workspace <name-or-id>\` on
-   every following call.
-2. **Get a project.** \`task list-projects\` (scoped by \`--workspace\`) to find one,
+1. **Name the session and load the workspace** (spine above) — once; later calls
+   inherit both.
+2. **Get a project.** \`task list-projects\` (scoped by the session's workspace) to find one,
    or \`task create-project --name "<name>"\` — note the **projectId** it returns.
 3. **Add tasks.** \`task create --project-id <projectId> --title "<title>"\` (add
    \`--description\`, dependencies, etc. — see \`nexus tools task create\`).
@@ -1314,39 +1444,35 @@ project → capture its \`projectId\` → create tasks with \`--project-id\`.
 ## Worked example — new project, two tasks, one depends on the other
 
 \`\`\`
-# 1. load the workspace — thread --workspace (name or id) on every later call
+# 1. name the session and load the workspace — once; loading binds the session
+#    to "product", so no later call repeats --session or --workspace
 nexus use \\
-  --memory "planning the launch" --goal "load the product workspace" \\
   --session launch-plan \\
+  --memory "planning the launch" --goal "load the product workspace" \\
   -- memory load-workspace "product"
 
-# 2. create a project — workspace comes from --workspace; capture the projectId
+# 2. create a project — workspace scope is inherited; capture the projectId
 nexus use \\
-  --workspace product --session launch-plan \\
   --memory "starting the Q3 launch project" --goal "create the Q3 Launch project" \\
   -- task create-project --name "Q3 Launch"
 # → result includes the projectId, e.g. "proj_def456"
 
 # 3. add tasks under that project
 nexus use \\
-  --workspace product --session launch-plan \\
   --memory "adding launch tasks" --goal "create the copy task" \\
   -- task create --project-id proj_def456 --title "Write launch copy"
 
 nexus use \\
-  --workspace product --session launch-plan \\
   --memory "adding the dependent task" --goal "create the publish task" \\
   -- task create --project-id proj_def456 --title "Publish blog post"
 
 # 4. see the board (statuses, what's blocked)
 nexus use \\
-  --workspace product --session launch-plan \\
   --memory "reviewing the launch tasks" --goal "list tasks in the project" \\
   -- task list --project-id proj_def456
 
 # 5. checkpoint
 nexus use \\
-  --workspace product --session launch-plan \\
   --memory "project + tasks created" --goal "checkpoint the setup" \\
   -- memory create-state --name launch-tasks-seeded \\
   --conversation-context "created Q3 Launch project with copy + publish tasks" \\
@@ -1361,8 +1487,11 @@ Run \`nexus tools task create\` / \`task move\` / \`task update\` for the exact 
 ## Pitfalls
 
 - **Putting \`--workspace-id\` inside the tool string** — rejected as a reserved
-  context field. Scope task tools with the top-level \`--workspace <name-or-id>\`
-  flag instead (the workspace you loaded); it accepts a name *or* an id.
+  context field. Task tools are scoped by the session's workspace — the one you
+  loaded, or the top-level \`--workspace <name-or-id>\` flag passed once; it
+  accepts a name *or* an id.
+- **"This session has no workspace yet"** — the session never chose. Load one
+  first (step 1); don't answer the steer with \`--workspace default\`.
 - **Creating tasks with no project** — \`task create\` needs \`--project-id\`; make or
   find the project first and capture the id it returns.
 - **\`task link-note\` needs a real \`--note-path\`** — a vault-relative path to an
@@ -1384,7 +1513,8 @@ update it," "answer a question from my notes," "add a section to Y," etc.
 
 ## Protocol
 
-1. **Load a workspace** (see the spine above), thread \`--workspace\`/\`--session\`.
+1. **Name the session and load a workspace** (see the spine above) — once; later
+   calls inherit both.
 2. **Find the note(s).** Pick the search that fits:
    - \`search content --query "<terms>"\` — semantic/keyword over note bodies.
    - \`search directory --query "<name>" --paths "<folder>"\` — by filename/path.
@@ -1407,27 +1537,25 @@ update it," "answer a question from my notes," "add a section to Y," etc.
 ## Worked example — add a summary under a heading
 
 \`\`\`
-# 1. load the workspace you picked from the list above (--workspace = name or id)
+# 1. name the session and load the workspace you picked from the list above —
+#    this is the only call that needs --session; loading binds the workspace
 nexus use \\
-  --memory "starting: summarize the auth notes" --goal "load the research workspace" \\
   --session auth-summary \\
+  --memory "starting: summarize the auth notes" --goal "load the research workspace" \\
   -- memory load-workspace "research"
 
-# 2. find
+# 2. find — no --session/--workspace: the vault remembers auth-summary → research
 nexus use \\
-  --workspace research --session auth-summary \\
   --memory "looking for the main auth note" --goal "locate the auth flow note" \\
   -- search content --query "authentication flow" --limit 5
 
 # 3. read the top hit (search gave a path, not the text)
 nexus use \\
-  --workspace research --session auth-summary \\
   --memory "found Projects/Auth/flow.md; reading it" --goal "read the auth flow note" \\
   -- content read --path Projects/Auth/flow.md --start-line 1
 
 # 4. edit — anchor on exact text pulled from the read
 nexus use \\
-  --workspace research --session auth-summary \\
   --memory "have the body; inserting a summary" --goal "replace the Summary section" \\
   -- content replace --path Projects/Auth/flow.md \\
   --start "## Summary" --end "## Details" \\
@@ -1435,7 +1563,6 @@ nexus use \\
 
 # 5. checkpoint (create-state needs name + context + task + file/step arrays)
 nexus use \\
-  --workspace research --session auth-summary \\
   --memory "summary written to flow.md" --goal "checkpoint the finished edit" \\
   -- memory create-state --name auth-summary-done \\
   --conversation-context "summarized the auth flow note into a Summary section" \\
@@ -1452,7 +1579,12 @@ nexus use \\
   \`start\`/\`end\`. Copy the anchors verbatim from the read.
 - **Answering a question from \`{path, score}\`** — read the note; don't fabricate
   from the ranking.
-- **Losing trace scope** — pass \`--workspace\` on every call, not just the load.
+- **Switching sessions by accident** — a different \`--session\` name is a
+  different session with its own remembered workspace. Stay on one name per
+  task; \`nexus context\` shows which one is current.
+- **"This session has no workspace yet"** — this session never chose. Load one
+  (\`memory load-workspace\`, on its own) or pass \`--workspace\` once; don't answer
+  it with \`--workspace default\`.
 - **Writing outside the vault** — \`..\`/\`~\`/absolute paths are rejected; keep
   paths vault-relative.
 `,

--- a/src/utils/cliAssets.ts
+++ b/src/utils/cliAssets.ts
@@ -7,7 +7,7 @@
  */
 
 /** Combined content hash — used to detect and refresh a stale on-disk install. */
-export const NEXUS_CLI_ASSETS_HASH = "5a6cadfe8840206d";
+export const NEXUS_CLI_ASSETS_HASH = "0cc1ae808e1c59cc";
 
 /** Bundled standalone `nexus` CLI (written to <dataDir>/nexus-cli.js). */
 export const NEXUS_CLI_JS = `#!/usr/bin/env node
@@ -715,7 +715,8 @@ CONTEXT (flags on \\\`use\\\`; \\\`tools\\\` accepts them too. \\\`playbook\\\` 
                           \\\`memory load-workspace <name>\\\`; every later call in that
                           session inherits it. Nothing defaults silently: an unbound
                           session's \\\`use\\\` fails with a steer (only \\\`memory
-                          list-workspaces\\\` / \\\`memory load-workspace\\\` run unbound).
+                          list-workspaces\\\` / \\\`load-workspace\\\` / \\\`create-workspace\\\`
+                          run unbound).
   --session <name>        PASS ONCE \\u2014 the vault remembers the CLI's current session.
                           Omit it and the CLI continues where it left off (or runs as
                           "nexus-cli" if it never chose). Pass a different name once
@@ -778,7 +779,8 @@ GOTCHAS
   \\u2022 --memory/--goal are enforced \\u2014 send real values or the call is rejected.
   \\u2022 "This session has no workspace yet" means choose once: \\\`--workspace <name>\\\` on
     this call, or \\\`memory load-workspace <name>\\\` in its own call (not batched with
-    other commands). Then drop --workspace; the session inherits it. Repeating
+    other commands; if none fits, \\\`memory create-workspace\\\` first, then load it).
+    Then drop --workspace; the session inherits it. Repeating
     --workspace on every call is harmless but unnecessary. \\\`--workspace default\\\`
     is the global workspace \\u2014 pass it deliberately, never as a placeholder.
   \\u2022 --session works the same way: choose once, then omit. Two different --session
@@ -1057,8 +1059,8 @@ For a common task, **\`nexus playbook <name>\`** gives you a ready-to-run recipe
   \`memory load-workspace <name>\`), then omit both — every later call continues
   that session and inherits its workspace. Nothing defaults silently: a session
   that never chose a workspace fails with *"This session has no workspace yet"*
-  (only \`memory list-workspaces\` / \`memory load-workspace\` run before the
-  choice). Pass a different value once to switch. \`nexus context\` shows what
+  (only \`memory list-workspaces\` / \`load-workspace\` / \`create-workspace\` run
+  before the choice). Pass a different value once to switch. \`nexus context\` shows what
   the vault currently remembers.
 - **You can't escape the vault.** Paths are vault-relative; \`..\`, \`~\`, and
   absolute paths are rejected. That's a guardrail, not a bug.
@@ -1173,7 +1175,9 @@ so you can go straight to \`nexus use\` without a separate \`nexus tools\` call.
    If none fits, create one with \`memory create-workspace\`, then load it. Loading
    scopes your traces, auto-loads that workspace's task summary, and **binds the
    session to it**. (This playbook only *lists* workspaces — loading is your
-   call, since only you know which one.)
+   call, since only you know which one.) These three — \`memory list-workspaces\`,
+   \`load-workspace\`, \`create-workspace\` — are the only commands that run before
+   a workspace is chosen; each in its own call.
 2. **Then omit \`--session\` and \`--workspace\`.** The vault remembers both: every
    later call continues that session and inherits its workspace. Pass a
    different value once to switch; \`nexus context\` shows what is remembered. A

--- a/tests/unit/CliSessionContinuity.test.ts
+++ b/tests/unit/CliSessionContinuity.test.ts
@@ -1,0 +1,380 @@
+/**
+ * CLI session continuity (#214, docs/plans/session-sticky-context-plan.md PR 2).
+ *
+ * The defect: every CLI command had to restate `--session`, and when it did
+ * not, the CLI filled `sessionId: 'nexus-cli'` (and `workspaceId: 'default'`)
+ * client-side — a second source of defaults outside the vault, and the
+ * `'default'` half is exactly how #214's misfiling happened. The fix moves
+ * both defaults to the server: the vault remembers the handle the CLI last
+ * chose with an explicit `--session` on a successful call (`cliCurrentSession`,
+ * bind point 3), a CLI call with no `--session` continues it, and only
+ * connections that identified themselves as the CLI on `initialize` get any of
+ * this. MCP clients and native chat are untouched.
+ *
+ * Also covered here: the ONE exemption from PR 1's UNBOUND rule — a useTools
+ * batch made entirely of workspace-selection commands runs under 'default'
+ * without binding, because the steer tells a fresh session to run exactly
+ * those, and `load-workspace` cannot need the workspace it is about to load.
+ *
+ * The SessionContextManager and ToolExecutionStrategy are REAL; see
+ * helpers/sessionStickyFixtures.ts for what is stubbed and why.
+ */
+
+import {
+  CLI_CLIENT_NAME,
+  CLI_DEFAULT_SESSION_HANDLE
+} from '../../src/handlers/strategies/ToolExecutionStrategy';
+import { parsePersistedSessionBindings } from '../../src/services/session/SessionBindingsStore';
+import {
+  WORKSPACE_ID_REQUIRED_MESSAGE,
+  isWorkspaceSelectionOnlyCommand
+} from '../../src/agents/toolManager/services/ToolCliNormalizer';
+import {
+  MemoryBindingsStore,
+  getToolsRequest,
+  makeManager,
+  makeSessionService,
+  makeStrategy,
+  makeToolManagerAgent,
+  useToolsRequest
+} from './helpers/sessionStickyFixtures';
+
+type Request = ReturnType<typeof useToolsRequest> & { clientName?: string };
+
+/** A request as the CLI sends it: identified on the connection, keys only when flags were given. */
+function cliRequest(base: Request, overrides: { sessionId?: string; workspaceId?: string } = {}): Request {
+  const args: Record<string, unknown> = { ...base.params.arguments };
+  delete args.sessionId;
+  delete args.workspaceId;
+  if (overrides.sessionId !== undefined) args.sessionId = overrides.sessionId;
+  if (overrides.workspaceId !== undefined) args.workspaceId = overrides.workspaceId;
+  return { params: { ...base.params, arguments: args }, clientName: CLI_CLIENT_NAME };
+}
+
+function cliUse(overrides: { sessionId?: string; workspaceId?: string; tool?: string } = {}): Request {
+  const { tool, ...rest } = overrides;
+  return cliRequest(useToolsRequest(tool ? { tool } : {}), rest);
+}
+
+function cliGetTools(overrides: { sessionId?: string; workspaceId?: string } = {}): Request {
+  return cliRequest(getToolsRequest(), overrides);
+}
+
+// ---------------------------------------------------------------------------
+// The CLI default: cliCurrentSession ?? 'nexus-cli', CLI connections only
+// ---------------------------------------------------------------------------
+
+describe('CLI session default', () => {
+  it('a CLI call with no sessionId and nothing remembered runs as "nexus-cli" — and that default is NOT bound', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(cliGetTools());
+
+    expect(captured.result?.success).toBe(true);
+    expect(captured.sessionInfo?.displaySessionId).toBe(CLI_DEFAULT_SESSION_HANDLE);
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'nexus-cli', workspaceId: 'default' })
+    );
+    // Falling back is not choosing: the vault still remembers nothing.
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('a non-CLI connection gets no default: with no sessionId it takes the pre-PR-2 fallback path', async () => {
+    // Red/green for the `clientName === 'nexus-cli'` gate: drop the gate and
+    // this call is partitioned as "nexus-cli" instead of reaching the
+    // SessionService fallback that MCP clients have always used.
+    const { manager, sessionService } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+    const request = cliGetTools();
+
+    await strategy.handle({ ...request, clientName: 'claude-desktop' });
+    await strategy.handle({ ...request, clientName: undefined });
+
+    expect(sessionService.createSession).not.toHaveBeenCalled();
+    expect(captured.sessionInfo?.displaySessionId).toBeUndefined();
+    expect(captured.sessionInfo?.sessionId).toBe('s-fallback');
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('a non-CLI connection never binds a current session, even with an explicit sessionId on a successful call', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle({ ...useToolsRequest({ sessionId: 'research', workspaceId: 'Research' }), clientName: 'claude-desktop' });
+    await strategy.handle(useToolsRequest({ sessionId: 'research', workspaceId: 'Research' }));
+
+    expect(captured.result?.success).toBe(true);
+    // PR 1 behaviour is intact: the workspace bind still happened...
+    expect(manager.resolveHandleWorkspace('research')).toBe('ws-research-id');
+    // ...but the CLI's slot is untouched.
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('a blank explicit sessionId on a CLI connection counts as absent and takes the default', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(cliGetTools({ sessionId: '   ' }));
+
+    expect(captured.sessionInfo?.displaySessionId).toBe(CLI_DEFAULT_SESSION_HANDLE);
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bind point 3 — an explicit --session on a CLI connection, once the call succeeds
+// ---------------------------------------------------------------------------
+
+describe('bind point 3: explicit --session on a CLI connection', () => {
+  it('remembers the handle after a successful useTools, and the next CLI call with no --session continues it AND inherits its workspace', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Research' }));
+    expect(manager.getCliCurrentSession()).toBe('research');
+
+    await strategy.handle(cliUse());
+
+    expect(batchExecute).toHaveBeenCalledTimes(2);
+    // Same internal session both times — the handle was resumed, not recreated.
+    expect(batchExecute.mock.calls[1][0].context.sessionId).toBe(batchExecute.mock.calls[0][0].context.sessionId);
+    expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+    // The workspace partition followed the RESOLVED handle: the inherited
+    // session inherited research's bind, so no workspaceId was needed.
+    expect(batchExecute.mock.calls[1][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('does not bind off a returned { success: false }', async () => {
+    // Red/green for the success guard: read handle()'s local `success` flag
+    // instead of the result and this remembers a session whose only call
+    // was refused.
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager, () =>
+      makeToolManagerAgent(() => ({ success: false, error: 'Invalid workspace "Nope".' }))
+    );
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Nope' }));
+
+    expect(captured.result?.success).toBe(false);
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('does not bind off a thrown call — including the unbound-workspace steer', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    // Fresh session, no workspace, a real tool: PR 1's steer is thrown by the
+    // normalizer and surfaces as a failed result.
+    await strategy.handle(cliUse({ sessionId: 'research' }));
+
+    expect(captured.result?.success).toBe(false);
+    expect(captured.result?.error).toContain(WORKSPACE_ID_REQUIRED_MESSAGE);
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('binds off a non-throwing getTools, so discovery can be the call that chooses the session', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(cliGetTools({ sessionId: 'research' }));
+
+    expect(captured.result?.success).toBe(true);
+    expect(manager.getCliCurrentSession()).toBe('research');
+    // Choosing a session chooses no workspace.
+    expect(manager.resolveHandleWorkspace('research')).toBeUndefined();
+  });
+
+  it('switching is the same gesture as choosing: pass a different --session once', async () => {
+    const { manager } = makeManager();
+    const { strategy, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Research' }));
+    await strategy.handle(cliUse({ sessionId: 'blog', workspaceId: 'Blog' }));
+    await strategy.handle(cliUse());
+
+    expect(manager.getCliCurrentSession()).toBe('blog');
+    expect(batchExecute.mock.calls.map(call => call[0].context.workspaceId))
+      .toEqual(['ws-research-id', 'ws-blog-id', 'ws-blog-id']);
+  });
+
+  it('the inherited handle is not a new choice: no write when the CLI keeps calling without --session', async () => {
+    const { manager } = makeManager();
+    const set = jest.spyOn(manager, 'setCliCurrentSession');
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Research' }));
+    await strategy.handle(cliUse());
+    await strategy.handle(cliUse());
+
+    expect(set).toHaveBeenCalledTimes(1);
+  });
+
+  it('remembers the handle the caller typed even when the display name was renamed, so it resumes the same session', async () => {
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValue([{ id: 's-other', workspaceId: 'ws-research-id', name: 'research' }]);
+    const { manager } = makeManager({ sessionService });
+    const { strategy, captured, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Research' }));
+    expect(captured.sessionInfo?.displaySessionId).toBe('research-2');
+    expect(manager.getCliCurrentSession()).toBe('research');
+
+    await strategy.handle(cliUse());
+
+    expect(batchExecute.mock.calls[1][0].context.sessionId).toBe(batchExecute.mock.calls[0][0].context.sessionId);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+describe('persistence: cliCurrentSession in session-bindings.json', () => {
+  it('round-trips through the store and a fresh manager over the same store resumes it', async () => {
+    const store = new MemoryBindingsStore();
+    const { manager: before } = makeManager({ store });
+    const { strategy } = makeStrategy(before);
+
+    await strategy.handle(cliUse({ sessionId: 'research', workspaceId: 'Research' }));
+    await before.flushBindings();
+    expect(store.doc?.cliCurrentSession).toBe('research');
+
+    // "Reload": the next CLI call with no --session must land in research.
+    const { manager: after } = makeManager({ store });
+    const resumed = makeStrategy(after);
+    await resumed.strategy.handle(cliUse());
+
+    expect(after.getCliCurrentSession()).toBe('research');
+    expect(resumed.batchExecute.mock.calls[0][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('is null in a fresh document and after clearAll', async () => {
+    const store = new MemoryBindingsStore();
+    const { manager } = makeManager({ store });
+    await manager.flushBindings();
+    expect(store.doc?.cliCurrentSession).toBeNull();
+
+    manager.setCliCurrentSession('research');
+    manager.clearAll();
+    expect(manager.getCliCurrentSession()).toBeNull();
+  });
+
+  it('the parser keeps a trimmed string and drops blank or non-string values', () => {
+    const base = { handles: {}, handleWorkspace: {} };
+    expect(parsePersistedSessionBindings({ ...base, cliCurrentSession: ' research ' })?.cliCurrentSession).toBe('research');
+    expect(parsePersistedSessionBindings({ ...base, cliCurrentSession: '   ' })?.cliCurrentSession).toBeNull();
+    expect(parsePersistedSessionBindings({ ...base, cliCurrentSession: 7 })?.cliCurrentSession).toBeNull();
+    expect(parsePersistedSessionBindings({ ...base, cliCurrentSession: null })?.cliCurrentSession).toBeNull();
+    // A PR 1 file has no slot at all.
+    expect(parsePersistedSessionBindings(base)?.cliCurrentSession).toBeNull();
+  });
+
+  it('setCliCurrentSession trims, ignores blanks, and does not schedule a save for an unchanged value', async () => {
+    const store = new MemoryBindingsStore();
+    const { manager } = makeManager({ store });
+
+    manager.setCliCurrentSession(' research ');
+    manager.setCliCurrentSession('');
+    expect(manager.getCliCurrentSession()).toBe('research');
+    await manager.flushBindings();
+    const savesAfterFirst = store.saves;
+
+    manager.setCliCurrentSession('research');
+    await manager.flushBindings();
+    // flushBindings always writes; what matters is that the unchanged set
+    // scheduled nothing on its own.
+    expect(store.saves).toBe(savesAfterFirst + 1);
+    expect(store.doc?.cliCurrentSession).toBe('research');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The workspace-selection exemption from the UNBOUND rule
+// ---------------------------------------------------------------------------
+
+describe('unbound useTools: the workspace-selection exemption', () => {
+  it('an unbound `memory list-workspaces` runs under "default" and binds nothing', async () => {
+    const { manager, sessionService } = makeManager();
+    const { strategy, captured, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ tool: 'memory list-workspaces' }));
+
+    expect(captured.result?.success).toBe(true);
+    expect(batchExecute).toHaveBeenCalledTimes(1);
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('default');
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId: 'default', name: 'nexus-cli' })
+    );
+    // A partition is not a choice: the next real command still has to name one.
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('an unbound `memory load-workspace research` runs, and ends bound to the LOADED workspace via bind point 2', async () => {
+    const { manager } = makeManager();
+    // The stubbed batch does what the real ToolBatchExecutionService does on a
+    // successful load: binds by the internal id it was handed.
+    const { strategy, batchExecute } = makeStrategy(manager, () => makeToolManagerAgent((params) => {
+      manager.bindSessionWorkspaceById(params.context.sessionId as string, 'ws-research-id');
+      return { success: true };
+    }));
+
+    await strategy.handle(cliUse({ tool: 'memory load-workspace research' }));
+
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('default');
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBe('ws-research-id');
+
+    // ...and the follow-up inherits it with no workspaceId at all.
+    await strategy.handle(cliUse());
+    expect(batchExecute.mock.calls[1][0].context.workspaceId).toBe('ws-research-id');
+  });
+
+  it('a mixed batch on an unbound session gets the steer and runs nothing — the trailing command must not run under "default"', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ tool: 'memory load-workspace research, content read --path notes/a.md' }));
+
+    expect(batchExecute).not.toHaveBeenCalled();
+    expect(captured.result?.success).toBe(false);
+    expect(captured.result?.error).toContain(WORKSPACE_ID_REQUIRED_MESSAGE);
+    expect(captured.result?.error).toMatch(/own call/);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('the exemption is a partition, not a choice: bind point 1 never fires off it', async () => {
+    const { manager } = makeManager();
+    const bind = jest.spyOn(manager, 'bindHandleWorkspace');
+    const { strategy } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ tool: 'memory list-workspaces' }));
+    await strategy.handle(cliUse({ tool: 'memory load-workspace research' }));
+
+    expect(bind).not.toHaveBeenCalled();
+  });
+
+  it('applies to MCP callers too — it is about the command, not the client', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured } = makeStrategy(manager);
+
+    await strategy.handle(useToolsRequest({ tool: 'memory list-workspaces' }));
+
+    expect(captured.result?.success).toBe(true);
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
+  it('isWorkspaceSelectionOnlyCommand accepts only batches made entirely of the two selection commands', () => {
+    expect(isWorkspaceSelectionOnlyCommand('memory load-workspace research')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memory load-workspace "My Research, v2"')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memory list-workspaces')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memoryManager loadWorkspace --workspace research')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memory list-workspaces, memory load-workspace research')).toBe(true);
+
+    expect(isWorkspaceSelectionOnlyCommand('memory load-workspace research, content read --path a.md')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('content read --path a.md')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('memory create-workspace --name X')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('memory')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand(undefined)).toBe(false);
+  });
+});

--- a/tests/unit/CliSessionContinuity.test.ts
+++ b/tests/unit/CliSessionContinuity.test.ts
@@ -310,6 +310,19 @@ describe('unbound useTools: the workspace-selection exemption', () => {
     expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
   });
 
+  it('an unbound `memory create-workspace --name X` runs under "default" and leaves the handle unbound (create, then load)', async () => {
+    const { manager } = makeManager();
+    const { strategy, captured, batchExecute } = makeStrategy(manager);
+
+    await strategy.handle(cliUse({ tool: 'memory create-workspace --name "Q3 Launch"' }));
+
+    expect(captured.result?.success).toBe(true);
+    expect(batchExecute).toHaveBeenCalledTimes(1);
+    expect(batchExecute.mock.calls[0][0].context.workspaceId).toBe('default');
+    // Creating is part of choosing, but it is not the choice: the load does that.
+    expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
+  });
+
   it('an unbound `memory load-workspace research` runs, and ends bound to the LOADED workspace via bind point 2', async () => {
     const { manager } = makeManager();
     // The stubbed batch does what the real ToolBatchExecutionService does on a
@@ -363,16 +376,19 @@ describe('unbound useTools: the workspace-selection exemption', () => {
     expect(manager.resolveHandleWorkspace('nexus-cli')).toBeUndefined();
   });
 
-  it('isWorkspaceSelectionOnlyCommand accepts only batches made entirely of the two selection commands', () => {
+  it('isWorkspaceSelectionOnlyCommand accepts only batches made entirely of the three selection commands', () => {
     expect(isWorkspaceSelectionOnlyCommand('memory load-workspace research')).toBe(true);
     expect(isWorkspaceSelectionOnlyCommand('memory load-workspace "My Research, v2"')).toBe(true);
     expect(isWorkspaceSelectionOnlyCommand('memory list-workspaces')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memory create-workspace --name X')).toBe(true);
     expect(isWorkspaceSelectionOnlyCommand('memoryManager loadWorkspace --workspace research')).toBe(true);
     expect(isWorkspaceSelectionOnlyCommand('memory list-workspaces, memory load-workspace research')).toBe(true);
+    expect(isWorkspaceSelectionOnlyCommand('memory create-workspace --name X, memory load-workspace X')).toBe(true);
 
     expect(isWorkspaceSelectionOnlyCommand('memory load-workspace research, content read --path a.md')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('memory create-workspace --name X, content read --path a.md')).toBe(false);
     expect(isWorkspaceSelectionOnlyCommand('content read --path a.md')).toBe(false);
-    expect(isWorkspaceSelectionOnlyCommand('memory create-workspace --name X')).toBe(false);
+    expect(isWorkspaceSelectionOnlyCommand('memory delete-workspace --id X')).toBe(false);
     expect(isWorkspaceSelectionOnlyCommand('memory')).toBe(false);
     expect(isWorkspaceSelectionOnlyCommand('')).toBe(false);
     expect(isWorkspaceSelectionOnlyCommand(undefined)).toBe(false);

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -16,29 +16,16 @@
  * (persistence round-trip, deleted-session drop).
  */
 
-import { ToolExecutionStrategy } from '../../src/handlers/strategies/ToolExecutionStrategy';
-import type {
-  IRequestHandlerDependencies,
-  IRequestContext,
-  SessionInfo,
-  ToolExecutionResult
-} from '../../src/handlers/interfaces/IRequestHandlerServices';
+import type { IRequestContext } from '../../src/handlers/interfaces/IRequestHandlerServices';
 import type { IAgent } from '../../src/agents/interfaces/IAgent';
 import type { ITool } from '../../src/agents/interfaces/ITool';
 import { SessionContextManager } from '../../src/services/SessionContextManager';
 import type { WorkspaceResolverLike } from '../../src/services/SessionContextManager';
 import {
   parsePersistedSessionBindings,
-  VaultSessionBindingsStore,
-  type PersistedSessionBindings,
-  type SessionBindingsStore
+  VaultSessionBindingsStore
 } from '../../src/services/session/SessionBindingsStore';
-import {
-  ToolCliNormalizer,
-  WORKSPACE_ID_REQUIRED_MESSAGE
-} from '../../src/agents/toolManager/services/ToolCliNormalizer';
-import { UseToolTool } from '../../src/agents/toolManager/tools/useTools';
-import { GetToolsTool } from '../../src/agents/toolManager/tools/getTools';
+import { WORKSPACE_ID_REQUIRED_MESSAGE } from '../../src/agents/toolManager/services/ToolCliNormalizer';
 import { ToolBatchExecutionService } from '../../src/agents/toolManager/services/ToolBatchExecutionService';
 import { RequestHandlerFactory } from '../../src/server/handlers/RequestHandlerFactory';
 import { AgentExecutionManager } from '../../src/server/execution/AgentExecutionManager';
@@ -46,211 +33,16 @@ import { AgentRegistry } from '../../src/server/services/AgentRegistry';
 import type { RequestRouter } from '../../src/handlers/RequestRouter';
 import type { Server as MCPSDKServer } from '@modelcontextprotocol/sdk/server/index.js';
 import type { App } from 'obsidian';
-
-// ---------------------------------------------------------------------------
-// Fixtures
-// ---------------------------------------------------------------------------
-
-/** Two real workspaces plus the global one; `Reserch` is a deliberate near-miss. */
-const WORKSPACES = [
-  { id: 'ws-research-id', name: 'Research' },
-  { id: 'ws-blog-id', name: 'Blog' }
-];
-
-function makeResolver(): WorkspaceResolverLike & { getWorkspaceByNameOrId: jest.Mock } {
-  return {
-    getWorkspaceByNameOrId: jest.fn(async (identifier: string) => {
-      const match = WORKSPACES.find(ws => ws.id === identifier || ws.name.toLowerCase() === identifier.toLowerCase());
-      return match ? { id: match.id } : null;
-    })
-  };
-}
-
-interface SessionServiceStub {
-  getSession: jest.Mock;
-  getAllSessions: jest.Mock;
-  createSession: jest.Mock;
-  updateSession: jest.Mock;
-}
-
-function makeSessionService(): SessionServiceStub {
-  return {
-    getSession: jest.fn().mockResolvedValue(null),
-    getAllSessions: jest.fn().mockResolvedValue([]),
-    createSession: jest.fn().mockResolvedValue(undefined),
-    updateSession: jest.fn().mockResolvedValue(undefined)
-  };
-}
-
-/** In-memory store standing in for the vault file. */
-class MemoryBindingsStore implements SessionBindingsStore {
-  doc: PersistedSessionBindings | null = null;
-  saves = 0;
-  async load(): Promise<PersistedSessionBindings | null> {
-    return this.doc ? JSON.parse(JSON.stringify(this.doc)) : null;
-  }
-  async save(doc: PersistedSessionBindings): Promise<void> {
-    this.saves += 1;
-    this.doc = JSON.parse(JSON.stringify(doc));
-  }
-}
-
-function makeManager(options: {
-  sessionService?: SessionServiceStub;
-  resolver?: WorkspaceResolverLike | null;
-  store?: SessionBindingsStore | null;
-} = {}): { manager: SessionContextManager; sessionService: SessionServiceStub } {
-  const sessionService = options.sessionService ?? makeSessionService();
-  const manager = new SessionContextManager();
-  manager.setSessionService(sessionService);
-  manager.setWorkspaceResolver(options.resolver === undefined ? makeResolver() : options.resolver);
-  if (options.store) {
-    manager.setBindingsStore(options.store);
-  }
-  return { manager, sessionService };
-}
-
-/**
- * A toolManager agent whose useTools/getTools are the REAL tools over a real
- * ToolCliNormalizer, so the unbound-useTools steer comes from production code
- * rather than a stub. The batch service is stubbed: it records the context it
- * was handed and returns whatever the test says the workspace guard decided.
- * `batchResult` receives the batch params so a test can act mid-execution the
- * way the real service does (bind point 2 fires inside `execute`).
- */
-type BatchParams = Parameters<ToolBatchExecutionService['execute']>[0];
-
-function makeToolManagerAgent(
-  batchResult: (params: BatchParams) => unknown = () => ({ success: true })
-): {
-  agent: IAgent;
-  batchExecute: jest.Mock;
-} {
-  // Minimal registry so normalizeExecutionCalls can resolve `content read`
-  // and `memory load-workspace` — the normalizer rejects unknown commands.
-  const readTool = {
-    slug: 'read', name: 'Read', description: 'Read a note', version: '1.0.0',
-    execute: jest.fn().mockResolvedValue({ success: true }),
-    getParameterSchema: () => ({ type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }),
-    getResultSchema: () => ({ type: 'object' })
-  } as unknown as ITool;
-  const loadWorkspaceTool = {
-    slug: 'loadWorkspace', name: 'Load Workspace', description: 'Load a workspace', version: '1.0.0',
-    execute: jest.fn().mockResolvedValue({ success: true }),
-    getParameterSchema: () => ({ type: 'object', properties: { workspace: { type: 'string' } }, required: ['workspace'] }),
-    getResultSchema: () => ({ type: 'object' })
-  } as unknown as ITool;
-  const stubAgent = (name: string, tool: ITool): IAgent => ({
-    name, description: '', version: '1.0.0',
-    getTools: () => [tool],
-    getTool: (slug: string) => (slug === tool.slug ? tool : undefined),
-    initialize: jest.fn(), executeTool: jest.fn(), setAgentManager: jest.fn()
-  });
-  const registry = new Map<string, IAgent>([
-    ['contentManager', stubAgent('contentManager', readTool)],
-    ['memoryManager', stubAgent('memoryManager', loadWorkspaceTool)]
-  ]);
-  const normalizer = new ToolCliNormalizer(registry);
-  const batchExecute = jest.fn(async (params: BatchParams) => batchResult(params));
-  const batchService = { execute: batchExecute } as unknown as ToolBatchExecutionService;
-  const useTools = new UseToolTool(batchService, normalizer);
-  const getTools = new GetToolsTool(registry, { workspaces: [], customAgents: [], vaultRoot: [] });
-  const tools = new Map<string, ITool>([['useTools', useTools], ['getTools', getTools]]);
-  const agent: IAgent = {
-    name: 'toolManager',
-    description: '',
-    version: '1.0.0',
-    getTools: () => Array.from(tools.values()),
-    getTool: (slug: string) => tools.get(slug),
-    initialize: jest.fn(),
-    executeTool: jest.fn(async (slug: string, params: Record<string, unknown>) => {
-      const tool = tools.get(slug);
-      if (!tool) throw new Error(`unknown tool ${slug}`);
-      return tool.execute(params);
-    }),
-    setAgentManager: jest.fn()
-  };
-  return { agent, batchExecute };
-}
-
-interface Captured {
-  result?: ToolExecutionResult;
-  sessionInfo?: SessionInfo;
-}
-
-function makeDeps(captured: Captured): IRequestHandlerDependencies {
-  return {
-    validationService: {
-      validateToolParams: jest.fn(async (params: Record<string, unknown>) => params),
-      validateSessionId: jest.fn(),
-      validateBatchOperations: jest.fn(),
-      validateBatchPaths: jest.fn()
-    },
-    sessionService: {
-      processSessionId: jest.fn(async (sessionId: string | undefined) => ({
-        sessionId: sessionId ?? 's-fallback',
-        isNewSession: false,
-        isNonStandardId: false
-      })),
-      generateSessionId: jest.fn(),
-      isStandardSessionId: jest.fn(),
-      shouldInjectInstructions: jest.fn().mockReturnValue(false)
-    },
-    toolExecutionService: {
-      // Real dispatch into the agent so a thrown normalizer steer propagates
-      // exactly the way ToolExecutionService.executeAgent rethrows it.
-      executeAgent: jest.fn(async (agent: IAgent, tool: string, params: Record<string, unknown>) => {
-        return await agent.executeTool(tool, params) as ToolExecutionResult;
-      })
-    },
-    responseFormatter: {
-      formatToolExecutionResponse: jest.fn((result: ToolExecutionResult, sessionInfo?: SessionInfo) => {
-        captured.result = result;
-        captured.sessionInfo = sessionInfo;
-        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
-      }),
-      formatSessionInstructions: jest.fn((_id, r) => r),
-      formatErrorResponse: jest.fn((err) => ({ content: [{ type: 'text', text: err.message }] }))
-    },
-    toolListService: {} as never,
-    resourceListService: {} as never,
-    resourceReadService: {} as never,
-    promptsListService: {} as never,
-    toolHelpService: {} as never,
-    schemaEnhancementService: {} as never
-  };
-}
-
-const ENVELOPE = {
-  sessionId: 'nexus-cli',
-  memory: 'Listed the vault and the workspaces.',
-  goal: 'Read one note.'
-};
-
-function useToolsRequest(extra: Record<string, unknown> = {}) {
-  return {
-    params: {
-      name: 'toolManager_useTools',
-      arguments: { ...ENVELOPE, tool: 'content read --path notes/a.md', ...extra }
-    }
-  };
-}
-
-function getToolsRequest(extra: Record<string, unknown> = {}) {
-  return {
-    params: {
-      name: 'toolManager_getTools',
-      arguments: { ...ENVELOPE, tool: '--help', ...extra }
-    }
-  };
-}
-
-function makeStrategy(manager: SessionContextManager, agentFactory = makeToolManagerAgent) {
-  const captured: Captured = {};
-  const { agent, batchExecute } = agentFactory();
-  const strategy = new ToolExecutionStrategy(makeDeps(captured), () => agent, manager);
-  return { strategy, captured, batchExecute };
-}
+import {
+  MemoryBindingsStore,
+  getToolsRequest,
+  makeManager,
+  makeResolver,
+  makeSessionService,
+  makeStrategy,
+  makeToolManagerAgent,
+  useToolsRequest
+} from './helpers/sessionStickyFixtures';
 
 // ---------------------------------------------------------------------------
 // Resolution order
@@ -627,7 +419,8 @@ describe('persistence: session-bindings.json', () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
-      handleWorkspace: { 'nexus-cli': 'default' }
+      handleWorkspace: { 'nexus-cli': 'default' },
+      cliCurrentSession: null
     };
     const sessionService = makeSessionService();
     sessionService.getAllSessions.mockResolvedValue([]); // deleted while unloaded
@@ -647,7 +440,8 @@ describe('persistence: session-bindings.json', () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
-      handleWorkspace: {}
+      handleWorkspace: {},
+      cliCurrentSession: null
     };
     const sessionService = makeSessionService();
     sessionService.getAllSessions.mockRejectedValue(new Error('storage cold'));
@@ -681,10 +475,11 @@ describe('persistence: session-bindings.json', () => {
     expect(parsePersistedSessionBindings({
       handles: { ok: { id: 'a', displaySessionId: 'b', workspaceId: 'c' }, bad: { id: 1 } },
       handleWorkspace: { h: 'ws', blank: '   ', wrong: 7 },
-      cliCurrentSession: 'nexus-cli' // PR 2's slot: ignored, not fatal
+      cliCurrentSession: ' research '
     })).toEqual({
       handles: { ok: { id: 'a', displaySessionId: 'b', workspaceId: 'c' } },
-      handleWorkspace: { h: 'ws' }
+      handleWorkspace: { h: 'ws' },
+      cliCurrentSession: 'research'
     });
   });
 
@@ -725,10 +520,14 @@ describe('persistence: session-bindings.json', () => {
     const path = '.obsidian/plugins/nexus/data/session-bindings.json';
     const store = new VaultSessionBindingsStore(adapter as never, path);
 
-    await store.save({ handles: {}, handleWorkspace: { 'nexus-cli': 'ws-research-id' } });
+    await store.save({ handles: {}, handleWorkspace: { 'nexus-cli': 'ws-research-id' }, cliCurrentSession: null });
 
     expect(adapter.mkdir).toHaveBeenCalledWith('.obsidian/plugins/nexus/data');
-    expect(await store.load()).toEqual({ handles: {}, handleWorkspace: { 'nexus-cli': 'ws-research-id' } });
+    expect(await store.load()).toEqual({
+      handles: {},
+      handleWorkspace: { 'nexus-cli': 'ws-research-id' },
+      cliCurrentSession: null
+    });
   });
 });
 

--- a/tests/unit/helpers/sessionStickyFixtures.ts
+++ b/tests/unit/helpers/sessionStickyFixtures.ts
@@ -1,0 +1,237 @@
+/**
+ * Shared fixtures for the session-sticky context tests (#214,
+ * docs/plans/session-sticky-context-plan.md): SessionStickyWorkspace.test.ts
+ * (PR 1) and CliSessionContinuity.test.ts (PR 2).
+ *
+ * The SessionContextManager is REAL; only storage (SessionService), the
+ * workspace lookup and the persistence store are stubbed — and none of them
+ * supplies the value an assertion depends on, except where a test is about
+ * that stub's data (persistence round-trip, deleted-session drop).
+ */
+
+import { ToolExecutionStrategy } from '../../../src/handlers/strategies/ToolExecutionStrategy';
+import type {
+  IRequestHandlerDependencies,
+  SessionInfo,
+  ToolExecutionResult
+} from '../../../src/handlers/interfaces/IRequestHandlerServices';
+import type { IAgent } from '../../../src/agents/interfaces/IAgent';
+import type { ITool } from '../../../src/agents/interfaces/ITool';
+import { SessionContextManager } from '../../../src/services/SessionContextManager';
+import type { WorkspaceResolverLike } from '../../../src/services/SessionContextManager';
+import type {
+  PersistedSessionBindings,
+  SessionBindingsStore
+} from '../../../src/services/session/SessionBindingsStore';
+import { ToolCliNormalizer } from '../../../src/agents/toolManager/services/ToolCliNormalizer';
+import { UseToolTool } from '../../../src/agents/toolManager/tools/useTools';
+import { GetToolsTool } from '../../../src/agents/toolManager/tools/getTools';
+import type { ToolBatchExecutionService } from '../../../src/agents/toolManager/services/ToolBatchExecutionService';
+
+/** Two real workspaces plus the global one; `Reserch` is a deliberate near-miss. */
+export const WORKSPACES = [
+  { id: 'ws-research-id', name: 'Research' },
+  { id: 'ws-blog-id', name: 'Blog' }
+];
+
+export function makeResolver(): WorkspaceResolverLike & { getWorkspaceByNameOrId: jest.Mock } {
+  return {
+    getWorkspaceByNameOrId: jest.fn(async (identifier: string) => {
+      const match = WORKSPACES.find(ws => ws.id === identifier || ws.name.toLowerCase() === identifier.toLowerCase());
+      return match ? { id: match.id, name: match.name } : null;
+    })
+  };
+}
+
+export interface SessionServiceStub {
+  getSession: jest.Mock;
+  getAllSessions: jest.Mock;
+  createSession: jest.Mock;
+  updateSession: jest.Mock;
+}
+
+export function makeSessionService(): SessionServiceStub {
+  return {
+    getSession: jest.fn().mockResolvedValue(null),
+    getAllSessions: jest.fn().mockResolvedValue([]),
+    createSession: jest.fn().mockResolvedValue(undefined),
+    updateSession: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+/** In-memory store standing in for the vault file. */
+export class MemoryBindingsStore implements SessionBindingsStore {
+  doc: PersistedSessionBindings | null = null;
+  saves = 0;
+  async load(): Promise<PersistedSessionBindings | null> {
+    return this.doc ? JSON.parse(JSON.stringify(this.doc)) : null;
+  }
+  async save(doc: PersistedSessionBindings): Promise<void> {
+    this.saves += 1;
+    this.doc = JSON.parse(JSON.stringify(doc));
+  }
+}
+
+export function makeManager(options: {
+  sessionService?: SessionServiceStub;
+  resolver?: WorkspaceResolverLike | null;
+  store?: SessionBindingsStore | null;
+} = {}): { manager: SessionContextManager; sessionService: SessionServiceStub } {
+  const sessionService = options.sessionService ?? makeSessionService();
+  const manager = new SessionContextManager();
+  manager.setSessionService(sessionService);
+  manager.setWorkspaceResolver(options.resolver === undefined ? makeResolver() : options.resolver);
+  if (options.store) {
+    manager.setBindingsStore(options.store);
+  }
+  return { manager, sessionService };
+}
+
+/**
+ * A toolManager agent whose useTools/getTools are the REAL tools over a real
+ * ToolCliNormalizer, so the unbound-useTools steer comes from production code
+ * rather than a stub. The batch service is stubbed: it records the context it
+ * was handed and returns whatever the test says the workspace guard decided.
+ * `batchResult` receives the batch params so a test can act mid-execution the
+ * way the real service does (bind point 2 fires inside `execute`).
+ */
+export type BatchParams = Parameters<ToolBatchExecutionService['execute']>[0];
+
+export function makeToolManagerAgent(
+  batchResult: (params: BatchParams) => unknown = () => ({ success: true })
+): {
+  agent: IAgent;
+  batchExecute: jest.Mock;
+} {
+  // Minimal registry so normalizeExecutionCalls can resolve `content read`,
+  // `memory load-workspace` and `memory list-workspaces` — the normalizer
+  // rejects unknown commands.
+  const readTool = {
+    slug: 'read', name: 'Read', description: 'Read a note', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: { path: { type: 'string' } }, required: ['path'] }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
+  const loadWorkspaceTool = {
+    slug: 'loadWorkspace', name: 'Load Workspace', description: 'Load a workspace', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: { workspace: { type: 'string' } }, required: ['workspace'] }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
+  const listWorkspacesTool = {
+    slug: 'listWorkspaces', name: 'List Workspaces', description: 'List workspaces', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: {} }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
+  const stubAgent = (name: string, tools: ITool[]): IAgent => ({
+    name, description: '', version: '1.0.0',
+    getTools: () => tools,
+    getTool: (slug: string) => tools.find(tool => tool.slug === slug),
+    initialize: jest.fn(), executeTool: jest.fn(), setAgentManager: jest.fn()
+  });
+  const registry = new Map<string, IAgent>([
+    ['contentManager', stubAgent('contentManager', [readTool])],
+    ['memoryManager', stubAgent('memoryManager', [loadWorkspaceTool, listWorkspacesTool])]
+  ]);
+  const normalizer = new ToolCliNormalizer(registry);
+  const batchExecute = jest.fn(async (params: BatchParams) => batchResult(params));
+  const batchService = { execute: batchExecute } as unknown as ToolBatchExecutionService;
+  const useTools = new UseToolTool(batchService, normalizer);
+  const getTools = new GetToolsTool(registry, { workspaces: [], customAgents: [], vaultRoot: [] });
+  const tools = new Map<string, ITool>([['useTools', useTools], ['getTools', getTools]]);
+  const agent: IAgent = {
+    name: 'toolManager',
+    description: '',
+    version: '1.0.0',
+    getTools: () => Array.from(tools.values()),
+    getTool: (slug: string) => tools.get(slug),
+    initialize: jest.fn(),
+    executeTool: jest.fn(async (slug: string, params: Record<string, unknown>) => {
+      const tool = tools.get(slug);
+      if (!tool) throw new Error(`unknown tool ${slug}`);
+      return tool.execute(params);
+    }),
+    setAgentManager: jest.fn()
+  };
+  return { agent, batchExecute };
+}
+
+export interface Captured {
+  result?: ToolExecutionResult;
+  sessionInfo?: SessionInfo;
+}
+
+export function makeDeps(captured: Captured): IRequestHandlerDependencies {
+  return {
+    validationService: {
+      validateToolParams: jest.fn(async (params: Record<string, unknown>) => params),
+      validateSessionId: jest.fn(),
+      validateBatchOperations: jest.fn(),
+      validateBatchPaths: jest.fn()
+    },
+    sessionService: {
+      processSessionId: jest.fn(async (sessionId: string | undefined) => ({
+        sessionId: sessionId ?? 's-fallback',
+        isNewSession: false,
+        isNonStandardId: false
+      })),
+      generateSessionId: jest.fn(),
+      isStandardSessionId: jest.fn(),
+      shouldInjectInstructions: jest.fn().mockReturnValue(false)
+    },
+    toolExecutionService: {
+      // Real dispatch into the agent so a thrown normalizer steer propagates
+      // exactly the way ToolExecutionService.executeAgent rethrows it.
+      executeAgent: jest.fn(async (agent: IAgent, tool: string, params: Record<string, unknown>) => {
+        return await agent.executeTool(tool, params) as ToolExecutionResult;
+      })
+    },
+    responseFormatter: {
+      formatToolExecutionResponse: jest.fn((result: ToolExecutionResult, sessionInfo?: SessionInfo) => {
+        captured.result = result;
+        captured.sessionInfo = sessionInfo;
+        return { content: [{ type: 'text', text: JSON.stringify(result) }] };
+      }),
+      formatSessionInstructions: jest.fn((_id, r) => r),
+      formatErrorResponse: jest.fn((err) => ({ content: [{ type: 'text', text: err.message }] }))
+    },
+    toolListService: {} as never,
+    resourceListService: {} as never,
+    resourceReadService: {} as never,
+    promptsListService: {} as never,
+    toolHelpService: {} as never,
+    schemaEnhancementService: {} as never
+  };
+}
+
+export const ENVELOPE = {
+  sessionId: 'nexus-cli',
+  memory: 'Listed the vault and the workspaces.',
+  goal: 'Read one note.'
+};
+
+export function useToolsRequest(extra: Record<string, unknown> = {}) {
+  return {
+    params: {
+      name: 'toolManager_useTools',
+      arguments: { ...ENVELOPE, tool: 'content read --path notes/a.md', ...extra }
+    }
+  };
+}
+
+export function getToolsRequest(extra: Record<string, unknown> = {}) {
+  return {
+    params: {
+      name: 'toolManager_getTools',
+      arguments: { ...ENVELOPE, tool: '--help', ...extra }
+    }
+  };
+}
+
+export function makeStrategy(manager: SessionContextManager, agentFactory = makeToolManagerAgent) {
+  const captured: Captured = {};
+  const { agent, batchExecute } = agentFactory();
+  const strategy = new ToolExecutionStrategy(makeDeps(captured), () => agent, manager);
+  return { strategy, captured, batchExecute };
+}

--- a/tests/unit/helpers/sessionStickyFixtures.ts
+++ b/tests/unit/helpers/sessionStickyFixtures.ts
@@ -104,8 +104,8 @@ export function makeToolManagerAgent(
   batchExecute: jest.Mock;
 } {
   // Minimal registry so normalizeExecutionCalls can resolve `content read`,
-  // `memory load-workspace` and `memory list-workspaces` — the normalizer
-  // rejects unknown commands.
+  // `memory load-workspace`, `memory list-workspaces` and
+  // `memory create-workspace` — the normalizer rejects unknown commands.
   const readTool = {
     slug: 'read', name: 'Read', description: 'Read a note', version: '1.0.0',
     execute: jest.fn().mockResolvedValue({ success: true }),
@@ -124,6 +124,12 @@ export function makeToolManagerAgent(
     getParameterSchema: () => ({ type: 'object', properties: {} }),
     getResultSchema: () => ({ type: 'object' })
   } as unknown as ITool;
+  const createWorkspaceTool = {
+    slug: 'createWorkspace', name: 'Create Workspace', description: 'Create a workspace', version: '1.0.0',
+    execute: jest.fn().mockResolvedValue({ success: true }),
+    getParameterSchema: () => ({ type: 'object', properties: { name: { type: 'string' } }, required: ['name'] }),
+    getResultSchema: () => ({ type: 'object' })
+  } as unknown as ITool;
   const stubAgent = (name: string, tools: ITool[]): IAgent => ({
     name, description: '', version: '1.0.0',
     getTools: () => tools,
@@ -132,7 +138,7 @@ export function makeToolManagerAgent(
   });
   const registry = new Map<string, IAgent>([
     ['contentManager', stubAgent('contentManager', [readTool])],
-    ['memoryManager', stubAgent('memoryManager', [loadWorkspaceTool, listWorkspacesTool])]
+    ['memoryManager', stubAgent('memoryManager', [loadWorkspaceTool, listWorkspacesTool, createWorkspaceTool])]
   ]);
   const normalizer = new ToolCliNormalizer(registry);
   const batchExecute = jest.fn(async (params: BatchParams) => batchResult(params));

--- a/tests/unit/nexusCliContext.test.ts
+++ b/tests/unit/nexusCliContext.test.ts
@@ -1,0 +1,162 @@
+/**
+ * tests/unit/nexusCliContext.test.ts
+ *
+ * `nexus context` end to end minus the socket: the server builds a snapshot
+ * from a REAL SessionContextManager (src/handlers/services/CliContextResource),
+ * ResourceReadStrategy serves it at `nexus://context` over the standard
+ * `resources/read` route, and the CLI parses and renders it (cli/context.ts).
+ * The two shapes are pinned against each other here so they cannot drift.
+ */
+import { ResourceReadStrategy } from '../../src/handlers/strategies/ResourceReadStrategy';
+import {
+    NEXUS_CONTEXT_RESOURCE_URI as SERVER_URI,
+    buildCliContextSnapshot,
+} from '../../src/handlers/services/CliContextResource';
+import type { IRequestHandlerDependencies } from '../../src/handlers/interfaces/IRequestHandlerServices';
+import {
+    NEXUS_CONTEXT_RESOURCE_URI as CLI_URI,
+    formatContextSnapshot,
+    parseContextSnapshot,
+} from '../../cli/context';
+import { makeManager, makeStrategy, useToolsRequest } from './helpers/sessionStickyFixtures';
+import { CLI_CLIENT_NAME } from '../../src/handlers/strategies/ToolExecutionStrategy';
+
+function makeReadStrategy(manager: ReturnType<typeof makeManager>['manager'] | undefined, vaultName?: string) {
+    const readResource = jest.fn(async (uri: string) => ({ contents: [{ uri, text: '# note', mimeType: 'text/markdown' }] }));
+    const deps = { resourceReadService: { readResource, readMultipleResources: jest.fn() } } as unknown as IRequestHandlerDependencies;
+    const strategy = new ResourceReadStrategy(deps, {} as never, { sessionContextManager: manager, vaultName });
+    return { strategy, readResource };
+}
+
+describe('nexus context', () => {
+    it('the CLI and the server agree on the resource URI', () => {
+        expect(CLI_URI).toBe(SERVER_URI);
+        expect(CLI_URI).toBe('nexus://context');
+    });
+
+    it('a fresh vault reports no session and the default handle, without creating anything', async () => {
+        const { manager, sessionService } = makeManager();
+
+        const snapshot = await buildCliContextSnapshot(manager, 'code');
+
+        expect(snapshot).toEqual({ vault: 'code', defaultSessionHandle: 'nexus-cli', cliSession: null });
+        expect(sessionService.createSession).not.toHaveBeenCalled();
+        expect(manager.getCliCurrentSession()).toBeNull();
+    });
+
+    it('after a CLI call chose a session and workspace, the snapshot names both — workspace by id AND name', async () => {
+        const { manager } = makeManager();
+        const { strategy } = makeStrategy(manager);
+        const request = useToolsRequest({ sessionId: 'research', workspaceId: 'Research' });
+        await strategy.handle({ ...request, clientName: CLI_CLIENT_NAME });
+
+        const snapshot = await buildCliContextSnapshot(manager, 'code');
+
+        expect(snapshot.cliSession).toEqual({
+            handle: 'research',
+            displaySessionId: 'research',
+            workspace: { id: 'ws-research-id', name: 'Research' }
+        });
+    });
+
+    it('a chosen session with no workspace yet reports workspace: null (unbound), not "default"', async () => {
+        const { manager } = makeManager();
+        manager.setCliCurrentSession('research');
+
+        const snapshot = await buildCliContextSnapshot(manager, 'code');
+
+        expect(snapshot.cliSession?.handle).toBe('research');
+        expect(snapshot.cliSession?.workspace).toBeNull();
+    });
+
+    it('ResourceReadStrategy answers nexus://context itself as JSON and never consults the vault-file reader', async () => {
+        const { manager } = makeManager();
+        manager.setCliCurrentSession('research');
+        manager.bindHandleWorkspace('research', 'ws-research-id');
+        const { strategy, readResource } = makeReadStrategy(manager, 'code');
+
+        const response = await strategy.handle({ method: 'resources/read', params: { uri: SERVER_URI } });
+
+        expect(readResource).not.toHaveBeenCalled();
+        expect(response.contents).toHaveLength(1);
+        expect(response.contents[0].mimeType).toBe('application/json');
+        expect(JSON.parse(response.contents[0].text)).toMatchObject({
+            vault: 'code',
+            cliSession: { handle: 'research', workspace: { id: 'ws-research-id', name: 'Research' } }
+        });
+    });
+
+    it('other URIs still go to the vault-file reader, so the resource is additive', async () => {
+        const { strategy, readResource } = makeReadStrategy(undefined);
+
+        await strategy.handle({ method: 'resources/read', params: { uri: 'obsidian://Notes/a.md' } });
+
+        expect(readResource).toHaveBeenCalledWith('obsidian://Notes/a.md');
+    });
+
+    it('with no manager wired (tests, early boot) the resource still answers instead of throwing', async () => {
+        const { strategy } = makeReadStrategy(undefined, undefined);
+
+        const response = await strategy.handle({ method: 'resources/read', params: { uri: SERVER_URI } });
+
+        expect(JSON.parse(response.contents[0].text)).toEqual({ vault: null, defaultSessionHandle: 'nexus-cli', cliSession: null });
+    });
+
+    describe('CLI rendering', () => {
+        it('parses exactly what the server serves', async () => {
+            const { manager } = makeManager();
+            manager.setCliCurrentSession('research');
+            manager.bindHandleWorkspace('research', 'ws-research-id');
+            const { strategy } = makeReadStrategy(manager, 'code');
+
+            const parsed = parseContextSnapshot(await strategy.handle({ method: 'resources/read', params: { uri: CLI_URI } }));
+
+            expect(parsed).toEqual({
+                vault: 'code',
+                defaultSessionHandle: 'nexus-cli',
+                cliSession: { handle: 'research', displaySessionId: null, workspace: { id: 'ws-research-id', name: 'Research' } }
+            });
+        });
+
+        it('renders a fresh vault as "none" with the pass-once steer', () => {
+            const text = formatContextSnapshot({ vault: 'code', defaultSessionHandle: 'nexus-cli', cliSession: null });
+
+            expect(text).toMatch(/^Vault: +code$/m);
+            expect(text).toMatch(/^Session: +none/m);
+            expect(text).toContain('"nexus-cli"');
+            expect(text).toMatch(/^Workspace: +unbound/m);
+            expect(text).toMatch(/--session <name> once/);
+        });
+
+        it('renders a remembered session with its workspace name and id, and a renamed display name', () => {
+            const text = formatContextSnapshot({
+                vault: 'code',
+                defaultSessionHandle: 'nexus-cli',
+                cliSession: { handle: 'research', displaySessionId: 'research-2', workspace: { id: 'ws-research-id', name: 'Research' } }
+            });
+
+            expect(text).toMatch(/^Session: +research +\(display name: research-2\)$/m);
+            expect(text).toMatch(/^Workspace: +Research +\(ws-research-id\)$/m);
+            expect(text).not.toMatch(/none|unbound/);
+        });
+
+        it('renders a remembered session whose workspace is still unbound', () => {
+            const text = formatContextSnapshot({
+                vault: 'code',
+                defaultSessionHandle: 'nexus-cli',
+                cliSession: { handle: 'research', displaySessionId: 'research', workspace: null }
+            });
+
+            expect(text).toMatch(/^Session: +research$/m);
+            expect(text).toMatch(/^Workspace: +unbound/m);
+        });
+
+        it('fails loudly on a reply that is not the documented shape', () => {
+            expect(() => parseContextSnapshot({ contents: [] })).toThrow(/no text content/);
+            expect(() => parseContextSnapshot({ contents: [{ text: '{ nope' }] })).toThrow(/not JSON/);
+            expect(() => parseContextSnapshot({ contents: [{ text: '{"vault":"code"}' }] })).toThrow(/missing fields/);
+            expect(() => parseContextSnapshot({ contents: [{ text: '{"defaultSessionHandle":"x","cliSession":{"nope":1}}' }] }))
+                .toThrow(/malformed cliSession/);
+        });
+    });
+});

--- a/tests/unit/nexusCliEnvelope.test.ts
+++ b/tests/unit/nexusCliEnvelope.test.ts
@@ -1,0 +1,80 @@
+/**
+ * tests/unit/nexusCliEnvelope.test.ts
+ *
+ * The CLI sends `workspaceId` / `sessionId` ONLY when the flag was given
+ * (#214, session-sticky-context-plan.md PR 2). It used to fill
+ * `workspaceId: 'default'` and `sessionId: 'nexus-cli'` client-side; the
+ * server owns both defaults now, and a client-side `'default'` is exactly
+ * the silent misfiling the plan removes. Pure builders, no socket.
+ */
+import {
+    buildPlaybookEnvelope,
+    buildToolsEnvelope,
+    buildUseEnvelope,
+    contextFromFlags,
+} from '../../cli/envelope';
+
+describe('CLI envelope carries no client-side defaults', () => {
+    it('contextFromFlags emits a key only for a flag that was given', () => {
+        expect(contextFromFlags({})).toEqual({});
+        expect(contextFromFlags({ memory: 'm', goal: 'g', json: true })).toEqual({});
+        expect(contextFromFlags({ workspace: 'Research' })).toEqual({ workspaceId: 'Research' });
+        expect(contextFromFlags({ session: 'research' })).toEqual({ sessionId: 'research' });
+        expect(contextFromFlags({ workspace: 'Research', session: 'research' }))
+            .toEqual({ workspaceId: 'Research', sessionId: 'research' });
+    });
+
+    it('a boolean flag value (flag given with no value) is not a workspace or session', () => {
+        // parseOuterArgs rejects this shape before it gets here, but the
+        // builder must not turn `true` into a string either way.
+        expect(contextFromFlags({ workspace: true, session: true })).toEqual({});
+    });
+
+    it('`use` sends only tool, memory and goal when no context flags were given — no "default", no "nexus-cli"', () => {
+        const args = buildUseEnvelope({ memory: 'm', goal: 'g' }, 'storage list', 'm', 'g');
+
+        expect(args).toEqual({ tool: 'storage list', memory: 'm', goal: 'g' });
+        expect(args).not.toHaveProperty('workspaceId');
+        expect(args).not.toHaveProperty('sessionId');
+        expect(JSON.stringify(args)).not.toMatch(/default|nexus-cli/);
+    });
+
+    it('`use` forwards the flags that were given, unchanged', () => {
+        const args = buildUseEnvelope(
+            { workspace: 'Research', session: 'research', constraints: 'read only', 'operation-id': 'op-1' },
+            'storage list', 'm', 'g'
+        );
+
+        expect(args).toEqual({
+            tool: 'storage list',
+            workspaceId: 'Research',
+            sessionId: 'research',
+            memory: 'm',
+            goal: 'g',
+            constraints: 'read only',
+            operationId: 'op-1',
+        });
+    });
+
+    it('`tools` auto-fills memory/goal for discovery but never the workspace or session', () => {
+        const args = buildToolsEnvelope({}, 'storage list');
+
+        expect(args.tool).toBe('storage list');
+        expect(typeof args.memory).toBe('string');
+        expect(args.goal).toContain('storage list');
+        expect(args).not.toHaveProperty('workspaceId');
+        expect(args).not.toHaveProperty('sessionId');
+
+        expect(buildToolsEnvelope({ session: 'research', memory: 'mine', goal: 'also mine' }, '--help'))
+            .toEqual({ tool: '--help', sessionId: 'research', memory: 'mine', goal: 'also mine' });
+    });
+
+    it('`playbook` fills memory/goal and forwards only the context flags given', () => {
+        expect(buildPlaybookEnvelope({}, 'vault-work')).toEqual({
+            memory: 'Loading the "vault-work" playbook.',
+            goal: 'Prepare to run the vault-work task.',
+        });
+        expect(buildPlaybookEnvelope({ workspace: 'Research' }, 'tasks')).toMatchObject({ workspaceId: 'Research' });
+        expect(buildPlaybookEnvelope({ workspace: 'Research' }, 'tasks')).not.toHaveProperty('sessionId');
+    });
+});


### PR DESCRIPTION
Part of #214 — PR 2 of `docs/plans/session-sticky-context-plan.md`. Stacked on #386 (base: `feat/session-sticky-workspace`), which stacks on #384.

## Summary

The CLI no longer needs `--session` or `--workspace` on every call. Both are chosen once and remembered **in the vault** — the CLI holds no state and fills no defaults.

- **`cliCurrentSession` per vault** (`session-bindings.json`, alongside PR 1's handle and workspace bindings). In `ToolExecutionStrategy.processSession` the session handle resolves `explicit → cliCurrentSession ?? 'nexus-cli' → today's fallback`, but **only** for connections that identified as `nexus-cli` on `initialize` (`clientName` from PR 1). MCP clients and native chat behave exactly as before. The `'nexus-cli'` fallback preserves today's behaviour and is a default, not a bind.
- **Bind point 3**: an explicit `--session <name>` on a CLI connection becomes the vault's current session once the call succeeds (`useTools`: `result.success !== false`; `getTools`: any non-throwing result). Because the workspace is resolved for the *resolved* handle, an inherited CLI session inherits its bound workspace too.
- **UNBOUND exemption**: a `useTools` batch made **entirely** of `memory load-workspace` / `memory list-workspaces` / `memory create-workspace` runs on an unbound session, partitioned under `default` without binding — a fresh session has to be able to see, create and pick a workspace, and those commands live behind `useTools`. A successful `load-workspace` still binds via bind point 2. Mixed batches get the steer (one `workspaceId` is stamped on the whole batch, so trailing commands would otherwise run under `default` while the session was being bound elsewhere). Without this, removing the CLI's `'default'` fill made the steer tell you to run a command it would itself refuse.
- **`nexus context [--json]`**: read-only view of what this vault remembers for the CLI (vault, current session, display name, bound workspace). Served as an unlisted MCP resource `nexus://context` over the existing `resources/read` — no third tool, no new JSON-RPC method, invisible to `resources/list`.
- **CLI**: envelope builders extracted to `cli/envelope.ts`; `workspaceId`/`sessionId` are sent only when the flag was given. `cliAssets.ts` regenerated.
- **Guidance** rewritten to "choose once, it is remembered": `nexus --help`, `skill/SKILL.md`, `cli/agents-snippet.md`, `skill/playbooks/_preamble.md` and all playbooks, `guide/nexus-cli.md`. `WORKSPACE_ID_REQUIRED_MESSAGE` names the three commands that run before a choice.

## Test plan

- [x] `npm run test` — 5148 passed / 0 failed (baseline at PR 1 tip: 5108). New `CliSessionContinuity.test.ts`, `nexusCliEnvelope.test.ts`, `nexusCliContext.test.ts`; PR 1 fixtures extracted to `tests/unit/helpers/sessionStickyFixtures.ts`
- [x] Red/green: remove the `clientName === 'nexus-cli'` gate → 2 red; remove bind point 3's success guard → 1 red; exemption every→first-segment → 2 red; remove `create-workspace` from the set → 2 red
- [x] `shippedGuidanceCommands`, `cliGuidanceDrift`, `ToolManagerCliSyntax` pass unweakened; `npm run build` exit 0
- [ ] Live after merge (from the `code` vault): `nexus context` (expect none / unbound) → `nexus use --session research --workspace <ws> … -- storage list --path /` → `nexus context` (research + ws) → same `use` without flags (inherits) → `nexus use --session fresh … -- memory list-workspaces` (runs unbound) → mixed batch on `fresh` (expect steer "…in its own call") → `memory load-workspace <ws>` (binds) → plugin reload → `nexus context` still shows it; `session-bindings.json` has `cliCurrentSession`

## Merge note

Touches `cli/nexus-cli.ts` help text and the regenerated `src/utils/cliAssets.ts`, as does #385 (cwd vault discovery). Whichever merges second needs a small rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
