### PR TITLE
fix(sessions): harden session-bindings persistence after live checks (#214)

### DIFF
--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -466,17 +466,25 @@ export class SessionContextManager {
 
   /**
    * Check a restored handle's session against storage once, and ALWAYS keep
-   * the entry. The handle's continuity is what the caller wants: when
-   * storage lists the session, trust the entry; when it does not, re-create
-   * the record with the same id (best-effort) and trust the entry anyway.
+   * the entry. The handle's continuity is what the caller wants; what varies
+   * on a miss is only whether the session RECORD is re-created here:
    *
-   * Never drop on a miss. `SessionService.getAllSessions` returns `[]` while
-   * storage is still hydrating after a reload (it swallows the error), and a
-   * call a few seconds in saw exactly that: the restored `default::live-check`
-   * was dropped and a new id minted — the regression this handle map exists
-   * to prevent. A session that was genuinely deleted while unloaded is
-   * therefore resurrected with its old id, which is the lesser evil versus
-   * silently renumbering a live session because storage was cold.
+   * - Storage lists the session → trust the entry.
+   * - Storage returned a NON-EMPTY list without it → a definite delete while
+   *   the plugin was unloaded. Re-create the record with the same id
+   *   (best-effort) so the handle resumes rather than renumbering — the
+   *   lesser evil.
+   * - Storage returned `[]` → ambiguous. `SessionService.getAllSessions`
+   *   swallows errors and returns `[]` while storage is still hydrating after
+   *   a reload (a call a few seconds in saw exactly that and dropped
+   *   `default::live-check` — the regression this map exists to prevent), and
+   *   an empty workspace looks the same. Do NOT re-create here:
+   *   SessionRepository.create appends the JSONL `session_created` event
+   *   before the SQLite INSERT, so re-creating a session that merely was not
+   *   listed yet would leave a duplicate event in the source of truth on
+   *   every cold reload. Keep the entry, mark it verified, and let trace
+   *   capture's own auto-create supply the record later if it really is
+   *   missing (it already creates sessions for trace storage).
    *
    * A lookup that THROWS keeps the entry unverified (re-checked next call)
    * and returns it, as before.
@@ -507,9 +515,17 @@ export class SessionContextManager {
       }
     }
 
-    if (!sessions.some(session => session.id === entry.id)) {
+    if (sessions.some(session => session.id === entry.id)) {
+      return entry;
+    }
+
+    if (sessions.length === 0) {
       logger.systemLog(
-        `Restored session handle "${key}" points at session ${entry.id}, which storage does not list; keeping the handle and re-creating the record`
+        `Restored session handle "${key}" points at session ${entry.id}, but storage listed no sessions for workspace ${entry.workspaceId} (cold or empty); keeping the handle, record not re-created`
+      );
+    } else {
+      logger.systemLog(
+        `Restored session handle "${key}" points at session ${entry.id}, which storage no longer lists; keeping the handle and re-creating the record`
       );
       try {
         // createAutoSession already logs and swallows a failed createSession

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -69,13 +69,6 @@ export interface SessionWorkspaceResolution {
 const GLOBAL_WORKSPACE_ID = 'default';
 
 /**
- * How long consecutive binding changes are coalesced before one write. A
- * session's first few calls (getTools, useTools, load-workspace) all mutate
- * the map within a second or two; one file write per burst is plenty.
- */
-const BINDINGS_SAVE_DEBOUNCE_MS = 300;
-
-/**
  * SessionContextManager
  * 
  * Provides a centralized service for managing and persisting workspace context
@@ -138,8 +131,19 @@ export class SessionContextManager {
   // Persistence for handles + handleWorkspace. Null in tests and before wiring;
   // every store operation is best-effort and degrades to "pass it once again".
   private bindingsStore: SessionBindingsStore | null = null;
-  private bindingsSaveTimer: number | null = null;
   private bindingsRestore: Promise<void> | null = null;
+
+  // Write-through with in-flight coalescing, deliberately NOT a timer. A
+  // debounced `window.setTimeout` sat pending for minutes while Obsidian was
+  // in the background — Electron throttles background renderer timers, and the
+  // CLI is used precisely when Obsidian is not focused — so the file lagged
+  // the in-memory state and a quit in that window lost the bind. Instead: a
+  // change with no write in flight starts one now; a change during a write
+  // sets `bindingsDirty`, and the writer runs once more when it settles. Each
+  // write snapshots the state as it is when that write starts, so a burst
+  // collapses to at most two writes and the file always ends current.
+  private bindingsWrite: Promise<void> | null = null;
+  private bindingsDirty = false;
 
   // Disposer for the session-deleted subscription so re-wiring or teardown can
   // unregister cleanly.
@@ -272,35 +276,71 @@ export class SessionContextManager {
   }
 
   /**
-   * Coalesce binding changes into one write. Fire-and-forget: a failed write
-   * is logged by the store and the next change retries.
+   * Persist a binding change. Write-through: starts a write immediately when
+   * none is in flight, otherwise marks the state dirty so the in-flight
+   * writer runs once more when it settles (see `bindingsWrite`). Fire-and-
+   * forget: a failed write is logged and the next change retries.
    */
   private scheduleBindingsSave(): void {
     if (!this.bindingsStore) {
       return;
     }
-    if (this.bindingsSaveTimer) {
-      window.clearTimeout(this.bindingsSaveTimer);
+    if (this.bindingsWrite) {
+      this.bindingsDirty = true;
+      return;
     }
-    this.bindingsSaveTimer = window.setTimeout(() => {
-      this.bindingsSaveTimer = null;
-      void this.flushBindings();
-    }, BINDINGS_SAVE_DEBOUNCE_MS);
+    this.startBindingsWrite(this.snapshotBindings());
   }
 
-  /** Write the current bindings now, cancelling any pending debounced write. */
-  async flushBindings(): Promise<void> {
-    if (this.bindingsSaveTimer) {
-      window.clearTimeout(this.bindingsSaveTimer);
-      this.bindingsSaveTimer = null;
+  /**
+   * Begin the writer with `doc` as its first payload. Must only be called
+   * with no write in flight. The writer keeps going while changes arrive
+   * mid-write, each pass snapshotting the state as it stands at that moment,
+   * and stops as soon as the store is unwired (cleanup) so it can never write
+   * the emptied maps over the file.
+   */
+  private startBindingsWrite(doc: PersistedSessionBindings): void {
+    const store = this.bindingsStore;
+    if (!store) {
+      return;
     }
+    this.bindingsDirty = false;
+    this.bindingsWrite = (async () => {
+      try {
+        await this.saveBindings(store, doc);
+        while (this.bindingsDirty && this.bindingsStore === store) {
+          this.bindingsDirty = false;
+          await this.saveBindings(store, this.snapshotBindings());
+        }
+      } finally {
+        this.bindingsWrite = null;
+      }
+    })();
+  }
+
+  private async saveBindings(store: SessionBindingsStore, doc: PersistedSessionBindings): Promise<void> {
+    try {
+      await store.save(doc);
+    } catch (error) {
+      logger.systemWarn(`Session bindings save failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  /**
+   * Resolve once the current bindings are on disk: waits for any in-flight
+   * write (and the follow-up it owes for changes made meanwhile), or starts a
+   * write now when nothing is in flight.
+   */
+  async flushBindings(): Promise<void> {
     if (!this.bindingsStore) {
       return;
     }
-    try {
-      await this.bindingsStore.save(this.snapshotBindings());
-    } catch (error) {
-      logger.systemWarn(`Session bindings save failed: ${error instanceof Error ? error.message : String(error)}`);
+    if (!this.bindingsWrite) {
+      this.startBindingsWrite(this.snapshotBindings());
+    }
+    const inFlight = this.bindingsWrite;
+    if (inFlight) {
+      await inFlight;
     }
   }
 
@@ -662,17 +702,25 @@ export class SessionContextManager {
    * (ServiceContainer.clear) so the in-memory handle map and session-deleted
    * subscription do not survive a plugin reload. The persisted bindings DO
    * survive — that is what lets a returning handle resume its session — so
-   * any pending debounced write is flushed before memory is cleared.
+   * anything the writer still owes is written before memory is cleared.
    */
   cleanup(): void {
     if (this.sessionDeletedUnsubscribe) {
       this.sessionDeletedUnsubscribe();
       this.sessionDeletedUnsubscribe = null;
     }
-    if (this.bindingsSaveTimer) {
-      // Snapshot before clearAll() empties the maps; the write itself is
-      // fire-and-forget because Obsidian does not await plugin unload.
-      void this.flushBindings();
+    const store = this.bindingsStore;
+    const inFlight = this.bindingsWrite;
+    if (store && inFlight) {
+      // Every change already started its own write; the only state not yet on
+      // disk is what arrived while that write was in flight. Snapshot it NOW,
+      // synchronously, before clearAll() empties the maps, and write it after
+      // the in-flight write settles so the two cannot land out of order. The
+      // writer's own follow-up stops once the store is unwired below, so this
+      // is the last write. Fire-and-forget: Obsidian does not await unload.
+      const finalDoc = this.snapshotBindings();
+      this.bindingsDirty = false;
+      void inFlight.then(() => this.saveBindings(store, finalDoc));
     }
     this.bindingsStore = null;
     this.bindingsRestore = null;

--- a/src/services/SessionContextManager.ts
+++ b/src/services/SessionContextManager.ts
@@ -99,12 +99,16 @@ export class SessionContextManager {
   private sessionHandleMap: Map<string, { id: string; displaySessionId: string; workspaceId: string }> = new Map();
 
   // Handle entries restored from session-bindings.json that have not yet been
-  // checked against storage. A restored entry is only trusted once
-  // `sessionService.getAllSessions(entry.workspaceId)` confirms the session
-  // still exists; a session deleted while the plugin was unloaded is dropped
-  // at that point instead of being silently resumed. The check is lazy (on the
-  // handle's first use) rather than at service init because storage is cold
-  // during startup hydration and would report every session as missing.
+  // checked against storage. On the handle's first use
+  // `sessionService.getAllSessions(entry.workspaceId)` is consulted once; the
+  // entry is KEPT either way — a miss re-creates the session record with the
+  // same id (best-effort) rather than minting a new one. The check is lazy
+  // rather than at service init because storage is cold during startup
+  // hydration, and it cannot be allowed to drop anything for the same reason:
+  // a call a few seconds after reload saw an empty list and renumbered a live
+  // session (see verifyRestoredHandle). What the check still buys is the
+  // display-name uniqueness pass in createUniqueSessionDisplayName, which
+  // skips unverified entries so a stale name never forces a `-2`.
   private unverifiedHandleKeys: Set<string> = new Set();
 
   // Handle → workspace id of the LAST DELIBERATE bind (#214). Distinct from
@@ -461,16 +465,27 @@ export class SessionContextManager {
   }
 
   /**
-   * Confirm a restored handle's session still exists in storage. Returns the
-   * entry when it does (and marks it trusted), or null after dropping the
-   * entry when the session is gone. A lookup that THROWS keeps the entry
-   * unverified and returns it — a storage hiccup must not rename a live
-   * session to `<handle>-2`.
+   * Check a restored handle's session against storage once, and ALWAYS keep
+   * the entry. The handle's continuity is what the caller wants: when
+   * storage lists the session, trust the entry; when it does not, re-create
+   * the record with the same id (best-effort) and trust the entry anyway.
+   *
+   * Never drop on a miss. `SessionService.getAllSessions` returns `[]` while
+   * storage is still hydrating after a reload (it swallows the error), and a
+   * call a few seconds in saw exactly that: the restored `default::live-check`
+   * was dropped and a new id minted — the regression this handle map exists
+   * to prevent. A session that was genuinely deleted while unloaded is
+   * therefore resurrected with its old id, which is the lesser evil versus
+   * silently renumbering a live session because storage was cold.
+   *
+   * A lookup that THROWS keeps the entry unverified (re-checked next call)
+   * and returns it, as before.
    */
   private async verifyRestoredHandle(
     key: string,
-    entry: { id: string; displaySessionId: string; workspaceId: string }
-  ): Promise<{ id: string; displaySessionId: string; workspaceId: string } | null> {
+    entry: { id: string; displaySessionId: string; workspaceId: string },
+    sessionDescription?: string
+  ): Promise<{ id: string; displaySessionId: string; workspaceId: string }> {
     if (!this.unverifiedHandleKeys.has(key)) {
       return entry;
     }
@@ -485,25 +500,30 @@ export class SessionContextManager {
       return entry;
     }
 
-    if (sessions.some(session => session.id === entry.id)) {
-      // Trust every key that points at this session, not just the one looked up.
-      for (const [otherKey, other] of this.sessionHandleMap.entries()) {
-        if (other.id === entry.id) {
-          this.unverifiedHandleKeys.delete(otherKey);
-        }
-      }
-      return entry;
-    }
-
-    logger.systemLog(`Restored session handle "${key}" points at deleted session ${entry.id}; dropping it`);
+    // Trust every key that points at this session, not just the one looked up.
     for (const [otherKey, other] of this.sessionHandleMap.entries()) {
       if (other.id === entry.id) {
-        this.sessionHandleMap.delete(otherKey);
         this.unverifiedHandleKeys.delete(otherKey);
       }
     }
-    this.scheduleBindingsSave();
-    return null;
+
+    if (!sessions.some(session => session.id === entry.id)) {
+      logger.systemLog(
+        `Restored session handle "${key}" points at session ${entry.id}, which storage does not list; keeping the handle and re-creating the record`
+      );
+      try {
+        // createAutoSession already logs and swallows a failed createSession
+        // (e.g. "Workspace X not found" while storage is cold); the guard here
+        // is belt-and-braces so nothing on this path can throw or drop.
+        await this.createAutoSession(entry.id, entry.displaySessionId, sessionDescription, entry.workspaceId);
+      } catch (error) {
+        logger.systemWarn(
+          `Could not re-create session ${entry.id} for restored handle "${key}": ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+
+    return entry;
   }
 
   /**
@@ -770,7 +790,9 @@ export class SessionContextManager {
     if (!isStandardSessionId(sessionId)) {
       const key = this.handleKey(workspaceId, sessionId);
       const knownHandle = this.sessionHandleMap.get(key);
-      const existingHandle = knownHandle ? await this.verifyRestoredHandle(key, knownHandle) : null;
+      const existingHandle = knownHandle
+        ? await this.verifyRestoredHandle(key, knownHandle, sessionDescription)
+        : null;
       if (existingHandle) {
         return {
           id: existingHandle.id,

--- a/src/utils/sessionUtils.ts
+++ b/src/utils/sessionUtils.ts
@@ -4,13 +4,40 @@
  */
 
 /**
- * Generate a standardized session ID based on current datetime
+ * The whole-second UTC timestamp (ms) the last id was issued for, or null
+ * before the first call. Module-level so every caller in the process shares
+ * one monotonic sequence.
+ */
+let lastIssuedSecondMs: number | null = null;
+
+/**
+ * Format a whole-second UTC timestamp as s-YYYYMMDDhhmmss.
+ */
+function formatSessionId(secondMs: number): string {
+    return `s-${new Date(secondMs).toISOString().replace(/[-:.TZ]/g, '').slice(0, 14)}`;
+}
+
+/**
+ * Generate a standardized session ID based on current datetime, strictly
+ * increasing within a process.
+ *
+ * The format has one-second resolution, so two sessions created in the same
+ * second used to get the same id and the second `createSession` was a no-op —
+ * two handles then pointed at one record (seen live: `nexus-cli` on an unbound
+ * call, then `--session live-check`, both `s-20260912194746`). When the clock
+ * has not moved past the last issued id, the id is taken from the last one
+ * plus one second, computed on a Date so minute/hour/day carry correctly.
+ * The `s-` + 14 digits format is unchanged; `isStandardSessionId` still holds.
+ *
  * @returns Session ID in the format s-YYYYMMDDhhmmss
  */
 export function generateSessionId(): string {
-    const now = new Date();
-    const formattedDate = now.toISOString().replace(/[-:.TZ]/g, '').slice(0, 14);
-    return `s-${formattedDate}`;
+    let secondMs = Math.floor(Date.now() / 1000) * 1000;
+    if (lastIssuedSecondMs !== null && secondMs <= lastIssuedSecondMs) {
+        secondMs = lastIssuedSecondMs + 1000;
+    }
+    lastIssuedSecondMs = secondMs;
+    return formatSessionId(secondMs);
 }
 
 /**

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -421,9 +421,11 @@ describe('persistence: session-bindings.json', () => {
   // returns [] while storage is still hydrating after a reload, and a call a
   // few seconds in saw exactly that: the handle was dropped and a new id
   // minted — the regression this map exists to prevent. Continuity wins: the
-  // same id is kept and the record re-created with it, whether the empty list
-  // came from cold storage or from a real delete.
-  it('a restored handle whose session storage does not list keeps the SAME id and re-creates the record with it', async () => {
+  // same id is kept either way. Only a DEFINITE delete (a non-empty list that
+  // lacks the id) re-creates the record; an empty list is ambiguous between
+  // cold and empty, and re-creating there would append a duplicate
+  // session_created event to the JSONL source of truth on every cold reload.
+  it('a restored handle whose session was deleted (non-empty list without it) keeps the SAME id and re-creates the record with it', async () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
@@ -431,7 +433,8 @@ describe('persistence: session-bindings.json', () => {
       cliCurrentSession: null
     };
     const sessionService = makeSessionService();
-    sessionService.getAllSessions.mockResolvedValue([]); // deleted while unloaded — or not yet loaded
+    // Storage is warm — it lists another session — and ours is not there.
+    sessionService.getAllSessions.mockResolvedValue([{ id: 's-20260101000001', workspaceId: 'default', name: 'other' }]);
     const { manager } = makeManager({ store, sessionService });
 
     const result = await manager.validateSessionId('nexus-cli', 'resumed after reload', 'default');
@@ -450,7 +453,7 @@ describe('persistence: session-bindings.json', () => {
     expect(store.doc?.handles['default::nexus-cli']?.id).toBe('s-20260101000000');
   });
 
-  it('cold storage (empty list, then warm) never renames: the same id is used on every call and the check runs once', async () => {
+  it('cold storage (empty list, then warm) never renames and does NOT re-create: same id every call, check runs once', async () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'ws-research-id::live-check': { id: 's-20260912194746', displaySessionId: 'live-check', workspaceId: 'ws-research-id' } },
@@ -470,11 +473,14 @@ describe('persistence: session-bindings.json', () => {
     expect(cold.displaySessionIdChanged).toBe(false);
     expect(warm).toEqual(cold);
     expect(sessionService.getAllSessions).toHaveBeenCalledTimes(1);
+    // The empty list is ambiguous (cold or empty workspace): no re-create,
+    // so a cold reload never appends a duplicate session_created event.
+    expect(sessionService.createSession).not.toHaveBeenCalled();
     expect(await manager.resolveWorkspaceForSession(undefined, 'live-check'))
       .toEqual({ workspaceId: 'ws-research-id', explicit: false });
   });
 
-  it('a failed re-create (workspace not found while storage is cold) only logs; the handle is still kept', async () => {
+  it('a failed re-create (e.g. workspace not found) only logs; the handle is still kept', async () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'ws-research-id::live-check': { id: 's-20260912194746', displaySessionId: 'live-check', workspaceId: 'ws-research-id' } },
@@ -482,7 +488,7 @@ describe('persistence: session-bindings.json', () => {
       cliCurrentSession: null
     };
     const sessionService = makeSessionService();
-    sessionService.getAllSessions.mockResolvedValue([]);
+    sessionService.getAllSessions.mockResolvedValue([{ id: 's-other', workspaceId: 'ws-research-id', name: 'other' }]);
     sessionService.createSession.mockRejectedValue(new Error('Workspace ws-research-id not found'));
     const { manager } = makeManager({ store, sessionService });
 

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -34,6 +34,7 @@ import type { RequestRouter } from '../../src/handlers/RequestRouter';
 import type { Server as MCPSDKServer } from '@modelcontextprotocol/sdk/server/index.js';
 import type { App } from 'obsidian';
 import {
+  HeldBindingsStore,
   MemoryBindingsStore,
   getToolsRequest,
   makeManager,
@@ -41,6 +42,7 @@ import {
   makeSessionService,
   makeStrategy,
   makeToolManagerAgent,
+  settle,
   useToolsRequest
 } from './helpers/sessionStickyFixtures';
 
@@ -483,29 +485,89 @@ describe('persistence: session-bindings.json', () => {
     });
   });
 
-  it('writes are debounced into one save per burst and flushed on cleanup', async () => {
-    jest.useFakeTimers();
-    try {
-      const store = new MemoryBindingsStore();
-      const { manager } = makeManager({ store });
+  // Persistence is write-through, not debounced: a 300 ms timer sat pending
+  // for minutes while Obsidian was in the background (Electron throttles
+  // background renderer timers, and the CLI runs precisely then), so the file
+  // lagged the in-memory state. No timers anywhere in this block — the
+  // HeldBindingsStore controls what is in flight.
+  it('the first change writes immediately, with no timer to wait on', async () => {
+    const store = new HeldBindingsStore();
+    const { manager } = makeManager({ store });
 
-      manager.bindHandleWorkspace('a', 'ws-research-id');
-      manager.bindHandleWorkspace('b', 'ws-blog-id');
-      manager.bindHandleWorkspace('c', 'default');
-      expect(store.saves).toBe(0);
+    manager.bindHandleWorkspace('a', 'ws-research-id');
 
-      await jest.advanceTimersByTimeAsync(1000);
-      expect(store.saves).toBe(1);
-      expect(Object.keys(store.doc?.handleWorkspace ?? {})).toEqual(['a', 'b', 'c']);
+    expect(store.started).toHaveLength(1);
+    expect(store.started[0].handleWorkspace).toEqual({ a: 'ws-research-id' });
+  });
 
-      manager.bindHandleWorkspace('d', 'default');
-      manager.cleanup();
-      await Promise.resolve();
-      expect(store.saves).toBe(2);
-      expect(store.doc?.handleWorkspace.d).toBe('default');
-    } finally {
-      jest.useRealTimers();
-    }
+  it('a burst of N binds while a write is in flight produces exactly 2 writes, and the second carries all N', async () => {
+    const store = new HeldBindingsStore();
+    const { manager } = makeManager({ store });
+
+    manager.bindHandleWorkspace('a', 'ws-research-id'); // write 1 starts, held
+    manager.bindHandleWorkspace('b', 'ws-blog-id');
+    manager.bindHandleWorkspace('c', 'default');
+    manager.setCliCurrentSession('c');
+    expect(store.started).toHaveLength(1);
+
+    expect(store.release()).toBe(true); // write 1 settles
+    await settle();
+
+    // One follow-up, snapshotting the state as it stands now — not one write
+    // per change, and not a stale copy taken when the changes happened.
+    expect(store.started).toHaveLength(2);
+    expect(Object.keys(store.started[1].handleWorkspace)).toEqual(['a', 'b', 'c']);
+    expect(store.started[1].cliCurrentSession).toBe('c');
+
+    expect(store.release()).toBe(true);
+    await settle();
+    expect(store.started).toHaveLength(2);
+    expect(store.doc?.handleWorkspace).toEqual({ a: 'ws-research-id', b: 'ws-blog-id', c: 'default' });
+  });
+
+  it('flushBindings resolves once the changes made during an in-flight write are on disk', async () => {
+    const store = new HeldBindingsStore();
+    const { manager } = makeManager({ store });
+
+    manager.bindHandleWorkspace('a', 'ws-research-id');
+    manager.bindHandleWorkspace('b', 'ws-blog-id');
+    let flushed = false;
+    const flush = manager.flushBindings().then(() => { flushed = true; });
+
+    store.release();
+    await settle();
+    expect(flushed).toBe(false); // the follow-up carrying b is still in flight
+
+    store.release();
+    await flush;
+    expect(store.doc?.handleWorkspace).toEqual({ a: 'ws-research-id', b: 'ws-blog-id' });
+
+    // Nothing in flight: flush writes now, so a caller can rely on "current
+    // state is on disk" without knowing the writer's history.
+    const second = manager.flushBindings();
+    expect(store.started).toHaveLength(3);
+    store.release();
+    await second;
+  });
+
+  it('cleanup snapshots before the maps are cleared and writes it after the in-flight write, never the emptied state', async () => {
+    const store = new HeldBindingsStore();
+    const { manager } = makeManager({ store });
+
+    manager.bindHandleWorkspace('a', 'ws-research-id'); // held
+    manager.bindHandleWorkspace('d', 'default');       // dirty
+    manager.cleanup();                                  // maps now empty
+
+    expect(store.started).toHaveLength(1);
+    store.release();
+    await settle();
+
+    expect(store.started).toHaveLength(2);
+    expect(store.started[1].handleWorkspace).toEqual({ a: 'ws-research-id', d: 'default' });
+    store.release();
+    await settle();
+    expect(store.doc?.handleWorkspace.d).toBe('default');
+    expect(store.inFlight).toBe(0);
   });
 
   it('the vault store creates the data folder and writes through the adapter, never Node fs', async () => {

--- a/tests/unit/SessionStickyWorkspace.test.ts
+++ b/tests/unit/SessionStickyWorkspace.test.ts
@@ -13,7 +13,7 @@
  * REAL throughout; only storage (SessionService), the workspace lookup and the
  * persistence store are stubbed — and none of them supplies the value an
  * assertion depends on, except where the test is about that stub's data
- * (persistence round-trip, deleted-session drop).
+ * (persistence round-trip, storage-miss re-create).
  */
 
 import type { IRequestContext } from '../../src/handlers/interfaces/IRequestHandlerServices';
@@ -417,7 +417,13 @@ describe('persistence: session-bindings.json', () => {
     expect(afterService.createSession).not.toHaveBeenCalled();
   });
 
-  it('a restored handle whose session was deleted is dropped, and the handle gets a fresh session', async () => {
+  // A restored handle is never dropped on a storage miss. `getAllSessions`
+  // returns [] while storage is still hydrating after a reload, and a call a
+  // few seconds in saw exactly that: the handle was dropped and a new id
+  // minted — the regression this map exists to prevent. Continuity wins: the
+  // same id is kept and the record re-created with it, whether the empty list
+  // came from cold storage or from a real delete.
+  it('a restored handle whose session storage does not list keeps the SAME id and re-creates the record with it', async () => {
     const store = new MemoryBindingsStore();
     store.doc = {
       handles: { 'default::nexus-cli': { id: 's-20260101000000', displaySessionId: 'nexus-cli', workspaceId: 'default' } },
@@ -425,17 +431,66 @@ describe('persistence: session-bindings.json', () => {
       cliCurrentSession: null
     };
     const sessionService = makeSessionService();
-    sessionService.getAllSessions.mockResolvedValue([]); // deleted while unloaded
+    sessionService.getAllSessions.mockResolvedValue([]); // deleted while unloaded — or not yet loaded
     const { manager } = makeManager({ store, sessionService });
 
-    const result = await manager.validateSessionId('nexus-cli', undefined, 'default');
+    const result = await manager.validateSessionId('nexus-cli', 'resumed after reload', 'default');
 
-    expect(result.created).toBe(true);
-    expect(result.id).not.toBe('s-20260101000000');
-    // Not renamed either: the stale display name must not force a suffix.
+    expect(result.id).toBe('s-20260101000000');
+    expect(result.created).toBe(false);
     expect(result.displaySessionId).toBe('nexus-cli');
+    expect(sessionService.createSession).toHaveBeenCalledTimes(1);
+    expect(sessionService.createSession).toHaveBeenCalledWith({
+      id: 's-20260101000000',
+      name: 'nexus-cli',
+      description: 'resumed after reload',
+      workspaceId: 'default'
+    });
     await manager.flushBindings();
-    expect(store.doc?.handles['default::nexus-cli']?.id).toBe(result.id);
+    expect(store.doc?.handles['default::nexus-cli']?.id).toBe('s-20260101000000');
+  });
+
+  it('cold storage (empty list, then warm) never renames: the same id is used on every call and the check runs once', async () => {
+    const store = new MemoryBindingsStore();
+    store.doc = {
+      handles: { 'ws-research-id::live-check': { id: 's-20260912194746', displaySessionId: 'live-check', workspaceId: 'ws-research-id' } },
+      handleWorkspace: { 'live-check': 'ws-research-id' },
+      cliCurrentSession: 'live-check'
+    };
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValueOnce([]); // ~3 s after reload: still hydrating
+    sessionService.getAllSessions.mockResolvedValue([{ id: 's-20260912194746', workspaceId: 'ws-research-id', name: 'live-check' }]);
+    const { manager } = makeManager({ store, sessionService });
+
+    const cold = await manager.validateSessionId('live-check', undefined, 'ws-research-id');
+    const warm = await manager.validateSessionId('live-check', undefined, 'ws-research-id');
+
+    expect(cold.id).toBe('s-20260912194746');
+    expect(cold.displaySessionId).toBe('live-check');
+    expect(cold.displaySessionIdChanged).toBe(false);
+    expect(warm).toEqual(cold);
+    expect(sessionService.getAllSessions).toHaveBeenCalledTimes(1);
+    expect(await manager.resolveWorkspaceForSession(undefined, 'live-check'))
+      .toEqual({ workspaceId: 'ws-research-id', explicit: false });
+  });
+
+  it('a failed re-create (workspace not found while storage is cold) only logs; the handle is still kept', async () => {
+    const store = new MemoryBindingsStore();
+    store.doc = {
+      handles: { 'ws-research-id::live-check': { id: 's-20260912194746', displaySessionId: 'live-check', workspaceId: 'ws-research-id' } },
+      handleWorkspace: {},
+      cliCurrentSession: null
+    };
+    const sessionService = makeSessionService();
+    sessionService.getAllSessions.mockResolvedValue([]);
+    sessionService.createSession.mockRejectedValue(new Error('Workspace ws-research-id not found'));
+    const { manager } = makeManager({ store, sessionService });
+
+    const result = await manager.validateSessionId('live-check', undefined, 'ws-research-id');
+
+    expect(result.id).toBe('s-20260912194746');
+    expect(result.created).toBe(false);
+    expect(manager.describeHandle('live-check', 'ws-research-id')?.id).toBe('s-20260912194746');
   });
 
   it('a storage lookup that throws keeps the restored handle rather than renaming a live session', async () => {

--- a/tests/unit/helpers/sessionStickyFixtures.ts
+++ b/tests/unit/helpers/sessionStickyFixtures.ts
@@ -72,6 +72,55 @@ export class MemoryBindingsStore implements SessionBindingsStore {
   }
 }
 
+/**
+ * A store whose writes stay in flight until the test releases them, so a
+ * test can hold the manager in its "write in progress" state and observe how
+ * changes made meanwhile are coalesced. `save` records the payload the moment
+ * the write STARTS (that is what the manager snapshotted) and resolves only
+ * when `release()` is called for it.
+ */
+export class HeldBindingsStore implements SessionBindingsStore {
+  doc: PersistedSessionBindings | null = null;
+  /** Payloads in the order writes started. */
+  started: PersistedSessionBindings[] = [];
+  private pending: Array<() => void> = [];
+
+  async load(): Promise<PersistedSessionBindings | null> {
+    return this.doc ? JSON.parse(JSON.stringify(this.doc)) : null;
+  }
+
+  save(doc: PersistedSessionBindings): Promise<void> {
+    const copy = JSON.parse(JSON.stringify(doc)) as PersistedSessionBindings;
+    this.started.push(copy);
+    return new Promise<void>(resolve => {
+      this.pending.push(() => {
+        this.doc = copy;
+        resolve();
+      });
+    });
+  }
+
+  /** Number of writes started but not yet released. */
+  get inFlight(): number {
+    return this.pending.length;
+  }
+
+  /** Complete the oldest in-flight write; returns false if there is none. */
+  release(): boolean {
+    const next = this.pending.shift();
+    if (!next) return false;
+    next();
+    return true;
+  }
+}
+
+/** Let the manager's writer observe a released write and take its next step. */
+export async function settle(): Promise<void> {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 export function makeManager(options: {
   sessionService?: SessionServiceStub;
   resolver?: WorkspaceResolverLike | null;

--- a/tests/unit/helpers/sessionStickyFixtures.ts
+++ b/tests/unit/helpers/sessionStickyFixtures.ts
@@ -6,7 +6,7 @@
  * The SessionContextManager is REAL; only storage (SessionService), the
  * workspace lookup and the persistence store are stubbed — and none of them
  * supplies the value an assertion depends on, except where a test is about
- * that stub's data (persistence round-trip, deleted-session drop).
+ * that stub's data (persistence round-trip, storage-miss re-create).
  */
 
 import { ToolExecutionStrategy } from '../../../src/handlers/strategies/ToolExecutionStrategy';

--- a/tests/unit/sessionUtils.test.ts
+++ b/tests/unit/sessionUtils.test.ts
@@ -1,0 +1,103 @@
+/**
+ * generateSessionId (#214, docs/plans/session-sticky-context-plan.md PR 4).
+ *
+ * The id format `s-YYYYMMDDhhmmss` has one-second resolution. Live, two
+ * sessions created in the same second (`nexus-cli` on an unbound call, then
+ * `--session live-check`) both got `s-20260912194746`; the second
+ * `createSession` was a no-op and two handles pointed at one record. Ids must
+ * be strictly increasing within a process while keeping the exact format that
+ * `isStandardSessionId` (and everything keyed off it) depends on.
+ *
+ * Each test loads a fresh copy of the module so the "last issued id" state
+ * starts empty; the clock is pinned with modern fake timers, which drive
+ * `Date.now()`.
+ */
+
+type SessionUtils = typeof import('../../src/utils/sessionUtils');
+
+function loadFresh(): SessionUtils {
+  let mod: SessionUtils | undefined;
+  jest.isolateModules(() => {
+    mod = jest.requireActual<SessionUtils>('../../src/utils/sessionUtils');
+  });
+  if (!mod) throw new Error('module did not load');
+  return mod;
+}
+
+const STANDARD = /^s-\d{14}$/;
+
+describe('generateSessionId', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('two calls in the same second yield different ids, both standard, the second greater', () => {
+    jest.useFakeTimers({ now: Date.UTC(2026, 8, 12, 19, 47, 46, 120) });
+    const { generateSessionId, isStandardSessionId } = loadFresh();
+
+    const first = generateSessionId();
+    jest.setSystemTime(Date.UTC(2026, 8, 12, 19, 47, 46, 880)); // same second
+    const second = generateSessionId();
+
+    expect(first).toBe('s-20260912194746');
+    expect(second).toBe('s-20260912194747');
+    expect(first).toMatch(STANDARD);
+    expect(second).toMatch(STANDARD);
+    expect(isStandardSessionId(first)).toBe(true);
+    expect(isStandardSessionId(second)).toBe(true);
+    expect(second > first).toBe(true);
+  });
+
+  it('a call in a later second uses the clock, not the counter', () => {
+    jest.useFakeTimers({ now: Date.UTC(2026, 8, 12, 19, 47, 46) });
+    const { generateSessionId } = loadFresh();
+
+    expect(generateSessionId()).toBe('s-20260912194746');
+    jest.setSystemTime(Date.UTC(2026, 8, 12, 19, 47, 49));
+    expect(generateSessionId()).toBe('s-20260912194749');
+  });
+
+  it('a burst of N calls in one second yields N distinct, strictly increasing ids', () => {
+    jest.useFakeTimers({ now: Date.UTC(2026, 8, 12, 19, 47, 46) });
+    const { generateSessionId } = loadFresh();
+
+    const ids = Array.from({ length: 5 }, () => generateSessionId());
+
+    expect(new Set(ids).size).toBe(5);
+    for (let i = 1; i < ids.length; i += 1) {
+      expect(ids[i] > ids[i - 1]).toBe(true);
+      expect(ids[i]).toMatch(STANDARD);
+    }
+  });
+
+  it('carries the bump across the minute, hour, day, month and year boundaries', () => {
+    jest.useFakeTimers({ now: Date.UTC(2026, 11, 31, 23, 59, 59) });
+    const { generateSessionId } = loadFresh();
+
+    expect(generateSessionId()).toBe('s-20261231235959');
+    expect(generateSessionId()).toBe('s-20270101000000');
+  });
+
+  it('a clock that moves backwards (after the bump ran ahead) still never repeats an id', () => {
+    jest.useFakeTimers({ now: Date.UTC(2026, 8, 12, 19, 47, 46) });
+    const { generateSessionId } = loadFresh();
+
+    const a = generateSessionId(); // :46
+    const b = generateSessionId(); // :47 (ahead of the clock)
+    jest.setSystemTime(Date.UTC(2026, 8, 12, 19, 47, 47, 500)); // clock catches up to :47
+    const c = generateSessionId();
+
+    expect([a, b, c]).toEqual(['s-20260912194746', 's-20260912194747', 's-20260912194748']);
+  });
+});
+
+describe('isStandardSessionId', () => {
+  it('accepts exactly s- plus 14 digits and nothing else', () => {
+    const { isStandardSessionId } = loadFresh();
+    expect(isStandardSessionId('s-20260912194746')).toBe(true);
+    expect(isStandardSessionId('s-2026091219474')).toBe(false);
+    expect(isStandardSessionId('s-202609121947461')).toBe(false);
+    expect(isStandardSessionId('nexus-cli')).toBe(false);
+    expect(isStandardSessionId('S-20260912194746')).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #214 — PR 4 of `docs/plans/session-sticky-context-plan.md`: hardening from the live checks run after #386/#387 merged.

## Summary

Three findings from exercising the sticky-context flow live in the `code` vault, each with its own commit:

1. **Write-through persistence instead of a timer.** The 300 ms `window.setTimeout` debounce sat pending for *minutes* while Obsidian was in the background — Electron throttles background renderer timers, and the CLI is used precisely when Obsidian is not focused. In-memory state was right; `session-bindings.json` lagged until the renderer woke, so a quit in that window lost the bind. Now a change with no write in flight starts one immediately; a change during a write sets a dirty flag and the writer runs once more, re-snapshotting — a burst collapses to at most two writes. `cleanup()` snapshots synchronously before clearing the maps and chains the final write behind any in-flight one; the writer stops once the store is unwired so emptied maps are never written.
2. **A restored handle is never dropped on a storage miss.** A call ~3 s after reload found `getAllSessions` still returning `[]` (storage hydrating), and the restored `default::live-check` was dropped and a new session id minted — the regression the handle map exists to prevent. Now the entry is always kept. When storage returns a non-empty list that lacks the id (a definite delete) the record is re-created with the same id, best-effort; when it returns `[]` (cold or genuinely empty — indistinguishable) the handle is kept without re-creating, so a cold reload can't append a duplicate `session_created` event to the JSONL source of truth. Trace capture auto-creates the record later if needed.
3. **`generateSessionId` is strictly increasing per process.** Two sessions created in the same second both got `s-20260912194746`; the second `createSession` was a no-op and two handles pointed at one record. The `s-` + 14-digit format is unchanged (`isStandardSessionId` untouched); when the clock hasn't passed the last issued id, the next id is last + 1 s, computed on a `Date` so minute/hour/day/year carries are correct.

## Test plan

- [x] `npm run test` — 5182 passed / 0 failed (baseline 5171): 4 timer-free persistence tests over a held-write store fixture (immediate first write; N-bind burst → exactly 2 writes carrying all N; flush waits for the follow-up; cleanup writes the pre-clear snapshot); cold-list keeps id without re-create; definite-delete keeps id and re-creates once; failed re-create only logs; new `sessionUtils.test.ts` (same-second distinct + increasing, 5-call burst, year-end carry, clock catch-up)
- [x] Red/green per fix: dirty-only writes → 4 red; drop-on-miss restored → 3 red; re-create on `[]` → 1 red; monotonic guard disabled → 4 red
- [x] `npm run build` exit 0
- [ ] Live after merge (`code` vault, Obsidian unfocused): `--session pr4-check --workspace default` then `cat` the bindings file within 1 s; reload and call within 3 s → same session id in `nexus context`, no `-2`; two sessions in the same second → distinct ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)
